### PR TITLE
feat: add Serena doctor guardrails for parallel-safe usage

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -319,6 +319,8 @@ tfx setup
 /tfx-multi "refactor auth + update UI + add tests"
 ```
 > **참고**: Deep 스킬(`/tfx-deep-*`, `/tfx-persist`, `/tfx-ralph`)은 완전한 Tri-CLI 합의(Tier 1)를 위해 **psmux**(또는 tmux), **triflux Hub**, **Codex CLI**, **Gemini CLI**가 필요합니다. 전제조건이 충족되지 않으면 Tier 3(Claude 단독, single-model) 모드로 자동 전환됩니다. `tfx doctor`로 환경을 확인하세요.
+>
+> **Serena 참고**: Serena MCP는 stateful합니다. 따라서 **같은 프로젝트**를 다루는 에이전트끼리만 하나의 Serena 인스턴스를 공유하는 것이 안전합니다. 서로 다른 프로젝트를 병렬로 작업할 때는 Serena 인스턴스를 분리하세요. Serena가 `No active project`를 보고하면 Codex Serena 설정의 `--project-from-cwd`(또는 `--project <path>`)를 확인하고 `tfx doctor`를 다시 실행하세요.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ tfx setup
 /tfx-multi "refactor auth + update UI + add tests"
 ```
 > **Note**: Deep skills (`/tfx-deep-*`, `/tfx-persist`, `/tfx-ralph`) require **psmux** (or tmux), **triflux Hub**, **Codex CLI**, and **Gemini CLI** for full Tri-CLI consensus (Tier 1). Without these prerequisites, skills automatically degrade to Tier 3 (Claude-only, single-model) mode. Run `tfx doctor` to check your environment.
+>
+> **Serena note**: Serena MCP is stateful. Share one Serena instance only across agents working on the **same project**. For parallel work across different projects, prefer separate Serena instances. If Serena reports `No active project`, check your Codex Serena config for `--project-from-cwd` (or `--project <path>`) and rerun `tfx doctor`.
 
 ---
 

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -1004,6 +1004,48 @@ function getOptionValue(args, optionName) {
   return args[index + 1] ?? null;
 }
 
+function extractTomlSection(content, sectionName) {
+  const lines = String(content ?? "").split(/\r?\n/);
+  const header = `[${sectionName}]`;
+  const start = lines.findIndex((line) => line.trim() === header);
+  if (start === -1) return "";
+  const collected = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*\[.+\]\s*$/.test(line)) break;
+    collected.push(line);
+  }
+  return collected.join("\n");
+}
+
+function inspectSerenaMcpConfig(configContent) {
+  const section = extractTomlSection(configContent, "mcp_servers.serena");
+  if (!section.trim()) {
+    return {
+      present: false,
+      hasProjectBinding: false,
+      hasContextCodex: false,
+      startupTimeoutSec: null,
+      timeoutRecommended: false,
+    };
+  }
+
+  const hasProjectBinding = section.includes("--project-from-cwd")
+    || /--project(?:\s|=|")/.test(section);
+  const hasContextCodex = /--context(?:\s|",\s*")?codex/i.test(section) || /"codex"/i.test(section);
+  const timeoutMatch = section.match(/startup_timeout_sec\s*=\s*([0-9.]+)/i);
+  const startupTimeoutSec = timeoutMatch ? Number(timeoutMatch[1]) : null;
+  const timeoutRecommended = startupTimeoutSec !== null && startupTimeoutSec >= 30;
+
+  return {
+    present: true,
+    hasProjectBinding,
+    hasContextCodex,
+    startupTimeoutSec,
+    timeoutRecommended,
+  };
+}
+
 function statusBadge(status) {
   switch (status) {
     case "present":
@@ -1346,6 +1388,69 @@ async function cmdDoctor(options = {}) {
         addDoctorCheck(report, { name: "codex-legacy-models", status: "issues", models: legacyFound, fix: "tfx setup" });
         issues++;
       }
+    }
+
+    // 4.5 Serena MCP
+    section("Serena MCP");
+    if (existsSync(CODEX_CONFIG_PATH)) {
+      const codexConfig = readFileSync(CODEX_CONFIG_PATH, "utf8");
+      const serenaConfig = inspectSerenaMcpConfig(codexConfig);
+      if (!serenaConfig.present) {
+        warn("serena MCP 설정 없음");
+        info("권장: [mcp_servers.serena]에 --project-from-cwd, --context codex, startup_timeout_sec=30+ 설정");
+        addDoctorCheck(report, {
+          name: "serena-mcp",
+          status: "missing",
+          path: CODEX_CONFIG_PATH,
+          fix: "Codex config에 Serena MCP 설정을 추가하세요.",
+        });
+        issues++;
+      } else {
+        const hasSerenaIssues = !serenaConfig.hasProjectBinding || !serenaConfig.timeoutRecommended;
+
+        if (serenaConfig.hasProjectBinding) ok("project binding: 정상");
+        else {
+          warn("project binding 없음");
+          info("권장: --project-from-cwd 또는 --project <path>");
+          issues++;
+        }
+
+        if (serenaConfig.hasContextCodex) info("context codex: 설정됨");
+        else info("context codex: 미설정");
+
+        if (serenaConfig.startupTimeoutSec === null) {
+          warn("startup_timeout_sec 미설정");
+          info("권장: startup_timeout_sec = 30 이상");
+          issues++;
+        } else if (serenaConfig.timeoutRecommended) {
+          ok(`startup timeout: ${serenaConfig.startupTimeoutSec}s`);
+        } else {
+          warn(`startup timeout 낮음: ${serenaConfig.startupTimeoutSec}s`);
+          info("권장: startup_timeout_sec = 30 이상");
+          issues++;
+        }
+
+        addDoctorCheck(report, {
+          name: "serena-mcp",
+          status: hasSerenaIssues ? "issues" : "ok",
+          path: CODEX_CONFIG_PATH,
+          project_binding: serenaConfig.hasProjectBinding,
+          context_codex: serenaConfig.hasContextCodex,
+          startup_timeout_sec: serenaConfig.startupTimeoutSec,
+          ...(hasSerenaIssues
+            ? { fix: "Serena MCP에 --project-from-cwd 와 startup_timeout_sec=30+ 를 설정하세요." }
+            : {}),
+        });
+      }
+    } else {
+      addDoctorCheck(report, {
+        name: "serena-mcp",
+        status: "missing",
+        path: CODEX_CONFIG_PATH,
+        fix: "Codex config를 생성하고 Serena MCP 설정을 추가하세요.",
+      });
+      warn("config.toml 미존재 — Serena MCP 진단 건너뜀");
+      issues++;
     }
 
     // 5. Gemini CLI

--- a/tests/integration/triflux-cli.test.mjs
+++ b/tests/integration/triflux-cli.test.mjs
@@ -114,6 +114,24 @@ describe("triflux CLI JSON and schema surface", { timeout: 30000 }, () => {
     assert.ok(payload.checks.some((check) => check.name === "warmup-cache"));
   });
 
+  it("doctor --json은 Serena MCP project binding / timeout 진단을 포함해야 한다", () => {
+    const homeDir = createHomeDir();
+    writeFileSync(join(homeDir, ".codex", "config.toml"), [
+      "[mcp_servers.serena]",
+      'command = "uvx"',
+      'args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "codex"]',
+      'startup_timeout_sec = 10',
+      "",
+    ].join("\n"), "utf8");
+
+    const payload = parseStdoutJson(runCli(["doctor", "--json"], { homeDir }));
+    const serenaCheck = payload.checks.find((check) => check.name === "serena-mcp");
+    assert.ok(serenaCheck, "serena-mcp check missing");
+    assert.equal(serenaCheck.status, "issues");
+    assert.equal(serenaCheck.project_binding, false);
+    assert.equal(serenaCheck.startup_timeout_sec, 10);
+  });
+
   it("multi status --json은 팀 상태가 없을 때 offline JSON을 반환해야 한다", () => {
     const result = runCli(["multi", "status", "--json"]);
     const payload = parseStdoutJson(result);


### PR DESCRIPTION
## Summary
- add a dedicated `serena-mcp` doctor check that inspects Codex Serena config for project binding and startup timeout
- document Serena's stateful same-project sharing rule in both English and Korean READMEs
- add an integration test that locks the new doctor JSON contract for missing project binding / low timeout cases

## Why
Issue #45 is about reducing the "Serena keeps crashing" failure mode that is often really:
- no active project
- missing onboarding/readiness
- shared state used unsafely in parallel contexts

This PR adds immediate guardrails without overreaching into auto-recovery or per-lane Serena orchestration.

## Verification
- `node --check bin/triflux.mjs`
- `node --check tests/integration/triflux-cli.test.mjs`
- `node --test --test-force-exit --test-concurrency=1 tests/integration/triflux-cli.test.mjs`
- architect review: approved

## Follow-up
- auto-recovery / auto-activation path if Triflux later decides to own Serena lifecycle more aggressively
- stronger runtime separation for Serena-enabled parallel lanes if needed

Closes #45
