### PR TITLE
feat: #9 Windows 경로 유틸 통합 모듈

### DIFF
--- a/hub/lib/path-utils.mjs
+++ b/hub/lib/path-utils.mjs
@@ -1,0 +1,167 @@
+// hub/lib/path-utils.mjs — Windows/POSIX 경로 변환 유틸리티
+
+import { platform } from 'node:os';
+
+/**
+ * Windows 경로를 Git Bash 스타일 POSIX 경로로 변환한다.
+ * C:\foo\bar → /c/foo/bar
+ * 이미 POSIX 경로면 그대로 반환.
+ * null/undefined → 빈 문자열
+ * @param {string|null|undefined} windowsPath
+ * @returns {string}
+ */
+export function toPosixPath(windowsPath) {
+  if (windowsPath == null) return '';
+  const p = String(windowsPath);
+  if (!p) return '';
+
+  // 이미 POSIX 경로 (/ 로 시작하거나 드라이브 레터 없음)
+  const winDriveMatch = p.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!winDriveMatch) {
+    // 백슬래시만 있는 상대 경로도 forward slash로 변환
+    return p.replace(/\\/g, '/');
+  }
+
+  const drive = winDriveMatch[1].toLowerCase();
+  const rest = winDriveMatch[2].replace(/\\/g, '/');
+  return `/${drive}/${rest}`;
+}
+
+/**
+ * POSIX 경로(Git Bash 스타일)를 Windows 경로로 변환한다.
+ * /c/foo/bar → C:\foo\bar
+ * 이미 Windows 경로면 그대로 반환.
+ * null/undefined → 빈 문자열
+ * @param {string|null|undefined} posixPath
+ * @returns {string}
+ */
+export function toWindowsPath(posixPath) {
+  if (posixPath == null) return '';
+  const p = String(posixPath);
+  if (!p) return '';
+
+  // 이미 Windows 경로
+  if (/^[A-Za-z]:/.test(p)) {
+    return p.replace(/\//g, '\\');
+  }
+
+  // Git Bash 스타일: /c/foo/bar
+  const gitBashMatch = p.match(/^\/([a-zA-Z])(\/.*)?$/);
+  if (gitBashMatch) {
+    const drive = gitBashMatch[1].toUpperCase();
+    const rest = gitBashMatch[2] ? gitBashMatch[2].replace(/\//g, '\\') : '\\';
+    return `${drive}:${rest}`;
+  }
+
+  return p;
+}
+
+/**
+ * 현재 OS에 맞게 경로를 정규화한다.
+ * win32: backslash, 그 외: forward slash
+ * @param {string|null|undefined} p
+ * @returns {string}
+ */
+export function normalizePath(p) {
+  if (p == null) return '';
+  const str = String(p);
+  if (process.platform === 'win32') {
+    return str.replace(/\//g, '\\');
+  }
+  return str.replace(/\\/g, '/');
+}
+
+/**
+ * 쉘 타입에 맞는 경로로 변환한다.
+ * @param {string|null|undefined} path
+ * @param {'git-bash'|'wsl'|'cmd'|'powershell'} shellType
+ * @returns {string}
+ */
+export function resolveShellPath(path, shellType) {
+  if (path == null) return '';
+  const p = String(path);
+
+  switch (shellType) {
+    case 'git-bash':
+      return toPosixPath(p);
+
+    case 'wsl': {
+      // Git Bash 경로를 먼저 Windows로 변환 후 WSL 형식으로
+      let winPath = /^[A-Za-z]:/.test(p) ? p : toWindowsPath(p);
+      const wslDriveMatch = winPath.match(/^([A-Za-z]):[/\\](.*)/);
+      if (wslDriveMatch) {
+        const drive = wslDriveMatch[1].toLowerCase();
+        const rest = wslDriveMatch[2].replace(/\\/g, '/');
+        return rest ? `/mnt/${drive}/${rest}` : `/mnt/${drive}`;
+      }
+      // 이미 /mnt/ 형식이면 그대로
+      if (p.startsWith('/mnt/')) return p;
+      return p.replace(/\\/g, '/');
+    }
+
+    case 'cmd':
+    case 'powershell':
+      return toWindowsPath(p);
+
+    default:
+      return p;
+  }
+}
+
+/**
+ * 환경 변수와 플랫폼 정보로 현재 쉘 타입을 추론한다.
+ * @returns {'git-bash'|'wsl'|'cmd'|'powershell'|'unix'}
+ */
+export function detectShellType() {
+  // WSL 감지: WSL_DISTRO_NAME 또는 WSLENV
+  if (process.env.WSL_DISTRO_NAME || process.env.WSLENV) {
+    return 'wsl';
+  }
+
+  // Windows 플랫폼
+  if (process.platform === 'win32') {
+    const shell = process.env.SHELL || '';
+    const term = process.env.TERM || '';
+    const msystem = process.env.MSYSTEM || '';
+
+    // Git Bash 감지: SHELL=/usr/bin/bash + MSYSTEM=MINGW64 등
+    if (
+      shell.includes('bash') ||
+      msystem.startsWith('MINGW') ||
+      msystem.startsWith('MSYS') ||
+      term === 'xterm'
+    ) {
+      return 'git-bash';
+    }
+
+    // PowerShell 감지
+    if (process.env.PSModulePath || process.env.PSHOME) {
+      return 'powershell';
+    }
+
+    return 'cmd';
+  }
+
+  // 비-Windows
+  return 'unix';
+}
+
+/**
+ * WSL 경로 여부를 확인한다 (/mnt/ 시작).
+ * @param {string|null|undefined} p
+ * @returns {boolean}
+ */
+export function isWslPath(p) {
+  if (p == null) return false;
+  return String(p).startsWith('/mnt/');
+}
+
+/**
+ * Git Bash 경로 여부를 확인한다 (/c/ 또는 /d/ 등 단일 소문자 드라이브 레터).
+ * @param {string|null|undefined} p
+ * @returns {boolean}
+ */
+export function isGitBashPath(p) {
+  if (p == null) return false;
+  return /^\/[a-zA-Z](\/|$)/.test(String(p));
+}

--- a/tests/unit/path-utils.test.mjs
+++ b/tests/unit/path-utils.test.mjs
@@ -1,0 +1,204 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  toPosixPath,
+  toWindowsPath,
+  normalizePath,
+  resolveShellPath,
+  detectShellType,
+  isWslPath,
+  isGitBashPath,
+} from '../../hub/lib/path-utils.mjs';
+
+describe('hub/lib/path-utils.mjs', () => {
+  describe('toPosixPath', () => {
+    it('Windows C: 경로를 POSIX로 변환한다', () => {
+      assert.equal(toPosixPath('C:\\foo\\bar'), '/c/foo/bar');
+    });
+
+    it('Windows D: 경로를 POSIX로 변환한다', () => {
+      assert.equal(toPosixPath('D:\\Users\\test'), '/d/Users/test');
+    });
+
+    it('드라이브 레터만 있는 경우 처리한다', () => {
+      assert.equal(toPosixPath('C:\\'), '/c/');
+    });
+
+    it('이미 POSIX 경로면 그대로 반환한다', () => {
+      assert.equal(toPosixPath('/usr/local/bin'), '/usr/local/bin');
+    });
+
+    it('forward slash가 섞인 Windows 경로도 처리한다', () => {
+      assert.equal(toPosixPath('C:/foo/bar'), '/c/foo/bar');
+    });
+
+    it('null → 빈 문자열', () => {
+      assert.equal(toPosixPath(null), '');
+    });
+
+    it('undefined → 빈 문자열', () => {
+      assert.equal(toPosixPath(undefined), '');
+    });
+
+    it('빈 문자열 → 빈 문자열', () => {
+      assert.equal(toPosixPath(''), '');
+    });
+  });
+
+  describe('toWindowsPath', () => {
+    it('Git Bash POSIX 경로를 Windows로 변환한다', () => {
+      assert.equal(toWindowsPath('/c/foo/bar'), 'C:\\foo\\bar');
+    });
+
+    it('/d/ 경로를 Windows로 변환한다', () => {
+      assert.equal(toWindowsPath('/d/Users/test'), 'D:\\Users\\test');
+    });
+
+    it('이미 Windows 경로면 그대로 반환한다 (슬래시 정규화 포함)', () => {
+      assert.equal(toWindowsPath('C:\\foo\\bar'), 'C:\\foo\\bar');
+    });
+
+    it('Windows 경로에 forward slash가 있으면 backslash로 변환한다', () => {
+      assert.equal(toWindowsPath('C:/foo/bar'), 'C:\\foo\\bar');
+    });
+
+    it('null → 빈 문자열', () => {
+      assert.equal(toWindowsPath(null), '');
+    });
+
+    it('undefined → 빈 문자열', () => {
+      assert.equal(toWindowsPath(undefined), '');
+    });
+
+    it('빈 문자열 → 빈 문자열', () => {
+      assert.equal(toWindowsPath(''), '');
+    });
+  });
+
+  describe('normalizePath', () => {
+    it('win32 플랫폼에서 forward slash를 backslash로 변환한다', () => {
+      const result = normalizePath('C:/foo/bar');
+      if (process.platform === 'win32') {
+        assert.equal(result, 'C:\\foo\\bar');
+      } else {
+        assert.equal(result, 'C:/foo/bar');
+      }
+    });
+
+    it('비-Windows 플랫폼에서 backslash를 forward slash로 변환한다', () => {
+      const result = normalizePath('foo\\bar\\baz');
+      if (process.platform === 'win32') {
+        assert.equal(result, 'foo\\bar\\baz');
+      } else {
+        assert.equal(result, 'foo/bar/baz');
+      }
+    });
+
+    it('null → 빈 문자열', () => {
+      assert.equal(normalizePath(null), '');
+    });
+
+    it('undefined → 빈 문자열', () => {
+      assert.equal(normalizePath(undefined), '');
+    });
+  });
+
+  describe('resolveShellPath', () => {
+    it('git-bash: Windows 경로를 POSIX로 변환한다', () => {
+      assert.equal(resolveShellPath('C:\\foo\\bar', 'git-bash'), '/c/foo/bar');
+    });
+
+    it('git-bash: 이미 POSIX면 그대로', () => {
+      assert.equal(resolveShellPath('/usr/local', 'git-bash'), '/usr/local');
+    });
+
+    it('wsl: Windows 경로를 /mnt/ 형식으로 변환한다', () => {
+      assert.equal(resolveShellPath('C:\\foo\\bar', 'wsl'), '/mnt/c/foo/bar');
+    });
+
+    it('wsl: Git Bash 경로를 /mnt/ 형식으로 변환한다', () => {
+      assert.equal(resolveShellPath('/c/foo/bar', 'wsl'), '/mnt/c/foo/bar');
+    });
+
+    it('wsl: 이미 /mnt/ 경로면 그대로', () => {
+      assert.equal(resolveShellPath('/mnt/c/foo/bar', 'wsl'), '/mnt/c/foo/bar');
+    });
+
+    it('cmd: POSIX 경로를 Windows로 변환한다', () => {
+      assert.equal(resolveShellPath('/c/foo/bar', 'cmd'), 'C:\\foo\\bar');
+    });
+
+    it('powershell: POSIX 경로를 Windows로 변환한다', () => {
+      assert.equal(resolveShellPath('/d/Users/test', 'powershell'), 'D:\\Users\\test');
+    });
+
+    it('null → 빈 문자열', () => {
+      assert.equal(resolveShellPath(null, 'git-bash'), '');
+    });
+  });
+
+  describe('detectShellType', () => {
+    it('문자열을 반환한다', () => {
+      const result = detectShellType();
+      assert.equal(typeof result, 'string');
+    });
+
+    it('유효한 쉘 타입 중 하나를 반환한다', () => {
+      const valid = new Set(['git-bash', 'wsl', 'cmd', 'powershell', 'unix']);
+      assert.ok(valid.has(detectShellType()));
+    });
+  });
+
+  describe('isWslPath', () => {
+    it('/mnt/ 로 시작하면 true', () => {
+      assert.equal(isWslPath('/mnt/c/foo/bar'), true);
+    });
+
+    it('/mnt/ 로 시작하지 않으면 false', () => {
+      assert.equal(isWslPath('/c/foo/bar'), false);
+    });
+
+    it('Windows 경로는 false', () => {
+      assert.equal(isWslPath('C:\\foo\\bar'), false);
+    });
+
+    it('null → false', () => {
+      assert.equal(isWslPath(null), false);
+    });
+
+    it('undefined → false', () => {
+      assert.equal(isWslPath(undefined), false);
+    });
+  });
+
+  describe('isGitBashPath', () => {
+    it('/c/... 패턴은 true', () => {
+      assert.equal(isGitBashPath('/c/foo/bar'), true);
+    });
+
+    it('/d/... 패턴은 true', () => {
+      assert.equal(isGitBashPath('/d/Users/test'), true);
+    });
+
+    it('/mnt/c/... 는 false (WSL 경로)', () => {
+      assert.equal(isGitBashPath('/mnt/c/foo'), false);
+    });
+
+    it('/usr/local 같은 일반 POSIX 경로는 false', () => {
+      assert.equal(isGitBashPath('/usr/local/bin'), false);
+    });
+
+    it('Windows 경로는 false', () => {
+      assert.equal(isGitBashPath('C:\\foo\\bar'), false);
+    });
+
+    it('null → false', () => {
+      assert.equal(isGitBashPath(null), false);
+    });
+
+    it('undefined → false', () => {
+      assert.equal(isGitBashPath(undefined), false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Windows 경로 유틸 통합 모듈 (#9)
- 7개 함수: toPosixPath, toWindowsPath, normalizePath, resolveShellPath, detectShellType, isWslPath, isGitBashPath
- 기존 파일 미수정 (추후 마이그레이션)

## Test plan
- [x] path-utils.test.mjs 41개 테스트 통과
