### PR TITLE
Preserve Codex resume continuity in routed output

### DIFF
--- a/docs/research/codex-plugin-cc-reverse-engineering-2026-04.md
+++ b/docs/research/codex-plugin-cc-reverse-engineering-2026-04.md
@@ -1,0 +1,332 @@
+# codex-plugin-cc Reverse Engineering Notes
+
+Date: 2026-04-03
+Clone location: `C:\Users\SSAFY\Desktop\Projects\cli\codex-plugin-cc`
+Target version: `@openai/codex-plugin-cc@1.0.2`
+
+## 1. Product intent
+
+`codex-plugin-cc` is not a general orchestration system. It is a Claude Code plugin whose core promise is:
+
+- keep the user inside Claude Code
+- delegate selected work to the local Codex runtime
+- preserve Codex thread continuity so the user can resume or manage runs later
+- expose that runtime through a small set of slash commands and one thin subagent
+
+This intent is explicit in:
+
+- `README.md`
+- `plugins/codex/commands/*.md`
+- `plugins/codex/agents/codex-rescue.md`
+
+The plugin is optimized for one host environment, one external delegate, and one narrow workflow family:
+
+- review current code with Codex
+- ask Codex to rescue/investigate/fix
+- manage the resulting jobs from Claude Code
+
+## 2. Repository structure
+
+The codebase is intentionally narrow:
+
+- `plugins/codex/commands/*.md`
+  - Claude slash command entrypoints
+- `plugins/codex/agents/codex-rescue.md`
+  - thin forwarding subagent
+- `plugins/codex/scripts/codex-companion.mjs`
+  - single command runtime for setup, review, task, status, result, cancel
+- `plugins/codex/scripts/lib/codex.mjs`
+  - Codex app-server client orchestration and thread/turn capture
+- `plugins/codex/scripts/lib/state.mjs`
+  - workspace-scoped state + job index
+- `plugins/codex/scripts/lib/tracked-jobs.mjs`
+  - background job lifecycle and progress persistence
+- `plugins/codex/scripts/lib/job-control.mjs`
+  - status/result/cancel resolution and session filtering
+- `plugins/codex/scripts/lib/render.mjs`
+  - user-facing text rendering, including resume hints
+- `plugins/codex/scripts/lib/broker-lifecycle.mjs`
+  - shared broker startup/teardown for a reusable app-server runtime
+- `plugins/codex/scripts/session-lifecycle-hook.mjs`
+  - Claude session hook to export session data and clean up on session end
+- `plugins/codex/scripts/stop-review-gate-hook.mjs`
+  - optional stop-time review gate
+- `tests/*.test.mjs`
+  - strong runtime-level regression coverage
+
+## 3. Command surface
+
+The plugin exposes six user-visible command families:
+
+- `/codex:setup`
+  - environment, auth, and optional review-gate management
+- `/codex:review`
+  - built-in read-only review path
+- `/codex:adversarial-review`
+  - structured, steerable design challenge review
+- `/codex:rescue`
+  - task delegation to Codex with optional backgrounding and resume behavior
+- `/codex:status`
+  - active/recent job inspection
+- `/codex:result`
+  - final stored result retrieval
+- `/codex:cancel`
+  - interrupt active work
+
+The important architectural point is that the slash commands are thin shells. They almost all converge on `scripts/codex-companion.mjs`.
+
+## 4. Runtime architecture
+
+### 4.1 One central runtime
+
+`plugins/codex/scripts/codex-companion.mjs` is the real product core.
+
+It centralizes:
+
+- command parsing
+- model/effort normalization
+- setup checks
+- review dispatch
+- task dispatch
+- background worker spawning
+- job persistence
+- status/result/cancel behavior
+- rendering
+
+This is a strong architectural decision. The plugin avoids re-implementing Codex invocation logic in every slash command or agent prompt.
+
+### 4.2 Review path split
+
+The plugin has two different review implementations.
+
+`/codex:review`
+
+- implemented in `executeReviewRun()`
+- uses `runAppServerReview()` in `lib/codex.mjs`
+- validates the request against Codex's native review target model
+- stays read-only
+- does not accept arbitrary focus text
+
+`/codex:adversarial-review`
+
+- implemented in the same `executeReviewRun()` function but through the non-native path
+- builds a custom prompt from `prompts/adversarial-review.md`
+- runs `runAppServerTurn()`
+- requests structured JSON output via `schemas/review-output.schema.json`
+- renders richer findings with severity ordering through `lib/render.mjs`
+
+The plugin therefore treats "plain review" and "pressure-test review" as different product surfaces, not one flag on the same call.
+
+### 4.3 Task / rescue path
+
+The rescue path is built around persistent task threads.
+
+Key behavior from `executeTaskRun()` in `codex-companion.mjs`:
+
+- task threads are persisted with `persistThread: true`
+- `--resume`/`--resume-last` reopens the latest tracked task thread for the repo
+- default prompt for resume is `DEFAULT_CONTINUE_PROMPT`
+- write mode is explicit and changes sandbox from `read-only` to `workspace-write`
+- the rendered task result is built with `renderTaskResult()`
+
+This is the single biggest product difference from a simple one-shot wrapper:
+
+- the plugin treats Codex work as a resumable thread, not just an execution result
+
+### 4.4 Background execution
+
+Background execution is not a shell hack. It is a structured stateful flow:
+
+- `handleTask()` creates a job record
+- `enqueueBackgroundTask()` stores the request payload
+- `spawnDetachedTaskWorker()` starts a detached Node worker
+- `handleTaskWorker()` rehydrates the stored request
+- `runTrackedJob()` updates JSON state and append-only log files
+
+This design gives the plugin first-class `/status`, `/result`, and `/cancel` semantics.
+
+## 5. Codex transport model
+
+### 5.1 App server first
+
+The plugin is built around the Codex app server, not around scraping one-shot CLI output.
+
+`lib/codex.mjs` uses:
+
+- `CodexAppServerClient.connect(...)`
+- `thread/start`
+- `thread/resume`
+- `turn/start`
+- `review/start`
+- `turn/interrupt`
+- `thread/list`
+
+That means the plugin operates on explicit Codex objects:
+
+- threads
+- turns
+- review threads
+- interruptions
+
+### 5.2 Shared broker with direct fallback
+
+`withAppServer()` in `lib/codex.mjs` tries a shared broker-backed client first when present.
+
+If broker transport is busy or unavailable, it falls back to direct client startup.
+
+This is backed by:
+
+- `lib/broker-lifecycle.mjs`
+- `scripts/app-server-broker.mjs`
+- `getSessionRuntimeStatus()`
+
+The runtime therefore has two real transport modes:
+
+- direct startup
+- shared session via broker
+
+The mode is not hidden. It is surfaced in setup/status rendering.
+
+## 6. Session and state model
+
+### 6.1 Workspace-scoped state
+
+`lib/state.mjs` hashes the canonical workspace root and stores per-workspace state under:
+
+- `CLAUDE_PLUGIN_DATA/state/<slug>-<hash>`
+- fallback: temp dir if plugin data dir is not available
+
+Stored artifacts include:
+
+- `state.json`
+- per-job JSON files
+- per-job logs
+- broker session metadata
+
+### 6.2 Claude session scoping
+
+`session-lifecycle-hook.mjs` exports the Claude session id via:
+
+- `CODEX_COMPANION_SESSION_ID`
+
+This id is then used to:
+
+- filter visible jobs to the current Claude session
+- choose a resume candidate for the current session
+- clean up session-owned jobs on session end
+
+This is a crucial product decision:
+
+- workspace state is durable
+- session views are scoped
+
+### 6.3 Resume-friendly rendering
+
+`lib/render.mjs` treats `threadId` as a first-class UX artifact.
+
+It renders:
+
+- `Codex session ID: ...`
+- `Resume in Codex: codex resume <thread>`
+
+This appears in:
+
+- stored result rendering
+- job detail rendering
+- active/recent job tables
+
+The plugin assumes that a Codex run without resumability is materially worse UX.
+
+## 7. Hook model
+
+The plugin uses Claude hooks for two purposes.
+
+### 7.1 Session lifecycle
+
+`session-lifecycle-hook.mjs`
+
+- on `SessionStart`
+  - exports session id and plugin data dir into Claude's env file
+- on `SessionEnd`
+  - shuts down broker
+  - kills leftover running job processes
+  - removes session-owned jobs from state
+
+### 7.2 Optional stop gate
+
+`stop-review-gate-hook.mjs`
+
+- checks whether review gate is enabled in config
+- verifies Codex setup/auth first
+- runs a stop-time review task through `codex-companion.mjs task --json`
+- blocks session end if the result begins with `BLOCK:`
+
+This is intentionally expensive and guarded in README because it can create a Claude/Codex feedback loop.
+
+## 8. Prompting and agent design
+
+The plugin is disciplined about Claude-side scope.
+
+`plugins/codex/commands/rescue.md` and `plugins/codex/agents/codex-rescue.md` enforce:
+
+- the Claude subagent is a thin forwarder
+- one Bash call to the companion runtime
+- no repo inspection by the forwarding agent
+- no follow-up summarization
+- write-capable rescue by default unless the user requests read-only behavior
+
+This prevents "double orchestration":
+
+- Claude does not half-solve the task before handing it to Codex
+- Codex remains the real task executor
+
+## 9. Testing strategy
+
+The repo is unusually well tested for a plugin this small.
+
+Tests cover:
+
+- broker endpoint and lifecycle behavior
+- runtime setup detection
+- fake Codex execution
+- task backgrounding
+- session filtering
+- resume candidate selection
+- result rendering
+- review-gate behavior
+- shared session runtime reporting
+
+The test suite is not just unit-level. It encodes product contracts.
+
+## 10. Design strengths
+
+- Single runtime core instead of duplicated command logic
+- App-server-native thread/turn model
+- Explicit resume semantics
+- Workspace + session-scoped job model
+- Strong render layer that exposes actionable next steps
+- Clean hook-based session cleanup
+- Good regression coverage for operational behavior
+
+## 11. Design limits
+
+- It is single-delegate by design: Codex inside Claude Code
+- It is not a multi-model scheduler
+- It assumes Claude Code plugin semantics and lifecycle hooks
+- Background management is oriented around one plugin runtime, not around distributed worker surfaces
+
+## 12. What is reusable for Triflux
+
+Strong candidates:
+
+- Preserve Codex session/thread identifiers and surface `codex resume` hints
+- Make transport/runtime mode more explicit in user-facing results
+- Keep durable, workspace-scoped job metadata when Triflux chooses asynchronous Codex work
+- Treat "review" and "steerable challenge review" as distinct contracts when relevant
+
+Weak candidates:
+
+- Porting the whole broker/session model into Triflux wholesale
+- Replacing Triflux's multi-surface execution model with a plugin-style thin forwarder
+
+The plugin is strongest where it treats Codex as a first-class stateful runtime. That idea transfers. Its Claude-plugin-specific shell does not.

--- a/docs/research/triflux-codex-plugin-cc-comparison-2026-04.md
+++ b/docs/research/triflux-codex-plugin-cc-comparison-2026-04.md
@@ -1,0 +1,233 @@
+# Triflux vs codex-plugin-cc Comparison
+
+Date: 2026-04-03
+
+## 1. Scope
+
+This comparison focuses only on Codex invocation mechanics and the product intent around them.
+
+It does not try to compare:
+
+- Gemini integration
+- Claude-native orchestration in general
+- Triflux dashboard/team UX outside Codex execution
+
+## 2. Triflux Codex execution surfaces
+
+Code-level inspection shows four concrete surfaces.
+
+### Family A: routed one-shot execution
+
+Primary files:
+
+- `scripts/tfx-route.sh`
+- `scripts/tfx-route-post.mjs`
+
+Behavior:
+
+- resolves role/profile to Codex CLI arguments
+- supports `exec`, `mcp`, and `auto` transport selection
+- falls back from MCP bootstrap to legacy exec when needed
+- post-processes stdout/stderr into a compact `TFX-ROUTE RESULT`
+
+Intent:
+
+- cheap one-shot analysis/review/planning
+- centralized CLI policy and fallback logic
+
+### Family B: headless or direct worker execution
+
+Primary files:
+
+- `hub/workers/codex-mcp.mjs`
+- `hub/workers/delegator-mcp.mjs`
+- `hub/team/backend.mjs`
+- `hub/team/headless.mjs`
+- `hub/team/pane.mjs`
+
+Behavior:
+
+- direct MCP workers can talk to `codex mcp-server` over stdio and keep thread identity in process memory
+- headless workers use `CodexBackend.buildArgs()` to run `codex exec ... --output-last-message`
+- interactive pane startup uses `buildCliCommand("codex")` and prompt injection
+- result collection is oriented around files or pane capture, not around Codex thread state
+
+Intent:
+
+- durable implementation/test/refactor work
+- worker panes and long-lived sessions
+
+### Family C: native wrapper delegation
+
+Primary files:
+
+- `hub/team/native.mjs`
+- `.claude/agents/slim-wrapper.md` referenced by native wrapper flows
+
+Behavior:
+
+- Claude native teammates are forced to delegate via `tfx-route.sh`
+- async job polling is added on top of the routed path
+- the wrapper is strict about not allowing direct repo edits
+
+Intent:
+
+- use Claude-native teammate control while still centralizing external Codex/Gemini invocation
+
+### Practical summary
+
+From a code view the four surfaces are:
+
+1. `scripts/tfx-route.sh` routed one-shot
+2. `hub/workers/codex-mcp.mjs` direct MCP worker path
+3. `hub/team/pane.mjs` and related direct interactive pane startup
+4. `hub/team/backend.mjs`/`hub/team/headless.mjs` headless one-shot worker path
+
+From a product view the user's "about three ways" instinct is still basically right:
+
+1. routed one-shot
+2. direct/headless worker execution
+3. native teammate wrapper that still delegates to the routed path
+
+## 3. codex-plugin-cc execution model
+
+`codex-plugin-cc` has one dominant execution surface:
+
+- `codex-companion.mjs` backed by the Codex app server
+
+Everything else is a thin shell around that runtime:
+
+- slash commands
+- rescue subagent
+- session hooks
+- stop-review gate
+
+This is the opposite of Triflux:
+
+- Triflux has many surfaces and central route policy
+- `codex-plugin-cc` has one stateful runtime and many thin entrypoints
+
+## 4. Intent difference
+
+### Triflux
+
+Core intent:
+
+- orchestrate across multiple models and multiple execution surfaces
+- pick the cheapest or most useful surface per task
+- support both text-oriented and implementation-oriented paths
+
+That is why Triflux contains:
+
+- route policy
+- team/headless runtime
+- pane runtime
+- dashboard/runtime monitoring
+
+### codex-plugin-cc
+
+Core intent:
+
+- give Claude Code users a reliable way to call into Codex
+- preserve Codex continuity, not multi-model orchestration
+- make review, rescue, status, result, and cancel feel native
+
+That is why the plugin invests in:
+
+- thread persistence
+- broker/direct runtime reporting
+- session-scoped job filtering
+- result rendering with resume hints
+
+## 5. Mechanism difference
+
+### Transport
+
+Triflux:
+
+- shell and worker oriented
+- `codex exec` and optional MCP bootstrap in `tfx-route.sh`
+- pane/headless execution separately built in team runtime
+
+codex-plugin-cc:
+
+- app-server-native
+- broker/shared-session aware
+- explicit thread/turn/review objects
+
+### State
+
+Triflux:
+
+- execution results are often text-first
+- state exists for team orchestration, but not every routed Codex run preserves Codex-native session continuity
+
+codex-plugin-cc:
+
+- jobs are first-class persisted records
+- `threadId` is a user-visible artifact
+- session filtering and resume behavior are built in
+
+### UX
+
+Triflux:
+
+- optimized for route output, orchestration status, and cross-model flows
+
+codex-plugin-cc:
+
+- optimized for "what did Codex do, and how do I resume/manage it now?"
+
+## 6. What should not be copied
+
+- Triflux should not collapse into a single plugin-style runtime
+- Triflux should not adopt Claude-plugin assumptions as core architecture
+- Triflux should not replace multi-surface orchestration with a thin-forwarder-only model
+
+Those changes would fight Triflux's product intent.
+
+## 7. What is worth copying
+
+The strongest transferable idea is:
+
+- preserve Codex thread/session continuity wherever Triflux already invokes Codex successfully
+
+This idea fits Triflux because it improves all of the following without changing the overall architecture:
+
+- debuggability
+- follow-up handoff
+- resume ergonomics
+- user trust in routed executions
+
+## 8. Selected improvement for this pass
+
+Chosen feature:
+
+- surface Codex session id and `codex resume <id>` hint in routed Triflux output when the session id is available
+
+Why this one:
+
+- direct value
+- low-risk scope
+- aligns with `codex-plugin-cc`'s strongest UX idea
+- does not force Triflux into the plugin's single-runtime architecture
+
+Implemented in:
+
+- `scripts/tfx-route-post.mjs`
+- `tests/unit/v24-functions.test.mjs`
+
+Behavior:
+
+- extract session/thread ids from routed Codex output or stderr metadata
+- append a stable resume hint if one is available and not already present
+- preserve existing compact output style
+
+## 9. Deferred ideas
+
+These are plausible future follow-ups but were intentionally not included in this PR-sized change:
+
+- expose effective Codex transport mode (`exec`, `mcp`, `exec-fallback`) in the user-visible routed output
+- persist asynchronous routed Codex jobs with session-aware status/result commands
+- split Triflux review paths into native review vs steerable adversarial review contracts
+- normalize session/thread surfacing across routed, headless, and pane-based Codex paths

--- a/scripts/tfx-route-post.mjs
+++ b/scripts/tfx-route-post.mjs
@@ -118,6 +118,83 @@ function filterCodexOutput(rawOutput) {
   return result.join("\n");
 }
 
+function findSessionIdInObject(value) {
+  if (!value || typeof value !== "object") return null;
+
+  const directKeys = ["sessionId", "session_id", "threadId", "thread_id"];
+  for (const key of directKeys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === "object") {
+      const found = findSessionIdInObject(nested);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+function extractCodexSessionId(rawOutput, stderrContent = "") {
+  const sessionPatterns = [
+    /Resume in Codex:\s*codex resume\s+([^\s]+)/i,
+    /Codex session ID:\s*([^\s]+)/i,
+    /session id:\s*([^\s]+)/i,
+  ];
+
+  const combinedText = `${rawOutput || ""}\n${stderrContent || ""}`;
+  for (const pattern of sessionPatterns) {
+    const match = combinedText.match(pattern);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  for (const line of String(rawOutput || "").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      const sessionId = findSessionIdInObject(parsed);
+      if (sessionId) return sessionId;
+    } catch {
+      // ignore non-JSON lines
+    }
+  }
+
+  return null;
+}
+
+function appendCodexResumeHint(output, rawOutput, stderrContent = "") {
+  const normalizedOutput = String(output || "").trim();
+  if (/Codex session ID:/i.test(normalizedOutput) || /codex resume\s+/i.test(normalizedOutput)) {
+    return normalizedOutput;
+  }
+
+  const sessionId = extractCodexSessionId(rawOutput, stderrContent);
+  if (!sessionId) {
+    return normalizedOutput;
+  }
+
+  const hint = `Codex session ID: ${sessionId}\nResume in Codex: codex resume ${sessionId}`;
+  return normalizedOutput ? `${normalizedOutput}\n\n${hint}` : hint;
+}
+
+function prepareCliOutput(rawOutput, cliType, { cleanTui = true, stderrContent = "" } = {}) {
+  let prepared = cliType === "codex" ? filterCodexOutput(rawOutput) : rawOutput;
+  if (cleanTui && process.env.TFX_CLEAN_TUI !== "0") {
+    prepared = cleanTuiArtifacts(prepared, cliType);
+  }
+  if (cliType === "codex") {
+    prepared = appendCodexResumeHint(prepared, rawOutput, stderrContent);
+  }
+  return prepared;
+}
+
 function cleanTuiArtifacts(output, cliType) {
   if (!output) return output;
 
@@ -390,18 +467,18 @@ function main() {
       console.log("status: success");
     }
     console.log("=== OUTPUT ===");
-    let filtered = cliType === "codex" ? filterCodexOutput(rawOutput) : rawOutput;
-    if (a.clean_tui !== "false" && process.env.TFX_CLEAN_TUI !== "0") {
-      filtered = cleanTuiArtifacts(filtered, cliType);
-    }
+    const filtered = prepareCliOutput(rawOutput, cliType, {
+      cleanTui: a.clean_tui !== "false",
+      stderrContent,
+    });
     console.log(truncateOutput(filtered, maxBytes));
   } else if (exitCode === 124) {
     console.log(`status: timeout (${timeout}s 초과)`);
     console.log("=== PARTIAL OUTPUT ===");
-    let partialFiltered = rawOutput;
-    if (a.clean_tui !== "false" && process.env.TFX_CLEAN_TUI !== "0") {
-      partialFiltered = cleanTuiArtifacts(partialFiltered, cliType);
-    }
+    const partialFiltered = prepareCliOutput(rawOutput, cliType, {
+      cleanTui: a.clean_tui !== "false",
+      stderrContent,
+    });
     console.log(truncateOutput(partialFiltered, maxBytes));
     console.log("=== STDERR ===");
     console.log(stderrContent.split("\n").slice(-10).join("\n"));
@@ -411,10 +488,10 @@ function main() {
     console.log(stderrContent.split("\n").slice(-20).join("\n"));
     if (rawOutput) {
       console.log("=== PARTIAL OUTPUT ===");
-      let partialFiltered = rawOutput;
-      if (a.clean_tui !== "false" && process.env.TFX_CLEAN_TUI !== "0") {
-        partialFiltered = cleanTuiArtifacts(partialFiltered, cliType);
-      }
+      const partialFiltered = prepareCliOutput(rawOutput, cliType, {
+        cleanTui: a.clean_tui !== "false",
+        stderrContent,
+      });
       console.log(truncateOutput(partialFiltered, maxBytes));
     }
   }
@@ -425,4 +502,4 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main();
 }
 
-export { cleanTuiArtifacts };
+export { appendCodexResumeHint, cleanTuiArtifacts, extractCodexSessionId };

--- a/tests/unit/v24-functions.test.mjs
+++ b/tests/unit/v24-functions.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { cleanTuiArtifacts } from "../../scripts/tfx-route-post.mjs";
+import { appendCodexResumeHint, cleanTuiArtifacts, extractCodexSessionId } from "../../scripts/tfx-route-post.mjs";
 import { replaceProfileSection, hasProfileSection } from "../../scripts/setup.mjs";
 
 describe("v2.4 신규 JS 함수 테스트", () => {
@@ -51,6 +51,32 @@ describe("v2.4 신규 JS 함수 테스트", () => {
       // claude
       const claudeText = "━━━━━━━\nClaude response";
       assert.equal(cleanTuiArtifacts(claudeText, "claude"), "Claude response");
+    });
+  });
+
+  describe("Codex session resume helpers", () => {
+    it("7. stderr의 session id를 추출한다", () => {
+      const stderr = "OpenAI Codex\nsession id: thr_route_123\nmodel: gpt-5.4";
+      assert.equal(extractCodexSessionId("", stderr), "thr_route_123");
+    });
+
+    it("8. JSON line의 threadId를 추출한다", () => {
+      const rawOutput = '{"type":"completed","threadId":"thr_json_456"}';
+      assert.equal(extractCodexSessionId(rawOutput, ""), "thr_json_456");
+    });
+
+    it("9. 세션 정보가 없을 때만 resume 힌트를 덧붙인다", () => {
+      const stderr = "session id: thr_route_789";
+      const output = appendCodexResumeHint("Useful Text", "", stderr);
+      assert.equal(
+        output,
+        "Useful Text\n\nCodex session ID: thr_route_789\nResume in Codex: codex resume thr_route_789",
+      );
+    });
+
+    it("10. 기존 resume 힌트가 있으면 중복 추가하지 않는다", () => {
+      const existing = "Done.\n\nCodex session ID: thr_existing\nResume in Codex: codex resume thr_existing";
+      assert.equal(appendCodexResumeHint(existing, "", "session id: thr_other"), existing);
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve Codex session continuity in routed `TFX-ROUTE RESULT` output by appending `Codex session ID` and `codex resume` hints when available
- add regression coverage for session-id extraction and duplicate-hint suppression in `tfx-route-post`
- commit reusable reverse-engineering/comparison notes for `codex-plugin-cc` vs Triflux Codex invocation paths

## Why
`codex-plugin-cc` treats Codex thread identity as a first-class UX artifact. Triflux's routed one-shot Codex path already succeeds operationally, but it was discarding that continuity signal. This PR ports the useful idea without pulling Triflux toward the plugin's single-runtime architecture.

## Files
- `scripts/tfx-route-post.mjs`
- `tests/unit/v24-functions.test.mjs`
- `docs/research/codex-plugin-cc-reverse-engineering-2026-04.md`
- `docs/research/triflux-codex-plugin-cc-comparison-2026-04.md`

## Verification
- `node --test tests/unit/v24-functions.test.mjs`
- `npx tsc --noEmit --pretty false` on changed files via diagnostics

## Not tested
- `npm test` did not complete within 300s in the current dirty worktree, so I did not claim full-suite green
