### PR TITLE
feat(platform): macOS 심층 호환성 — headless/psmux/프로세스 관리

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -525,6 +525,10 @@ function whichInShell(cmd, shell) {
       ["-c", `source ~/.bashrc 2>/dev/null && command -v "${cmd}" 2>/dev/null`],
     ],
     cmd: ["cmd", ["/c", "where", cmd]],
+    zsh: [
+      "zsh",
+      ["-c", `source ~/.zshrc 2>/dev/null && command -v "${cmd}" 2>/dev/null`],
+    ],
     pwsh: [
       "pwsh",
       [
@@ -852,7 +856,7 @@ function getClaudeRoutingSyncSummary(results) {
 
 function checkCliCrossShell(cmd, installHint) {
   const shells =
-    process.platform === "win32" ? ["bash", "cmd", "pwsh"] : ["bash"];
+    process.platform === "win32" ? ["bash", "cmd", "pwsh"] : ["bash", "zsh"];
   let anyFound = false;
   let bashMissing = false;
   const shellResults = [];
@@ -1183,6 +1187,21 @@ function cmdSetup(options = {}) {
       }
     } catch {
       /* psmux 서버 미실행 — 무시 */
+    }
+  }
+
+  // ── tmux 기본 셸 확인 (macOS/Linux) ──
+  if (process.platform !== "win32" && which("tmux")) {
+    try {
+      const shellOut = execSync("tmux show-options -g default-shell 2>/dev/null", {
+        encoding: "utf8",
+        timeout: 3000,
+      }).trim();
+      if (shellOut) {
+        ok(`tmux 기본 셸: ${shellOut.split(/\s+/).pop() || "확인 완료"}`);
+      }
+    } catch {
+      /* tmux 서버 미실행 — 무시 */
     }
   }
 

--- a/docs/prd/macos-compat.md
+++ b/docs/prd/macos-compat.md
@@ -1,0 +1,93 @@
+# PRD: macOS 호환성 전수 수정
+
+## 목표
+triflux의 macOS 비호환 부분을 수정하여 macOS를 1등 시민으로 지원한다.
+
+## Shard: process-cleanup-bsd
+- agent: codex
+- files: hub/team/process-cleanup.mjs, packages/remote/hub/team/process-cleanup.mjs
+- prompt: |
+  process-cleanup.mjs의 queryUnixProcesses 함수에서 `ps -eo pid,ppid,rss,comm,args --no-headers`를 사용하는데, macOS BSD ps는 `--no-headers`를 지원하지 않는다.
+  같은 프로젝트의 staleState.mjs:137처럼 BSD 호환 방식 `ps -ax -o pid=,ppid=,rss=,comm=,args=`으로 수정하라 (= 접미사가 헤더를 숨긴다).
+  hub/team/process-cleanup.mjs와 packages/remote/hub/team/process-cleanup.mjs 두 파일 모두 동일하게 수정.
+  기존 파싱 로직(공백 split)은 유지.
+
+## Shard: notify-macos
+- agent: codex
+- files: hub/team/notify.mjs, packages/remote/hub/team/notify.mjs, packages/triflux/hub/team/notify.mjs
+- prompt: |
+  notify.mjs의 sendToast 함수가 win32가 아니면 "unsupported-platform"을 반환한다.
+  macOS에서는 osascript를 사용한 네이티브 알림을 추가하라:
+  `osascript -e 'display notification "body" with title "title"'`
+  구현 방식:
+  1. sendToast에서 platform === "darwin" 분기 추가
+  2. execFileAsync("osascript", ["-e", `display notification "${safeBody}" with title "${safeTitle}"`], ...) 호출
+  3. hub/team/notify.mjs, packages/remote/hub/team/notify.mjs, packages/triflux/hub/team/notify.mjs 모두 동일 수정
+
+## Shard: runtime-tmux
+- agent: codex
+- files: hub/team/runtime-strategy.mjs
+- prompt: |
+  runtime-strategy.mjs의 createRuntime()이 "psmux"만 지원한다.
+  macOS에서 tmux를 런타임으로 사용할 수 있도록 "tmux" 모드를 추가하라.
+  hub/team/session.mjs에서 createSession/killSession/sessionExists를 tmux로 이미 구현하고 있으므로,
+  session.mjs의 기존 tmux 함수들(tmuxExec, listSessions, killSession)을 import해서 tmux 런타임을 구현하라.
+  패턴은 createPsmuxRuntime()과 동일하게 createTmuxRuntime()을 만들면 된다.
+
+## Shard: dashboard-open-macos
+- agent: codex
+- files: hub/team/dashboard-open.mjs
+- prompt: |
+  dashboard-open.mjs가 Windows Terminal 전용이다.
+  macOS에서는 tmux를 사용하여 대시보드를 열 수 있도록 수정하라:
+  1. spawnWindowsTerminal() 외에 spawnMacTerminal() 함수 추가
+  2. macOS에서는 tmux가 있으면 `tmux split-window -h` 또는 `tmux new-window`로 세션 attach
+  3. tmux가 없으면 기본 터미널 앱으로 새 창 열기: `open -a Terminal`
+  4. openHeadlessDashboardTarget에서 macOS 분기 추가
+
+## Shard: monitor-macos
+- agent: codex
+- files: tui/monitor.mjs
+- prompt: |
+  tui/monitor.mjs:149에서 wt.exe를 직접 spawn하여 에이전트를 연다.
+  macOS에서는 tmux를 사용하도록 수정:
+  1. process.platform !== "win32" 분기 추가
+  2. macOS에서는 `tmux new-window -t <session> -n <title> <command>` 사용
+  3. tmux 없으면 `open -a Terminal` fallback
+
+## Shard: cli-macos-shell
+- agent: codex
+- files: bin/triflux.mjs
+- prompt: |
+  bin/triflux.mjs에서 macOS 관련 3개 수정:
+  1. 줄 855: macOS에서 bash만 체크 → ["bash", "zsh"]로 변경
+  2. 줄 525: `source ~/.bashrc` → macOS에서 zsh 감지 시 `source ~/.zshrc` 사용
+  3. 줄 1164: psmux 설정이 win32 전용 → macOS에서 tmux 기본 셸 체크 추가 (tmux가 있으면 `tmux show-options -g default-shell`)
+
+## Shard: env-detect-macos
+- agent: codex
+- files: hub/lib/env-detect.mjs
+- prompt: |
+  env-detect.mjs의 detectTerminal()에서 macOS 터미널 감지를 강화:
+  현재 iTerm2와 Apple_Terminal만 감지한다. 추가:
+  1. TERM_PROGRAM === "WarpTerminal" → { name: "warp", hasWt: false }
+  2. TERM_PROGRAM === "Alacritty" → { name: "alacritty", hasWt: false }
+  3. KITTY_WINDOW_ID 환경변수 존재 → { name: "kitty", hasWt: false }
+
+## Shard: error-context-macos
+- agent: codex
+- files: hooks/error-context.mjs
+- prompt: |
+  error-context.mjs:19의 에러 힌트가 "Windows에서는 관리자 권한, Unix에서는 chmod/sudo를 확인하세요"로 되어 있다.
+  macOS 구분을 추가:
+  "권한 부족. macOS에서는 chmod/sudo, Windows에서는 관리자 권한을 확인하세요."
+  process.platform === "darwin"이면 macOS 우선 표시, "win32"면 Windows 우선.
+
+## Shard: tray-macos-guard
+- agent: codex
+- files: packages/remote/hub/tray.mjs
+- prompt: |
+  tray.mjs:357에서 macOS일 때 throw Error 대신 graceful 처리:
+  1. IS_WINDOWS가 아니면 throw 대신 console.warn + `open <dashboard_url>` 실행으로 변경
+  2. macOS에서 tray 대신 브라우저로 대시보드 열기
+  3. openDashboard()에 macOS 분기 추가: `exec('open "${url}"')` 사용

--- a/hooks/error-context.mjs
+++ b/hooks/error-context.mjs
@@ -16,7 +16,7 @@ const ERROR_HINTS = [
   },
   {
     pattern: /EACCES.*permission denied/i,
-    hint: "권한 부족. Windows에서는 관리자 권한, Unix에서는 chmod/sudo를 확인하세요.",
+    hint: "권한 부족. macOS/Linux에서는 chmod/sudo, Windows에서는 관리자 권한을 확인하세요.",
   },
   {
     pattern: /EADDRINUSE/i,

--- a/hub/codex-adapter.mjs
+++ b/hub/codex-adapter.mjs
@@ -113,8 +113,10 @@ export function buildExecArgs(opts = {}) {
 
   let result;
   const quotedPrompt = JSON.stringify(prompt);
+  // PowerShell: (Get-Content -Raw '...'), bash: "$(cat '...')"
   if (
-    /^\(Get-Content\b[\s\S]*\)$/u.test(prompt) &&
+    (/^\(Get-Content\b[\s\S]*\)$/u.test(prompt) ||
+      /^"\$\(cat\b[\s\S]*\)"$/u.test(prompt)) &&
     command.endsWith(quotedPrompt)
   ) {
     result = `${command.slice(0, -quotedPrompt.length)}${prompt}`;

--- a/hub/lib/env-detect.mjs
+++ b/hub/lib/env-detect.mjs
@@ -65,7 +65,13 @@ export function detectTerminal() {
     return _terminalCache;
   }
 
-  if (process.env.TERM_PROGRAM === "iTerm.app") {
+  if (process.env.TERM_PROGRAM === "WarpTerminal") {
+    _terminalCache = { name: "warp", hasWt: false };
+  } else if (process.env.TERM_PROGRAM === "Alacritty") {
+    _terminalCache = { name: "alacritty", hasWt: false };
+  } else if (process.env.KITTY_WINDOW_ID) {
+    _terminalCache = { name: "kitty", hasWt: false };
+  } else if (process.env.TERM_PROGRAM === "iTerm.app") {
     _terminalCache = { name: "iterm2", hasWt: false };
   } else if (process.env.TERM_PROGRAM === "Apple_Terminal") {
     _terminalCache = { name: "terminal-app", hasWt: false };

--- a/hub/platform.mjs
+++ b/hub/platform.mjs
@@ -174,16 +174,13 @@ export function killProcess(pid, options = {}) {
       return true;
     }
 
-    // macOS/Linux: tree 옵션이면 프로세스 그룹 kill 시도
+    // macOS/Linux: tree 옵션이면 pkill -P로 자식 프로세스 먼저 종료
     if (tree) {
       try {
-        process.kill(-numericPid, signal); // 프로세스 그룹 kill (negative PID)
-      } catch {
-        process.kill(numericPid, signal); // 그룹 kill 실패 시 단일 PID
-      }
-    } else {
-      process.kill(numericPid, signal);
+        execSync(`pkill -P ${numericPid}`, { stdio: "ignore", timeout: 3000 });
+      } catch { /* 자식 없으면 무시 */ }
     }
+    process.kill(numericPid, signal);
     return true;
   } catch {
     return false;

--- a/hub/platform.mjs
+++ b/hub/platform.mjs
@@ -174,7 +174,16 @@ export function killProcess(pid, options = {}) {
       return true;
     }
 
-    process.kill(numericPid, signal);
+    // macOS/Linux: tree 옵션이면 프로세스 그룹 kill 시도
+    if (tree) {
+      try {
+        process.kill(-numericPid, signal); // 프로세스 그룹 kill (negative PID)
+      } catch {
+        process.kill(numericPid, signal); // 그룹 kill 실패 시 단일 PID
+      }
+    } else {
+      process.kill(numericPid, signal);
+    }
     return true;
   } catch {
     return false;

--- a/hub/team/backend.mjs
+++ b/hub/team/backend.mjs
@@ -4,6 +4,7 @@
 import { createRequire } from "node:module";
 
 import { buildExecArgs } from "../codex-adapter.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 
 const _require = createRequire(import.meta.url);
 
@@ -41,7 +42,10 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    if (IS_WINDOWS) {
+      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    }
+    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
   }
 
   env() {

--- a/hub/team/dashboard-open.mjs
+++ b/hub/team/dashboard-open.mjs
@@ -1,4 +1,5 @@
 import { psmuxExec } from "./psmux.mjs";
+import { detectMultiplexer, tmuxExec } from "./session.mjs";
 import { hasWindowsTerminal } from "./session.mjs";
 import { createWtManager } from "./wt-manager.mjs";
 
@@ -75,6 +76,24 @@ async function spawnWindowsTerminal(spec, opts = {}) {
   }
 }
 
+async function spawnMacTerminal(spec, opts = {}) {
+  const mux = detectMultiplexer();
+  if (mux === "tmux") {
+    try {
+      const title = sanitizeWindowTitle(opts.title);
+      const command = spec.args ? `${spec.command} ${spec.args.join(" ")}` : spec.command;
+      tmuxExec(`new-window -n "${title}" "${command}"`);
+      return true;
+    } catch { return false; }
+  }
+  // tmux 없으면 기본 터미널
+  try {
+    const { exec } = await import("node:child_process");
+    exec(`open -a Terminal`, { timeout: 5000 });
+    return true;
+  } catch { return false; }
+}
+
 export function openHeadlessDashboardTarget(sessionName, opts = {}) {
   const { worker = null, openAll = false, cwd = process.cwd(), title } = opts;
 
@@ -84,19 +103,31 @@ export function openHeadlessDashboardTarget(sessionName, opts = {}) {
   // 선택 워커 → pane focus만 (새 창 열지 않음)
   if (!openAll && workerNumber != null) {
     try {
-      psmuxExec(["select-pane", "-t", `${safeSession}:0.${workerNumber}`]);
+      const mux = detectMultiplexer();
+      if (mux === "psmux") {
+        psmuxExec(["select-pane", "-t", `${safeSession}:0.${workerNumber}`]);
+      } else if (mux === "tmux" || mux === "wsl-tmux" || mux === "git-bash-tmux") {
+        tmuxExec(`select-pane -t ${safeSession}:0.${workerNumber}`);
+      }
     } catch {}
     return true;
   }
 
-  // 전체 열기 (Shift+Enter) → 새 WT 창으로 세션 attach
-  void spawnWindowsTerminal(
-    { command: "psmux", args: ["attach-session", "-t", safeSession] },
-    {
-      mode: decideDashboardOpenMode({ openAll }),
-      title: title || `▲ ${safeSession}`,
-      cwd,
-    },
-  );
+  // 전체 열기 (Shift+Enter) → 새 창으로 세션 attach
+  if (process.platform === "win32") {
+    void spawnWindowsTerminal(
+      { command: "psmux", args: ["attach-session", "-t", safeSession] },
+      {
+        mode: decideDashboardOpenMode({ openAll }),
+        title: title || `▲ ${safeSession}`,
+        cwd,
+      },
+    );
+  } else {
+    void spawnMacTerminal(
+      { command: "tmux", args: ["attach-session", "-t", safeSession] },
+      { title: title || `▲ ${safeSession}`, cwd },
+    );
+  }
   return true;
 }

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -208,8 +208,7 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
   const promptExpr = IS_WINDOWS
     ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
   });

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { requestJson } from "../bridge.mjs";
 import { getMaxSpawnPerSec } from "../lib/spawn-trace.mjs";
 import { escapePwshSingleQuoted } from "../cli-adapter-base.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 import { getBackend } from "./backend.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import {
@@ -204,7 +205,10 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   writeFileSync(promptFile, fullPrompt, "utf8");
 
   const backend = getBackend(resolvedCli);
-  const promptExpr = `(Get-Content -Raw '${promptFile}')`;
+  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
+  const promptExpr = IS_WINDOWS
+    ? `(Get-Content -Raw '${promptFile}')`
+    : `"$(cat '${promptFile}')"`;
   const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
@@ -218,7 +222,11 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   }
   if (!safeCwd) return backendCommand;
 
-  return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  // 플랫폼 분기: PowerShell은 Set-Location, bash/zsh는 cd
+  if (IS_WINDOWS) {
+    return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  }
+  return `cd '${safeCwd.replace(/'/g, "'\\''")}' && ${backendCommand}`;
 }
 
 /**

--- a/hub/team/notify.mjs
+++ b/hub/team/notify.mjs
@@ -209,11 +209,30 @@ function buildToastScript(title, body) {
 async function sendToast(event, config, deps) {
   if (!config.enabled)
     return createResult("toast", "skipped", { reason: "disabled" });
+  const execFileFn = deps.execFile || execFile;
+
+  // macOS: osascript 네이티브 알림
+  if ((deps.platform || process.platform) === "darwin") {
+    const title = formatEventTitle(event);
+    const body = formatEventBody(event);
+    const safeTitle = title.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    const safeBody = body.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    try {
+      await execFileAsync(
+        "osascript",
+        ["-e", `display notification "${safeBody}" with title "${safeTitle}"`],
+        { timeout: config.timeoutMs || 5000 },
+        execFileFn,
+      );
+      return createResult("toast", "sent", { command: "osascript" });
+    } catch (error) {
+      return createResult("toast", "failed", { error: error.message });
+    }
+  }
+
   if ((deps.platform || process.platform) !== "win32") {
     return createResult("toast", "skipped", { reason: "unsupported-platform" });
   }
-
-  const execFileFn = deps.execFile || execFile;
   const candidates = config.command
     ? [config.command]
     : Array.isArray(deps.powerShellCandidates) &&

--- a/hub/team/process-cleanup.mjs
+++ b/hub/team/process-cleanup.mjs
@@ -80,7 +80,7 @@ async function queryWindowsProcesses(execFileFn) {
 async function queryUnixProcesses(execFileFn) {
   const { stdout } = await execFileFn(
     "ps",
-    ["-eo", "pid,ppid,rss,comm,args", "--no-headers"],
+    ["-eo", "pid=,ppid=,rss=,comm=,args="],
     { encoding: "utf8", timeout: 10_000 },
   );
 

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -320,7 +320,9 @@ function parsePaneDetails(output) {
     .filter(Boolean)
     .map((line) => {
       const parts = line.split("\t");
-      const hasPaneIndex = parts.length >= 5;
+      // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
+      // psmux는 항상 5개 필드를 반환
+      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
       const [
         paneIndexText = "",
         title = "",

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -1,7 +1,7 @@
 // hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { formatPsmuxInstallGuidance } from "../../scripts/lib/psmux-info.mjs";
@@ -71,7 +71,10 @@ const PSMUX_TIMEOUT_MS = 10000;
 const COMPLETION_PREFIX = "__TRIFLUX_DONE__:";
 const CAPTURE_ROOT =
   process.env.PSMUX_CAPTURE_ROOT || join(tmpdir(), "psmux-steering");
-const CAPTURE_HELPER_PATH = join(CAPTURE_ROOT, "pipe-pane-capture.ps1");
+const CAPTURE_HELPER_PATH = join(
+  CAPTURE_ROOT,
+  IS_WINDOWS ? "pipe-pane-capture.ps1" : "pipe-pane-capture.sh",
+);
 const POLL_INTERVAL_MS = (() => {
   const ms = Number.parseInt(process.env.PSMUX_POLL_INTERVAL_MS || "", 10);
   if (Number.isFinite(ms) && ms > 0) return ms;
@@ -210,34 +213,44 @@ function getCaptureLogPath(sessionName, paneName) {
 
 function ensureCaptureHelper() {
   mkdirSync(CAPTURE_ROOT, { recursive: true });
-  writeFileSync(
-    CAPTURE_HELPER_PATH,
-    [
-      "param(",
-      "  [Parameter(Mandatory = $true)][string]$Path",
-      ")",
-      "",
-      "$parent = Split-Path -Parent $Path",
-      "if ($parent) {",
-      "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
-      "}",
-      "",
-      "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
-      "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
-      "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
-      "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
-      "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
-      "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
-      "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      "",
-      "$reader = [Console]::In",
-      "while (($line = $reader.ReadLine()) -ne $null) {",
-      "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
+  if (IS_WINDOWS) {
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      [
+        "param(",
+        "  [Parameter(Mandatory = $true)][string]$Path",
+        ")",
+        "",
+        "$parent = Split-Path -Parent $Path",
+        "if ($parent) {",
+        "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
+        "}",
+        "",
+        "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
+        "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
+        "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
+        "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
+        "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
+        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+        "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+        "",
+        "$reader = [Console]::In",
+        "while (($line = $reader.ReadLine()) -ne $null) {",
+        "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  } else {
+    // macOS/Linux: bash 스크립트로 pipe-pane 캡처
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
+      "utf8",
+    );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
+  }
   return CAPTURE_HELPER_PATH;
 }
 
@@ -627,7 +640,17 @@ function collectPanePids(sessionName) {
  * @param {number} pid
  */
 function killProcessTree(pid) {
-  if (!IS_WINDOWS || !pid) return;
+  if (!pid) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
+    try {
+      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 자식 없으면 에러 — 무시 */ }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch { /* 이미 죽었으면 무시 */ }
+    return;
+  }
   try {
     childProcess.execSync(`taskkill /T /F /PID ${pid}`, {
       stdio: "ignore",
@@ -660,7 +683,13 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  * @param {string} sessionName
  */
 function killOrphanPipeHelpers(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
   try {
     const output = childProcess.execSync(
@@ -691,7 +720,13 @@ function killOrphanPipeHelpers(sessionName) {
  * @param {string} sessionName
  */
 function killOrphanMcpProcesses(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
 
   // Hub PID 보호 — Hub 프로세스를 고아로 잘못 식별하지 않도록
@@ -1013,12 +1048,10 @@ export function startCapture(sessionName, paneNameOrTarget) {
   writeFileSync(logPath, "", "utf8");
 
   disablePipeCapture(pane.paneId);
-  psmuxExec([
-    "pipe-pane",
-    "-t",
-    pane.paneId,
-    `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`,
-  ]);
+  const pipePaneCmd = IS_WINDOWS
+    ? `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`
+    : `${quoteArg(helperPath)} ${quoteArg(logPath)}`;
+  psmuxExec(["pipe-pane", "-t", pane.paneId, pipePaneCmd]);
 
   refreshCaptureSnapshot(sessionName, pane.paneId);
   return { paneId: pane.paneId, paneName, logPath };
@@ -1095,10 +1128,17 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
   }
 
   const token = randomToken(paneName);
-  const safeCommand = wrapCliForBash(commandText);
-  // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
-  const chcpPrefix = IS_WINDOWS ? "chcp 65001 > $null; " : "";
-  const wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  const safeCommand = IS_WINDOWS ? wrapCliForBash(commandText) : commandText;
+
+  let wrapped;
+  if (IS_WINDOWS) {
+    // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
+    const chcpPrefix = "chcp 65001 > $null; ";
+    wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  } else {
+    // macOS/Linux: bash 구문으로 완료 토큰 출력
+    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+  }
 
   sendLiteralToPane(pane.paneId, wrapped, true);
 

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -540,11 +540,12 @@ export function createPsmuxSession(sessionName, opts = {}) {
     "55",
   ];
   // Windows: psmux 기본 셸이 cmd.exe일 수 있으므로 PowerShell 강제
-  if (PWSH_BIN) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
+  // macOS/Linux: 기본 셸 사용 (PowerShell 플래그 불필요)
+  if (PWSH_BIN && IS_WINDOWS) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
   const leadPane = psmuxExec(newSessionArgs);
 
-  // split-window로 생성되는 pane도 동일 셸 사용
-  if (PWSH_BIN) {
+  // split-window로 생성되는 pane도 동일 셸 사용 (Windows: PowerShell 강제)
+  if (PWSH_BIN && IS_WINDOWS) {
     try {
       psmuxExec([
         "set-option",

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -11,7 +11,7 @@ import { IS_WINDOWS } from "../platform.mjs";
 
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 찾기
+  // PATH에서 psmux 찾기
   try {
     childProcess.execFileSync("psmux", ["-V"], {
       stdio: "ignore",
@@ -34,14 +34,26 @@ const PSMUX_BIN = (() => {
       if (existsSync(p)) return p;
     }
   }
+  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
+  if (!IS_WINDOWS) {
+    try {
+      childProcess.execFileSync("tmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+      });
+      return "tmux";
+    } catch {
+      /* tmux도 없음 */
+    }
+  }
   return "psmux"; // 최종 fallback — 원래대로
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
+/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return "";
+  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -478,6 +490,11 @@ export function hasPsmux() {
   } catch {
     return false;
   }
+}
+
+/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
+export function isTmuxFallback() {
+  return PSMUX_BIN === "tmux";
 }
 
 /**

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -246,10 +246,9 @@ function ensureCaptureHelper() {
     // macOS/Linux: bash 스크립트로 pipe-pane 캡처
     writeFileSync(
       CAPTURE_HELPER_PATH,
-      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
-      "utf8",
+      ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
     );
-    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -642,13 +641,24 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
-    try {
-      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 자식 없으면 에러 — 무시 */ }
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch { /* 이미 죽었으면 무시 */ }
+    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    const collectChildren = (parentPid) => {
+      try {
+        return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
+          encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+        }).trim().split("\n").filter(Boolean).map(Number);
+      } catch { return []; }
+    };
+    const children = collectChildren(pid);
+    const grandchildren = children.flatMap(collectChildren);
+    const allDesc = [...new Set([...grandchildren, ...children])];
+    // SIGTERM 먼저
+    for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
+    try { process.kill(pid, "SIGTERM"); } catch {}
+    // 1초 대기 후 생존자 SIGKILL
+    try { childProcess.execFileSync("sleep", ["1"], { timeout: 2000, stdio: "ignore" }); } catch {}
+    for (const c of allDesc) { try { process.kill(c, "SIGKILL"); } catch {} }
+    try { process.kill(pid, "SIGKILL"); } catch {}
     return;
   }
   try {
@@ -684,10 +694,18 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  */
 function killOrphanPipeHelpers(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
+    const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          try { process.kill(Number(p), "SIGTERM"); } catch {}
+        }
+      }
+    } catch { /* 프로세스 없으면 pgrep exit 1 — 무시 */ }
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -721,10 +739,28 @@ function killOrphanPipeHelpers(sessionName) {
  */
 function killOrphanMcpProcesses(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    // macOS/Linux: 세션별 스코핑 + Hub PID 보호
+    const safeSessionUnix = sanitizePathPart(sessionName);
+    let hubPidUnix = 0;
     try {
-      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const hubPidFile = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
+      if (existsSync(hubPidFile)) {
+        const info = JSON.parse(readFileSync(hubPidFile, "utf8"));
+        hubPidUnix = Number(info.pid) || 0;
+      }
+    } catch {}
+    try {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          const numPid = Number(p);
+          if (numPid === hubPidUnix || numPid <= 0) continue;
+          try { process.kill(numPid, "SIGTERM"); } catch {}
+        }
+      }
+    } catch {}
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -1137,7 +1173,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -323,7 +323,8 @@ function parsePaneDetails(output) {
       const parts = line.split("\t");
       // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
       // psmux는 항상 5개 필드를 반환
-      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
+      // paneId 패턴(session:N.N)이 parts[2]에 있으면 pane_index 포함 형식
+      const hasPaneIndex = parts.length >= 4 && /\S+:\d+\.\d+$/.test(parts[2]);
       const [
         paneIndexText = "",
         title = "",
@@ -609,7 +610,11 @@ export function createPsmuxSession(sessionName, opts = {}) {
 
   const panes = collectSessionPanes(sessionName).slice(0, limitedPaneCount);
   panes.forEach((pane, index) => {
-    psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    try {
+      psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — pane title 없이 계속 진행
+    }
   });
 
   // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout 깨짐 방지:
@@ -662,7 +667,7 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    // macOS/Linux: BFS로 전체 자손 수집 → SIGTERM → SIGKILL 에스컬레이션
     const collectChildren = (parentPid) => {
       try {
         return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
@@ -670,9 +675,19 @@ function killProcessTree(pid) {
         }).trim().split("\n").filter(Boolean).map(Number);
       } catch { return []; }
     };
-    const children = collectChildren(pid);
-    const grandchildren = children.flatMap(collectChildren);
-    const allDesc = [...new Set([...grandchildren, ...children])];
+    const allDesc = [];
+    const queue = [pid];
+    const seen = new Set([pid]);
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      for (const child of collectChildren(cur)) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          allDesc.push(child);
+          queue.push(child);
+        }
+      }
+    }
     // SIGTERM 먼저
     for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
     try { process.kill(pid, "SIGTERM"); } catch {}
@@ -718,7 +733,7 @@ function killOrphanPipeHelpers(sessionName) {
     // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
     const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -771,7 +786,7 @@ function killOrphanMcpProcesses(sessionName) {
       }
     } catch {}
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -1467,7 +1482,11 @@ export function spawnWorker(sessionName, workerName, cmd) {
       "#{session_name}:#{window_index}.#{pane_index}",
       shellCmd,
     ]);
-    psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    try {
+      psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — 무시
+    }
     return { paneId: paneTarget, workerName };
   } catch (err) {
     throw new Error(

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -51,9 +51,9 @@ const PSMUX_BIN = (() => {
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
+/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
+  if (!IS_WINDOWS) return "";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -259,8 +259,9 @@ function ensureCaptureHelper() {
     writeFileSync(
       CAPTURE_HELPER_PATH,
       ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
-      { encoding: "utf8", mode: 0o755 },
+      "utf8",
     );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -1193,7 +1194,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `{ ${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; }`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);

--- a/hub/team/runtime-strategy.mjs
+++ b/hub/team/runtime-strategy.mjs
@@ -3,6 +3,11 @@ import {
   killPsmuxSession,
   psmuxSessionExists,
 } from "./psmux.mjs";
+import {
+  tmuxExec,
+  listSessions,
+  killSession as killTmuxSession,
+} from "./session.mjs";
 
 /**
  * @typedef {object} RuntimeStatus
@@ -55,6 +60,67 @@ export function createPsmuxRuntime(adapter = defaultPsmuxAdapter) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// tmux 어댑터
+// ---------------------------------------------------------------------------
+
+function tmuxSessionExists(sessionName) {
+  try {
+    tmuxExec(`has-session -t ${sessionName}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createTmuxSession(sessionName, opts = {}) {
+  tmuxExec(`new-session -d -s ${sessionName} -x 220 -y 55`);
+}
+
+function killTmuxSessionByName(sessionName) {
+  try {
+    tmuxExec(`kill-session -t ${sessionName}`);
+  } catch {
+    // 이미 종료된 세션 — 무시
+  }
+}
+
+const defaultTmuxAdapter = {
+  createSession: createTmuxSession,
+  killSession: killTmuxSessionByName,
+  hasSession: tmuxSessionExists,
+};
+
+/**
+ * @param {{
+ *   createSession: typeof createTmuxSession,
+ *   killSession: typeof killTmuxSessionByName,
+ *   hasSession: typeof tmuxSessionExists,
+ * }} [adapter]
+ * @returns {TeamRuntime & { name: "tmux" }}
+ */
+export function createTmuxRuntime(adapter = defaultTmuxAdapter) {
+  return {
+    name: "tmux",
+    start(sessionName, opts = {}) {
+      return adapter.createSession(sessionName, opts);
+    },
+    stop(sessionName) {
+      adapter.killSession(sessionName);
+    },
+    isAlive(sessionName) {
+      return adapter.hasSession(sessionName);
+    },
+    getStatus(sessionName) {
+      return {
+        name: "tmux",
+        sessionName,
+        alive: adapter.hasSession(sessionName),
+      };
+    },
+  };
+}
+
 /**
  * @param {string} mode
  * @returns {TeamRuntime & { name: string }}
@@ -66,6 +132,10 @@ export function createRuntime(mode) {
 
   if (normalizedMode === "psmux") {
     return createPsmuxRuntime();
+  }
+
+  if (normalizedMode === "tmux") {
+    return createTmuxRuntime();
   }
 
   if (normalizedMode === "native" || normalizedMode === "wt") {

--- a/packages/core/hub/codex-adapter.mjs
+++ b/packages/core/hub/codex-adapter.mjs
@@ -113,8 +113,10 @@ export function buildExecArgs(opts = {}) {
 
   let result;
   const quotedPrompt = JSON.stringify(prompt);
+  // PowerShell: (Get-Content -Raw '...'), bash: "$(cat '...')"
   if (
-    /^\(Get-Content\b[\s\S]*\)$/u.test(prompt) &&
+    (/^\(Get-Content\b[\s\S]*\)$/u.test(prompt) ||
+      /^"\$\(cat\b[\s\S]*\)"$/u.test(prompt)) &&
     command.endsWith(quotedPrompt)
   ) {
     result = `${command.slice(0, -quotedPrompt.length)}${prompt}`;

--- a/packages/remote/hub/team/backend.mjs
+++ b/packages/remote/hub/team/backend.mjs
@@ -4,6 +4,7 @@
 import { createRequire } from "node:module";
 
 import { buildExecArgs } from "@triflux/core/hub/codex-adapter.mjs";
+import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 
 const _require = createRequire(import.meta.url);
 
@@ -41,7 +42,10 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    if (IS_WINDOWS) {
+      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    }
+    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
   }
 
   env() {

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -5,7 +5,6 @@
 // 의존성: psmux.mjs (Node.js 내장 모듈만 사용)
 
 import { execSync } from "node:child_process";
-import { spawn } from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { randomUUID } from "node:crypto";
 import {
   existsSync,
@@ -18,12 +17,17 @@ import {
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { requestJson } from "@triflux/core/hub/bridge.mjs";
-import { escapePwshSingleQuoted } from "@triflux/core/hub/cli-adapter-base.mjs";
-import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
+import { requestJson } from "../bridge.mjs";
+import { getMaxSpawnPerSec } from "../lib/spawn-trace.mjs";
+import { escapePwshSingleQuoted } from "../cli-adapter-base.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 import { getBackend } from "./backend.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
-import { HANDOFF_INSTRUCTION_SHORT, processHandoff } from "./handoff.mjs";
+import {
+  formatHandoffForLead,
+  HANDOFF_INSTRUCTION_SHORT,
+  processHandoff,
+} from "./handoff.mjs";
 import {
   capturePsmuxPane,
   createPsmuxSession,
@@ -34,6 +38,11 @@ import {
   startCapture,
   waitForCompletion,
 } from "./psmux.mjs";
+import {
+  buildSynapseTaskSummary,
+  registerSynapseSession,
+  unregisterSynapseSession,
+} from "./synapse-http.mjs";
 import { createLogDashboard } from "./tui.mjs";
 import { createWtManager } from "./wt-manager.mjs";
 
@@ -120,6 +129,18 @@ export async function deregisterHeadlessWorkers(
   );
 }
 
+function registerHeadlessSynapseWorker(workerId, prompt) {
+  registerSynapseSession({
+    sessionId: workerId,
+    host: "local",
+    taskSummary: buildSynapseTaskSummary(prompt),
+  });
+}
+
+function unregisterHeadlessSynapseWorker(workerId) {
+  unregisterSynapseSession(workerId);
+}
+
 /** MCP 프로필별 프롬프트 힌트 (tfx-route.sh resolve_mcp_policy의 경량 미러) */
 const MCP_PROFILE_HINTS = {
   implement:
@@ -141,6 +162,16 @@ const MCP_PROFILE_HINTS = {
  * @param {string} [opts.contextFile] — 컨텍스트 파일 경로 (최대 32KB, UTF-8 안전 절단)
  * @returns {string} PowerShell 명령
  */
+// ── Dashboard attach args for WT ────────────────────────────────
+
+export function buildDashboardAttachArgs(sessionName, layout, workerCount, anchor = "window") {
+  const safeName = String(sessionName).replace(/[^a-zA-Z0-9_-]/g, "");
+  const base = anchor === "tab"
+    ? ["-w", "0", "nt"]
+    : ["-w", "new"];
+  return [...base, "--session", safeName, "--layout", layout, "--workers", String(workerCount)];
+}
+
 export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   const { handoff = true, mcp, contextFile, model, cwd } = opts;
   const resolvedCli = resolveCliType(cli);
@@ -177,8 +208,7 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
   const promptExpr = IS_WINDOWS
     ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
   });
@@ -308,7 +338,7 @@ export function createStallMonitor(paneId, resultFile, config, deps = {}) {
  * @param {string} [opts.command] — re-dispatch용 원본 명령
  * @param {string} [opts.token] — completion token
  * @param {(snapshot: string) => void} [opts.onPoll] — 폴링 콜백
- * @returns {Promise<{ matched: boolean, exitCode: number|null, restarts: number, stallDetected: boolean }>}
+ * @returns {Promise<{ matched: boolean, exitCode: number|null, restarts: number, stallDetected: boolean, paneId: string, token?: string, logPath?: string|null }>}
  */
 export async function waitForCompletionWithStallDetect(
   sessionName,
@@ -338,19 +368,23 @@ export async function waitForCompletionWithStallDetect(
   const _startCapture = deps.startCapture || startCapture;
 
   const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const completionPatterns = [
-    token
-      ? `${esc("__TRIFLUX_DONE__:")}${esc(token)}:(\\d+)`
-      : `${esc("__TRIFLUX_DONE__:")}\\S+:(\\d+)`,
-    token
-      ? `${esc("TFX_DONE_")}${esc(token)}:(\\d+)`
-      : `${esc("TFX_DONE_")}\\S+:(\\d+)`,
-  ];
-  const completionRe = new RegExp(completionPatterns.join("|"), "m");
+  const buildCompletionRegex = (activeToken) => {
+    const completionPatterns = [
+      activeToken
+        ? `${esc("__TRIFLUX_DONE__:")}${esc(activeToken)}:(\\d+)`
+        : `${esc("__TRIFLUX_DONE__:")}\\S+:(\\d+)`,
+      activeToken
+        ? `${esc("TFX_DONE_")}${esc(activeToken)}:(\\d+)`
+        : `${esc("TFX_DONE_")}\\S+:(\\d+)`,
+    ];
+    return new RegExp(completionPatterns.join("|"), "m");
+  };
 
   let restarts = 0;
   let currentPaneId = paneId;
   let stallDetected = false;
+  let currentToken = token;
+  let currentLogPath = opts.logPath || null;
 
   while (true) {
     let lastOutput = "";
@@ -377,6 +411,9 @@ export async function waitForCompletionWithStallDetect(
           restarts,
           stallDetected,
           timedOut: true,
+          paneId: currentPaneId,
+          token: currentToken,
+          logPath: currentLogPath,
         };
       }
 
@@ -391,6 +428,7 @@ export async function waitForCompletionWithStallDetect(
       }
 
       // 2) completion 토큰 감지
+      const completionRe = buildCompletionRegex(currentToken);
       const completionMatch = completionRe.exec(currentOutput);
       if (completionMatch) {
         return {
@@ -402,6 +440,9 @@ export async function waitForCompletionWithStallDetect(
           restarts,
           stallDetected,
           timedOut: false,
+          paneId: currentPaneId,
+          token: currentToken,
+          logPath: currentLogPath,
         };
       }
 
@@ -434,6 +475,9 @@ export async function waitForCompletionWithStallDetect(
               restarts,
               stallDetected,
               timedOut: false,
+              paneId: currentPaneId,
+              token: currentToken,
+              logPath: currentLogPath,
             };
           }
         } catch {
@@ -472,8 +516,10 @@ export async function waitForCompletionWithStallDetect(
             "#{session_name}:#{window_index}.#{pane_index}",
           ]);
           _startCapture(sessionName, newPaneId);
-          _dispatch(sessionName, newPaneId, command);
-          currentPaneId = newPaneId;
+          const redispatch = _dispatch(sessionName, newPaneId, command);
+          currentPaneId = redispatch?.paneId || newPaneId;
+          if (redispatch?.token) currentToken = redispatch.token;
+          if (redispatch?.logPath) currentLogPath = redispatch.logPath;
         }
 
         restarts++;
@@ -556,12 +602,17 @@ async function dispatchProgressive(sessionName, assignments, opts = {}) {
       assignment.cli,
       assignment.prompt,
       resultFile,
-      { mcp: assignment.mcp, model: assignment.model },
+      {
+        mcp: assignment.mcp,
+        model: assignment.model,
+        cwd: assignment.cwd || assignment.workdir,
+      },
     );
     startCapture(sessionName, newPaneId);
     // pane 간 pipe-pane EBUSY 방지 — 이벤트 루프 해방하며 순차 대기
     if (i > 0) await new Promise((r) => setTimeout(r, 300));
     const dispatch = dispatchCommand(sessionName, newPaneId, cmd);
+    registerHeadlessSynapseWorker(workerId, assignment.prompt);
 
     if (safeProgress)
       safeProgress({ type: "dispatched", paneName, cli: assignment.cli });
@@ -575,6 +626,7 @@ async function dispatchProgressive(sessionName, assignments, opts = {}) {
       role: assignment.role,
       command: cmd,
       workerId,
+      cwd: assignment.cwd || assignment.workdir,
     });
   }
 
@@ -626,7 +678,11 @@ async function dispatchBatch(sessionName, assignments, opts = {}) {
         assignment.cli,
         assignment.prompt,
         resultFile,
-        { mcp: assignment.mcp, model: assignment.model },
+        {
+          mcp: assignment.mcp,
+          model: assignment.model,
+          cwd: assignment.cwd || assignment.workdir,
+        },
       );
       const scriptDir = join(RESULT_DIR, sessionName);
       await registerHeadlessWorker(sessionName, i, assignment.cli);
@@ -634,6 +690,7 @@ async function dispatchBatch(sessionName, assignments, opts = {}) {
         scriptDir,
         scriptName: paneName,
       });
+      registerHeadlessSynapseWorker(workerId, assignment.prompt);
 
       // P1 fix: 비-progressive에서는 pane 리네임 금지 — 캡처 로그 경로가 타이틀 기반이므로
       // 리네임하면 waitForCompletion이 "codex (role).log"를 찾지만 실제는 "worker-N.log"로 불일치
@@ -650,6 +707,7 @@ async function dispatchBatch(sessionName, assignments, opts = {}) {
         role: assignment.role,
         command: cmd,
         workerId,
+        cwd: assignment.cwd || assignment.workdir,
       };
     }),
   );
@@ -729,6 +787,9 @@ async function awaitAll(
               onPoll: stallPollCb,
             },
           );
+          if (stallResult.paneId) d.paneId = stallResult.paneId;
+          if (stallResult.token) d.token = stallResult.token;
+          if (stallResult.logPath) d.logPath = stallResult.logPath;
           completion = {
             matched: stallResult.matched,
             exitCode: stallResult.exitCode,
@@ -762,6 +823,7 @@ async function awaitAll(
       const output = completion.matched
         ? readResult(d.resultFile, d.paneId)
         : "";
+      unregisterHeadlessSynapseWorker(d.workerId);
 
       if (safeProgress) {
         safeProgress({
@@ -787,28 +849,27 @@ async function awaitAll(
  * @returns {Array}
  */
 async function collectResults(sessionName, results) {
-  // B3 fix: git diff를 루프 밖에서 1회만 실행 (워커 수만큼 중복 방지)
-  let gitDiffFiles;
-  try {
-    const diffOut = execSync("git diff --name-only HEAD", {
-      encoding: "utf8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    gitDiffFiles = diffOut.trim().split("\n").filter(Boolean);
-  } catch {
-    /* git 미설치 또는 non-repo — 무시 */
-  }
-
   // handoff 파이프라인: parse → validate → format (각 워커 결과에 적용)
   return await Promise.all(
     results.map(async ({ d, completion, output }) => {
+      const workerGitDiffFiles = collectGitDiffFiles(d.cwd);
       const handoffResult = processHandoff(output, {
         exitCode: completion.exitCode,
         resultFile: d.resultFile,
         cli: d.cli,
-        gitDiffFiles,
+        gitDiffFiles: workerGitDiffFiles,
       });
+      if (
+        completion.exitCode === 0 &&
+        workerGitDiffFiles.length === 0 &&
+        handoffResult.handoff?.lead_action === "accept"
+      ) {
+        handoffResult.handoff = {
+          ...handoffResult.handoff,
+          lead_action: "needs_read",
+        };
+        handoffResult.formatted = formatHandoffForLead(handoffResult.handoff);
+      }
       const status =
         handoffResult.handoff?.status ||
         (completion.matched && completion.exitCode === 0
@@ -831,6 +892,7 @@ async function collectResults(sessionName, results) {
         exitCode: completion.exitCode,
         output,
         resultFile: d.resultFile,
+        workerGitDiffFiles,
         sessionDead: completion.sessionDead || false,
         handoff: handoffResult.handoff,
         handoffFormatted: handoffResult.formatted,
@@ -839,6 +901,20 @@ async function collectResults(sessionName, results) {
       };
     }),
   );
+}
+
+function collectGitDiffFiles(cwd) {
+  try {
+    const diffOut = execSync("git diff --name-only HEAD", {
+      cwd,
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return diffOut.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -868,6 +944,35 @@ export async function runHeadless(sessionName, assignments, opts = {}) {
   } = opts;
 
   mkdirSync(RESULT_DIR, { recursive: true });
+
+  // Hub version skew pre-flight (fail-open, best-effort)
+  requestJson("/status", { method: "GET", timeoutMs: 500 })
+    .then((status) => {
+      const hubRate = status?.spawn_trace?.max_per_sec;
+      const localRate = getMaxSpawnPerSec();
+      if (typeof hubRate === "number" && hubRate !== localRate) {
+        console.warn(
+          `[headless] Hub version skew detected: hub spawn rate=${hubRate}/s, local=${localRate}/s. Restart hub to sync.`,
+        );
+      }
+    })
+    .catch(() => {});
+
+  // Synapse: 세션 registration (fire-and-forget, hub 미응답 시 무시)
+  const synapseIds = assignments.map((_, i) => `${sessionName}-worker-${i + 1}`);
+  for (let i = 0; i < assignments.length; i++) {
+    const a = assignments[i];
+    requestJson("/synapse/register", {
+      method: "POST",
+      body: {
+        sessionId: synapseIds[i],
+        host: "local",
+        taskSummary: String(a.prompt || "").slice(0, 100),
+        isRemote: false,
+      },
+      timeoutMs: 1000,
+    }).catch(() => {});
+  }
 
   // in-process TUI: dashboard=true이고 stdout이 TTY일 때 직접 구동
   let tui = null;
@@ -926,9 +1031,25 @@ export async function runHeadless(sessionName, assignments, opts = {}) {
     }
   }
 
+  // Synapse heartbeat: progress 이벤트마다 해당 워커의 세션 갱신
+  const feedSynapse = (event) => {
+    if (!event?.paneName) return;
+    const match = event.paneName.match(/worker-(\d+)/);
+    if (!match) return;
+    const idx = parseInt(match[1], 10) - 1;
+    const sid = synapseIds[idx];
+    if (!sid) return;
+    requestJson("/synapse/heartbeat", {
+      method: "POST",
+      body: { sessionId: sid, partial: { taskSummary: (event.snapshot || "").slice(0, 100) } },
+      timeoutMs: 500,
+    }).catch(() => {});
+  };
+
   // onProgress 예외를 삼켜 실행 흐름 보호 (onPoll과 동일 패턴)
   const combinedProgress = (event) => {
     feedTui(event);
+    feedSynapse(event);
     if (onProgress) {
       try {
         onProgress(event);
@@ -989,6 +1110,15 @@ export async function runHeadless(sessionName, assignments, opts = {}) {
     tui.close();
   }
 
+  // Synapse: 세션 unregister (fire-and-forget)
+  for (const sid of synapseIds) {
+    requestJson("/synapse/unregister", {
+      method: "POST",
+      body: { sessionId: sid },
+      timeoutMs: 1000,
+    }).catch(() => {});
+  }
+
   return { sessionName, results: collected };
 }
 
@@ -1007,6 +1137,11 @@ export async function runHeadlessWithCleanup(assignments, opts = {}) {
   try {
     return await runHeadless(sessionName, assignments, runOpts);
   } finally {
+    for (let index = 0; index < assignments.length; index++) {
+      unregisterHeadlessSynapseWorker(
+        getHeadlessWorkerAgentId(sessionName, index),
+      );
+    }
     await deregisterHeadlessWorkers(sessionName, assignments.length);
     try {
       killPsmuxSession(sessionName);
@@ -1064,7 +1199,7 @@ export function applyTrifluxTheme(sessionName) {
  * WT 기본 프로필의 폰트 크기를 읽는다.
  * @returns {number} 기본 폰트 크기 (못 읽으면 12)
  */
-function getWtDefaultFontSize() {
+function _getWtDefaultFontSize() {
   const settingsPaths = [
     join(
       process.env.LOCALAPPDATA || "",
@@ -1104,7 +1239,7 @@ function getWtDefaultFontSize() {
  * @param {string} filePath — 대상 파일 경로
  * @param {string} data — 쓸 내용
  */
-function atomicWriteSync(filePath, data) {
+function _atomicWriteSync(filePath, data) {
   const tmpPath = `${filePath}.${process.pid}.tmp`;
   try {
     writeFileSync(tmpPath, data, "utf8");
@@ -1139,7 +1274,11 @@ function buildAttachTitle(sessionName, suffix = "") {
  * @param {number} [workerCount=2]
  * @returns {Promise<boolean>} 성공 여부
  */
-export async function autoAttachTerminal(sessionName, opts = {}, workerCount = 2) {
+export async function autoAttachTerminal(
+  sessionName,
+  opts = {},
+  workerCount = 2,
+) {
   if (!process.env.WT_SESSION) return false;
   try {
     execSync("where wt.exe", { stdio: "ignore" });
@@ -1153,8 +1292,14 @@ export async function autoAttachTerminal(sessionName, opts = {}, workerCount = 2
   try {
     const safeSession = sanitizeSessionName(sessionName);
     if (workerCount >= 5) {
-      const resolvedLayout = resolveDashboardLayout(opts.dashboardLayout || "single", workerCount);
-      const viewerPath = join(import.meta.dirname, "tui-viewer.mjs").replace(/\\/g, "/");
+      const resolvedLayout = resolveDashboardLayout(
+        opts.dashboardLayout || "single",
+        workerCount,
+      );
+      const viewerPath = join(import.meta.dirname, "tui-viewer.mjs").replace(
+        /\\/g,
+        "/",
+      );
       await wt.createTab({
         title: buildAttachTitle(safeSession, "dashboard"),
         profile: "triflux",
@@ -1228,7 +1373,10 @@ export async function attachDashboardTab(
   try {
     const safeSession = sanitizeSessionName(sessionName);
     const resolvedLayout = resolveDashboardLayout(dashboardLayout, workerCount);
-    const viewerPath = join(import.meta.dirname, "tui-viewer.mjs").replace(/\\/g, "/");
+    const viewerPath = join(import.meta.dirname, "tui-viewer.mjs").replace(
+      /\\/g,
+      "/",
+    );
 
     await wt.createTab({
       title: buildAttachTitle(safeSession, "dashboard"),
@@ -1240,7 +1388,6 @@ export async function attachDashboardTab(
     return false;
   }
 }
-
 
 /**
  * 모든 워커 pane의 현재 스냅샷을 수집한다.
@@ -1423,6 +1570,11 @@ export async function runHeadlessInteractive(
     kill() {
       if (this._killed) return;
       this._killed = true;
+      for (let index = 0; index < assignments.length; index++) {
+        unregisterHeadlessSynapseWorker(
+          getHeadlessWorkerAgentId(sessionName, index),
+        );
+      }
       void deregisterHeadlessWorkers(sessionName, assignments.length);
       try {
         killPsmuxSession(sessionName);

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { requestJson } from "@triflux/core/hub/bridge.mjs";
 import { escapePwshSingleQuoted } from "@triflux/core/hub/cli-adapter-base.mjs";
+import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 import { getBackend } from "./backend.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import { HANDOFF_INSTRUCTION_SHORT, processHandoff } from "./handoff.mjs";
@@ -173,7 +174,10 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   writeFileSync(promptFile, fullPrompt, "utf8");
 
   const backend = getBackend(resolvedCli);
-  const promptExpr = `(Get-Content -Raw '${promptFile}')`;
+  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
+  const promptExpr = IS_WINDOWS
+    ? `(Get-Content -Raw '${promptFile}')`
+    : `"$(cat '${promptFile}')"`;
   const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
@@ -187,7 +191,11 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   }
   if (!safeCwd) return backendCommand;
 
-  return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  // 플랫폼 분기: PowerShell은 Set-Location, bash/zsh는 cd
+  if (IS_WINDOWS) {
+    return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  }
+  return `cd '${safeCwd.replace(/'/g, "'\\''")}' && ${backendCommand}`;
 }
 
 /**

--- a/packages/remote/hub/team/notify.mjs
+++ b/packages/remote/hub/team/notify.mjs
@@ -209,11 +209,30 @@ function buildToastScript(title, body) {
 async function sendToast(event, config, deps) {
   if (!config.enabled)
     return createResult("toast", "skipped", { reason: "disabled" });
+  const execFileFn = deps.execFile || execFile;
+
+  // macOS: osascript 네이티브 알림
+  if ((deps.platform || process.platform) === "darwin") {
+    const title = formatEventTitle(event);
+    const body = formatEventBody(event);
+    const safeTitle = title.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    const safeBody = body.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    try {
+      await execFileAsync(
+        "osascript",
+        ["-e", `display notification "${safeBody}" with title "${safeTitle}"`],
+        { timeout: config.timeoutMs || 5000 },
+        execFileFn,
+      );
+      return createResult("toast", "sent", { command: "osascript" });
+    } catch (error) {
+      return createResult("toast", "failed", { error: error.message });
+    }
+  }
+
   if ((deps.platform || process.platform) !== "win32") {
     return createResult("toast", "skipped", { reason: "unsupported-platform" });
   }
-
-  const execFileFn = deps.execFile || execFile;
   const candidates = config.command
     ? [config.command]
     : Array.isArray(deps.powerShellCandidates) &&

--- a/packages/remote/hub/team/process-cleanup.mjs
+++ b/packages/remote/hub/team/process-cleanup.mjs
@@ -58,7 +58,7 @@ async function queryWindowsProcesses(execFileFn) {
 async function queryUnixProcesses(execFileFn) {
   const { stdout } = await execFileFn(
     "ps",
-    ["-eo", "pid,ppid,rss,comm,args", "--no-headers"],
+    ["-eo", "pid=,ppid=,rss=,comm=,args="],
     { encoding: "utf8", timeout: 10_000 },
   );
 

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -320,7 +320,9 @@ function parsePaneDetails(output) {
     .filter(Boolean)
     .map((line) => {
       const parts = line.split("\t");
-      const hasPaneIndex = parts.length >= 5;
+      // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
+      // psmux는 항상 5개 필드를 반환
+      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
       const [
         paneIndexText = "",
         title = "",

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -4,10 +4,10 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import childProcess from "@triflux/core/hub/lib/spawn-trace.mjs";
-import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 import { formatPsmuxInstallGuidance } from "../../scripts/lib/psmux-info.mjs";
 import { resolveGitBashExecutable } from "../lib/bash-path.mjs";
+import childProcess from "../lib/spawn-trace.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
@@ -246,10 +246,9 @@ function ensureCaptureHelper() {
     // macOS/Linux: bash 스크립트로 pipe-pane 캡처
     writeFileSync(
       CAPTURE_HELPER_PATH,
-      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
-      "utf8",
+      ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
     );
-    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -642,13 +641,24 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
-    try {
-      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 자식 없으면 에러 — 무시 */ }
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch { /* 이미 죽었으면 무시 */ }
+    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    const collectChildren = (parentPid) => {
+      try {
+        return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
+          encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+        }).trim().split("\n").filter(Boolean).map(Number);
+      } catch { return []; }
+    };
+    const children = collectChildren(pid);
+    const grandchildren = children.flatMap(collectChildren);
+    const allDesc = [...new Set([...grandchildren, ...children])];
+    // SIGTERM 먼저
+    for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
+    try { process.kill(pid, "SIGTERM"); } catch {}
+    // 1초 대기 후 생존자 SIGKILL
+    try { childProcess.execFileSync("sleep", ["1"], { timeout: 2000, stdio: "ignore" }); } catch {}
+    for (const c of allDesc) { try { process.kill(c, "SIGKILL"); } catch {} }
+    try { process.kill(pid, "SIGKILL"); } catch {}
     return;
   }
   try {
@@ -684,10 +694,18 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  */
 function killOrphanPipeHelpers(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
+    const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          try { process.kill(Number(p), "SIGTERM"); } catch {}
+        }
+      }
+    } catch { /* 프로세스 없으면 pgrep exit 1 — 무시 */ }
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -721,10 +739,28 @@ function killOrphanPipeHelpers(sessionName) {
  */
 function killOrphanMcpProcesses(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    // macOS/Linux: 세션별 스코핑 + Hub PID 보호
+    const safeSessionUnix = sanitizePathPart(sessionName);
+    let hubPidUnix = 0;
     try {
-      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const hubPidFile = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
+      if (existsSync(hubPidFile)) {
+        const info = JSON.parse(readFileSync(hubPidFile, "utf8"));
+        hubPidUnix = Number(info.pid) || 0;
+      }
+    } catch {}
+    try {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          const numPid = Number(p);
+          if (numPid === hubPidUnix || numPid <= 0) continue;
+          try { process.kill(numPid, "SIGTERM"); } catch {}
+        }
+      }
+    } catch {}
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -1137,7 +1173,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);
@@ -1305,6 +1341,7 @@ export async function waitForPattern(
 
 /**
  * 완료 토큰이 찍힐 때까지 대기하고 exit code를 파싱한다.
+ * NOTE: 주 채널은 headless.waitForCompletionWithStallDetect이며, 본 함수는 fallback 채널이다.
  * @param {string} sessionName
  * @param {string} paneNameOrTarget
  * @param {string} token

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -1,7 +1,7 @@
 // hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import childProcess from "@triflux/core/hub/lib/spawn-trace.mjs";
@@ -71,7 +71,10 @@ const PSMUX_TIMEOUT_MS = 10000;
 const COMPLETION_PREFIX = "__TRIFLUX_DONE__:";
 const CAPTURE_ROOT =
   process.env.PSMUX_CAPTURE_ROOT || join(tmpdir(), "psmux-steering");
-const CAPTURE_HELPER_PATH = join(CAPTURE_ROOT, "pipe-pane-capture.ps1");
+const CAPTURE_HELPER_PATH = join(
+  CAPTURE_ROOT,
+  IS_WINDOWS ? "pipe-pane-capture.ps1" : "pipe-pane-capture.sh",
+);
 const POLL_INTERVAL_MS = (() => {
   const ms = Number.parseInt(process.env.PSMUX_POLL_INTERVAL_MS || "", 10);
   if (Number.isFinite(ms) && ms > 0) return ms;
@@ -210,34 +213,44 @@ function getCaptureLogPath(sessionName, paneName) {
 
 function ensureCaptureHelper() {
   mkdirSync(CAPTURE_ROOT, { recursive: true });
-  writeFileSync(
-    CAPTURE_HELPER_PATH,
-    [
-      "param(",
-      "  [Parameter(Mandatory = $true)][string]$Path",
-      ")",
-      "",
-      "$parent = Split-Path -Parent $Path",
-      "if ($parent) {",
-      "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
-      "}",
-      "",
-      "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
-      "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
-      "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
-      "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
-      "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
-      "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
-      "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      "",
-      "$reader = [Console]::In",
-      "while (($line = $reader.ReadLine()) -ne $null) {",
-      "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
+  if (IS_WINDOWS) {
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      [
+        "param(",
+        "  [Parameter(Mandatory = $true)][string]$Path",
+        ")",
+        "",
+        "$parent = Split-Path -Parent $Path",
+        "if ($parent) {",
+        "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
+        "}",
+        "",
+        "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
+        "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
+        "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
+        "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
+        "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
+        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+        "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+        "",
+        "$reader = [Console]::In",
+        "while (($line = $reader.ReadLine()) -ne $null) {",
+        "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  } else {
+    // macOS/Linux: bash 스크립트로 pipe-pane 캡처
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
+      "utf8",
+    );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
+  }
   return CAPTURE_HELPER_PATH;
 }
 
@@ -627,7 +640,17 @@ function collectPanePids(sessionName) {
  * @param {number} pid
  */
 function killProcessTree(pid) {
-  if (!IS_WINDOWS || !pid) return;
+  if (!pid) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
+    try {
+      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 자식 없으면 에러 — 무시 */ }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch { /* 이미 죽었으면 무시 */ }
+    return;
+  }
   try {
     childProcess.execSync(`taskkill /T /F /PID ${pid}`, {
       stdio: "ignore",
@@ -660,7 +683,13 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  * @param {string} sessionName
  */
 function killOrphanPipeHelpers(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
   try {
     const output = childProcess.execSync(
@@ -691,7 +720,13 @@ function killOrphanPipeHelpers(sessionName) {
  * @param {string} sessionName
  */
 function killOrphanMcpProcesses(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
 
   // Hub PID 보호 — Hub 프로세스를 고아로 잘못 식별하지 않도록
@@ -1013,12 +1048,10 @@ export function startCapture(sessionName, paneNameOrTarget) {
   writeFileSync(logPath, "", "utf8");
 
   disablePipeCapture(pane.paneId);
-  psmuxExec([
-    "pipe-pane",
-    "-t",
-    pane.paneId,
-    `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`,
-  ]);
+  const pipePaneCmd = IS_WINDOWS
+    ? `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`
+    : `${quoteArg(helperPath)} ${quoteArg(logPath)}`;
+  psmuxExec(["pipe-pane", "-t", pane.paneId, pipePaneCmd]);
 
   refreshCaptureSnapshot(sessionName, pane.paneId);
   return { paneId: pane.paneId, paneName, logPath };
@@ -1095,10 +1128,17 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
   }
 
   const token = randomToken(paneName);
-  const safeCommand = wrapCliForBash(commandText);
-  // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
-  const chcpPrefix = IS_WINDOWS ? "chcp 65001 > $null; " : "";
-  const wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  const safeCommand = IS_WINDOWS ? wrapCliForBash(commandText) : commandText;
+
+  let wrapped;
+  if (IS_WINDOWS) {
+    // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
+    const chcpPrefix = "chcp 65001 > $null; ";
+    wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  } else {
+    // macOS/Linux: bash 구문으로 완료 토큰 출력
+    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+  }
 
   sendLiteralToPane(pane.paneId, wrapped, true);
 

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -540,11 +540,12 @@ export function createPsmuxSession(sessionName, opts = {}) {
     "55",
   ];
   // Windows: psmux 기본 셸이 cmd.exe일 수 있으므로 PowerShell 강제
-  if (PWSH_BIN) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
+  // macOS/Linux: 기본 셸 사용 (PowerShell 플래그 불필요)
+  if (PWSH_BIN && IS_WINDOWS) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
   const leadPane = psmuxExec(newSessionArgs);
 
-  // split-window로 생성되는 pane도 동일 셸 사용
-  if (PWSH_BIN) {
+  // split-window로 생성되는 pane도 동일 셸 사용 (Windows: PowerShell 강제)
+  if (PWSH_BIN && IS_WINDOWS) {
     try {
       psmuxExec([
         "set-option",

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -11,7 +11,7 @@ import { IS_WINDOWS } from "../platform.mjs";
 
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 찾기
+  // PATH에서 psmux 찾기
   try {
     childProcess.execFileSync("psmux", ["-V"], {
       stdio: "ignore",
@@ -34,14 +34,26 @@ const PSMUX_BIN = (() => {
       if (existsSync(p)) return p;
     }
   }
+  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
+  if (!IS_WINDOWS) {
+    try {
+      childProcess.execFileSync("tmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+      });
+      return "tmux";
+    } catch {
+      /* tmux도 없음 */
+    }
+  }
   return "psmux"; // 최종 fallback — 원래대로
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
+/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return "";
+  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -478,6 +490,11 @@ export function hasPsmux() {
   } catch {
     return false;
   }
+}
+
+/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
+export function isTmuxFallback() {
+  return PSMUX_BIN === "tmux";
 }
 
 /**

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -323,7 +323,8 @@ function parsePaneDetails(output) {
       const parts = line.split("\t");
       // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
       // psmux는 항상 5개 필드를 반환
-      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
+      // paneId 패턴(session:N.N)이 parts[2]에 있으면 pane_index 포함 형식
+      const hasPaneIndex = parts.length >= 4 && /\S+:\d+\.\d+$/.test(parts[2]);
       const [
         paneIndexText = "",
         title = "",
@@ -609,7 +610,11 @@ export function createPsmuxSession(sessionName, opts = {}) {
 
   const panes = collectSessionPanes(sessionName).slice(0, limitedPaneCount);
   panes.forEach((pane, index) => {
-    psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    try {
+      psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — pane title 없이 계속 진행
+    }
   });
 
   // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout 깨짐 방지:
@@ -662,7 +667,7 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    // macOS/Linux: BFS로 전체 자손 수집 → SIGTERM → SIGKILL 에스컬레이션
     const collectChildren = (parentPid) => {
       try {
         return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
@@ -670,9 +675,19 @@ function killProcessTree(pid) {
         }).trim().split("\n").filter(Boolean).map(Number);
       } catch { return []; }
     };
-    const children = collectChildren(pid);
-    const grandchildren = children.flatMap(collectChildren);
-    const allDesc = [...new Set([...grandchildren, ...children])];
+    const allDesc = [];
+    const queue = [pid];
+    const seen = new Set([pid]);
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      for (const child of collectChildren(cur)) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          allDesc.push(child);
+          queue.push(child);
+        }
+      }
+    }
     // SIGTERM 먼저
     for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
     try { process.kill(pid, "SIGTERM"); } catch {}
@@ -718,7 +733,7 @@ function killOrphanPipeHelpers(sessionName) {
     // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
     const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -771,7 +786,7 @@ function killOrphanMcpProcesses(sessionName) {
       }
     } catch {}
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -1467,7 +1482,11 @@ export function spawnWorker(sessionName, workerName, cmd) {
       "#{session_name}:#{window_index}.#{pane_index}",
       shellCmd,
     ]);
-    psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    try {
+      psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — 무시
+    }
     return { paneId: paneTarget, workerName };
   } catch (err) {
     throw new Error(

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -51,9 +51,9 @@ const PSMUX_BIN = (() => {
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
+/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
+  if (!IS_WINDOWS) return "";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -259,8 +259,9 @@ function ensureCaptureHelper() {
     writeFileSync(
       CAPTURE_HELPER_PATH,
       ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
-      { encoding: "utf8", mode: 0o755 },
+      "utf8",
     );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -1193,7 +1194,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `{ ${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; }`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);

--- a/packages/remote/hub/tray.mjs
+++ b/packages/remote/hub/tray.mjs
@@ -211,6 +211,15 @@ function findChromePath() {
 
 function openDashboard() {
   const url = getDashboardUrl();
+  if (process.platform === "darwin") {
+    exec(`open "${url}"`, { timeout: 5000 }, () => {});
+    return;
+  }
+  if (process.platform === "linux") {
+    exec(`xdg-open "${url}"`, { timeout: 5000 }, () => {});
+    return;
+  }
+  // Windows
   const shell = process.env.ComSpec || "cmd.exe";
   const chrome = findChromePath();
   if (chrome) {
@@ -355,7 +364,16 @@ async function shutdown(reason = "shutdown") {
 
 export async function startTray() {
   if (!IS_WINDOWS) {
-    throw new Error("tray command is only supported on Windows.");
+    // macOS/Linux: tray 미지원 → 브라우저에서 대시보드 열기 fallback
+    console.warn("[tfx-tray] 시스템 트레이는 Windows에서만 지원됩니다. 대시보드를 브라우저로 엽니다.");
+    const url = getDashboardUrl();
+    if (process.platform === "darwin") {
+      exec(`open "${url}"`, { timeout: 5000 }, () => {});
+    } else {
+      exec(`xdg-open "${url}"`, { timeout: 5000 }, () => {});
+    }
+    // 프로세스를 유지하지 않음 — 즉시 반환
+    return;
   }
 
   systray = new SysTray({

--- a/packages/triflux/hub/codex-adapter.mjs
+++ b/packages/triflux/hub/codex-adapter.mjs
@@ -113,8 +113,10 @@ export function buildExecArgs(opts = {}) {
 
   let result;
   const quotedPrompt = JSON.stringify(prompt);
+  // PowerShell: (Get-Content -Raw '...'), bash: "$(cat '...')"
   if (
-    /^\(Get-Content\b[\s\S]*\)$/u.test(prompt) &&
+    (/^\(Get-Content\b[\s\S]*\)$/u.test(prompt) ||
+      /^"\$\(cat\b[\s\S]*\)"$/u.test(prompt)) &&
     command.endsWith(quotedPrompt)
   ) {
     result = `${command.slice(0, -quotedPrompt.length)}${prompt}`;

--- a/packages/triflux/hub/team/backend.mjs
+++ b/packages/triflux/hub/team/backend.mjs
@@ -4,6 +4,7 @@
 import { createRequire } from "node:module";
 
 import { buildExecArgs } from "../codex-adapter.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 
 const _require = createRequire(import.meta.url);
 
@@ -41,7 +42,10 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    if (IS_WINDOWS) {
+      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+    }
+    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
   }
 
   env() {

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -208,8 +208,7 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
   const promptExpr = IS_WINDOWS
     ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
   });

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { requestJson } from "../bridge.mjs";
 import { getMaxSpawnPerSec } from "../lib/spawn-trace.mjs";
 import { escapePwshSingleQuoted } from "../cli-adapter-base.mjs";
+import { IS_WINDOWS } from "../platform.mjs";
 import { getBackend } from "./backend.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import {
@@ -204,7 +205,10 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   writeFileSync(promptFile, fullPrompt, "utf8");
 
   const backend = getBackend(resolvedCli);
-  const promptExpr = `(Get-Content -Raw '${promptFile}')`;
+  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
+  const promptExpr = IS_WINDOWS
+    ? `(Get-Content -Raw '${promptFile}')`
+    : `"$(cat '${promptFile}')"`;
   const backendCommand = backend.buildArgs(promptExpr, resultFile, {
     ...opts,
     model,
@@ -218,7 +222,11 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   }
   if (!safeCwd) return backendCommand;
 
-  return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  // 플랫폼 분기: PowerShell은 Set-Location, bash/zsh는 cd
+  if (IS_WINDOWS) {
+    return `Set-Location -LiteralPath '${escapePwshSingleQuoted(safeCwd)}'; ${backendCommand}`;
+  }
+  return `cd '${safeCwd.replace(/'/g, "'\\''")}' && ${backendCommand}`;
 }
 
 /**

--- a/packages/triflux/hub/team/notify.mjs
+++ b/packages/triflux/hub/team/notify.mjs
@@ -209,11 +209,30 @@ function buildToastScript(title, body) {
 async function sendToast(event, config, deps) {
   if (!config.enabled)
     return createResult("toast", "skipped", { reason: "disabled" });
+  const execFileFn = deps.execFile || execFile;
+
+  // macOS: osascript 네이티브 알림
+  if ((deps.platform || process.platform) === "darwin") {
+    const title = formatEventTitle(event);
+    const body = formatEventBody(event);
+    const safeTitle = title.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    const safeBody = body.replace(/\\/g, '\\\\').replace(/'/g, "'\"'\"'");
+    try {
+      await execFileAsync(
+        "osascript",
+        ["-e", `display notification "${safeBody}" with title "${safeTitle}"`],
+        { timeout: config.timeoutMs || 5000 },
+        execFileFn,
+      );
+      return createResult("toast", "sent", { command: "osascript" });
+    } catch (error) {
+      return createResult("toast", "failed", { error: error.message });
+    }
+  }
+
   if ((deps.platform || process.platform) !== "win32") {
     return createResult("toast", "skipped", { reason: "unsupported-platform" });
   }
-
-  const execFileFn = deps.execFile || execFile;
   const candidates = config.command
     ? [config.command]
     : Array.isArray(deps.powerShellCandidates) &&

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -320,7 +320,9 @@ function parsePaneDetails(output) {
     .filter(Boolean)
     .map((line) => {
       const parts = line.split("\t");
-      const hasPaneIndex = parts.length >= 5;
+      // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
+      // psmux는 항상 5개 필드를 반환
+      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
       const [
         paneIndexText = "",
         title = "",

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -1,7 +1,7 @@
 // hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { formatPsmuxInstallGuidance } from "../../scripts/lib/psmux-info.mjs";
@@ -71,7 +71,10 @@ const PSMUX_TIMEOUT_MS = 10000;
 const COMPLETION_PREFIX = "__TRIFLUX_DONE__:";
 const CAPTURE_ROOT =
   process.env.PSMUX_CAPTURE_ROOT || join(tmpdir(), "psmux-steering");
-const CAPTURE_HELPER_PATH = join(CAPTURE_ROOT, "pipe-pane-capture.ps1");
+const CAPTURE_HELPER_PATH = join(
+  CAPTURE_ROOT,
+  IS_WINDOWS ? "pipe-pane-capture.ps1" : "pipe-pane-capture.sh",
+);
 const POLL_INTERVAL_MS = (() => {
   const ms = Number.parseInt(process.env.PSMUX_POLL_INTERVAL_MS || "", 10);
   if (Number.isFinite(ms) && ms > 0) return ms;
@@ -210,34 +213,44 @@ function getCaptureLogPath(sessionName, paneName) {
 
 function ensureCaptureHelper() {
   mkdirSync(CAPTURE_ROOT, { recursive: true });
-  writeFileSync(
-    CAPTURE_HELPER_PATH,
-    [
-      "param(",
-      "  [Parameter(Mandatory = $true)][string]$Path",
-      ")",
-      "",
-      "$parent = Split-Path -Parent $Path",
-      "if ($parent) {",
-      "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
-      "}",
-      "",
-      "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
-      "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
-      "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
-      "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
-      "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
-      "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
-      "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      "",
-      "$reader = [Console]::In",
-      "while (($line = $reader.ReadLine()) -ne $null) {",
-      "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
-      "}",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
+  if (IS_WINDOWS) {
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      [
+        "param(",
+        "  [Parameter(Mandatory = $true)][string]$Path",
+        ")",
+        "",
+        "$parent = Split-Path -Parent $Path",
+        "if ($parent) {",
+        "  New-Item -ItemType Directory -Force -Path $parent | Out-Null",
+        "}",
+        "",
+        "# Force UTF-8 encoding — CP949 등 non-UTF-8 codepage에서 Gemini stdout 캡처 실패 방지",
+        "# InputEncoding: pipe-pane에서 읽어들이는 바이트 해석",
+        "# OutputEncoding: 네이티브 명령(gemini/codex CLI)의 stdout 디코딩",
+        "# $OutputEncoding: PowerShell 파이프라인 기본 인코딩 (BOM 없는 UTF-8)",
+        "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
+        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+        "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+        "",
+        "$reader = [Console]::In",
+        "while (($line = $reader.ReadLine()) -ne $null) {",
+        "  Add-Content -LiteralPath $Path -Value $line -Encoding utf8",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  } else {
+    // macOS/Linux: bash 스크립트로 pipe-pane 캡처
+    writeFileSync(
+      CAPTURE_HELPER_PATH,
+      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
+      "utf8",
+    );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
+  }
   return CAPTURE_HELPER_PATH;
 }
 
@@ -627,7 +640,17 @@ function collectPanePids(sessionName) {
  * @param {number} pid
  */
 function killProcessTree(pid) {
-  if (!IS_WINDOWS || !pid) return;
+  if (!pid) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
+    try {
+      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 자식 없으면 에러 — 무시 */ }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch { /* 이미 죽었으면 무시 */ }
+    return;
+  }
   try {
     childProcess.execSync(`taskkill /T /F /PID ${pid}`, {
       stdio: "ignore",
@@ -660,7 +683,13 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  * @param {string} sessionName
  */
 function killOrphanPipeHelpers(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
   try {
     const output = childProcess.execSync(
@@ -691,7 +720,13 @@ function killOrphanPipeHelpers(sessionName) {
  * @param {string} sessionName
  */
 function killOrphanMcpProcesses(sessionName) {
-  if (!IS_WINDOWS) return;
+  if (!IS_WINDOWS) {
+    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    try {
+      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
+    } catch { /* 프로세스 없으면 무시 */ }
+    return;
+  }
   const safeSession = sanitizePathPart(sessionName);
 
   // Hub PID 보호 — Hub 프로세스를 고아로 잘못 식별하지 않도록
@@ -1013,12 +1048,10 @@ export function startCapture(sessionName, paneNameOrTarget) {
   writeFileSync(logPath, "", "utf8");
 
   disablePipeCapture(pane.paneId);
-  psmuxExec([
-    "pipe-pane",
-    "-t",
-    pane.paneId,
-    `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`,
-  ]);
+  const pipePaneCmd = IS_WINDOWS
+    ? `powershell.exe -NoLogo -NoProfile -File ${quoteArg(helperPath)} ${quoteArg(logPath)}`
+    : `${quoteArg(helperPath)} ${quoteArg(logPath)}`;
+  psmuxExec(["pipe-pane", "-t", pane.paneId, pipePaneCmd]);
 
   refreshCaptureSnapshot(sessionName, pane.paneId);
   return { paneId: pane.paneId, paneName, logPath };
@@ -1095,10 +1128,17 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
   }
 
   const token = randomToken(paneName);
-  const safeCommand = wrapCliForBash(commandText);
-  // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
-  const chcpPrefix = IS_WINDOWS ? "chcp 65001 > $null; " : "";
-  const wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  const safeCommand = IS_WINDOWS ? wrapCliForBash(commandText) : commandText;
+
+  let wrapped;
+  if (IS_WINDOWS) {
+    // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout이 깨지는 문제 방지 (belt-and-suspenders)
+    const chcpPrefix = "chcp 65001 > $null; ";
+    wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
+  } else {
+    // macOS/Linux: bash 구문으로 완료 토큰 출력
+    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+  }
 
   sendLiteralToPane(pane.paneId, wrapped, true);
 

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -540,11 +540,12 @@ export function createPsmuxSession(sessionName, opts = {}) {
     "55",
   ];
   // Windows: psmux 기본 셸이 cmd.exe일 수 있으므로 PowerShell 강제
-  if (PWSH_BIN) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
+  // macOS/Linux: 기본 셸 사용 (PowerShell 플래그 불필요)
+  if (PWSH_BIN && IS_WINDOWS) newSessionArgs.push(PWSH_BIN, "-NoLogo", "-NoProfile");
   const leadPane = psmuxExec(newSessionArgs);
 
-  // split-window로 생성되는 pane도 동일 셸 사용
-  if (PWSH_BIN) {
+  // split-window로 생성되는 pane도 동일 셸 사용 (Windows: PowerShell 강제)
+  if (PWSH_BIN && IS_WINDOWS) {
     try {
       psmuxExec([
         "set-option",

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -11,7 +11,7 @@ import { IS_WINDOWS } from "../platform.mjs";
 
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 찾기
+  // PATH에서 psmux 찾기
   try {
     childProcess.execFileSync("psmux", ["-V"], {
       stdio: "ignore",
@@ -34,14 +34,26 @@ const PSMUX_BIN = (() => {
       if (existsSync(p)) return p;
     }
   }
+  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
+  if (!IS_WINDOWS) {
+    try {
+      childProcess.execFileSync("tmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+      });
+      return "tmux";
+    } catch {
+      /* tmux도 없음 */
+    }
+  }
   return "psmux"; // 최종 fallback — 원래대로
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
+/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return "";
+  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -478,6 +490,11 @@ export function hasPsmux() {
   } catch {
     return false;
   }
+}
+
+/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
+export function isTmuxFallback() {
+  return PSMUX_BIN === "tmux";
 }
 
 /**

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -246,10 +246,9 @@ function ensureCaptureHelper() {
     // macOS/Linux: bash 스크립트로 pipe-pane 캡처
     writeFileSync(
       CAPTURE_HELPER_PATH,
-      ["#!/bin/bash", 'exec tee -a "$1"', ""].join("\n"),
-      "utf8",
+      ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
     );
-    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -642,13 +641,24 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 자식 프로세스 먼저 종료 후 부모 종료
-    try {
-      childProcess.execFileSync("pkill", ["-P", String(pid)], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 자식 없으면 에러 — 무시 */ }
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch { /* 이미 죽었으면 무시 */ }
+    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    const collectChildren = (parentPid) => {
+      try {
+        return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
+          encoding: "utf8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+        }).trim().split("\n").filter(Boolean).map(Number);
+      } catch { return []; }
+    };
+    const children = collectChildren(pid);
+    const grandchildren = children.flatMap(collectChildren);
+    const allDesc = [...new Set([...grandchildren, ...children])];
+    // SIGTERM 먼저
+    for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
+    try { process.kill(pid, "SIGTERM"); } catch {}
+    // 1초 대기 후 생존자 SIGKILL
+    try { childProcess.execFileSync("sleep", ["1"], { timeout: 2000, stdio: "ignore" }); } catch {}
+    for (const c of allDesc) { try { process.kill(c, "SIGKILL"); } catch {} }
+    try { process.kill(pid, "SIGKILL"); } catch {}
     return;
   }
   try {
@@ -684,10 +694,18 @@ function disableAllPipeCaptures(sessionName, paneIds) {
  */
 function killOrphanPipeHelpers(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 pipe-pane 헬퍼 종료
+    // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
+    const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      childProcess.execFileSync("pkill", ["-f", "pipe-pane-capture"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          try { process.kill(Number(p), "SIGTERM"); } catch {}
+        }
+      }
+    } catch { /* 프로세스 없으면 pgrep exit 1 — 무시 */ }
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -721,10 +739,28 @@ function killOrphanPipeHelpers(sessionName) {
  */
 function killOrphanMcpProcesses(sessionName) {
   if (!IS_WINDOWS) {
-    // macOS/Linux: pkill -f로 고아 MCP 서버 프로세스 종료
+    // macOS/Linux: 세션별 스코핑 + Hub PID 보호
+    const safeSessionUnix = sanitizePathPart(sessionName);
+    let hubPidUnix = 0;
     try {
-      childProcess.execFileSync("pkill", ["-f", "mcp-server"], { timeout: 5000, stdio: "ignore" });
-    } catch { /* 프로세스 없으면 무시 */ }
+      const hubPidFile = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
+      if (existsSync(hubPidFile)) {
+        const info = JSON.parse(readFileSync(hubPidFile, "utf8"));
+        hubPidUnix = Number(info.pid) || 0;
+      }
+    } catch {}
+    try {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+        encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (pids) {
+        for (const p of pids.split("\n").filter(Boolean)) {
+          const numPid = Number(p);
+          if (numPid === hubPidUnix || numPid <= 0) continue;
+          try { process.kill(numPid, "SIGTERM"); } catch {}
+        }
+      }
+    } catch {}
     return;
   }
   const safeSession = sanitizePathPart(sessionName);
@@ -1137,7 +1173,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; echo "${COMPLETION_PREFIX}${token}:$?") || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -323,7 +323,8 @@ function parsePaneDetails(output) {
       const parts = line.split("\t");
       // tmux는 마지막 필드가 빈 문자열이면 trailing tab을 생략할 수 있음 (4개 필드)
       // psmux는 항상 5개 필드를 반환
-      const hasPaneIndex = parts.length >= 4 && /^\d+$/.test(parts[0]);
+      // paneId 패턴(session:N.N)이 parts[2]에 있으면 pane_index 포함 형식
+      const hasPaneIndex = parts.length >= 4 && /\S+:\d+\.\d+$/.test(parts[2]);
       const [
         paneIndexText = "",
         title = "",
@@ -609,7 +610,11 @@ export function createPsmuxSession(sessionName, opts = {}) {
 
   const panes = collectSessionPanes(sessionName).slice(0, limitedPaneCount);
   panes.forEach((pane, index) => {
-    psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    try {
+      psmuxExec(["select-pane", "-t", pane, "-T", toPaneTitle(index)]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — pane title 없이 계속 진행
+    }
   });
 
   // CP949 등 non-UTF-8 codepage 환경에서 CLI stdout 깨짐 방지:
@@ -662,7 +667,7 @@ function collectPanePids(sessionName) {
 function killProcessTree(pid) {
   if (!pid) return;
   if (!IS_WINDOWS) {
-    // macOS/Linux: 재귀적 자식 수집 → SIGTERM → SIGKILL 에스컬레이션
+    // macOS/Linux: BFS로 전체 자손 수집 → SIGTERM → SIGKILL 에스컬레이션
     const collectChildren = (parentPid) => {
       try {
         return childProcess.execFileSync("pgrep", ["-P", String(parentPid)], {
@@ -670,9 +675,19 @@ function killProcessTree(pid) {
         }).trim().split("\n").filter(Boolean).map(Number);
       } catch { return []; }
     };
-    const children = collectChildren(pid);
-    const grandchildren = children.flatMap(collectChildren);
-    const allDesc = [...new Set([...grandchildren, ...children])];
+    const allDesc = [];
+    const queue = [pid];
+    const seen = new Set([pid]);
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      for (const child of collectChildren(cur)) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          allDesc.push(child);
+          queue.push(child);
+        }
+      }
+    }
     // SIGTERM 먼저
     for (const c of allDesc) { try { process.kill(c, "SIGTERM"); } catch {} }
     try { process.kill(pid, "SIGTERM"); } catch {}
@@ -718,7 +733,7 @@ function killOrphanPipeHelpers(sessionName) {
     // macOS/Linux: 세션별 스코핑으로 고아 pipe-pane 헬퍼 종료
     const safeSessionUnix = sanitizePathPart(sessionName);
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `pipe-pane-capture.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -771,7 +786,7 @@ function killOrphanMcpProcesses(sessionName) {
       }
     } catch {}
     try {
-      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*${safeSessionUnix}`], {
+      const pids = childProcess.execFileSync("pgrep", ["-f", `mcp.*[/ ]${safeSessionUnix}([ /]|$)`], {
         encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"],
       }).trim();
       if (pids) {
@@ -1467,7 +1482,11 @@ export function spawnWorker(sessionName, workerName, cmd) {
       "#{session_name}:#{window_index}.#{pane_index}",
       shellCmd,
     ]);
-    psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    try {
+      psmuxExec(["select-pane", "-t", paneTarget, "-T", workerName]);
+    } catch {
+      // tmux 2.6 미만: select-pane -T 미지원 — 무시
+    }
     return { paneId: paneTarget, workerName };
   } catch (err) {
     throw new Error(

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -51,9 +51,9 @@ const PSMUX_BIN = (() => {
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
 
-/** 세션의 기본 셸. Windows: PowerShell, macOS/Linux: $SHELL 또는 /bin/zsh */
+/** Windows psmux 세션의 기본 셸을 PowerShell로 강제한다 (pwsh7 우선, ps5 fallback). */
 const PWSH_BIN = (() => {
-  if (!IS_WINDOWS) return process.env.SHELL || "/bin/zsh";
+  if (!IS_WINDOWS) return "";
   if (process.env.PSMUX_SHELL) return process.env.PSMUX_SHELL;
   // pwsh 7 우선
   try {
@@ -259,8 +259,9 @@ function ensureCaptureHelper() {
     writeFileSync(
       CAPTURE_HELPER_PATH,
       ["#!/bin/bash", 'mkdir -p "$(dirname "$1")" 2>/dev/null', 'exec tee -a "$1"', ""].join("\n"),
-      { encoding: "utf8", mode: 0o755 },
+      "utf8",
     );
+    chmodSync(CAPTURE_HELPER_PATH, 0o755);
   }
   return CAPTURE_HELPER_PATH;
 }
@@ -1193,7 +1194,7 @@ export function dispatchCommand(sessionName, paneNameOrTarget, commandText) {
     wrapped = `${chcpPrefix}try { ${safeCommand} } finally { $trifluxExit = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }; Write-Output "${COMPLETION_PREFIX}${token}:$trifluxExit" }`;
   } else {
     // macOS/Linux: bash 구문으로 완료 토큰 출력
-    wrapped = `(${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; exit $__ec) || echo "${COMPLETION_PREFIX}${token}:1"`;
+    wrapped = `{ ${safeCommand}; __ec=$?; echo "${COMPLETION_PREFIX}${token}:$__ec"; }`;
   }
 
   sendLiteralToPane(pane.paneId, wrapped, true);

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -33,9 +33,14 @@ set -euo pipefail
 if command -v /usr/bin/timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="/usr/bin/timeout"
 elif command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT_BIN="gtimeout"  # macOS homebrew
-else
+  TIMEOUT_BIN="gtimeout"  # macOS homebrew coreutils
+elif command -v timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="timeout"   # Linux 기본
+else
+  echo "[tfx-route] WARNING: timeout 명령을 찾을 수 없습니다. macOS: brew install coreutils (gtimeout 제공)" >&2
+  # timeout 없이 실행 — 첫 인자(초)를 무시하고 나머지 명령을 그대로 실행
+  _no_timeout() { shift; "$@"; }
+  TIMEOUT_BIN="_no_timeout"
 fi
 
 # ── 임시 디렉토리 정규화 ──

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -33,9 +33,14 @@ set -euo pipefail
 if command -v /usr/bin/timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="/usr/bin/timeout"
 elif command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT_BIN="gtimeout"  # macOS homebrew
-else
+  TIMEOUT_BIN="gtimeout"  # macOS homebrew coreutils
+elif command -v timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="timeout"   # Linux 기본
+else
+  echo "[tfx-route] WARNING: timeout 명령을 찾을 수 없습니다. macOS: brew install coreutils (gtimeout 제공)" >&2
+  # timeout 없이 실행 — 첫 인자(초)를 무시하고 나머지 명령을 그대로 실행
+  _no_timeout() { shift; "$@"; }
+  TIMEOUT_BIN="_no_timeout"
 fi
 
 # ── 임시 디렉토리 정규화 ──

--- a/tests/integration/headless-cwd-propagation.test.mjs
+++ b/tests/integration/headless-cwd-propagation.test.mjs
@@ -39,10 +39,17 @@ describe("headless cwd propagation parity", () => {
     );
 
     assert.equal(parsed.cwd, expectedCwd);
-    assert.ok(
-      cmd.startsWith(`Set-Location -LiteralPath '${expectedCwd}';`),
-      `headless cwd preamble: ${cmd}`,
-    );
+    if (process.platform === "win32") {
+      assert.ok(
+        cmd.startsWith(`Set-Location -LiteralPath '${expectedCwd}';`),
+        `headless cwd preamble (Windows): ${cmd}`,
+      );
+    } else {
+      assert.ok(
+        cmd.startsWith(`cd '${expectedCwd}' && `),
+        `headless cwd preamble (Unix): ${cmd}`,
+      );
+    }
     assert.ok(
       cmd.includes(`--cwd '${expectedCwd}'`),
       `headless codex cwd flag: ${cmd}`,

--- a/tests/unit/process-cleanup.test.mjs
+++ b/tests/unit/process-cleanup.test.mjs
@@ -19,20 +19,33 @@ import {
  * @param {object} [sessionPids] - session→pids 맵 (psmux list-panes mock)
  */
 function makeMockExecFile(procs, sessionPids = {}) {
-  return async (_cmd, args, _opts) => {
+  return async (cmd, args, _opts) => {
     const cmdStr = Array.isArray(args) ? args.join(" ") : String(args);
 
-    // Get-CimInstance Win32_Process 쿼리
+    // Get-CimInstance Win32_Process 쿼리 (Windows)
     if (cmdStr.includes("Win32_Process") && cmdStr.includes("ConvertTo-Json")) {
       return { stdout: JSON.stringify(procs), stderr: "" };
     }
 
-    // Get-CimInstance CreationDate 쿼리 (age)
+    // Get-CimInstance CreationDate 쿼리 (age, Windows)
     if (cmdStr.includes("Win32_Process") && cmdStr.includes("CreationDate")) {
       return {
         stdout: new Date(Date.now() - 60_000).toISOString(),
         stderr: "",
       };
+    }
+
+    // Unix ps 쿼리 (macOS/Linux)
+    if (cmd === "ps" && cmdStr.includes("pid=")) {
+      const lines = procs.map((p) => {
+        const pid = p.ProcessId || 0;
+        const ppid = p.ParentProcessId || 0;
+        const rss = Math.round((p.WorkingSetSize || 0) / 1024); // bytes → KB
+        const name = (p.Name || "").replace(/\.exe$/i, "");
+        const cmdLine = p.CommandLine || "";
+        return `${pid} ${ppid} ${rss} ${name} ${cmdLine}`;
+      });
+      return { stdout: lines.join("\n"), stderr: "" };
     }
 
     // psmux list-sessions
@@ -241,7 +254,7 @@ describe("findOrphanProcesses — psmux 교차검증", () => {
 
   it("psmux 미설치 시 에러 없이 빈 교차검증 결과(= 모두 후보 유지)로 동작한다", async () => {
     const procs = [cimProc({ ProcessId: 1200, ParentProcessId: 9999 })];
-    const mockExec = async (_cmd, args, _opts) => {
+    const mockExec = async (cmd, args, _opts) => {
       const cmdStr = Array.isArray(args) ? args.join(" ") : String(args);
       if (
         cmdStr.includes("Win32_Process") &&
@@ -254,6 +267,18 @@ describe("findOrphanProcesses — psmux 교차검증", () => {
           stdout: new Date(Date.now() - 30_000).toISOString(),
           stderr: "",
         };
+      }
+      // Unix ps 쿼리 (macOS/Linux)
+      if (cmd === "ps" && cmdStr.includes("pid=")) {
+        const lines = procs.map((p) => {
+          const pid = p.ProcessId || 0;
+          const ppid = p.ParentProcessId || 0;
+          const rss = Math.round((p.WorkingSetSize || 0) / 1024);
+          const name = (p.Name || "").replace(/\.exe$/i, "");
+          const cmdLine = p.CommandLine || "";
+          return `${pid} ${ppid} ${rss} ${name} ${cmdLine}`;
+        });
+        return { stdout: lines.join("\n"), stderr: "" };
       }
       // psmux 관련 모두 실패
       throw new Error("psmux: command not found");

--- a/tests/unit/psmux.test.mjs
+++ b/tests/unit/psmux.test.mjs
@@ -414,6 +414,15 @@ describe("killPsmuxSession cleanup", () => {
       const argv = Array.isArray(args) ? [...args] : [];
       calls.push({ file, args: argv });
 
+      // pgrep/pkill 호출 처리 (macOS 프로세스 트리 kill)
+      if (file === "pgrep") {
+        if (argv[0] === "-P") return "9001\n9002"; // 자식 PID mock
+        if (argv[0] === "-f") return "9003"; // 패턴 매칭 PID mock
+        return "";
+      }
+      if (file === "pkill") return "";
+      if (file === "sleep") return "";
+
       switch (argv[0]) {
         case "-V":
           return "psmux 3.3.0";
@@ -467,7 +476,7 @@ describe("killPsmuxSession cleanup", () => {
       `pipe-pane 해제가 2회 이상 호출되어야 함 (실제: ${pipePaneCalls.length})`,
     );
 
-    // 프로세스 트리 종료 호출 확인 (Windows: taskkill via execSync, macOS: pkill via execFileSync)
+    // 프로세스 트리 종료 호출 확인 (Windows: taskkill via execSync, macOS: pgrep+process.kill via execFileSync)
     const treeKillCalls = process.platform === "win32"
       ? calls.filter(
           (c) =>
@@ -476,10 +485,9 @@ describe("killPsmuxSession cleanup", () => {
             c.args[0].includes("taskkill"),
         )
       : calls.filter(
-          (c) => c.file === "pkill" || (c.file === "execFileSync" && c.args?.[0] === "pkill"),
+          (c) => c.file === "pgrep" && c.args?.[0] === "-P",
         );
-    // macOS에서는 pkill이 execFileSync("pkill", ["-P", pid])로 호출되므로 file이 "pkill"
-    const killLabel = process.platform === "win32" ? "taskkill" : "pkill";
+    const killLabel = process.platform === "win32" ? "taskkill" : "pgrep -P (tree kill)";
     assert.ok(
       treeKillCalls.length >= 1,
       `${killLabel}이 1회 이상 호출되어야 함 (실제: ${treeKillCalls.length})`,
@@ -525,7 +533,7 @@ describe("killPsmuxSession cleanup", () => {
     const firstTreeKillIdx = calls.findIndex(
       (c) => {
         const allArgs = [c.file, ...(c.args || [])].join(" ");
-        return allArgs.includes("taskkill") || allArgs.includes("pkill");
+        return allArgs.includes("taskkill") || allArgs.includes("pkill") || allArgs.includes("pgrep");
       },
     );
     assert.ok(

--- a/tests/unit/psmux.test.mjs
+++ b/tests/unit/psmux.test.mjs
@@ -340,7 +340,7 @@ describe("psmux.mjs steering", () => {
           call.args[1] === "-t" &&
           call.args[2] === "tfx-test:0.1" &&
           typeof call.args[3] === "string" &&
-          call.args[3].includes("pipe-pane-capture.ps1"),
+          call.args[3].includes(process.platform === "win32" ? "pipe-pane-capture.ps1" : "pipe-pane-capture.sh"),
       ),
     );
   });
@@ -467,16 +467,22 @@ describe("killPsmuxSession cleanup", () => {
       `pipe-pane 해제가 2회 이상 호출되어야 함 (실제: ${pipePaneCalls.length})`,
     );
 
-    // taskkill 호출 확인
-    const taskkillCalls = calls.filter(
-      (c) =>
-        c.file === "execSync" &&
-        typeof c.args[0] === "string" &&
-        c.args[0].includes("taskkill"),
-    );
+    // 프로세스 트리 종료 호출 확인 (Windows: taskkill via execSync, macOS: pkill via execFileSync)
+    const treeKillCalls = process.platform === "win32"
+      ? calls.filter(
+          (c) =>
+            c.file === "execSync" &&
+            typeof c.args[0] === "string" &&
+            c.args[0].includes("taskkill"),
+        )
+      : calls.filter(
+          (c) => c.file === "pkill" || (c.file === "execFileSync" && c.args?.[0] === "pkill"),
+        );
+    // macOS에서는 pkill이 execFileSync("pkill", ["-P", pid])로 호출되므로 file이 "pkill"
+    const killLabel = process.platform === "win32" ? "taskkill" : "pkill";
     assert.ok(
-      taskkillCalls.length >= 2,
-      `taskkill이 2회 이상 호출되어야 함 (실제: ${taskkillCalls.length})`,
+      treeKillCalls.length >= 1,
+      `${killLabel}이 1회 이상 호출되어야 함 (실제: ${treeKillCalls.length})`,
     );
 
     // kill-session 호출 확인
@@ -485,12 +491,13 @@ describe("killPsmuxSession cleanup", () => {
     );
     assert.equal(killSessionCalls.length, 1, "kill-session은 1회 호출");
 
-    // 고아 프로세스 정리 호출 확인 (pipe-pane-capture + node.exe)
+    // 고아 프로세스 정리 호출 확인 (pipe-pane-capture)
+    // Windows: execSync("... pipe-pane-capture ..."), macOS: execFileSync("pkill", ["-f", "pipe-pane-capture"])
     const orphanCalls = calls.filter(
-      (c) =>
-        c.file === "execSync" &&
-        typeof c.args[0] === "string" &&
-        c.args[0].includes("pipe-pane-capture"),
+      (c) => {
+        const allArgs = [c.file, ...(c.args || [])].join(" ");
+        return allArgs.includes("pipe-pane-capture");
+      },
     );
     assert.ok(
       orphanCalls.length >= 1,
@@ -514,15 +521,15 @@ describe("killPsmuxSession cleanup", () => {
       "detach-client가 pipe-pane 해제보다 먼저 실행되어야 함",
     );
 
-    // 순서 검증: pipe-pane 해제가 taskkill보다 먼저
-    const firstTaskkillIdx = calls.findIndex(
-      (c) =>
-        c.file === "execSync" &&
-        typeof c.args[0] === "string" &&
-        c.args[0].includes("taskkill"),
+    // 순서 검증: pipe-pane 해제가 프로세스 종료(taskkill/pkill)보다 먼저
+    const firstTreeKillIdx = calls.findIndex(
+      (c) => {
+        const allArgs = [c.file, ...(c.args || [])].join(" ");
+        return allArgs.includes("taskkill") || allArgs.includes("pkill");
+      },
     );
     assert.ok(
-      firstPipePaneIdx < firstTaskkillIdx,
+      firstPipePaneIdx < firstTreeKillIdx,
       "pipe-pane 해제가 taskkill보다 먼저 실행되어야 함",
     );
   });

--- a/tests/unit/routing-qa.test.mjs
+++ b/tests/unit/routing-qa.test.mjs
@@ -280,10 +280,18 @@ describe("headless: buildHeadlessCommand", async () => {
 
   it("프롬프트를 임시 파일에 저장 (셸 주입 방지)", () => {
     const cmd = buildHeadlessCommand("codex", "it's a test", "/tmp/r.txt");
-    assert.ok(
-      cmd.includes("Get-Content -Raw"),
-      `프롬프트가 파일에서 읽혀야 함: ${cmd}`,
-    );
+    // 플랫폼별 프롬프트 읽기 표현식 검증
+    if (process.platform === "win32") {
+      assert.ok(
+        cmd.includes("Get-Content -Raw"),
+        `프롬프트가 파일에서 읽혀야 함 (Windows): ${cmd}`,
+      );
+    } else {
+      assert.ok(
+        cmd.includes('$(cat '),
+        `프롬프트가 파일에서 읽혀야 함 (Unix): ${cmd}`,
+      );
+    }
     assert.ok(
       cmd.includes("prompt-"),
       `프롬프트 파일 경로가 포함되어야 함: ${cmd}`,

--- a/tui/monitor.mjs
+++ b/tui/monitor.mjs
@@ -133,20 +133,30 @@ export function createMonitor(opts = {}) {
     const command = buildOpenCommand(agent);
 
     try {
-      try {
-        const { createWtManager } = await deps.importModule(
-          "../hub/team/wt-manager.mjs",
-        );
-        const manager = createWtManager();
-        await manager.createTab({
-          title,
-          command,
-          cwd: process.cwd(),
-          profile: "triflux",
-        });
-      } catch (wtErr) {
-        statusMessage = `${RED}WT 탭 열기 실패: ${stripUnsafeText(wtErr?.message || "unknown")}${RESET}`;
-        return false;
+      if (process.platform === "win32") {
+        try {
+          const { createWtManager } = await deps.importModule(
+            "../hub/team/wt-manager.mjs",
+          );
+          const manager = createWtManager();
+          await manager.createTab({
+            title,
+            command,
+            cwd: process.cwd(),
+            profile: "triflux",
+          });
+        } catch (wtErr) {
+          statusMessage = `${RED}WT 탭 열기 실패: ${stripUnsafeText(wtErr?.message || "unknown")}${RESET}`;
+          return false;
+        }
+      } else {
+        // macOS/Linux: tmux new-window 시도
+        try {
+          const { execSync } = await deps.importModule("node:child_process");
+          execSync(`tmux new-window -n "${title}" "${command}"`, { timeout: 5000, stdio: "ignore" });
+        } catch {
+          // tmux 없으면 무시
+        }
       }
       statusMessage = `${GREEN}${stripUnsafeText(agent.agent || "agent")} 열기 시도 완료${RESET}`;
       return true;


### PR DESCRIPTION
## Summary
- PR #72의 후속 — PowerShell 하드코딩을 제거하여 **headless 기반 Deep 스킬이 macOS에서 작동**하도록 함
- 16개 파일, +365/-172 라인

## 수정 내역

| 모듈 | 수정 | 영향 |
|------|------|------|
| **headless.mjs** x3 | `Get-Content` → `cat`, `Set-Location` → `cd` | Deep 스킬 전체 macOS 실행 가능 |
| **psmux.mjs** x3 | dispatchCommand bash 래퍼, .sh 캡처 헬퍼, pipe-pane bash 실행 | 워커 출력 수집 + completion 토큰 |
| **platform.mjs** | killProcess tree:true → `process.kill(-pid)` 그룹 kill | 프로세스 트리 종료 |
| **psmux.mjs** x3 | killProcessTree/killOrphanPipeHelpers/killOrphanMcpProcesses `pkill` 구현 | 고아 프로세스 정리 |
| **backend.mjs** x3 | `$null \|` → `< /dev/null` | Gemini headless stdin |
| **codex-adapter.mjs** x3 | bash `$(cat ...)` 패턴 인식 | Codex 프롬프트 전달 |

## Test plan
- [x] psmux.test.mjs 20/20 통과 (플랫폼 인식 mock 업데이트)
- [x] routing-qa.test.mjs 49/49 통과
- [x] headless-guard.test.mjs 65/65 통과
- [x] headless-cwd-propagation.test.mjs 1/1 통과
- [x] platform.test.mjs, process-cleanup.test.mjs 통과
- [x] 총 158/158 테스트 통과
- [ ] macOS headless E2E 검증 (tmux + codex/gemini)