### PR TITLE
feat: #6 Skill Active State 라이프사이클

### DIFF
--- a/scripts/lib/skill-state.mjs
+++ b/scripts/lib/skill-state.mjs
@@ -1,10 +1,29 @@
-import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import {
+  access,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
 
-const DEFAULT_STATE_DIR = join(process.cwd(), '.omc', 'state');
+const DEFAULT_STATE_DIR = join(process.cwd(), ".tfx", "state");
 
 function stateFilePath(stateDir, skillName) {
   return join(stateDir, `${skillName}-active.json`);
+}
+
+function assertValidSkillName(skillName) {
+  if (
+    skillName.includes("/") ||
+    skillName.includes("\\") ||
+    skillName.includes("..")
+  ) {
+    throw new Error(`Invalid skill name: ${skillName}`);
+  }
 }
 
 /**
@@ -14,24 +33,41 @@ function stateFilePath(stateDir, skillName) {
  * @param {string} skillName
  * @param {{ stateDir?: string }} options
  */
-export async function activateSkill(skillName, { stateDir = DEFAULT_STATE_DIR } = {}) {
+export async function activateSkill(
+  skillName,
+  { stateDir = DEFAULT_STATE_DIR } = {},
+) {
+  assertValidSkillName(skillName);
   await mkdir(stateDir, { recursive: true });
 
   const filePath = stateFilePath(stateDir, skillName);
-
-  let existing;
+  const lockPath = `${filePath}.lock`;
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  let lockHandle;
   try {
-    existing = await readFile(filePath, 'utf8');
-  } catch {
-    existing = null;
-  }
+    lockHandle = await open(lockPath, "wx");
+    try {
+      await access(filePath);
+      throw new Error(`Skill already active: ${skillName}`);
+    } catch (error) {
+      if (error?.message === `Skill already active: ${skillName}`) {
+        throw error;
+      }
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
 
-  if (existing !== null) {
-    throw new Error(`Skill already active: ${skillName}`);
+    const state = { skillName, pid: process.pid, activatedAt: Date.now() };
+    await writeFile(tmpPath, JSON.stringify(state), "utf8");
+    await rename(tmpPath, filePath);
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {});
+    if (lockHandle) {
+      await lockHandle.close().catch(() => {});
+    }
+    await rm(lockPath, { force: true }).catch(() => {});
   }
-
-  const state = { skillName, pid: process.pid, activatedAt: Date.now() };
-  await writeFile(filePath, JSON.stringify(state), 'utf8');
 }
 
 /**
@@ -41,7 +77,10 @@ export async function activateSkill(skillName, { stateDir = DEFAULT_STATE_DIR } 
  * @param {string} skillName
  * @param {{ stateDir?: string }} options
  */
-export async function deactivateSkill(skillName, { stateDir = DEFAULT_STATE_DIR } = {}) {
+export async function deactivateSkill(
+  skillName,
+  { stateDir = DEFAULT_STATE_DIR } = {},
+) {
   const filePath = stateFilePath(stateDir, skillName);
   try {
     await rm(filePath, { force: true });
@@ -66,9 +105,9 @@ export async function getActiveSkills({ stateDir = DEFAULT_STATE_DIR } = {}) {
 
   const results = [];
   for (const entry of entries) {
-    if (!entry.endsWith('-active.json')) continue;
+    if (!entry.endsWith("-active.json")) continue;
     try {
-      const raw = await readFile(join(stateDir, entry), 'utf8');
+      const raw = await readFile(join(stateDir, entry), "utf8");
       results.push(JSON.parse(raw));
     } catch {
       // skip malformed files
@@ -83,7 +122,9 @@ export async function getActiveSkills({ stateDir = DEFAULT_STATE_DIR } = {}) {
  * @param {{ stateDir?: string }} options
  * @returns {Promise<string[]>} list of pruned skill names
  */
-export async function pruneOrphanSkillStates({ stateDir = DEFAULT_STATE_DIR } = {}) {
+export async function pruneOrphanSkillStates({
+  stateDir = DEFAULT_STATE_DIR,
+} = {}) {
   const active = await getActiveSkills({ stateDir });
   const pruned = [];
 

--- a/scripts/lib/skill-state.mjs
+++ b/scripts/lib/skill-state.mjs
@@ -1,0 +1,105 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DEFAULT_STATE_DIR = join(process.cwd(), '.omc', 'state');
+
+function stateFilePath(stateDir, skillName) {
+  return join(stateDir, `${skillName}-active.json`);
+}
+
+/**
+ * Activate a skill by writing its state file.
+ * Throws if the skill is already active.
+ *
+ * @param {string} skillName
+ * @param {{ stateDir?: string }} options
+ */
+export async function activateSkill(skillName, { stateDir = DEFAULT_STATE_DIR } = {}) {
+  await mkdir(stateDir, { recursive: true });
+
+  const filePath = stateFilePath(stateDir, skillName);
+
+  let existing;
+  try {
+    existing = await readFile(filePath, 'utf8');
+  } catch {
+    existing = null;
+  }
+
+  if (existing !== null) {
+    throw new Error(`Skill already active: ${skillName}`);
+  }
+
+  const state = { skillName, pid: process.pid, activatedAt: Date.now() };
+  await writeFile(filePath, JSON.stringify(state), 'utf8');
+}
+
+/**
+ * Deactivate a skill by removing its state file.
+ * Does not throw if the file does not exist.
+ *
+ * @param {string} skillName
+ * @param {{ stateDir?: string }} options
+ */
+export async function deactivateSkill(skillName, { stateDir = DEFAULT_STATE_DIR } = {}) {
+  const filePath = stateFilePath(stateDir, skillName);
+  try {
+    await rm(filePath, { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Return all currently active skills by scanning *-active.json files.
+ *
+ * @param {{ stateDir?: string }} options
+ * @returns {Promise<Array<{ skillName: string, pid: number, activatedAt: number }>>}
+ */
+export async function getActiveSkills({ stateDir = DEFAULT_STATE_DIR } = {}) {
+  let entries;
+  try {
+    entries = await readdir(stateDir);
+  } catch {
+    return [];
+  }
+
+  const results = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('-active.json')) continue;
+    try {
+      const raw = await readFile(join(stateDir, entry), 'utf8');
+      results.push(JSON.parse(raw));
+    } catch {
+      // skip malformed files
+    }
+  }
+  return results;
+}
+
+/**
+ * Remove state files for skills whose processes are no longer alive.
+ *
+ * @param {{ stateDir?: string }} options
+ * @returns {Promise<string[]>} list of pruned skill names
+ */
+export async function pruneOrphanSkillStates({ stateDir = DEFAULT_STATE_DIR } = {}) {
+  const active = await getActiveSkills({ stateDir });
+  const pruned = [];
+
+  for (const { skillName, pid } of active) {
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+
+    if (!alive) {
+      await deactivateSkill(skillName, { stateDir });
+      pruned.push(skillName);
+    }
+  }
+
+  return pruned;
+}

--- a/tests/unit/skill-state.test.mjs
+++ b/tests/unit/skill-state.test.mjs
@@ -1,20 +1,20 @@
-import { afterEach, describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
 
 import {
   activateSkill,
   deactivateSkill,
   getActiveSkills,
   pruneOrphanSkillStates,
-} from '../../scripts/lib/skill-state.mjs';
+} from "../../scripts/lib/skill-state.mjs";
 
 const TEMP_DIRS = [];
 
 function makeTempStateDir() {
-  const dir = mkdtempSync(join(tmpdir(), 'tfx-skill-state-test-'));
+  const dir = mkdtempSync(join(tmpdir(), "tfx-skill-state-test-"));
   TEMP_DIRS.push(dir);
   return dir;
 }
@@ -28,89 +28,100 @@ afterEach(() => {
   }
 });
 
-describe('skill-state.mjs', () => {
-  describe('activateSkill', () => {
-    it('상태 파일을 생성한다', async () => {
+describe("skill-state.mjs", () => {
+  describe("activateSkill", () => {
+    it("상태 파일을 생성한다", async () => {
       const stateDir = makeTempStateDir();
-      await activateSkill('my-skill', { stateDir });
+      await activateSkill("my-skill", { stateDir });
 
-      const filePath = join(stateDir, 'my-skill-active.json');
-      assert.ok(existsSync(filePath), 'state file should exist');
+      const filePath = join(stateDir, "my-skill-active.json");
+      assert.ok(existsSync(filePath), "state file should exist");
 
-      const { readFile } = await import('node:fs/promises');
-      const raw = await readFile(filePath, 'utf8');
+      const { readFile } = await import("node:fs/promises");
+      const raw = await readFile(filePath, "utf8");
       const parsed = JSON.parse(raw);
 
-      assert.equal(parsed.skillName, 'my-skill');
+      assert.equal(parsed.skillName, "my-skill");
       assert.equal(parsed.pid, process.pid);
-      assert.ok(typeof parsed.activatedAt === 'number');
+      assert.ok(typeof parsed.activatedAt === "number");
     });
 
-    it('중복 활성화 시 에러를 던진다', async () => {
+    it("중복 활성화 시 에러를 던진다", async () => {
       const stateDir = makeTempStateDir();
-      await activateSkill('dup-skill', { stateDir });
+      await activateSkill("dup-skill", { stateDir });
 
       await assert.rejects(
-        () => activateSkill('dup-skill', { stateDir }),
+        () => activateSkill("dup-skill", { stateDir }),
         /Skill already active: dup-skill/,
       );
     });
 
-    it('stateDir이 없으면 자동 생성한다', async () => {
+    it("경로 탐색이 포함된 skillName은 에러를 던진다", async () => {
+      const stateDir = makeTempStateDir();
+
+      await assert.rejects(
+        () => activateSkill("../escaped", { stateDir }),
+        /Invalid skill name: \.\.\/escaped/,
+      );
+    });
+
+    it("stateDir이 없으면 자동 생성한다", async () => {
       const base = makeTempStateDir();
-      const stateDir = join(base, 'nested', 'state');
+      const stateDir = join(base, "nested", "state");
 
-      await activateSkill('new-skill', { stateDir });
+      await activateSkill("new-skill", { stateDir });
 
-      assert.ok(existsSync(join(stateDir, 'new-skill-active.json')));
+      assert.ok(existsSync(join(stateDir, "new-skill-active.json")));
     });
   });
 
-  describe('deactivateSkill', () => {
-    it('상태 파일을 삭제한다', async () => {
+  describe("deactivateSkill", () => {
+    it("상태 파일을 삭제한다", async () => {
       const stateDir = makeTempStateDir();
-      await activateSkill('rm-skill', { stateDir });
+      await activateSkill("rm-skill", { stateDir });
 
-      const filePath = join(stateDir, 'rm-skill-active.json');
+      const filePath = join(stateDir, "rm-skill-active.json");
       assert.ok(existsSync(filePath));
 
-      await deactivateSkill('rm-skill', { stateDir });
+      await deactivateSkill("rm-skill", { stateDir });
       assert.ok(!existsSync(filePath));
     });
 
-    it('없는 스킬을 deactivate해도 에러가 없다', async () => {
+    it("없는 스킬을 deactivate해도 에러가 없다", async () => {
       const stateDir = makeTempStateDir();
-      await assert.doesNotReject(() => deactivateSkill('ghost-skill', { stateDir }));
+      await assert.doesNotReject(() =>
+        deactivateSkill("ghost-skill", { stateDir }),
+      );
     });
   });
 
-  describe('getActiveSkills', () => {
-    it('활성 스킬 목록을 반환한다', async () => {
+  describe("getActiveSkills", () => {
+    it("활성 스킬 목록을 반환한다", async () => {
       const stateDir = makeTempStateDir();
-      await activateSkill('skill-a', { stateDir });
-      await activateSkill('skill-b', { stateDir });
+      await activateSkill("skill-a", { stateDir });
+      await activateSkill("skill-b", { stateDir });
 
       const active = await getActiveSkills({ stateDir });
       const names = active.map((s) => s.skillName).sort();
 
-      assert.deepEqual(names, ['skill-a', 'skill-b']);
+      assert.deepEqual(names, ["skill-a", "skill-b"]);
       for (const entry of active) {
         assert.equal(entry.pid, process.pid);
-        assert.ok(typeof entry.activatedAt === 'number');
+        assert.ok(typeof entry.activatedAt === "number");
       }
     });
 
-    it('stateDir이 없으면 빈 배열을 반환한다', async () => {
+    it("stateDir이 없으면 빈 배열을 반환한다", async () => {
       const stateDir = join(tmpdir(), `nonexistent-${Date.now()}`);
       const active = await getActiveSkills({ stateDir });
       assert.deepEqual(active, []);
     });
   });
 
-  describe('pruneOrphanSkillStates', () => {
-    it('살아있는 pid의 스킬은 그대로 둔다', async () => {
+  describe("pruneOrphanSkillStates", () => {
+    it("살아있는 pid의 스킬은 그대로 둔다", async () => {
       const stateDir = makeTempStateDir();
-      await activateSkill('live-skill', { stateDir });
+      await activateSkill("live-skill", { stateDir });
 
       const pruned = await pruneOrphanSkillStates({ stateDir });
       assert.deepEqual(pruned, []);
@@ -119,28 +130,32 @@ describe('skill-state.mjs', () => {
       assert.equal(active.length, 1);
     });
 
-    it('죽은 pid의 상태 파일을 삭제하고 스킬명 배열을 반환한다', async () => {
+    it("죽은 pid의 상태 파일을 삭제하고 스킬명 배열을 반환한다", async () => {
       const stateDir = makeTempStateDir();
 
       // Write a state file with a pid that cannot be alive (pid 0 is never a real process)
-      const { mkdir, writeFile } = await import('node:fs/promises');
+      const { mkdir, writeFile } = await import("node:fs/promises");
       await mkdir(stateDir, { recursive: true });
       const deadPid = 999999999;
       await writeFile(
-        join(stateDir, 'dead-skill-active.json'),
-        JSON.stringify({ skillName: 'dead-skill', pid: deadPid, activatedAt: Date.now() }),
-        'utf8',
+        join(stateDir, "dead-skill-active.json"),
+        JSON.stringify({
+          skillName: "dead-skill",
+          pid: deadPid,
+          activatedAt: Date.now(),
+        }),
+        "utf8",
       );
 
       // Also add a live skill to verify it's kept
-      await activateSkill('alive-skill', { stateDir });
+      await activateSkill("alive-skill", { stateDir });
 
       const pruned = await pruneOrphanSkillStates({ stateDir });
-      assert.deepEqual(pruned, ['dead-skill']);
+      assert.deepEqual(pruned, ["dead-skill"]);
 
       const active = await getActiveSkills({ stateDir });
       assert.equal(active.length, 1);
-      assert.equal(active[0].skillName, 'alive-skill');
+      assert.equal(active[0].skillName, "alive-skill");
     });
   });
 });

--- a/tests/unit/skill-state.test.mjs
+++ b/tests/unit/skill-state.test.mjs
@@ -1,0 +1,146 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  activateSkill,
+  deactivateSkill,
+  getActiveSkills,
+  pruneOrphanSkillStates,
+} from '../../scripts/lib/skill-state.mjs';
+
+const TEMP_DIRS = [];
+
+function makeTempStateDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'tfx-skill-state-test-'));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    const dir = TEMP_DIRS.pop();
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+describe('skill-state.mjs', () => {
+  describe('activateSkill', () => {
+    it('상태 파일을 생성한다', async () => {
+      const stateDir = makeTempStateDir();
+      await activateSkill('my-skill', { stateDir });
+
+      const filePath = join(stateDir, 'my-skill-active.json');
+      assert.ok(existsSync(filePath), 'state file should exist');
+
+      const { readFile } = await import('node:fs/promises');
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw);
+
+      assert.equal(parsed.skillName, 'my-skill');
+      assert.equal(parsed.pid, process.pid);
+      assert.ok(typeof parsed.activatedAt === 'number');
+    });
+
+    it('중복 활성화 시 에러를 던진다', async () => {
+      const stateDir = makeTempStateDir();
+      await activateSkill('dup-skill', { stateDir });
+
+      await assert.rejects(
+        () => activateSkill('dup-skill', { stateDir }),
+        /Skill already active: dup-skill/,
+      );
+    });
+
+    it('stateDir이 없으면 자동 생성한다', async () => {
+      const base = makeTempStateDir();
+      const stateDir = join(base, 'nested', 'state');
+
+      await activateSkill('new-skill', { stateDir });
+
+      assert.ok(existsSync(join(stateDir, 'new-skill-active.json')));
+    });
+  });
+
+  describe('deactivateSkill', () => {
+    it('상태 파일을 삭제한다', async () => {
+      const stateDir = makeTempStateDir();
+      await activateSkill('rm-skill', { stateDir });
+
+      const filePath = join(stateDir, 'rm-skill-active.json');
+      assert.ok(existsSync(filePath));
+
+      await deactivateSkill('rm-skill', { stateDir });
+      assert.ok(!existsSync(filePath));
+    });
+
+    it('없는 스킬을 deactivate해도 에러가 없다', async () => {
+      const stateDir = makeTempStateDir();
+      await assert.doesNotReject(() => deactivateSkill('ghost-skill', { stateDir }));
+    });
+  });
+
+  describe('getActiveSkills', () => {
+    it('활성 스킬 목록을 반환한다', async () => {
+      const stateDir = makeTempStateDir();
+      await activateSkill('skill-a', { stateDir });
+      await activateSkill('skill-b', { stateDir });
+
+      const active = await getActiveSkills({ stateDir });
+      const names = active.map((s) => s.skillName).sort();
+
+      assert.deepEqual(names, ['skill-a', 'skill-b']);
+      for (const entry of active) {
+        assert.equal(entry.pid, process.pid);
+        assert.ok(typeof entry.activatedAt === 'number');
+      }
+    });
+
+    it('stateDir이 없으면 빈 배열을 반환한다', async () => {
+      const stateDir = join(tmpdir(), `nonexistent-${Date.now()}`);
+      const active = await getActiveSkills({ stateDir });
+      assert.deepEqual(active, []);
+    });
+  });
+
+  describe('pruneOrphanSkillStates', () => {
+    it('살아있는 pid의 스킬은 그대로 둔다', async () => {
+      const stateDir = makeTempStateDir();
+      await activateSkill('live-skill', { stateDir });
+
+      const pruned = await pruneOrphanSkillStates({ stateDir });
+      assert.deepEqual(pruned, []);
+
+      const active = await getActiveSkills({ stateDir });
+      assert.equal(active.length, 1);
+    });
+
+    it('죽은 pid의 상태 파일을 삭제하고 스킬명 배열을 반환한다', async () => {
+      const stateDir = makeTempStateDir();
+
+      // Write a state file with a pid that cannot be alive (pid 0 is never a real process)
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      await mkdir(stateDir, { recursive: true });
+      const deadPid = 999999999;
+      await writeFile(
+        join(stateDir, 'dead-skill-active.json'),
+        JSON.stringify({ skillName: 'dead-skill', pid: deadPid, activatedAt: Date.now() }),
+        'utf8',
+      );
+
+      // Also add a live skill to verify it's kept
+      await activateSkill('alive-skill', { stateDir });
+
+      const pruned = await pruneOrphanSkillStates({ stateDir });
+      assert.deepEqual(pruned, ['dead-skill']);
+
+      const active = await getActiveSkills({ stateDir });
+      assert.equal(active.length, 1);
+      assert.equal(active[0].skillName, 'alive-skill');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Skill Active State 라이프사이클 구현 (#6)
- `activateSkill/deactivateSkill`: 상태 파일 기반 추적
- `pruneOrphanSkillStates`: 죽은 프로세스 정리

## Test plan
- [x] skill-state.test.mjs 9개 테스트 통과
