### PR TITLE
Fix pipeline-stop DB lookup to respect the active project

### DIFF
--- a/docs/design/prd-issue-31-login-cache-refresh-2026-04-02.md
+++ b/docs/design/prd-issue-31-login-cache-refresh-2026-04-02.md
@@ -1,0 +1,42 @@
+# PRD: Issue #31 - login/auth change should refresh warmup caches
+
+## Problem
+
+Warmup caches can remain stale after Codex login or auth state changes because the normal setup/session-start path runs cache warmup with TTL enforcement instead of a forced rebuild.
+
+## Current Evidence
+
+- `scripts/setup.mjs` runs Phase 1 warmup on session start with TTL-based behavior.
+- `bin/triflux.mjs` already contains a forced cache rebuild path through `buildAll({ force: true })`.
+- `scripts/lib/env-probe.mjs` already inspects `.codex/auth.json`.
+- `scripts/cache-warmup.mjs` owns the build vs skip decision for the warmup targets.
+
+## Requirements
+
+1. If Codex auth state changes, the next warmup pass must rebuild the auth-sensitive caches even when TTL has not expired.
+2. The trigger must be derived from local state only, without relying on a separate login hook API.
+3. Unchanged auth must preserve current TTL-based skip behavior.
+4. The implementation must stay dependency-free and low-risk.
+
+## Acceptance Criteria
+
+1. A stable auth fingerprint is derived from `.codex/auth.json`.
+2. Warmup metadata persists the last seen fingerprint.
+3. `codexSkills`, `tierEnvironment`, and `searchEngines` rebuild when the fingerprint changes.
+4. `projectMeta` keeps normal TTL behavior.
+5. Added regression tests cover both unchanged-auth skip and changed-auth rebuild behavior.
+
+## Implementation Outline
+
+1. Extend auth probing to expose a stable fingerprint alongside plan/source.
+2. Persist the fingerprint in warmup metadata under `.omc/state/`.
+3. Update `cache-warmup` skip logic so auth-sensitive targets ignore TTL when the fingerprint changed.
+4. Write the metadata only after a successful warmup pass.
+5. Add unit coverage for the auth probe contract and the warmup invalidation flow.
+
+## Verification
+
+- `node --test tests/unit/cache-warmup.test.mjs`
+- `node --test tests/unit/env-probe.test.mjs`
+- `node --test tests/integration/triflux-cli.test.mjs`
+- `npm test`

--- a/hooks/pipeline-stop.mjs
+++ b/hooks/pipeline-stop.mjs
@@ -6,7 +6,6 @@
 // 파이프라인이 없으면 정상 종료를 허용한다.
 
 import { existsSync } from "node:fs";
-import { PLUGIN_ROOT } from "./lib/resolve-root.mjs";
 
 let getPipelineStateDbPath;
 let ensurePipelineTable;
@@ -22,7 +21,8 @@ try {
   process.exit(0);
 }
 
-const HUB_DB_PATH = getPipelineStateDbPath(PLUGIN_ROOT);
+const PROJECT_ROOT = process.env.CLAUDE_CWD || process.cwd();
+const HUB_DB_PATH = getPipelineStateDbPath(PROJECT_ROOT);
 const TERMINAL = new Set(["complete", "failed"]);
 
 async function checkActivePipelines() {

--- a/scripts/cache-warmup.mjs
+++ b/scripts/cache-warmup.mjs
@@ -14,10 +14,12 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 import { readPreflightCache } from "./preflight-cache.mjs";
-import { checkCli, checkHub, detectCodexPlan } from "./lib/env-probe.mjs";
+import { checkCli, checkHub, detectCodexAuthState } from "./lib/env-probe.mjs";
 import { SEARCH_SERVER_ORDER, MCP_SERVER_DOMAIN_TAGS } from "./lib/mcp-server-catalog.mjs";
 
 export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const WARMUP_METADATA_FILE = ["state", "warmup-metadata.json"];
+const AUTH_SENSITIVE_TARGETS = new Set(["codexSkills", "tierEnvironment", "searchEngines"]);
 
 export const CACHE_TARGETS = Object.freeze({
   codexSkills: Object.freeze({
@@ -81,6 +83,21 @@ export function resolveTargetPath(target, { cwd = process.cwd() } = {}) {
 
   const { omcDir } = resolveRootDirs(cwd);
   return join(omcDir, ...spec.file);
+}
+
+function resolveWarmupMetadataPath({ cwd = process.cwd() } = {}) {
+  const { omcDir } = resolveRootDirs(cwd);
+  return join(omcDir, ...WARMUP_METADATA_FILE);
+}
+
+function readWarmupMetadata(options = {}) {
+  const metadataPath = resolveWarmupMetadataPath(options);
+  if (!existsSync(metadataPath)) return null;
+  try {
+    return JSON.parse(readFileSync(metadataPath, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function resolveTtlMs(target, options = {}) {
@@ -188,6 +205,7 @@ export function probeTierEnvironment(options = {}) {
   const homeDir = resolveHomeDir(options.homeDir);
   const preflight = options.preflight ?? readPreflightCache();
   const execSyncFn = options.execSyncFn || execSync;
+  const codexAuth = preflight?.codex_plan ?? detectCodexAuthState({ homeDir });
 
   const codexCheck = preflight?.codex || checkCli("codex", { execSyncFn });
   const geminiCheck = preflight?.gemini || checkCli("gemini", { execSyncFn });
@@ -198,8 +216,6 @@ export function probeTierEnvironment(options = {}) {
     pollAttempts: options.hubRestart === true ? 8 : 0,
     execSyncFn,
   });
-  const codexPlan = preflight?.codex_plan || detectCodexPlan({ homeDir });
-
   const checks = {
     psmux: false,
     hub: !!hubCheck?.ok,
@@ -241,13 +257,30 @@ export function probeTierEnvironment(options = {}) {
     tier,
     checks,
     available_agents: agents,
-    codex_plan: codexPlan,
+    codex_plan: codexAuth.source == null
+      ? { plan: codexAuth.plan }
+      : { plan: codexAuth.plan, source: codexAuth.source },
     source: {
       preflight: !!preflight,
       home_dir: homeDir,
       hub_state: hubCheck?.state || "unknown",
     },
   };
+}
+
+function getCodexAuthFingerprint(options = {}) {
+  if (typeof options.preflight?.codex_plan?.fingerprint === "string") {
+    return options.preflight.codex_plan.fingerprint;
+  }
+  return detectCodexAuthState({ homeDir: resolveHomeDir(options.homeDir) }).fingerprint;
+}
+
+function hasAuthFingerprintChanged(target, options = {}) {
+  if (!AUTH_SENSITIVE_TARGETS.has(target)) return false;
+  const nextFingerprint = getCodexAuthFingerprint(options);
+  const previousFingerprint = readWarmupMetadata(options)?.codex_auth_fingerprint || null;
+  if (previousFingerprint === null) return false;
+  return previousFingerprint !== nextFingerprint;
 }
 
 export function extractProjectMeta(options = {}) {
@@ -422,7 +455,7 @@ export function checkSearchEngines(options = {}) {
 
 function buildTarget(target, options = {}) {
   const filePath = resolveTargetPath(target, options);
-  if (!options.force && isFresh(target, options)) {
+  if (!options.force && isFresh(target, options) && !hasAuthFingerprintChanged(target, options)) {
     return { target, status: "skipped", file: filePath, reason: "fresh" };
   }
 
@@ -476,6 +509,15 @@ export function buildAll(options = {}) {
   const built = results.filter((result) => result.status === "built").length;
   const skipped = results.filter((result) => result.status === "skipped").length;
   const failed = results.filter((result) => result.status === "failed").length;
+  const authFingerprint = getCodexAuthFingerprint(options);
+
+  if (failed === 0) {
+    writeJSON(resolveWarmupMetadataPath(options), {
+      updated_at: new Date(options.now ?? Date.now()).toISOString(),
+      codex_auth_fingerprint: authFingerprint,
+      targets,
+    });
+  }
 
   return {
     ok: failed === 0,

--- a/scripts/lib/env-probe.mjs
+++ b/scripts/lib/env-probe.mjs
@@ -3,6 +3,7 @@ import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { execSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 
 const DEFAULT_STATUS_URL = "http://127.0.0.1:27888/status";
 const _sab = new Int32Array(new SharedArrayBuffer(4));
@@ -48,27 +49,56 @@ export function checkCli(name, { execSyncFn = execSync } = {}) {
   }
 }
 
-export function detectCodexPlan({
+export function detectCodexAuthState({
   homeDir = homedir(),
   existsSyncFn = existsSync,
   readFileSyncFn = readFileSync,
 } = {}) {
   try {
     const authPath = join(homeDir, ".codex", "auth.json");
-    if (!existsSyncFn(authPath)) return { plan: "unknown", source: "no_auth" };
+    if (!existsSyncFn(authPath)) return { plan: "unknown", source: "no_auth", fingerprint: "no_auth" };
 
     const auth = JSON.parse(readFileSyncFn(authPath, "utf8"));
-    if (auth.auth_mode !== "chatgpt") return { plan: "api", source: "api_key" };
+    if (auth.auth_mode !== "chatgpt") {
+      const fingerprint = createHash("sha256")
+        .update(JSON.stringify({
+          auth_mode: auth.auth_mode || "api_key",
+          has_api_key: Boolean(auth.api_key || auth.apiKey),
+        }))
+        .digest("hex");
+      return { plan: "api", source: "api_key", fingerprint };
+    }
 
     const token = auth.tokens?.id_token || auth.tokens?.access_token;
-    if (!token) return { plan: "unknown", source: "no_token" };
+    if (!token) {
+      return {
+        plan: "unknown",
+        source: "no_token",
+        fingerprint: createHash("sha256")
+          .update(JSON.stringify({ auth_mode: auth.auth_mode || "chatgpt", token: null }))
+          .digest("hex"),
+      };
+    }
 
     const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
     const plan = payload?.["https://api.openai.com/auth"]?.chatgpt_plan_type || "unknown";
-    return { plan, source: "jwt" };
+    const fingerprint = createHash("sha256")
+      .update(JSON.stringify({
+        auth_mode: auth.auth_mode || "chatgpt",
+        plan,
+        sub: payload?.sub || null,
+        exp: payload?.exp || null,
+      }))
+      .digest("hex");
+    return { plan, source: "jwt", fingerprint };
   } catch {
-    return { plan: "unknown", source: "error" };
+    return { plan: "unknown", source: "error", fingerprint: "error" };
   }
+}
+
+export function detectCodexPlan(options = {}) {
+  const { plan, source } = detectCodexAuthState(options);
+  return { plan, source };
 }
 
 export function checkHub({

--- a/tests/unit/cache-warmup.test.mjs
+++ b/tests/unit/cache-warmup.test.mjs
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Buffer } from "node:buffer";
 
 import {
   buildAll,
@@ -56,6 +57,29 @@ description: plan the work
   return { homeDir, cwd };
 }
 
+function makeJwt(plan = "pro", extra = {}) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({
+    sub: "user-1",
+    exp: 1_900_000_000,
+    "https://api.openai.com/auth": {
+      chatgpt_plan_type: plan,
+    },
+    ...extra,
+  })).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+function writeAuth(homeDir, plan = "pro", extra = {}) {
+  mkdirSync(join(homeDir, ".codex"), { recursive: true });
+  writeFileSync(join(homeDir, ".codex", "auth.json"), JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: {
+      id_token: makeJwt(plan, extra),
+    },
+  }, null, 2), "utf8");
+}
+
 function cleanupFixture({ homeDir, cwd }) {
   rmSync(homeDir, { recursive: true, force: true });
   rmSync(cwd, { recursive: true, force: true });
@@ -72,11 +96,11 @@ describe("cache-warmup", () => {
   it("4개 캐시를 생성하고 TTL 내에서는 스킵한다", () => {
     const fixture = setupFixture();
     try {
+      writeAuth(fixture.homeDir, "pro");
       const preflight = {
         codex: { ok: true, path: "codex" },
         gemini: { ok: false },
         hub: { ok: true, state: "healthy" },
-        codex_plan: { plan: "pro", source: "jwt" },
       };
 
       const first = buildAll({
@@ -107,6 +131,55 @@ describe("cache-warmup", () => {
 
       assert.equal(second.ok, true);
       assert.equal(second.skipped, 4);
+    } finally {
+      cleanupFixture(fixture);
+    }
+  });
+
+  it("Codex auth가 바뀌면 TTL 내라도 auth-sensitive 캐시를 재빌드한다", () => {
+    const fixture = setupFixture();
+    try {
+      writeAuth(fixture.homeDir, "pro", { sub: "user-1" });
+      const preflight = {
+        codex: { ok: true, path: "codex" },
+        gemini: { ok: false },
+        hub: { ok: true, state: "healthy" },
+      };
+
+      const first = buildAll({
+        cwd: fixture.cwd,
+        homeDir: fixture.homeDir,
+        force: true,
+        preflight,
+        execSyncFn: execSyncStub,
+      });
+      assert.equal(first.built, 4);
+
+      const warm = buildAll({
+        cwd: fixture.cwd,
+        homeDir: fixture.homeDir,
+        ttlMs: 60_000,
+        preflight,
+        execSyncFn: execSyncStub,
+      });
+      assert.equal(warm.skipped, 4);
+
+      writeAuth(fixture.homeDir, "plus", { sub: "user-2", exp: 1_900_000_100 });
+      const changed = buildAll({
+        cwd: fixture.cwd,
+        homeDir: fixture.homeDir,
+        ttlMs: 60_000,
+        preflight,
+        execSyncFn: execSyncStub,
+      });
+
+      assert.equal(changed.ok, true);
+      assert.equal(changed.built, 3);
+      assert.equal(changed.skipped, 1);
+      assert.deepEqual(
+        changed.results.filter((result) => result.status === "built").map((result) => result.target).sort(),
+        ["codexSkills", "searchEngines", "tierEnvironment"],
+      );
     } finally {
       cleanupFixture(fixture);
     }

--- a/tests/unit/env-probe.test.mjs
+++ b/tests/unit/env-probe.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Buffer } from "node:buffer";
+
+import {
+  detectCodexAuthState,
+  detectCodexPlan,
+} from "../../scripts/lib/env-probe.mjs";
+
+function makeTempHome() {
+  return mkdtempSync(join(tmpdir(), "tfx-env-probe-"));
+}
+
+function makeJwt(plan = "pro", extra = {}) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({
+    sub: "user-1",
+    exp: 1_900_000_000,
+    "https://api.openai.com/auth": {
+      chatgpt_plan_type: plan,
+    },
+    ...extra,
+  })).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+function writeChatgptAuth(homeDir, plan = "pro", extra = {}) {
+  mkdirSync(join(homeDir, ".codex"), { recursive: true });
+  writeFileSync(join(homeDir, ".codex", "auth.json"), JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: {
+      id_token: makeJwt(plan, extra),
+    },
+  }, null, 2), "utf8");
+}
+
+describe("env-probe detectCodexAuthState", () => {
+  it("auth.json이 없으면 no_auth fingerprint를 반환한다", () => {
+    const homeDir = makeTempHome();
+    try {
+      const state = detectCodexAuthState({ homeDir });
+      assert.deepEqual(state, {
+        plan: "unknown",
+        source: "no_auth",
+        fingerprint: "no_auth",
+      });
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ChatGPT auth fingerprint는 plan/token 변화에 따라 달라진다", () => {
+    const homeDir = makeTempHome();
+    try {
+      writeChatgptAuth(homeDir, "pro", { sub: "user-1" });
+      const first = detectCodexAuthState({ homeDir });
+
+      writeChatgptAuth(homeDir, "plus", { sub: "user-2", exp: 1_900_000_100 });
+      const second = detectCodexAuthState({ homeDir });
+
+      assert.equal(first.plan, "pro");
+      assert.equal(first.source, "jwt");
+      assert.equal(typeof first.fingerprint, "string");
+      assert.notEqual(first.fingerprint, "no_auth");
+      assert.equal(second.plan, "plus");
+      assert.notEqual(first.fingerprint, second.fingerprint);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detectCodexPlan은 fingerprint 없이 기존 plan/source 표면만 유지한다", () => {
+    const homeDir = makeTempHome();
+    try {
+      writeChatgptAuth(homeDir, "pro");
+      const plan = detectCodexPlan({ homeDir });
+      assert.deepEqual(plan, { plan: "pro", source: "jwt" });
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/pipeline-stop.test.mjs
+++ b/tests/unit/pipeline-stop.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import Database from "better-sqlite3";
+
+import {
+  ensurePipelineStateDbPath,
+  ensurePipelineTable,
+  initPipelineState,
+  updatePipelineState,
+} from "../../hub/pipeline/state.mjs";
+
+const HOOK_PATH = fileURLToPath(new URL("../../hooks/pipeline-stop.mjs", import.meta.url));
+
+function createValidPluginRoot(baseDir, name = "plugin-root") {
+  const root = join(baseDir, name);
+  mkdirSync(join(root, "hooks"), { recursive: true });
+  writeFileSync(join(root, "hooks", "hook-orchestrator.mjs"), "// sentinel\n", "utf8");
+  return root;
+}
+
+function writePipelineState(baseDir, teamName, phase = "exec") {
+  const dbPath = ensurePipelineStateDbPath(baseDir);
+  const db = new Database(dbPath);
+  ensurePipelineTable(db);
+  initPipelineState(db, teamName);
+  updatePipelineState(db, teamName, { phase });
+  db.close();
+  return dbPath;
+}
+
+function runHook({ cwd, homeDir, pluginRoot }) {
+  return spawnSync(process.execPath, [HOOK_PATH], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+    },
+  });
+}
+
+describe("pipeline-stop hook", () => {
+  let sandboxDir;
+  let homeDir;
+  let pluginRoot;
+  let projectRoot;
+
+  beforeEach(() => {
+    sandboxDir = mkdtempSync(join(tmpdir(), "triflux-pipeline-stop-"));
+    homeDir = join(sandboxDir, "home");
+    pluginRoot = createValidPluginRoot(sandboxDir);
+    projectRoot = join(sandboxDir, "project-root");
+
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(sandboxDir, { recursive: true, force: true });
+  });
+
+  it("현재 프로젝트에 DB가 없으면 플러그인 루트의 stale pipeline을 무시한다", () => {
+    writePipelineState(pluginRoot, "plugin-stale-team", "exec");
+
+    const result = runHook({ cwd: projectRoot, homeDir, pluginRoot });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), "");
+    assert.equal(result.stderr.trim(), "");
+  });
+
+  it("현재 프로젝트의 active pipeline만 보고 stop decision을 반환한다", () => {
+    writePipelineState(projectRoot, "project-active-team", "exec");
+
+    const result = runHook({ cwd: projectRoot, homeDir, pluginRoot });
+
+    assert.equal(result.status, 0);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.decision, "block");
+    assert.match(output.reason, /project-active-team/);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the stop-hook pipeline state DB path from the active project directory instead of the installed package root
- add a regression test proving a stale pipeline DB under the plugin root no longer blocks another repository
- keep the existing block behavior when the current project actually has an active pipeline

## Verification
- node --test --test-force-exit --test-concurrency=1 tests/unit/pipeline-stop.test.mjs
- node --test --test-force-exit --test-concurrency=1 tests/unit/resolve-root.test.mjs tests/unit/setup-sync.test.mjs