### PR TITLE
Prevent dead tfx-hub registrations from spamming standalone Codex

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -25,6 +25,7 @@ import {
   syncAliasedSkillDir, hasProfileSection, replaceProfileSection,
   ensureCodexProfiles, getVersion, cleanupStaleSkills, DEPRECATED_SKILLS,
   extractManagedHookFilename, getManagedRegistryHooks, ensureHooksInSettings,
+  ensureCodexHubServerConfig,
 } from "../scripts/setup.mjs";
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -809,7 +810,7 @@ function cmdSetup(options = {}) {
   // hub MCP 사전 등록 (서버 미실행이어도 설정만 등록 — hub start 시 즉시 사용 가능)
   if (existsSync(join(PKG_ROOT, "hub", "server.mjs"))) {
     const defaultHubUrl = `http://127.0.0.1:${process.env.TFX_HUB_PORT || "27888"}/mcp`;
-    autoRegisterMcp(defaultHubUrl);
+    autoRegisterMcp(defaultHubUrl, { codexEnabled: false });
     summary.push({ item: "Hub MCP", status: "✅", detail: "등록됨" });
     console.log("");
   }
@@ -2951,38 +2952,20 @@ function startHubAfterUpdate(info) {
 }
 
 // 설치된 CLI에 tfx-hub MCP 서버 자동 등록 (1회 설정, 이후 재실행 불필요)
-function autoRegisterMcp(mcpUrl) {
+function autoRegisterMcp(mcpUrl, { codexEnabled = false } = {}) {
   section("MCP 자동 등록");
 
-  // Codex — codex mcp add
+  // Codex — config.json에 기본 disabled 엔트리로 등록
   if (which("codex")) {
     try {
-      // 이미 등록됐는지 확인
-      const list = execSync("codex mcp list 2>&1", { encoding: "utf8", timeout: 10000, stdio: ["pipe", "pipe", "pipe"], windowsHide: true });
-      if (list.includes("tfx-hub")) {
-        ok("Codex: 이미 등록됨");
+      const result = ensureCodexHubServerConfig({ mcpUrl, createIfMissing: true, enabled: codexEnabled });
+      if (!result.ok) throw new Error(result.reason || "unknown");
+      if (result.changed) {
+        ok(`Codex: config.json에 등록 완료 (${codexEnabled ? "enabled" : "기본 disabled"})`);
       } else {
-        execFileSync("codex", ["mcp", "add", "tfx-hub", "--url", mcpUrl], { timeout: 10000, stdio: "ignore", windowsHide: true });
-        ok("Codex: MCP 등록 완료");
+        ok(`Codex: 이미 등록됨 (${codexEnabled ? "enabled" : "기본 disabled"})`);
       }
-    } catch {
-      // mcp list/add 미지원 → 설정 파일 직접 수정
-      try {
-        const codexDir = join(homedir(), ".codex");
-        const configFile = join(codexDir, "config.json");
-        let config = {};
-        if (existsSync(configFile)) config = JSON.parse(readFileSync(configFile, "utf8"));
-        if (!config.mcpServers) config.mcpServers = {};
-        if (!config.mcpServers["tfx-hub"]) {
-          config.mcpServers["tfx-hub"] = { url: mcpUrl };
-          if (!existsSync(codexDir)) mkdirSync(codexDir, { recursive: true });
-          writeFileSync(configFile, JSON.stringify(config, null, 2) + "\n");
-          ok("Codex: config.json에 등록 완료");
-        } else {
-          ok("Codex: 이미 등록됨");
-        }
-      } catch (e) { warn(`Codex 등록 실패: ${e.message}`); }
-    }
+    } catch (e) { warn(`Codex 등록 실패: ${e.message}`); }
   } else {
     info("Codex: 미설치 (건너뜀)");
   }
@@ -3072,6 +3055,7 @@ async function cmdHub(args = [], options = {}) {
         try {
           const info = JSON.parse(readFileSync(HUB_PID_FILE, "utf8"));
           process.kill(info.pid, 0); // 프로세스 존재 확인
+          autoRegisterMcp(info.url, { codexEnabled: true });
           console.log(`\n  ${YELLOW}⚠${RESET} hub 이미 실행 중 (PID ${info.pid}, ${info.url})\n`);
           return;
         } catch {
@@ -3115,7 +3099,7 @@ async function cmdHub(args = [], options = {}) {
         console.log(`    PID:  ${hubInfo.pid}`);
         console.log(`    DB:   ${DIM}${getPipelineStateDbPath(PKG_ROOT)}${RESET}`);
         console.log("");
-        autoRegisterMcp(hubInfo.url);
+        autoRegisterMcp(hubInfo.url, { codexEnabled: true });
         console.log("");
       } else {
         // 직접 포그라운드 모드로 안내

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -412,6 +412,62 @@ function ensureCodexProfiles() {
   }
 }
 
+function ensureCodexHubServerConfig({
+  configFile = join(CODEX_DIR, "config.json"),
+  serverName = "tfx-hub",
+  mcpUrl,
+  createIfMissing = false,
+  enabled = false,
+} = {}) {
+  if (typeof mcpUrl !== "string" || !mcpUrl.trim()) {
+    return { ok: false, changed: false, reason: "missing_url" };
+  }
+
+  let config = {};
+  const hasConfig = existsSync(configFile);
+  if (!hasConfig && !createIfMissing) {
+    return { ok: true, changed: false, reason: "config_missing" };
+  }
+
+  if (hasConfig) {
+    try {
+      config = JSON.parse(readFileSync(configFile, "utf8"));
+    } catch (error) {
+      return { ok: false, changed: false, reason: `config_parse_failed:${error.message}` };
+    }
+  }
+
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+
+  const existing = config.mcpServers[serverName];
+  if (!existing && !createIfMissing) {
+    return { ok: true, changed: false, reason: "server_missing" };
+  }
+
+  const nextEntry = {
+    ...(existing && typeof existing === "object" ? existing : {}),
+    url: mcpUrl,
+    enabled,
+  };
+
+  const changed = JSON.stringify(existing ?? null) !== JSON.stringify(nextEntry);
+  if (!changed) {
+    return { ok: true, changed: false, reason: "already_normalized" };
+  }
+
+  config.mcpServers[serverName] = nextEntry;
+  try {
+    const configDir = dirname(configFile);
+    if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true });
+    writeFileSync(configFile, JSON.stringify(config, null, 2) + "\n", "utf8");
+    return { ok: true, changed: true, reason: existing ? "updated" : "created" };
+  } catch (error) {
+    return { ok: false, changed: false, reason: `config_write_failed:${error.message}` };
+  }
+}
+
 const WINDOWS_DEFAULT_NODE_PATH = "C:/Program Files/nodejs/node.exe";
 const MANAGED_HOOK_FILENAMES = new Set([
   "safety-guard.mjs",
@@ -659,6 +715,7 @@ export {
   DEPRECATED_SKILLS, LEGACY_CODEX_MODELS,
   buildAliasedSkillContent, syncAliasedSkillDir, getVersion, ensureCodexProfiles,
   cleanupStaleSkills, extractManagedHookFilename, getManagedRegistryHooks, ensureHooksInSettings,
+  ensureCodexHubServerConfig,
 };
 
 function runMcpGuardAudit() {
@@ -1261,6 +1318,15 @@ if (process.platform === "win32") {
 const codexProfileResult = ensureCodexProfiles();
 if (codexProfileResult.changed > 0) {
   synced++;
+}
+
+// ── Codex tfx-hub 엔트리 정규화 (standalone Codex startup noisy MCP 방지) ──
+{
+  const codexHubConfig = ensureCodexHubServerConfig({
+    mcpUrl: `http://127.0.0.1:${process.env.TFX_HUB_PORT || "27888"}/mcp`,
+    createIfMissing: false,
+  });
+  if (codexHubConfig.changed) synced++;
 }
 
 // ── Gemini 프로필 자동 보정 ──

--- a/skills/tfx-hub/SKILL.md
+++ b/skills/tfx-hub/SKILL.md
@@ -91,7 +91,9 @@ Bash("curl -s http://127.0.0.1:27888/status 2>/dev/null || echo '{\"error\":\"hu
 허브 시작 후 각 CLI에 MCP 서버로 등록:
 
 ```bash
-# Codex
+# Codex (수동 opt-in 예시)
+# triflux는 config.json을 자동 관리하며, standalone Codex 노이즈 방지를 위해
+# 사전 등록은 disabled로 두고 `tfx hub start` 이후에만 enabled로 전환한다.
 codex mcp add tfx-hub --url http://127.0.0.1:27888/mcp
 
 # Gemini (settings.json)

--- a/tests/integration/hub-start-codex-config.test.mjs
+++ b/tests/integration/hub-start-codex-config.test.mjs
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, '..', '..');
+const TRIFLUX_BIN = join(PROJECT_ROOT, 'bin', 'triflux.mjs');
+const SLEEP_SAB = new Int32Array(new SharedArrayBuffer(4));
+
+function makeIsolatedHome(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  mkdirSync(join(root, '.codex'), { recursive: true });
+  return root;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function sleepMs(ms) {
+  Atomics.wait(SLEEP_SAB, 0, 0, ms);
+}
+
+function runHubStart(homeDir, port) {
+  return execFileSync(process.execPath, [
+    TRIFLUX_BIN,
+    'hub',
+    'start',
+    '--port',
+    String(port),
+  ], {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      TFX_HUB_PORT: String(port),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function stopHubFromPidFile(homeDir) {
+  const pidPath = join(homeDir, '.claude', 'cache', 'tfx-hub', 'hub.pid');
+  if (!existsSync(pidPath)) return;
+
+  try {
+    const info = readJson(pidPath);
+    if (Number.isFinite(info?.pid)) {
+      for (const signal of ['SIGTERM', 'SIGKILL']) {
+        try { process.kill(info.pid, signal); } catch {}
+        const deadline = Date.now() + 3000;
+        while (Date.now() < deadline) {
+          try {
+            process.kill(info.pid, 0);
+            sleepMs(100);
+          } catch {
+            return;
+          }
+        }
+      }
+    }
+  } catch {
+    // best-effort cleanup only
+  }
+}
+
+describe('tfx hub start re-enables Codex MCP config', () => {
+  it('hub already running path should still flip tfx-hub back to enabled', () => {
+    const homeDir = makeIsolatedHome('tfx-hub-codex-');
+    const port = 28180 + Math.floor(Math.random() * 50);
+    const configPath = join(homeDir, '.codex', 'config.json');
+
+    try {
+      runHubStart(homeDir, port);
+
+      let config = readJson(configPath);
+      assert.equal(config.mcpServers['tfx-hub'].enabled, true);
+      assert.equal(config.mcpServers['tfx-hub'].url, `http://127.0.0.1:${port}/mcp`);
+
+      config.mcpServers['tfx-hub'].enabled = false;
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+
+      runHubStart(homeDir, port);
+
+      config = readJson(configPath);
+      assert.equal(config.mcpServers['tfx-hub'].enabled, true);
+      assert.equal(config.mcpServers['tfx-hub'].url, `http://127.0.0.1:${port}/mcp`);
+    } finally {
+      stopHubFromPidFile(homeDir);
+      try {
+        rmSync(homeDir, { recursive: true, force: true });
+      } catch {
+        // Windows may keep a transient handle on the temp home for a short time.
+      }
+    }
+  });
+});

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -16,6 +16,7 @@ const {
   PLUGIN_ROOT,
   CLAUDE_DIR,
   ensureHooksInSettings,
+  ensureCodexHubServerConfig,
 } = await import('../../scripts/setup.mjs');
 
 // ── helpers ──
@@ -191,5 +192,80 @@ describe('setup-sync: managed hook registration', () => {
       if (prevClaudePluginRoot === undefined) delete process.env.CLAUDE_PLUGIN_ROOT;
       else process.env.CLAUDE_PLUGIN_ROOT = prevClaudePluginRoot;
     }
+  });
+});
+
+describe('setup-sync: codex tfx-hub config normalization', () => {
+  before(ensureTmpDir);
+  after(cleanTmpDir);
+
+  it('createIfMissing=true면 tfx-hub를 disabled 기본값으로 생성한다', () => {
+    const configPath = join(TMP_DIR, 'codex-create.json');
+    const result = ensureCodexHubServerConfig({
+      configFile: configPath,
+      mcpUrl: 'http://127.0.0.1:27888/mcp',
+      createIfMissing: true,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    assert.deepEqual(config.mcpServers['tfx-hub'], {
+      url: 'http://127.0.0.1:27888/mcp',
+      enabled: false,
+    });
+  });
+
+  it('기존 tfx-hub 엔트리는 URL을 갱신하고 enabled=false로 정규화한다', () => {
+    const configPath = join(TMP_DIR, 'codex-update.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcpServers: {
+        'tfx-hub': { url: 'http://127.0.0.1:9999/mcp', enabled: true, note: 'keep-me' },
+        other: { url: 'http://127.0.0.1:3000/mcp' },
+      },
+    }, null, 2));
+
+    const result = ensureCodexHubServerConfig({
+      configFile: configPath,
+      mcpUrl: 'http://127.0.0.1:27888/mcp',
+      createIfMissing: false,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    assert.deepEqual(config.mcpServers['tfx-hub'], {
+      url: 'http://127.0.0.1:27888/mcp',
+      enabled: false,
+      note: 'keep-me',
+    });
+    assert.deepEqual(config.mcpServers.other, { url: 'http://127.0.0.1:3000/mcp' });
+  });
+
+  it('enabled=true를 요청하면 명시적으로 활성화 상태를 기록한다', () => {
+    const configPath = join(TMP_DIR, 'codex-enable.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcpServers: {
+        'tfx-hub': { url: 'http://127.0.0.1:27888/mcp', enabled: false },
+      },
+    }, null, 2));
+
+    const result = ensureCodexHubServerConfig({
+      configFile: configPath,
+      mcpUrl: 'http://127.0.0.1:27888/mcp',
+      createIfMissing: false,
+      enabled: true,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    assert.deepEqual(config.mcpServers['tfx-hub'], {
+      url: 'http://127.0.0.1:27888/mcp',
+      enabled: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep Codex tfx-hub pre-registration disabled by default during setup/sync
- re-enable the Codex entry after explicit \	fx hub start\, including the already-running path
- add helper-level and command-level regression coverage for the disabled → enabled transition

## Problem
Codex was inheriting a live \	fx-hub\ HTTP MCP registration even when the hub daemon was down. In standalone Codex sessions that produced connection-refused transport noise before the user even asked for hub-backed workflows.

## Fix
- centralize Codex config writes in a shared helper that preserves unrelated fields
- normalize existing Codex \	fx-hub\ entries to \nabled: false\ during setup sync
- keep setup-time / pre-registration disabled by default
- flip the entry back to \nabled: true\ after explicit \	fx hub start\, including when the hub is already running
- update the tfx-hub skill note to describe the new behavior

## Verification
- \
ode --test --test-force-exit --test-concurrency=1 tests/unit/setup-sync.test.mjs tests/unit/mcp-filter.test.mjs tests/integration/hub-start-codex-config.test.mjs\
- \
px tsc --noEmit --pretty false\ via LSP diagnostics on changed JS files
- \
pm pack --dry-run\

## Notes
- I attempted the broader \
pm test\ suite, but it stalled in unrelated coverage, so I used the targeted regression set above as the merge evidence for this fix.