### PR TITLE
Mitigate attached psmux cleanup freeze paths

### DIFF
--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -261,13 +261,19 @@ function parsePaneDetails(output) {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [title = "", paneId = "", dead = "0", deadStatus = ""] = line.split("\t");
+      const parts = line.split("\t");
+      const hasPaneIndex = parts.length >= 5;
+      const [paneIndexText = "", title = "", paneId = "", dead = "0", deadStatus = ""] = hasPaneIndex
+        ? parts
+        : ["", ...parts];
       const exitCode = dead === "1"
         ? Number.parseInt(deadStatus, 10)
         : null;
+      const paneIndex = Number.parseInt(paneIndexText, 10);
       return {
         title,
         paneId,
+        paneIndex: Number.isFinite(paneIndex) ? paneIndex : null,
         isDead: dead === "1",
         exitCode: Number.isFinite(exitCode) ? exitCode : dead === "1" ? 0 : null,
       };
@@ -292,7 +298,7 @@ function listPaneDetails(sessionName) {
     "-t",
     sessionName,
     "-F",
-    "#{pane_title}\t#{session_name}:#{window_index}.#{pane_index}\t#{pane_dead}\t#{pane_dead_status}",
+    "#{pane_index}\t#{pane_title}\t#{session_name}:#{window_index}.#{pane_index}\t#{pane_dead}\t#{pane_dead_status}",
   ]);
   return parsePaneDetails(output);
 }
@@ -617,12 +623,40 @@ function killOrphanMcpProcesses(sessionName) {
   }
 }
 
+function detachAttachedClients(sessionName, waitMs = 750) {
+  const attachedCount = getPsmuxSessionAttachedCount(sessionName);
+  if (!Number.isFinite(attachedCount) || attachedCount <= 0) return false;
+  try {
+    psmuxExec(["detach-client", "-t", sessionName], { stdio: "ignore" });
+    sleepMs(waitMs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findFallbackPane(sessionName, excludedPaneId) {
+  try {
+    const panes = listPaneDetails(sessionName)
+      .filter((pane) => pane.paneId !== excludedPaneId && !pane.isDead);
+    if (panes.length === 0) return null;
+    return panes.find((pane) => pane.title === "lead")
+      || panes.find((pane) => pane.paneIndex === 0)
+      || panes[0];
+  } catch {
+    return null;
+  }
+}
+
 /**
  * psmux 세션 종료
  * 순서: pipe-pane 해제 → pane 프로세스 트리 정리 → 세션 종료 → 고아 정리
  * @param {string} sessionName
  */
 export function killPsmuxSession(sessionName) {
+  // attach된 WT/ConPTY 클라이언트가 있으면 먼저 안전하게 분리한다.
+  detachAttachedClients(sessionName);
+
   // 1. pipe-pane 캡처 해제 — reader 프로세스에 EOF 전송하여 정상 종료 유도
   let paneIds = [];
   try {
@@ -1096,6 +1130,18 @@ export function killWorker(sessionName, workerName) {
   }
   try {
     const { paneId, status } = getWorkerStatus(sessionName, workerName);
+    const attachedCount = getPsmuxSessionAttachedCount(sessionName);
+    const fallbackPane = attachedCount > 0
+      ? findFallbackPane(sessionName, paneId)
+      : null;
+
+    if (fallbackPane?.paneId) {
+      try {
+        psmuxExec(["select-pane", "-t", fallbackPane.paneId]);
+      } catch {
+        // focus 회복 best-effort
+      }
+    }
 
     // pipe-pane 캡처 해제 — reader 프로세스 정상 종료 유도
     disablePipeCapture(paneId);
@@ -1126,10 +1172,12 @@ export function killWorker(sessionName, workerName) {
       // send-keys 실패 무시
     }
 
-    try {
-      psmuxExec(["send-keys", "-t", paneId, "exit", "Enter"]);
-    } catch {
-      // send-keys 실패 무시
+    if (!fallbackPane) {
+      try {
+        psmuxExec(["send-keys", "-t", paneId, "exit", "Enter"]);
+      } catch {
+        // send-keys 실패 무시
+      }
     }
 
     sleepMs(2000);
@@ -1138,6 +1186,14 @@ export function killWorker(sessionName, workerName) {
       psmuxExec(["kill-pane", "-t", paneId]);
     } catch {
       // 이미 종료된 pane — 무시
+    }
+
+    if (fallbackPane?.paneId) {
+      try {
+        psmuxExec(["select-pane", "-t", fallbackPane.paneId]);
+      } catch {
+        // pane 정리 후 focus 재선택 best-effort
+      }
     }
     return { killed: true };
   } catch (err) {

--- a/scripts/cache-warmup.mjs
+++ b/scripts/cache-warmup.mjs
@@ -309,6 +309,7 @@ export function extractProjectMeta(options = {}) {
   if (existsSync(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      name = pkg.name || name;
       description = pkg.description || "";
       testCmd = pkg.scripts?.test || null;
       lang = "JavaScript/ESM (Node.js)";

--- a/tests/unit/psmux.test.mjs
+++ b/tests/unit/psmux.test.mjs
@@ -372,7 +372,7 @@ describe("psmux.mjs steering", () => {
 });
 
 describe("killPsmuxSession cleanup", () => {
-  function mockForKillSession() {
+  function mockForKillSession({ attached = true } = {}) {
     const calls = [];
 
     const tracker = mock.method(childProcess, "execFileSync", (file, args) => {
@@ -382,6 +382,8 @@ describe("killPsmuxSession cleanup", () => {
       switch (argv[0]) {
         case "-V":
           return "psmux 3.3.0";
+        case "list-sessions":
+          return attached ? "tfx-kill: 1 windows (1 attached)" : "tfx-kill: 1 windows";
         case "list-panes": {
           const fmt = argv.find((a) => a.includes("pane_index"));
           if (fmt) {
@@ -390,6 +392,8 @@ describe("killPsmuxSession cleanup", () => {
           // #{pane_pid} format
           return "1234\n5678";
         }
+        case "detach-client":
+          return "";
         case "pipe-pane":
           return "";
         case "kill-session":
@@ -441,13 +445,106 @@ describe("killPsmuxSession cleanup", () => {
     );
     assert.ok(orphanCalls.length >= 1, "고아 pipe-pane 헬퍼 정리가 호출되어야 함");
 
-    // 순서 검증: pipe-pane 해제가 taskkill보다 먼저
+    const detachClientIdx = calls.findIndex(
+      (c) => Array.isArray(c.args) && c.args[0] === "detach-client",
+    );
+    assert.ok(detachClientIdx >= 0, "attached session이면 detach-client가 호출되어야 함");
+
+    // 순서 검증: detach-client가 pipe-pane / taskkill보다 먼저
     const firstPipePaneIdx = calls.findIndex(
       (c) => Array.isArray(c.args) && c.args[0] === "pipe-pane",
     );
+    assert.ok(detachClientIdx < firstPipePaneIdx, "detach-client가 pipe-pane 해제보다 먼저 실행되어야 함");
+
+    // 순서 검증: pipe-pane 해제가 taskkill보다 먼저
     const firstTaskkillIdx = calls.findIndex(
       (c) => c.file === "execSync" && typeof c.args[0] === "string" && c.args[0].includes("taskkill"),
     );
     assert.ok(firstPipePaneIdx < firstTaskkillIdx, "pipe-pane 해제가 taskkill보다 먼저 실행되어야 함");
+  });
+
+  it("unattached session이면 detach-client를 생략한다", async () => {
+    createTempCaptureRoot("psmux-kill-unattached-");
+    const { calls } = mockForKillSession({ attached: false });
+    const { killPsmuxSession } = await importFreshPsmux();
+
+    killPsmuxSession("tfx-kill");
+
+    const detachClientCalls = calls.filter(
+      (c) => Array.isArray(c.args) && c.args[0] === "detach-client",
+    );
+    assert.equal(detachClientCalls.length, 0, "unattached session에는 detach-client가 불필요");
+  });
+});
+
+describe("killWorker focus-safe cleanup", () => {
+  function mockForKillWorker({ attached = true, workerDead = false } = {}) {
+    const calls = [];
+
+    const tracker = mock.method(childProcess, "execFileSync", (file, args) => {
+      const argv = Array.isArray(args) ? [...args] : [];
+      calls.push({ file, args: argv });
+
+      switch (argv[0]) {
+        case "-V":
+          return "psmux 3.3.1";
+        case "list-sessions":
+          return attached ? "tfx-test: 1 windows (1 attached)" : "tfx-test: 1 windows";
+        case "list-panes":
+          if (argv.includes("#{pane_pid}")) return "4321";
+          return [
+            `0\tlead\ttfx-test:0.0\t0\t`,
+            `1\tworker-1\ttfx-test:0.1\t${workerDead ? "1" : "0"}\t0`,
+            "2\tworker-2\ttfx-test:0.2\t0\t",
+          ].join("\n");
+        case "select-pane":
+        case "pipe-pane":
+        case "send-keys":
+        case "kill-pane":
+          return "";
+        default:
+          throw new Error(`예상하지 못한 execFileSync 호출: ${argv.join(" ")}`);
+      }
+    });
+
+    const execSyncTracker = mock.method(childProcess, "execSync", (cmd) => {
+      calls.push({ file: "execSync", args: [cmd] });
+      return "";
+    });
+
+    registerRestore(() => tracker.mock.restore());
+    registerRestore(() => execSyncTracker.mock.restore());
+    return { calls };
+  }
+
+  it("attached session에서는 fallback pane을 먼저 선택하고 exit 전송을 생략한다", async () => {
+    createTempCaptureRoot("psmux-kill-worker-attached-");
+    const { calls } = mockForKillWorker({ attached: true });
+    const { killWorker } = await importFreshPsmux();
+
+    killWorker("tfx-test", "worker-1");
+
+    const selectPaneCalls = calls.filter(
+      (c) => Array.isArray(c.args) && c.args[0] === "select-pane",
+    );
+    assert.ok(selectPaneCalls.length >= 2, "attached cleanup은 fallback pane 재선택을 포함해야 함");
+
+    const sendExitCalls = calls.filter(
+      (c) => Array.isArray(c.args) && c.args[0] === "send-keys" && c.args.includes("exit"),
+    );
+    assert.equal(sendExitCalls.length, 0, "attached session에서는 exit 전송을 생략해야 함");
+  });
+
+  it("unattached session에서는 기존 exit 전송 경로를 유지한다", async () => {
+    createTempCaptureRoot("psmux-kill-worker-unattached-");
+    const { calls } = mockForKillWorker({ attached: false });
+    const { killWorker } = await importFreshPsmux();
+
+    killWorker("tfx-test", "worker-1");
+
+    const sendExitCalls = calls.filter(
+      (c) => Array.isArray(c.args) && c.args[0] === "send-keys" && c.args.includes("exit"),
+    );
+    assert.equal(sendExitCalls.length, 1, "unattached session에서는 exit 전송을 유지해야 함");
   });
 });


### PR DESCRIPTION
## Summary
- detach attached psmux clients before session teardown to avoid unsafe attached cleanup paths
- preserve focus more carefully during worker cleanup and avoid sending `exit` on attached sessions
- make cache warmup project naming stable in separated git worktrees and add regression coverage

## Why
Issue #43 tracks freeze/focus-loss risk when attached multi-pane psmux sessions are cleaned up inside Windows Terminal. Triflux already documented a detach-first contract, but runtime cleanup still had gaps. This PR closes the most direct Triflux-owned paths without broadening scope.

## Testing
- `node --test tests/unit/cache-buildup.test.mjs tests/unit/psmux.test.mjs tests/unit/session.test.mjs tests/unit/headless-dashboard-anchor.test.mjs`
- `npm run test:unit`
- `npm pack --dry-run`
- `git diff --check`

## Notes
- `npm test` was attempted in the isolated worktree, but it did not complete within the interactive wait window, so the verified evidence above is from targeted + unit coverage.

Closes #42
Closes #43
