### PR TITLE
fix(package): mesh/ 디렉토리 npm 패키지 누락 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "scripts",
     "hooks",
     "hud",
+    "mesh",
     ".claude-plugin",
     "README.md",
     "README.ko.md",


### PR DESCRIPTION
## Summary
- `package.json`의 `files` 필드에 `"mesh"` 추가
- `conductor.mjs` → `mesh/mesh-registry.mjs` import 시 `ERR_MODULE_NOT_FOUND` 해결
- `tfx-swarm` 실행 블로킹 해소

## Root Cause
`mesh/` 디렉토리가 프로젝트에 존재하지만 `package.json` `files` 필드에 누락되어 `npm publish` 시 패키지에 포함되지 않음.

## Verification
```
npm pack --dry-run | grep mesh/
```
7개 파일 전부 포함 확인.

## Test plan
- [ ] `npm pack --dry-run`으로 mesh/ 포함 확인
- [ ] 글로벌 설치 후 `planSwarm()` 호출 정상 동작 확인

Closes #60