### PR TITLE
fix(gemini-worker): Windows `.cmd` shim spawn ENOENT — cmd.exe 경유 + 수동 quoting

### DIFF
--- a/hub/workers/gemini-worker.mjs
+++ b/hub/workers/gemini-worker.mjs
@@ -2,7 +2,7 @@
 // ADR-006: --output-format stream-json 기반 단발 실행 워커.
 
 import { spawn } from "node:child_process";
-import { isAbsolute } from "node:path";
+import { existsSync } from "node:fs";
 import readline from "node:readline";
 
 import { extractText, terminateChild, withRetry } from "./worker-utils.mjs";
@@ -13,6 +13,38 @@ const DEFAULT_KILL_GRACE_MS = 1000;
 function toStringList(value) {
   if (!Array.isArray(value)) return [];
   return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+}
+
+// cmd.exe용 인자 이스케이프. 공백/특수문자 포함 시 큰따옴표로 감싸고
+// 내부 `"`와 trailing `\`를 올바르게 처리한다. 빈 문자열은 `""`로 보존된다.
+export function escapeCmdArg(arg) {
+  if (arg === "") return '""';
+  if (!/[\s"()^&|<>%!]/.test(arg)) return arg;
+  return `"${arg.replace(/(\\*)("|$)/g, (_, slashes, quote) =>
+    quote === '"' ? `${slashes}${slashes}\\"` : `${slashes}${slashes}`,
+  )}"`;
+}
+
+// Windows npm shim은 `.cmd` 확장자가 필요하지만 `command -v`는 확장자 없이 반환한다.
+// `.cmd`/`.bat`는 Node 20+ 이후 CVE-2024-27980 대응으로 `shell: false` spawn이 차단되므로,
+// cross-spawn 방식으로 `cmd.exe /d /s /c` 경유 + 수동 quoting하여 넘긴다.
+// `.exe`는 shell 없이 직접 실행 가능.
+export function resolveWindowsCommand(command, args) {
+  if (process.platform !== "win32") return { command, args, shell: false };
+  let resolved = command;
+  if (!/\.(cmd|bat|exe|ps1)$/i.test(resolved)) {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      if (existsSync(resolved + ext)) {
+        resolved = resolved + ext;
+        break;
+      }
+    }
+  }
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    const line = [resolved, ...args].map(escapeCmdArg).join(" ");
+    return { command: "cmd.exe", args: ["/d", "/s", "/c", line], shell: false };
+  }
+  return { command: resolved, args, shell: false };
 }
 
 function safeJsonParse(line) {
@@ -223,12 +255,14 @@ export class GeminiWorker {
       }),
     ];
 
-    const child = spawn(this.command, args, {
+    const { command: spawnCommand, args: spawnArgs, shell: useShell } =
+      resolveWindowsCommand(this.command, args);
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd: options.cwd || this.cwd,
       env: { ...this.env, ...(options.env || {}) },
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
-      shell: process.platform === "win32" && !isAbsolute(this.command),
+      shell: useShell,
     });
 
     this.child = child;

--- a/packages/remote/hub/workers/gemini-worker.mjs
+++ b/packages/remote/hub/workers/gemini-worker.mjs
@@ -2,7 +2,7 @@
 // ADR-006: --output-format stream-json 기반 단발 실행 워커.
 
 import { spawn } from "node:child_process";
-import { isAbsolute } from "node:path";
+import { existsSync } from "node:fs";
 import readline from "node:readline";
 
 import { extractText, terminateChild, withRetry } from "./worker-utils.mjs";
@@ -13,6 +13,38 @@ const DEFAULT_KILL_GRACE_MS = 1000;
 function toStringList(value) {
   if (!Array.isArray(value)) return [];
   return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+}
+
+// cmd.exe용 인자 이스케이프. 공백/특수문자 포함 시 큰따옴표로 감싸고
+// 내부 `"`와 trailing `\`를 올바르게 처리한다. 빈 문자열은 `""`로 보존된다.
+export function escapeCmdArg(arg) {
+  if (arg === "") return '""';
+  if (!/[\s"()^&|<>%!]/.test(arg)) return arg;
+  return `"${arg.replace(/(\\*)("|$)/g, (_, slashes, quote) =>
+    quote === '"' ? `${slashes}${slashes}\\"` : `${slashes}${slashes}`,
+  )}"`;
+}
+
+// Windows npm shim은 `.cmd` 확장자가 필요하지만 `command -v`는 확장자 없이 반환한다.
+// `.cmd`/`.bat`는 Node 20+ 이후 CVE-2024-27980 대응으로 `shell: false` spawn이 차단되므로,
+// cross-spawn 방식으로 `cmd.exe /d /s /c` 경유 + 수동 quoting하여 넘긴다.
+// `.exe`는 shell 없이 직접 실행 가능.
+export function resolveWindowsCommand(command, args) {
+  if (process.platform !== "win32") return { command, args, shell: false };
+  let resolved = command;
+  if (!/\.(cmd|bat|exe|ps1)$/i.test(resolved)) {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      if (existsSync(resolved + ext)) {
+        resolved = resolved + ext;
+        break;
+      }
+    }
+  }
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    const line = [resolved, ...args].map(escapeCmdArg).join(" ");
+    return { command: "cmd.exe", args: ["/d", "/s", "/c", line], shell: false };
+  }
+  return { command: resolved, args, shell: false };
 }
 
 function safeJsonParse(line) {
@@ -223,12 +255,14 @@ export class GeminiWorker {
       }),
     ];
 
-    const child = spawn(this.command, args, {
+    const { command: spawnCommand, args: spawnArgs, shell: useShell } =
+      resolveWindowsCommand(this.command, args);
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd: options.cwd || this.cwd,
       env: { ...this.env, ...(options.env || {}) },
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
-      shell: process.platform === "win32" && !isAbsolute(this.command),
+      shell: useShell,
     });
 
     this.child = child;

--- a/packages/triflux/hub/workers/gemini-worker.mjs
+++ b/packages/triflux/hub/workers/gemini-worker.mjs
@@ -2,7 +2,7 @@
 // ADR-006: --output-format stream-json 기반 단발 실행 워커.
 
 import { spawn } from "node:child_process";
-import { isAbsolute } from "node:path";
+import { existsSync } from "node:fs";
 import readline from "node:readline";
 
 import { extractText, terminateChild, withRetry } from "./worker-utils.mjs";
@@ -13,6 +13,38 @@ const DEFAULT_KILL_GRACE_MS = 1000;
 function toStringList(value) {
   if (!Array.isArray(value)) return [];
   return value.map((item) => String(item ?? "").trim()).filter(Boolean);
+}
+
+// cmd.exe용 인자 이스케이프. 공백/특수문자 포함 시 큰따옴표로 감싸고
+// 내부 `"`와 trailing `\`를 올바르게 처리한다. 빈 문자열은 `""`로 보존된다.
+export function escapeCmdArg(arg) {
+  if (arg === "") return '""';
+  if (!/[\s"()^&|<>%!]/.test(arg)) return arg;
+  return `"${arg.replace(/(\\*)("|$)/g, (_, slashes, quote) =>
+    quote === '"' ? `${slashes}${slashes}\\"` : `${slashes}${slashes}`,
+  )}"`;
+}
+
+// Windows npm shim은 `.cmd` 확장자가 필요하지만 `command -v`는 확장자 없이 반환한다.
+// `.cmd`/`.bat`는 Node 20+ 이후 CVE-2024-27980 대응으로 `shell: false` spawn이 차단되므로,
+// cross-spawn 방식으로 `cmd.exe /d /s /c` 경유 + 수동 quoting하여 넘긴다.
+// `.exe`는 shell 없이 직접 실행 가능.
+export function resolveWindowsCommand(command, args) {
+  if (process.platform !== "win32") return { command, args, shell: false };
+  let resolved = command;
+  if (!/\.(cmd|bat|exe|ps1)$/i.test(resolved)) {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      if (existsSync(resolved + ext)) {
+        resolved = resolved + ext;
+        break;
+      }
+    }
+  }
+  if (/\.(cmd|bat)$/i.test(resolved)) {
+    const line = [resolved, ...args].map(escapeCmdArg).join(" ");
+    return { command: "cmd.exe", args: ["/d", "/s", "/c", line], shell: false };
+  }
+  return { command: resolved, args, shell: false };
 }
 
 function safeJsonParse(line) {
@@ -223,12 +255,14 @@ export class GeminiWorker {
       }),
     ];
 
-    const child = spawn(this.command, args, {
+    const { command: spawnCommand, args: spawnArgs, shell: useShell } =
+      resolveWindowsCommand(this.command, args);
+    const child = spawn(spawnCommand, spawnArgs, {
       cwd: options.cwd || this.cwd,
       env: { ...this.env, ...(options.env || {}) },
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
-      shell: process.platform === "win32" && !isAbsolute(this.command),
+      shell: useShell,
     });
 
     this.child = child;

--- a/tests/unit/gemini-worker-windows.test.mjs
+++ b/tests/unit/gemini-worker-windows.test.mjs
@@ -1,0 +1,73 @@
+// tests/unit/gemini-worker-windows.test.mjs
+// Windows `.cmd` shim spawn 버그 회귀 테스트 (issue #68)
+//
+// - escapeCmdArg: cmd.exe용 인자 quoting
+// - resolveWindowsCommand: npm shim(`.cmd`)을 cmd.exe /d /s /c 경유로 변환
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  escapeCmdArg,
+  resolveWindowsCommand,
+} from "../../hub/workers/gemini-worker.mjs";
+
+describe("escapeCmdArg", () => {
+  it("특수문자가 없는 평범한 토큰은 그대로 반환", () => {
+    assert.equal(escapeCmdArg("gemini-3.1-pro-preview"), "gemini-3.1-pro-preview");
+    assert.equal(escapeCmdArg("--model"), "--model");
+    assert.equal(escapeCmdArg("yolo"), "yolo");
+  });
+
+  it("빈 문자열은 `\"\"`로 보존되어 cmd.exe에서 빈 인자로 전달된다", () => {
+    assert.equal(escapeCmdArg(""), '""');
+  });
+
+  it("공백이 포함되면 큰따옴표로 감싼다", () => {
+    assert.equal(escapeCmdArg("hello world"), '"hello world"');
+  });
+
+  it("내부 큰따옴표는 `\\\"`로 이스케이프된다", () => {
+    assert.equal(escapeCmdArg('say "hi"'), '"say \\"hi\\""');
+  });
+
+  it("cmd.exe 메타문자를 포함하면 quote된다", () => {
+    assert.equal(escapeCmdArg("a&b"), '"a&b"');
+    assert.equal(escapeCmdArg("a|b"), '"a|b"');
+    assert.equal(escapeCmdArg("a^b"), '"a^b"');
+    assert.equal(escapeCmdArg("a>b"), '"a>b"');
+  });
+});
+
+describe("resolveWindowsCommand", () => {
+  const isWin = process.platform === "win32";
+
+  it("non-Windows 플랫폼에서는 변경 없이 통과", { skip: isWin }, () => {
+    const result = resolveWindowsCommand("/usr/local/bin/gemini", ["--v"]);
+    assert.equal(result.command, "/usr/local/bin/gemini");
+    assert.deepEqual(result.args, ["--v"]);
+    assert.equal(result.shell, false);
+  });
+
+  it("Windows + `.cmd` 경로는 cmd.exe /d /s /c 로 래핑된다", { skip: !isWin }, () => {
+    const result = resolveWindowsCommand(
+      "C:\\fake\\npm\\gemini.cmd",
+      ["--model", "gemini-3.1-pro-preview", "--prompt", ""],
+    );
+    assert.equal(result.command, "cmd.exe");
+    assert.equal(result.args[0], "/d");
+    assert.equal(result.args[1], "/s");
+    assert.equal(result.args[2], "/c");
+    // 빈 문자열 인자가 `""`로 보존되어 gemini CLI가 `--prompt`를 옵션값으로 인식하게 한다
+    assert.match(result.args[3], /--prompt ""/);
+    assert.ok(result.args[3].includes("gemini.cmd"));
+    assert.equal(result.shell, false);
+  });
+
+  it("Windows + `.exe` 경로는 shell 없이 직접 실행", { skip: !isWin }, () => {
+    const result = resolveWindowsCommand("C:\\fake\\bin\\tool.exe", ["--v"]);
+    assert.equal(result.command, "C:\\fake\\bin\\tool.exe");
+    assert.deepEqual(result.args, ["--v"]);
+    assert.equal(result.shell, false);
+  });
+});


### PR DESCRIPTION
Fixes #68.

## 요약

Windows에서 `gemini-worker.mjs`가 npm `.cmd` shim을 spawn하지 못해 모든 Gemini route 호출이 즉시 claude-native로 폴백되던 문제를 해결합니다.

## 원인 (간략)

| 레이어 | 문제 |
|--------|------|
| `tfx-route.sh` | `command -v gemini` → `/c/.../npm/gemini` (확장자 없는 bash shim) |
| `gemini-worker.mjs:231` | `shell: win32 && !isAbsolute(cmd)` → 절대경로라 shell 비활성화 |
| Node.js 20+ | `.cmd`는 CVE-2024-27980 대응으로 `shell: false` spawn 불가 (EINVAL) |
| `shell: true` 단순 대체 | 빈 문자열 인자(`--prompt ""`) 소실로 gemini CLI가 usage 출력 |

결론: cross-spawn 방식으로 `cmd.exe /d /s /c` 경유 + 수동 인자 quoting이 필요.

## 변경

### `hub/workers/gemini-worker.mjs`

- `escapeCmdArg(arg)` 추가 — cmd.exe용 인자 quoting. 공백/특수문자(`"^&|<>%!()`) 감지 시 큰따옴표 래핑, 내부 `"`는 `\"`로 이스케이프, 빈 문자열은 `""`로 보존.
- `resolveWindowsCommand(command, args)` 추가 — Windows에서 확장자 없는 경로는 `.exe` → `.cmd` → `.bat` 순으로 탐지. `.cmd`/`.bat`는 `cmd.exe /d /s /c <quoted>` 로 래핑.
- spawn 호출부를 새 signature로 갱신 (`shell: false` 유지).
- 헬퍼 2개는 unit 테스트를 위해 `export` 처리.

### `tests/unit/gemini-worker-windows.test.mjs`

- `escapeCmdArg` 5건, `resolveWindowsCommand` 3건 (Windows-only 2, cross-platform 1).
- node:test + `assert/strict`.
- 7/8 pass (non-Windows skip 1건).

## 영향 범위

- `hub/workers/gemini-worker.mjs` (+ `packages/triflux/`, `packages/remote/` 미러 동기화)
- `claude-worker.mjs:334`는 shell 플래그 자체가 없어 동일 증상 잠재 (Claude CLI를 worker로 쓰는 경로는 현재 없지만, 필요 시 동일 helper를 공용화하는 후속 PR 고려).
- `codex-mcp.mjs`는 MCP transport 사용으로 직접 `spawn` 없음 → 영향 없음.

## 수정 전/후 동작 (Windows, Node 24.12.0)

```bash
# 수정 전
$ bash ~/.claude/scripts/tfx-route.sh gemini 'hi' minimal 60
[tfx-route] Gemini stream wrapper 실패(exit=1, stderr=235B). claude-native fallback.
[tfx-route-worker] spawn C:/Users/.../npm/gemini ENOENT
→ elapsed: 1s, ROUTE_TYPE=claude-native

# 수정 후
$ bash ~/.claude/scripts/tfx-route.sh gemini 'hi' minimal 180
[tfx-heartbeat] pid=X elapsed=12s output=0B ...
Attempt 1 failed: You have exhausted your capacity on this model.. Retrying ...
→ gemini.cmd 실제 호출 + API 통신 도달 (quota 소진은 별개 이슈)
```

## 테스트

```bash
$ node --test tests/unit/gemini-worker-windows.test.mjs
# 7 pass, 1 skip (non-Windows), 0 fail
```

전체 스위트는 로컬에서 돌리지 못했습니다 (CI에서 확인 부탁드립니다).

## 관련

- Issue: #68
- CVE: [CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980) — Node.js `.cmd`/`.bat` spawn 제한
- 참고: cross-spawn `parse.js` — Windows 경로 해석 로직
