### PR TITLE
feat: #10 Runtime Strategy 패턴 도입

### DIFF
--- a/hub/team/runtime-strategy.mjs
+++ b/hub/team/runtime-strategy.mjs
@@ -1,0 +1,147 @@
+// hub/team/runtime-strategy.mjs — Strategy pattern for team runtime backends
+
+/**
+ * Abstract base class for team runtime implementations.
+ * Concrete subclasses handle psmux, native, or wt execution environments.
+ */
+export class TeamRuntime {
+  get name() { throw new Error('not implemented'); }
+  async start(config) { throw new Error('not implemented'); }
+  async stop(state) { throw new Error('not implemented'); }
+  async isAlive(state) { throw new Error('not implemented'); }
+  async focus(member) { throw new Error('not implemented'); }
+  async sendKeys(member, text) { throw new Error('not implemented'); }
+  async interrupt(member) { throw new Error('not implemented'); }
+  async getStatus() { throw new Error('not implemented'); }
+}
+
+export class PsmuxRuntime extends TeamRuntime {
+  get name() { return 'psmux'; }
+
+  async start(config) {
+    console.log('[PsmuxRuntime] start called');
+    return {};
+  }
+
+  async stop(state) {
+    console.log('[PsmuxRuntime] stop called');
+    return {};
+  }
+
+  async isAlive(state) {
+    console.log('[PsmuxRuntime] isAlive called');
+    return false;
+  }
+
+  async focus(member) {
+    console.log('[PsmuxRuntime] focus called');
+    return {};
+  }
+
+  async sendKeys(member, text) {
+    console.log('[PsmuxRuntime] sendKeys called');
+    return {};
+  }
+
+  async interrupt(member) {
+    console.log('[PsmuxRuntime] interrupt called');
+    return {};
+  }
+
+  async getStatus() {
+    console.log('[PsmuxRuntime] getStatus called');
+    return {};
+  }
+}
+
+export class NativeRuntime extends TeamRuntime {
+  get name() { return 'native'; }
+
+  async start(config) {
+    console.log('[NativeRuntime] start called');
+    return {};
+  }
+
+  async stop(state) {
+    console.log('[NativeRuntime] stop called');
+    return {};
+  }
+
+  async isAlive(state) {
+    console.log('[NativeRuntime] isAlive called');
+    return false;
+  }
+
+  async focus(member) {
+    console.log('[NativeRuntime] focus called');
+    return {};
+  }
+
+  async sendKeys(member, text) {
+    console.log('[NativeRuntime] sendKeys called');
+    return {};
+  }
+
+  async interrupt(member) {
+    console.log('[NativeRuntime] interrupt called');
+    return {};
+  }
+
+  async getStatus() {
+    console.log('[NativeRuntime] getStatus called');
+    return {};
+  }
+}
+
+export class WtRuntime extends TeamRuntime {
+  get name() { return 'wt'; }
+
+  async start(config) {
+    console.log('[WtRuntime] start called');
+    return {};
+  }
+
+  async stop(state) {
+    console.log('[WtRuntime] stop called');
+    return {};
+  }
+
+  async isAlive(state) {
+    console.log('[WtRuntime] isAlive called');
+    return false;
+  }
+
+  async focus(member) {
+    console.log('[WtRuntime] focus called');
+    return {};
+  }
+
+  async sendKeys(member, text) {
+    console.log('[WtRuntime] sendKeys called');
+    return {};
+  }
+
+  async interrupt(member) {
+    console.log('[WtRuntime] interrupt called');
+    return {};
+  }
+
+  async getStatus() {
+    console.log('[WtRuntime] getStatus called');
+    return {};
+  }
+}
+
+/**
+ * Factory function that returns a TeamRuntime instance for the given mode.
+ * @param {'psmux'|'native'|'wt'} mode
+ * @returns {TeamRuntime}
+ */
+export function createRuntime(mode) {
+  switch (mode) {
+    case 'psmux': return new PsmuxRuntime();
+    case 'native': return new NativeRuntime();
+    case 'wt': return new WtRuntime();
+    default: throw new Error(`Unknown runtime mode: ${mode}`);
+  }
+}

--- a/tests/unit/runtime-strategy.test.mjs
+++ b/tests/unit/runtime-strategy.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  createRuntime,
+  NativeRuntime,
+  PsmuxRuntime,
+  TeamRuntime,
+  WtRuntime,
+} from "../../hub/team/runtime-strategy.mjs";
+
+const RUNTIME_METHODS = ['start', 'stop', 'isAlive', 'focus', 'sendKeys', 'interrupt', 'getStatus'];
+
+describe("createRuntime factory", () => {
+  it("'psmux' → PsmuxRuntime 인스턴스 반환", () => {
+    const rt = createRuntime('psmux');
+    assert.ok(rt instanceof PsmuxRuntime);
+    assert.ok(rt instanceof TeamRuntime);
+    assert.equal(rt.name, 'psmux');
+  });
+
+  it("'native' → NativeRuntime 인스턴스 반환", () => {
+    const rt = createRuntime('native');
+    assert.ok(rt instanceof NativeRuntime);
+    assert.ok(rt instanceof TeamRuntime);
+    assert.equal(rt.name, 'native');
+  });
+
+  it("'wt' → WtRuntime 인스턴스 반환", () => {
+    const rt = createRuntime('wt');
+    assert.ok(rt instanceof WtRuntime);
+    assert.ok(rt instanceof TeamRuntime);
+    assert.equal(rt.name, 'wt');
+  });
+
+  it("미지원 mode → Error throw", () => {
+    assert.throws(
+      () => createRuntime('invalid'),
+      { message: 'Unknown runtime mode: invalid' }
+    );
+  });
+});
+
+describe("TeamRuntime 추상 메서드", () => {
+  it("name getter 호출 시 에러", () => {
+    const base = new TeamRuntime();
+    assert.throws(() => base.name, { message: 'not implemented' });
+  });
+
+  for (const method of RUNTIME_METHODS) {
+    it(`${method}() 호출 시 에러`, async () => {
+      const base = new TeamRuntime();
+      await assert.rejects(async () => base[method](), { message: 'not implemented' });
+    });
+  }
+});
+
+describe("PsmuxRuntime duck-typing 검증", () => {
+  it("모든 메서드가 구현되어 있고 호출 가능", async () => {
+    const rt = createRuntime('psmux');
+    for (const method of RUNTIME_METHODS) {
+      assert.equal(typeof rt[method], 'function', `${method} 미구현`);
+      await assert.doesNotReject(async () => rt[method]());
+    }
+  });
+});
+
+describe("NativeRuntime duck-typing 검증", () => {
+  it("모든 메서드가 구현되어 있고 호출 가능", async () => {
+    const rt = createRuntime('native');
+    for (const method of RUNTIME_METHODS) {
+      assert.equal(typeof rt[method], 'function', `${method} 미구현`);
+      await assert.doesNotReject(async () => rt[method]());
+    }
+  });
+});
+
+describe("WtRuntime duck-typing 검증", () => {
+  it("모든 메서드가 구현되어 있고 호출 가능", async () => {
+    const rt = createRuntime('wt');
+    for (const method of RUNTIME_METHODS) {
+      assert.equal(typeof rt[method], 'function', `${method} 미구현`);
+      await assert.doesNotReject(async () => rt[method]());
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Runtime Strategy 패턴 도입 (#10)
- TeamRuntime 추상 클래스 + PsmuxRuntime/NativeRuntime/WtRuntime stub
- createRuntime() 팩토리 함수
- 기존 11곳 분기 미수정 (추후 마이그레이션)

## Test plan
- [x] runtime-strategy.test.mjs 15개 테스트 통과
