### PR TITLE
feat: #4 HUD Mission Board 모듈

### DIFF
--- a/hud/hud-qos-status.mjs
+++ b/hud/hud-qos-status.mjs
@@ -16,6 +16,7 @@ import {
   readJson, readStdinJson, getProviderAccountId, getCliArgValue,
 } from "./utils.mjs";
 import { selectTier } from "./terminal.mjs";
+import { getMissionBoardState } from "./mission-board.mjs";
 
 // Claude provider
 import {
@@ -41,7 +42,7 @@ import {
 // Renderers
 import {
   getClaudeRows, getProviderRow, getTeamRow,
-  renderAlignedRows, getMicroLine,
+  renderAlignedRows, getMicroLine, renderMissionBoard,
   readLatestBenchmarkDiff, formatTokenSummary,
   readTokenSavings, readSvAccumulator,
 } from "./renderers.mjs";
@@ -108,6 +109,7 @@ async function main() {
   const codexBuckets = codexSnapshot.buckets;
   const geminiSession = geminiSessionSnapshot.session;
   const geminiQuota = geminiQuotaSnapshot.quota;
+  const missionBoardState = await getMissionBoardState();
 
   // 누적 절약 데이터 읽기
   const svSavings = readTokenSavings();
@@ -174,6 +176,15 @@ async function main() {
   // tfx-multi 활성 시 팀 상태 행 추가 (v2.2)
   const teamRow = getTeamRow(CURRENT_TIER);
   if (teamRow) rows.push(teamRow);
+
+  const missionBoard = renderMissionBoard(missionBoardState);
+  if (missionBoard) {
+    rows.push({
+      prefix: bold(claudeOrange("\u25B2")),
+      left: missionBoard,
+      right: "",
+    });
+  }
 
   // 최근 벤치마크 diff → 토큰 요약 행 추가
   const latestDiff = readLatestBenchmarkDiff();

--- a/hud/mission-board.mjs
+++ b/hud/mission-board.mjs
@@ -44,5 +44,10 @@ export async function getMissionBoardState(sessionsDir = SESSIONS_DIR) {
     ? Math.round(agents.reduce((sum, a) => sum + a.progress, 0) / agents.length)
     : 0;
 
-  return { agents, dagLevel: 0, totalProgress };
+  return {
+    agents,
+    // TODO: derive dagLevel from real mission dependency metadata instead of hardcoding 0.
+    dagLevel: 0,
+    totalProgress,
+  };
 }

--- a/hud/mission-board.mjs
+++ b/hud/mission-board.mjs
@@ -1,0 +1,48 @@
+// ============================================================================
+// HUD Mission Board — .omc/state/sessions/ 기반 에이전트 진행률 집계
+// ============================================================================
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SESSIONS_DIR = join(homedir(), ".omc", "state", "sessions");
+
+/**
+ * .omc/state/sessions/ 디렉토리를 읽어 팀 상태를 반환한다.
+ * @returns {{ agents: Array<{name: string, status: string, progress: number}>, dagLevel: number, totalProgress: number } | null}
+ */
+export async function getMissionBoardState(sessionsDir = SESSIONS_DIR) {
+  let entries;
+  try {
+    entries = await readdir(sessionsDir);
+  } catch {
+    return null;
+  }
+
+  const jsonFiles = entries.filter((f) => f.endsWith(".json"));
+  if (jsonFiles.length === 0) return null;
+
+  const agents = [];
+  for (const file of jsonFiles) {
+    let data;
+    try {
+      const raw = await readFile(join(sessionsDir, file), "utf8");
+      data = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+
+    const name = data.name ?? file.replace(/\.json$/, "");
+    const status = data.status ?? "idle";
+    const progress = typeof data.progress === "number" ? data.progress : 0;
+    agents.push({ name, status, progress });
+  }
+
+  if (agents.length === 0) return null;
+
+  const totalProgress = agents.length > 0
+    ? Math.round(agents.reduce((sum, a) => sum + a.progress, 0) / agents.length)
+    : 0;
+
+  return { agents, dagLevel: 0, totalProgress };
+}

--- a/hud/renderers.mjs
+++ b/hud/renderers.mjs
@@ -123,6 +123,38 @@ export function getTeamRow(currentTier) {
 }
 
 // ============================================================================
+// Mission Board 렌더러
+// ============================================================================
+
+const STATUS_ICON = {
+  active: "*",
+  idle: ".",
+  done: "+",
+  failed: "!",
+};
+
+/**
+ * Mission Board 상태를 1줄 compact 포맷으로 렌더링한다.
+ * 예: "MB: exec:+ ui:* perf:. [2/3 67%]"
+ * @param {{ agents: Array<{name: string, status: string, progress: number}>, dagLevel: number, totalProgress: number } | null} state
+ * @returns {string}
+ */
+export function renderMissionBoard(state) {
+  if (!state) return "";
+
+  const { agents, totalProgress } = state;
+  const done = agents.filter((a) => a.status === "done").length;
+  const total = agents.length;
+
+  const parts = agents.map((a) => {
+    const icon = STATUS_ICON[a.status] ?? "?";
+    return `${a.name}:${icon}`;
+  });
+
+  return `MB: ${parts.join(" ")} [${done}/${total} ${totalProgress}%]`;
+}
+
+// ============================================================================
 // 행 정렬 렌더링
 // ============================================================================
 export function renderAlignedRows(rows) {

--- a/tests/unit/mission-board.test.mjs
+++ b/tests/unit/mission-board.test.mjs
@@ -1,0 +1,167 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { getMissionBoardState } from "../../hud/mission-board.mjs";
+import { renderMissionBoard } from "../../hud/renderers.mjs";
+
+const TEMP_DIRS = [];
+
+function makeTempDir() {
+  const dir = join(tmpdir(), `triflux-mb-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    const dir = TEMP_DIRS.pop();
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+describe("getMissionBoardState", () => {
+  it("세션 디렉토리가 없으면 null을 반환한다", async () => {
+    const result = await getMissionBoardState("/nonexistent/path/that/does/not/exist");
+    assert.equal(result, null);
+  });
+
+  it("세션 디렉토리가 비어있으면 null을 반환한다", async () => {
+    const dir = makeTempDir();
+    const result = await getMissionBoardState(dir);
+    assert.equal(result, null);
+  });
+
+  it("세션 파일을 정확히 파싱하여 agents를 반환한다", async () => {
+    const dir = makeTempDir();
+    writeJson(join(dir, "exec.json"), {
+      name: "exec",
+      status: "done",
+      startedAt: 1000,
+      completedAt: 2000,
+      progress: 100,
+    });
+    writeJson(join(dir, "ui.json"), {
+      name: "ui",
+      status: "active",
+      startedAt: 1000,
+      progress: 50,
+    });
+    writeJson(join(dir, "perf.json"), {
+      name: "perf",
+      status: "idle",
+      startedAt: 1000,
+      progress: 0,
+    });
+
+    const result = await getMissionBoardState(dir);
+    assert.ok(result !== null);
+    assert.equal(result.agents.length, 3);
+
+    const exec = result.agents.find((a) => a.name === "exec");
+    assert.ok(exec, "exec 에이전트가 존재해야 한다");
+    assert.equal(exec.status, "done");
+    assert.equal(exec.progress, 100);
+
+    const ui = result.agents.find((a) => a.name === "ui");
+    assert.ok(ui, "ui 에이전트가 존재해야 한다");
+    assert.equal(ui.status, "active");
+    assert.equal(ui.progress, 50);
+  });
+
+  it("progress 필드가 없으면 0으로 처리한다", async () => {
+    const dir = makeTempDir();
+    writeJson(join(dir, "worker.json"), {
+      name: "worker",
+      status: "active",
+    });
+
+    const result = await getMissionBoardState(dir);
+    assert.ok(result !== null);
+    const agent = result.agents[0];
+    assert.equal(agent.progress, 0);
+  });
+
+  it("totalProgress는 에이전트 평균 progress를 반올림한 값이다", async () => {
+    const dir = makeTempDir();
+    writeJson(join(dir, "a.json"), { name: "a", status: "done", progress: 100 });
+    writeJson(join(dir, "b.json"), { name: "b", status: "active", progress: 50 });
+    writeJson(join(dir, "c.json"), { name: "c", status: "idle", progress: 0 });
+
+    const result = await getMissionBoardState(dir);
+    assert.ok(result !== null);
+    // (100 + 50 + 0) / 3 = 50
+    assert.equal(result.totalProgress, 50);
+  });
+
+  it("json이 아닌 파일은 무시한다", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "notes.txt"), "not json", "utf8");
+    writeJson(join(dir, "exec.json"), { name: "exec", status: "done", progress: 100 });
+
+    const result = await getMissionBoardState(dir);
+    assert.ok(result !== null);
+    assert.equal(result.agents.length, 1);
+  });
+});
+
+describe("renderMissionBoard", () => {
+  it("state가 null이면 빈 문자열을 반환한다", () => {
+    assert.equal(renderMissionBoard(null), "");
+  });
+
+  it("정상 상태의 렌더링 포맷을 확인한다", () => {
+    const state = {
+      agents: [
+        { name: "exec", status: "done", progress: 100 },
+        { name: "ui", status: "active", progress: 50 },
+        { name: "perf", status: "idle", progress: 0 },
+      ],
+      dagLevel: 0,
+      totalProgress: 50,
+    };
+    const result = renderMissionBoard(state);
+    assert.equal(result, "MB: exec:+ ui:* perf:. [1/3 50%]");
+  });
+
+  it("done 카운트와 진행률을 정확히 계산한다", () => {
+    const state = {
+      agents: [
+        { name: "a", status: "done", progress: 100 },
+        { name: "b", status: "done", progress: 100 },
+        { name: "c", status: "active", progress: 30 },
+      ],
+      dagLevel: 0,
+      totalProgress: 77,
+    };
+    const result = renderMissionBoard(state);
+    assert.equal(result, "MB: a:+ b:+ c:* [2/3 77%]");
+  });
+
+  it("failed 상태 아이콘이 올바르게 렌더링된다", () => {
+    const state = {
+      agents: [
+        { name: "worker", status: "failed", progress: 0 },
+      ],
+      dagLevel: 0,
+      totalProgress: 0,
+    };
+    const result = renderMissionBoard(state);
+    assert.equal(result, "MB: worker:! [0/1 0%]");
+  });
+
+  it("에이전트가 없을 때 done 카운트가 0이다", () => {
+    const state = { agents: [], dagLevel: 0, totalProgress: 0 };
+    const result = renderMissionBoard(state);
+    assert.equal(result, "MB:  [0/0 0%]");
+  });
+});


### PR DESCRIPTION
## Summary
- HUD Mission Board 모듈 구현 (#4 P1)
- `getMissionBoardState()`: .omc/state/sessions/ 에서 팀 상태 읽기
- `renderMissionBoard()`: 1줄 compact 포맷 렌더링

## Test plan
- [x] mission-board.test.mjs 11개 테스트 통과
