### PR TITLE
fix(hub): pin port to 27888 + auto-sync Gemini/Claude settings.json

### DIFF
--- a/docs/prd/hub-port-lock/00-combined.md
+++ b/docs/prd/hub-port-lock/00-combined.md
@@ -1,0 +1,78 @@
+# PRD: tfx-hub 포트 고정 + Gemini/Claude settings MCP URL 동기화
+
+## 목표
+tfx-hub가 반드시 27888 포트에서 실행되게 하고(PRD-A), 동시에 클라이언트 설정 파일(`~/.gemini/settings.json`, `~/.claude/settings.json`)의 `mcpServers.tfx-hub.url`이 현재 Hub URL과 자동 동기화되는 안전망 유틸리티(PRD-B)를 추가한다. 두 shard는 파일 겹침이 없어 병렬 실행 가능하며, PRD-B 모듈이 없어도 PRD-A는 optional dynamic import로 safe degrade한다.
+
+## Shard: hub-port-lock
+- agent: codex
+- files: hub/server.mjs, hub/bridge.mjs, tests/unit/hub-port-bind.test.mjs
+- prompt: |
+    `hub/server.mjs`를 수정해 Hub가 **반드시 포트 27888**에 고정 바인딩되도록 한다. 상세 스펙은 `docs/prd/hub-port-lock/01-hub-port-bind.md`를 반드시 먼저 전부 읽고 그대로 따른다.
+
+    핵심 요구:
+    1. TFX_HUB_PORT env override 없을 시 27888 강제. 동적 포트 경로 제거.
+    2. EADDRINUSE 시 `~/.claude/cache/tfx-hub/hub.pid` 확인 → stale이면 자동 정리 후 재시도, 살아있으면 graceful exit(같은 Hub) 또는 명확한 에러(다른 Hub).
+    3. listen 성공 직후 `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({ hubUrl })`를 **optional dynamic import**로 호출. 모듈 부재/실패 시 warning log만 남기고 Hub 실행 계속.
+    4. 테스트 가능하도록 `resolveHubPort()`, `cleanStaleHubPid()`, `detectLivePeer()` 헬퍼 함수 분리 + export.
+    5. `hub/bridge.mjs`는 `hub.pid`의 port 우선, 없으면 27888 fallback.
+    6. `tests/unit/hub-port-bind.test.mjs` 신규: TFX_HUB_PORT 미지정/stale pid/live peer 3 케이스.
+
+    제약: hub.pid 파일 포맷 보존, packages/** 건드리지 않음, 외부 의존성 추가 금지.
+
+    실행/검증:
+    ```bash
+    node --test tests/unit/hub-port-bind.test.mjs
+    ```
+
+    완료 후 커밋:
+    ```bash
+    git add hub/server.mjs hub/bridge.mjs tests/unit/hub-port-bind.test.mjs
+    git commit -m "fix(hub): pin port to 27888 with stale pid cleanup"
+    ```
+
+## Shard: settings-mcp-sync
+- agent: codex
+- files: scripts/sync-hub-mcp-settings.mjs, tests/unit/sync-hub-mcp-settings.test.mjs
+- prompt: |
+    `scripts/sync-hub-mcp-settings.mjs`를 신규 작성하고 전용 테스트를 추가한다. 상세 스펙은 `docs/prd/hub-port-lock/02-settings-mcp-sync.md`를 반드시 먼저 전부 읽고 그대로 따른다.
+
+    시그니처 (변경 금지 — PRD-A가 이 형태로 호출):
+    ```js
+    export async function syncHubMcpSettings({ hubUrl, dryRun = false, logger = console })
+    // returns: { updated: string[], skipped: string[], errors: { path, reason }[] }
+    ```
+
+    대상 파일: `~/.gemini/settings.json`, `~/.claude/settings.json`, `~/.claude/settings.local.json`.
+
+    핵심 규칙:
+    1. 파일 없음 or `mcpServers` 없음 or `tfx-hub` 엔트리 없음 → 생성 금지, skip (사용자 의도 존중).
+    2. `tfx-hub.url`이 hubUrl과 일치 → skip, 다르면 url만 교체(다른 필드 보존).
+    3. JSON parse 실패 → errors 배열에 기록, 원본 파일 보존.
+    4. atomic write (tmp → rename). Windows rename overwrite 주의.
+    5. dryRun=true면 updated에는 들어가지만 실제 write 안 함.
+    6. process.exit 금지, throw 대신 errors에 누적.
+
+    테스트: tmp 디렉터리 + HOME env override로 8 케이스.
+
+    제약: node:fs, node:os, node:path만 사용. 외부 npm 의존성 금지. 2-space indent + trailing newline 유지.
+
+    실행/검증:
+    ```bash
+    node --test tests/unit/sync-hub-mcp-settings.test.mjs
+    ```
+
+    완료 후 커밋:
+    ```bash
+    git add scripts/sync-hub-mcp-settings.mjs tests/unit/sync-hub-mcp-settings.test.mjs
+    git commit -m "feat(scripts): sync Gemini/Claude settings.json tfx-hub URL"
+    ```
+
+## Codex 실행 제약 (자동 삽입됨)
+- stdin redirect 금지: `codex < file` → "stdin is not a terminal"
+- `codex exec "$(cat prompt.md)" --dangerously-bypass-approvals-and-sandbox` 사용
+- `codex exec`는 `--profile` 미지원. config.toml 기본 모델 사용
+- `--full-auto` CLI 플래그 금지 (config.toml sandbox와 충돌)
+- 테스트 병렬 실행 시 `.test-lock/pid.lock` 충돌 가능 — 순차 실행 권장
+
+## 완료 조건 (필수)
+각 shard는 자기 파일만 수정, 테스트 통과 후 개별 커밋. 두 shard 모두 성공해야 merge 단계 진입.

--- a/docs/prd/hub-port-lock/01-hub-port-bind.md
+++ b/docs/prd/hub-port-lock/01-hub-port-bind.md
@@ -1,0 +1,88 @@
+# PRD: Hub 포트 27888 고정 바인딩 + stale pid 정리
+
+## 목표
+tfx-hub가 **반드시 포트 27888**에서 실행되도록 보장한다. 현재 `hub/server.mjs`는 27888을 기본값으로 쓰지만 바인딩 실패 시 실제로 어떤 포트에 떨어지는지 확인되지 않은 상태로 stale `hub.pid` + 클라이언트(Gemini/Claude settings.json)의 stale `tfx-hub.url`을 유발해 MCP 도구 로딩 실패를 일으키고 있다. 27888이 이미 사용 중이면 `hub.pid`의 PID를 확인하여 **죽은 프로세스면 stale 정리 후 재바인딩**, **살아있으면 reuse 판정 후 정상 종료**, **다른 프로세스가 점유 중이면 명확한 에러로 실패**시킨다.
+
+## Shard: hub-port-lock
+- agent: codex
+- files: hub/server.mjs, hub/bridge.mjs, tests/unit/hub-port-bind.test.mjs
+- prompt: |
+    hub/server.mjs를 수정해 Hub가 포트 27888에 고정 바인딩되도록 한다.
+
+    ## 현재 동작 (확인 후 수정)
+    - `hub/server.mjs:466, 1544, 2019`에서 `port = parseInt(process.env.TFX_HUB_PORT || "27888", 10)` 사용
+    - `httpServer.listen(port, host, callback)` 호출 (L1544)
+    - 27888이 이미 점유된 경우 `EADDRINUSE` 에러 발생 시 현재 fallback 동작 불분명 — 실제로는 동적 포트(예: 29198)에 떨어진 상태가 확인됨 (`~/.claude/cache/tfx-hub/hub.pid` 참조)
+
+    ## 요구사항
+    1. **27888 고정 바인딩**: Hub 시작 시 반드시 27888에 listen 시도. `listen(0)` 또는 `listen(undefined)` 같은 암묵적 동적 할당 경로가 있다면 제거.
+    2. **EADDRINUSE 처리**:
+       - `~/.claude/cache/tfx-hub/hub.pid` 읽기
+       - pid가 존재하고 프로세스 살아있으면 (Node.js: `process.kill(pid, 0)` throw 없으면 alive):
+         - 같은 버전/같은 Hub면 "이미 실행 중입니다" 메시지와 함께 graceful exit(0)
+         - 다른 버전/프로세스면 사용자에게 명시적 에러: "포트 27888이 다른 Hub(pid=X, version=Y)에 의해 점유됨. `tfx hub stop` 후 재시도"
+       - pid 없거나 죽었으면 stale로 간주, `hub.pid` 삭제 후 바인딩 재시도 (최대 1회)
+       - 재시도 후에도 실패하면 명확한 에러 메시지 + exit 1
+    3. **동적 포트 금지**: 환경변수 `TFX_HUB_PORT` 미지정 시 27888로 강제. 숫자 파싱 실패해도 27888 fallback.
+    4. **hub/bridge.mjs 정합성**: bridge.mjs L59의 `process.env.TFX_HUB_PORT || "27888"`는 유지하되, bridge.mjs는 **hub.pid의 port를 우선 읽고**, 없으면 27888 fallback으로 동작하도록 정비 (이미 L53 근처에 유사 로직 있으면 유지).
+    5. **테스트**: `tests/unit/hub-port-bind.test.mjs` 신규 작성.
+       - case 1: TFX_HUB_PORT 미지정 → port === 27888
+       - case 2: stale hub.pid (pid=999999 같은 죽은 pid) → 자동 정리 후 27888 바인딩
+       - case 3: 이미 실행 중인 Hub 감지 → graceful exit 경로 확인 (프로세스 kill signal 테스트)
+       - 실제 네트워크 바인딩 없이 단위 테스트 가능한 형태로 로직을 함수로 분리 (예: `resolveHubPort()`, `cleanStaleHubPid()`, `detectLivePeer()`).
+    6. **안전망 연결 (B PRD 모듈 호출)**: Hub가 listen 성공한 직후, **optional dynamic import**로 `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({ hubUrl })`를 호출한다. 모듈이 아직 없을 수도 있으니 try/catch로 감싸고 실패 시 warning log만 남기고 Hub 실행을 계속한다. 시그니처 협의:
+       ```js
+       try {
+         const mod = await import(new URL('../scripts/sync-hub-mcp-settings.mjs', import.meta.url));
+         await mod.syncHubMcpSettings({ hubUrl: `http://${host}:${port}/mcp` });
+       } catch (err) {
+         if (err.code !== 'ERR_MODULE_NOT_FOUND') console.warn('[hub] mcp-sync skipped:', err.message);
+       }
+       ```
+
+    ## 제약
+    - 기존 `process.env.TFX_HUB_PORT` override는 **유지** (디버그/테스트용)
+    - `hub.pid` 파일 포맷 변경 금지 (현행: `{"pid","port","version","sessionId","startedAt","host","auth_mode","url","pipe_path",...}`)
+    - packages/triflux/hub/server.mjs, packages/remote/hub/server.mjs가 있어도 이번 scope는 **`hub/server.mjs`만** (sync는 별도 커밋)
+    - 테스트 파일은 Vitest 또는 Node's native test runner (기존 `tests/unit/*.test.mjs` 패턴 따름)
+
+    ## 완료 조건
+    - `hub/server.mjs`, `hub/bridge.mjs`, `tests/unit/hub-port-bind.test.mjs` 수정/신규 완료
+    - 신규 테스트 실행 통과
+    - 기존 `tests/unit/*.test.mjs` 영향 없음 (영향 있다면 이유 명시)
+    - 변경 전 27888 fallback 동작과 변경 후 27888 강제 바인딩 동작 차이를 커밋 메시지에 설명
+
+## 인터페이스
+```javascript
+// hub/server.mjs 내부 헬퍼 (테스트 가능하도록 export)
+export function resolveHubPort(env = process.env)
+// returns: 27888 (TFX_HUB_PORT override 없는 한)
+
+export function cleanStaleHubPid(pidFilePath = HUB_PID_FILE)
+// returns: { cleaned: boolean, reason: string }
+
+export function detectLivePeer(pidFilePath = HUB_PID_FILE)
+// returns: { alive: boolean, pid?: number, port?: number, version?: string }
+```
+
+## 제약
+- 27888 외 포트 바인딩 금지 (디버그 env override 제외)
+- hub.pid 파일 포맷 보존
+- B의 sync 모듈 없어도 Hub는 정상 시작 (optional 호출)
+
+## 의존성
+- 없음 (B는 안전망, 없어도 A 단독 동작)
+
+## 테스트 명령
+```bash
+node --test tests/unit/hub-port-bind.test.mjs
+```
+
+## 완료 조건 (필수)
+1. 변경 파일 검토
+2. 테스트 통과 확인
+3. 커밋:
+   ```bash
+   git add hub/server.mjs hub/bridge.mjs tests/unit/hub-port-bind.test.mjs
+   git commit -m "fix(hub): pin port to 27888 with stale pid cleanup"
+   ```

--- a/docs/prd/hub-port-lock/02-settings-mcp-sync.md
+++ b/docs/prd/hub-port-lock/02-settings-mcp-sync.md
@@ -1,0 +1,103 @@
+# PRD: Gemini/Claude settings.json MCP URL 자동 동기화 모듈
+
+## 목표
+Hub가 실행 중인 실제 URL을 `~/.gemini/settings.json`과 `~/.claude/settings.json`(및 `settings.local.json`)의 `mcpServers.tfx-hub.url`에 **덮어쓰는 유틸리티 모듈**을 신규 작성한다. Hub 시작 훅(PRD-A)에서 이 모듈을 호출하면 settings의 stale URL이 현재 Hub URL로 자동 맞춰지는 **안전망**이 된다. PRD-A가 27888 고정에 성공하면 이 동기화는 no-op(이미 일치)이고, 혹시 다른 포트에 떨어져도 클라이언트가 따라오게 만들어 MCP 연결 끊김을 방지한다.
+
+## Shard: settings-mcp-sync
+- agent: codex
+- files: scripts/sync-hub-mcp-settings.mjs, tests/unit/sync-hub-mcp-settings.test.mjs
+- prompt: |
+    `scripts/sync-hub-mcp-settings.mjs`를 신규 작성하고 전용 테스트를 추가한다.
+
+    ## 요구 시그니처 (A가 이 형태로 호출함. 변경 금지)
+    ```js
+    export async function syncHubMcpSettings({ hubUrl, dryRun = false, logger = console }) {
+      // hubUrl: "http://127.0.0.1:27888/mcp" 형식
+      // returns: {
+      //   updated: string[],   // 실제로 URL이 변경된 파일 경로
+      //   skipped: string[],   // 이미 일치하여 skip된 파일 경로
+      //   errors: { path: string, reason: string }[],  // 읽기/쓰기 실패
+      // }
+    }
+    ```
+
+    ## 대상 파일
+    1. `~/.gemini/settings.json` — `mcpServers.tfx-hub.url`
+    2. `~/.claude/settings.json` — `mcpServers.tfx-hub.url` (단, 없을 수도 있음)
+    3. `~/.claude/settings.local.json` — 동일 (존재 시에만)
+
+    경로는 `homedir()` 기반. Windows/POSIX 동일.
+
+    ## 동작 규칙
+    1. 파일이 없으면: **생성하지 않고 skip** (기존 구조 보존이 우선). errors 배열에 기록하지 않음 — 그냥 skip.
+    2. 파일 있지만 JSON 파싱 실패: errors에 `{ path, reason: "invalid json" }` 기록하고 그 파일은 수정 금지. 나머지 파일은 계속 처리.
+    3. `mcpServers` 키 없으면: 새로 생성하지 않고 skip (스킬 사용자가 tfx-hub를 의도적으로 제거한 경우 존중). 이 경우도 errors에 기록하지 않음.
+    4. `mcpServers.tfx-hub` 있으면:
+       - `url` 필드가 hubUrl과 정확히 일치 → skip
+       - 다르면 url만 교체 (다른 필드: `enabled`, `timeout`, `trust` 등은 **보존**)
+       - `dryRun: true`면 변경 계획만 보고하고 실제 write 금지. 결과는 `updated`에 포함하되 `reason: "dry-run"` 메타로 구분할 필요는 없음(dryRun 플래그로 호출자가 판단).
+    5. 쓰기 방식:
+       - JSON 포맷 2-space indent 보존, trailing newline 유지
+       - atomic write: 임시 파일(`{path}.tmp-{pid}`) → rename (Windows에서 rename은 대상 존재 시 실패하므로 먼저 unlink 후 rename, 또는 `fs.renameSync` with overwrite)
+       - 실패 시 errors에 기록하고 다음 파일 처리 계속
+    6. 동시성: 같은 파일에 대한 동시 호출 방지를 위해 **process 내 in-memory lock**만 필요 (SharedArrayBuffer나 파일 lock 불필요). 다른 프로세스와의 race는 Hub 시작 시점 1회 호출이므로 무시.
+
+    ## 로깅
+    - 각 파일에 대해 `logger.info('[mcp-sync] updated: {path}')` 또는 `skipped`, `error`
+    - 자세한 변경 전/후 값은 debug 수준(logger.debug)
+
+    ## 테스트 (`tests/unit/sync-hub-mcp-settings.test.mjs`)
+    - tmp 디렉터리에 가짜 `~/.gemini/settings.json`, `~/.claude/settings.json`을 만들어 `HOME` env override로 테스트
+    - case 1: settings.json 없음 → skip, updated=[]
+    - case 2: tfx-hub.url이 이미 일치 → skipped에 포함
+    - case 3: tfx-hub.url 다름 → updated에 포함, 파일 실제 내용 확인
+    - case 4: 다른 MCP 서버 동시 존재 → tfx-hub만 수정, 다른 서버 보존
+    - case 5: invalid JSON → errors에 포함, 파일 원본 보존
+    - case 6: dryRun=true → updated에는 들어가지만 파일은 실제로 안 변함
+    - case 7: mcpServers 키는 있지만 tfx-hub 엔트리 없음 → skip (생성 안 함)
+    - case 8: `tfx-hub` 엔트리의 다른 필드(enabled, trust 등) 보존 확인
+
+    Vitest 또는 Node native test runner 사용. 기존 `tests/unit/*.test.mjs` 스타일 따름.
+
+    ## 제약
+    - `mcpServers` 또는 `tfx-hub` 엔트리를 **없는 상태에서 생성하지 않는다** (사용자 의도 존중). 사용자가 처음 tfx 설치 시엔 `tfx setup`이 생성하는 것이 정책.
+    - 다른 JSON 필드 보존 (정렬, 불필요 재포맷 금지. 가능하면 `JSON.parse` → 수정 → `JSON.stringify(obj, null, 2)`. 키 순서가 달라질 수 있음은 허용)
+    - `process.exit` 호출 금지, 예외 throw 대신 errors 배열에 누적
+    - 외부 의존성 추가 금지 (node:fs, node:os, node:path만 사용)
+
+    ## 완료 조건
+    - `scripts/sync-hub-mcp-settings.mjs` 작성
+    - `tests/unit/sync-hub-mcp-settings.test.mjs` 작성, 전체 통과
+    - 커밋:
+      ```bash
+      git add scripts/sync-hub-mcp-settings.mjs tests/unit/sync-hub-mcp-settings.test.mjs
+      git commit -m "feat(scripts): sync Gemini/Claude settings.json tfx-hub URL"
+      ```
+
+## 인터페이스
+```javascript
+export async function syncHubMcpSettings({ hubUrl, dryRun = false, logger = console })
+// returns: { updated: string[], skipped: string[], errors: { path, reason }[] }
+```
+
+## 제약
+- 파일/키 없으면 생성하지 않음 (의도 존중)
+- atomic write
+- 외부 npm 의존성 추가 금지
+
+## 의존성
+- 없음 (A가 이 모듈을 optional import로 호출)
+
+## 테스트 명령
+```bash
+node --test tests/unit/sync-hub-mcp-settings.test.mjs
+```
+
+## 완료 조건 (필수)
+1. 변경 파일 검토
+2. 테스트 통과 확인
+3. 커밋:
+   ```bash
+   git add scripts/sync-hub-mcp-settings.mjs tests/unit/sync-hub-mcp-settings.test.mjs
+   git commit -m "feat(scripts): sync Gemini/Claude settings.json tfx-hub URL"
+   ```

--- a/hub/bridge.mjs
+++ b/hub/bridge.mjs
@@ -25,6 +25,7 @@ import { getPipelineStateDbPath } from "./pipeline/state.mjs";
 const HUB_PID_FILE = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
 const HUB_TOKEN_FILE = join(homedir(), ".claude", ".tfx-hub-token");
 const PROJECT_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const HUB_DEFAULT_PORT = 27888;
 
 function normalizeToken(raw) {
   if (raw == null) return null;
@@ -50,13 +51,18 @@ export function getHubUrl() {
   if (existsSync(HUB_PID_FILE)) {
     try {
       const info = JSON.parse(readFileSync(HUB_PID_FILE, "utf8"));
-      return `http://${info.host || "127.0.0.1"}:${info.port || 27888}`;
+      const pidPort = Number.parseInt(String(info?.port ?? ""), 10);
+      const port =
+        Number.isFinite(pidPort) && pidPort > 0 ? pidPort : HUB_DEFAULT_PORT;
+      return `http://${info.host || "127.0.0.1"}:${port}`;
     } catch {
       // 무시
     }
   }
 
-  const port = process.env.TFX_HUB_PORT || "27888";
+  const envPort = Number.parseInt(String(process.env.TFX_HUB_PORT ?? ""), 10);
+  const port =
+    Number.isFinite(envPort) && envPort > 0 ? envPort : HUB_DEFAULT_PORT;
   return `http://127.0.0.1:${port}`;
 }
 

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -68,6 +68,7 @@ const ALLOWED_ORIGIN_RE =
 const PROJECT_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const PUBLIC_DIR = resolve(join(PROJECT_ROOT, "hub", "public"));
 const CACHE_DIR = join(homedir(), ".claude", "cache");
+const HUB_DEFAULT_PORT = 27888;
 const BATCH_EVENTS_PATH = join(CACHE_DIR, "batch-events.jsonl");
 const SV_ACCUMULATOR_PATH = join(CACHE_DIR, "sv-accumulator.json");
 const CODEX_RATE_LIMITS_CACHE_PATH = join(
@@ -183,6 +184,171 @@ async function parseBody(req) {
 const PID_DIR = join(homedir(), ".claude", "cache", "tfx-hub");
 const PID_FILE = join(PID_DIR, "hub.pid");
 const TOKEN_FILE = join(homedir(), ".claude", ".tfx-hub-token");
+
+function readHubPidFile(
+  pidFilePath = PID_FILE,
+  { exists = existsSync, readFile = readFileSync } = {},
+) {
+  if (!exists(pidFilePath)) {
+    return { exists: false, info: null, error: null };
+  }
+
+  try {
+    return {
+      exists: true,
+      info: JSON.parse(readFile(pidFilePath, "utf8")),
+      error: null,
+    };
+  } catch (error) {
+    return { exists: true, info: null, error };
+  }
+}
+
+export function resolveHubPort(env = process.env) {
+  const parsed = Number.parseInt(String(env?.TFX_HUB_PORT ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : HUB_DEFAULT_PORT;
+}
+
+export function detectLivePeer(
+  pidFilePath = PID_FILE,
+  {
+    exists = existsSync,
+    readFile = readFileSync,
+    killFn = process.kill,
+  } = {},
+) {
+  const state = readHubPidFile(pidFilePath, { exists, readFile });
+  const info = state.info ?? null;
+  const pid = Number(info?.pid);
+  const port = Number(info?.port);
+  const base = {
+    alive: false,
+    pid: Number.isFinite(pid) && pid > 0 ? pid : undefined,
+    port: Number.isFinite(port) && port > 0 ? port : undefined,
+    version: typeof info?.version === "string" ? info.version : undefined,
+    host: typeof info?.host === "string" ? info.host : undefined,
+    url: typeof info?.url === "string" ? info.url : undefined,
+    reason: "missing",
+  };
+
+  if (!state.exists) return base;
+  if (state.error) return { ...base, reason: "invalid_json" };
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return { ...base, reason: "invalid_pid" };
+  }
+
+  if (isPidAlive(pid, killFn)) {
+    return {
+      alive: true,
+      pid,
+      port: base.port,
+      version: base.version,
+      host: base.host,
+      url: base.url,
+      reason: "alive",
+    };
+  }
+
+  return { ...base, reason: "dead" };
+}
+
+export function cleanStaleHubPid(
+  pidFilePath = PID_FILE,
+  {
+    exists = existsSync,
+    readFile = readFileSync,
+    unlink = unlinkSync,
+    killFn = process.kill,
+  } = {},
+) {
+  const peer = detectLivePeer(pidFilePath, { exists, readFile, killFn });
+  if (peer.alive) {
+    return { cleaned: false, reason: "alive", pid: peer.pid };
+  }
+  if (peer.reason === "missing") {
+    return { cleaned: false, reason: "missing" };
+  }
+
+  try {
+    unlink(pidFilePath);
+    return {
+      cleaned: true,
+      reason: peer.reason === "dead" ? "stale_pid" : peer.reason,
+      pid: peer.pid,
+    };
+  } catch (error) {
+    return {
+      cleaned: false,
+      reason: "unlink_failed",
+      pid: peer.pid,
+      error,
+    };
+  }
+}
+
+async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
+  try {
+    const mod = await import(
+      new URL("../scripts/sync-hub-mcp-settings.mjs", import.meta.url)
+    );
+    if (typeof mod?.syncHubMcpSettings !== "function") {
+      hubLog.warn({ hubUrl }, "hub.mcp_sync_missing_export");
+      return;
+    }
+    await mod.syncHubMcpSettings({ hubUrl });
+  } catch (error) {
+    const message = error?.message || String(error);
+    if (error?.code === "ERR_MODULE_NOT_FOUND") {
+      hubLog.warn({ hubUrl, err: message }, "hub.mcp_sync_missing");
+      return;
+    }
+    hubLog.warn({ hubUrl, err: message }, "hub.mcp_sync_skipped");
+  }
+}
+
+async function resolvePortInUse({
+  port,
+  host,
+  version,
+  pidFilePath = PID_FILE,
+  detectPeer = detectLivePeer,
+  cleanPid = cleanStaleHubPid,
+} = {}) {
+  const peer = detectPeer(pidFilePath);
+  if (peer.alive) {
+    const peerPort = Number(peer.port);
+    const sameHub =
+      peerPort === Number(port) &&
+      typeof peer.version === "string" &&
+      peer.version === version;
+    if (sameHub) {
+      return {
+        action: "reuse",
+        peer,
+        url: peer.url ?? buildHubUrl(peer.host || host, peerPort),
+      };
+    }
+
+    const peerDetails = [
+      `pid=${peer.pid ?? "unknown"}`,
+      `version=${peer.version ?? "unknown"}`,
+    ].join(", ");
+    return {
+      action: "error",
+      message: `포트 ${port}이 다른 Hub(${peerDetails})에 의해 점유됨. \`tfx hub stop\` 후 재시도`,
+    };
+  }
+
+  const cleaned = cleanPid(pidFilePath);
+  if (cleaned.cleaned) {
+    return { action: "retry", cleaned, peer };
+  }
+
+  return {
+    action: "error",
+    message: `Hub 포트 ${port}이(가) 이미 사용 중입니다. 다른 프로세스가 점유 중일 수 있습니다. \`tfx hub stop\` 후 재시도하세요. (PID file: ${pidFilePath})`,
+  };
+}
 
 function isPublicPath(path) {
   return (
@@ -463,7 +629,11 @@ export async function startHub({
   sessionId = process.pid,
   createDelegatorWorker = createDelegatorMcpWorker,
 } = {}) {
-  const port = portOpt ?? parseInt(process.env.TFX_HUB_PORT || "27888", 10);
+  const resolvedPort = Number.parseInt(String(portOpt ?? ""), 10);
+  const port =
+    Number.isFinite(resolvedPort) && resolvedPort > 0
+      ? resolvedPort
+      : resolveHubPort(process.env);
 
   const existingHub = await tryReuseExistingHub({ port, host });
   if (existingHub) return existingHub;
@@ -1476,41 +1646,7 @@ export async function startHub({
 
   mkdirSync(PID_DIR, { recursive: true });
 
-  // Stale PID 파일 정리 — 이전 Hub 프로세스가 비정상 종료된 경우
-  if (existsSync(PID_FILE)) {
-    try {
-      const prevInfo = JSON.parse(readFileSync(PID_FILE, "utf8"));
-      const prevPid = Number(prevInfo?.pid);
-      if (Number.isFinite(prevPid) && prevPid > 0) {
-        try {
-          process.kill(prevPid, 0); // alive 체크만
-          // 프로세스가 살아있으면 포트 충돌 가능성 — 기존 Hub 재사용 안내
-          if (Number(prevInfo.port) === Number(port)) {
-            hubLog.warn(
-              { prevPid, port },
-              "hub.stale_pid: previous hub still alive on same port",
-            );
-          }
-        } catch {
-          // 프로세스 죽음 → stale PID 파일 삭제
-          try {
-            unlinkSync(PID_FILE);
-          } catch {}
-          hubLog.info({ prevPid }, "hub.stale_pid_cleaned");
-        }
-      } else {
-        try {
-          unlinkSync(PID_FILE);
-        } catch {}
-      }
-    } catch {
-      try {
-        unlinkSync(PID_FILE);
-      } catch {}
-    }
-  }
-
-  const cleanupStartupFailure = async () => {
+  const cleanupStartupFailure = async ({ preserveTokenFile = false } = {}) => {
     try {
       router.stopSweeper();
     } catch {}
@@ -1526,9 +1662,11 @@ export async function startHub({
     try {
       store.close();
     } catch {}
-    try {
-      unlinkSync(TOKEN_FILE);
-    } catch {}
+    if (!preserveTokenFile) {
+      try {
+        unlinkSync(TOKEN_FILE);
+      } catch {}
+    }
     releaseStartupLock();
   };
 
@@ -1541,172 +1679,229 @@ export async function startHub({
   }
 
   return await new Promise((resolveHub, reject) => {
-    httpServer.listen(port, host, () => {
-      try {
-        let idleTimer = null;
-        let stopPromise = null;
+    let bindAttempts = 0;
 
-        const info = {
-          port,
-          host,
-          dbPath,
-          pid: process.pid,
-          hubToken: HUB_TOKEN,
-          authMode: HUB_TOKEN ? "token-required" : "localhost-only",
-          url: buildHubUrl(host, port),
-          pipe_path: pipe.path,
-          pipePath: pipe.path,
-          assign_callback_pipe_path: assignCallbacks.path,
-          assignCallbackPipePath: assignCallbacks.path,
-          version,
-          storeType: store.type || "sqlite",
-          idleTimeoutMs: hubIdleTimeoutMs,
-        };
+    const listenOnce = () => {
+      const onError = (err) => {
+        void (async () => {
+          if (err.code !== "EADDRINUSE") {
+            await cleanupStartupFailure();
+            reject(err);
+            return;
+          }
 
-        writeState({
-          pid: process.pid,
-          port,
-          host,
-          auth_mode: HUB_TOKEN ? "token-required" : "localhost-only",
-          url: info.url,
-          pipe_path: pipe.path,
-          pipePath: pipe.path,
-          assign_callback_pipe_path: assignCallbacks.path,
-          assignCallbackPipePath: assignCallbacks.path,
-          authMode: HUB_TOKEN ? "token-required" : "localhost-only",
-          startedAt,
-          started: startedAtMs,
-          version,
-          sessionId,
-          session_id: sessionId,
-        });
-        releaseStartupLock();
-
-        hubLog.info(
-          {
-            url: info.url,
-            pipePath: pipe.path,
-            assignCallbackPath: assignCallbacks.path,
-            pid: process.pid,
-            storeType: info.storeType,
+          const conflict = await resolvePortInUse({
+            port,
+            host,
             version,
-          },
-          "hub.started",
-        );
-        hubLog.debug(
-          {
-            publicDir: PUBLIC_DIR,
-            exists: existsSync(PUBLIC_DIR),
-            hasDashboard: existsSync(resolve(PUBLIC_DIR, "dashboard.html")),
-          },
-          "hub.public_dir",
-        );
-
-        /**
-         * Hub 서버 정지 함수.
-         *
-         * Trade-off (F01 — 영구 poisoning 허용):
-         * 첫 정지 호출에서 cleanup 파이프라인이 실패하면 stopPromise는 실패 상태로
-         * 고정되고, 이후 모든 호출은 동일한 실패 promise를 반환합니다. stopPromise를
-         * null로 리셋하면 재시도가 가능하지만, router sweeper / transports / pipe 등이
-         * 이미 부분 해제된 상태에서 두 번째 close가 실행되면 use-after-close 및
-         * race condition을 유발합니다. 실패한 stopFn은 프로세스 전체 재시작으로 복구해야
-         * 하며, 이 동작은 의도된 설계입니다.
-         */
-        const stopFn = async () => {
-          if (stopPromise) return stopPromise;
-
-          stopPromise = (async () => {
-            router.stopSweeper();
-            clearInterval(hitlTimer);
-            clearInterval(sessionTimer);
-            clearInterval(rateLimitTimer);
-            clearInterval(orphanCleanupTimer);
-            if (idleTimer) {
-              clearInterval(idleTimer);
-            }
-            for (const [, session] of transports) {
-              try {
-                await session.mcp.close();
-              } catch {}
-              try {
-                await session.transport.close();
-              } catch {}
-            }
-            transports.clear();
-            await pipe.stop();
-            await assignCallbacks.stop();
-            await delegatorWorker.stop().catch(() => {});
-            try { synapseRegistry.destroy(); } catch {}
-            store.close();
-            try {
-              unlinkSync(PID_FILE);
-            } catch {}
-            try {
-              unlinkSync(TOKEN_FILE);
-            } catch {}
-            httpServer.closeAllConnections();
-            await new Promise((resolveClose) => httpServer.close(resolveClose));
-          })().catch((error) => {
-            hubLog.error({ err: String(error?.message || error) }, "hub.stop_error");
-            // stopPromise를 null로 리셋하지 않음 — double-close 방지
           });
-
-          return stopPromise;
-        };
-
-        if (hubIdleTimeoutMs > 0) {
-          idleTimer = setInterval(() => {
-            const idleMs = Date.now() - lastRequestAt;
-            if (idleMs < hubIdleTimeoutMs) return;
+          if (conflict.action === "retry" && bindAttempts < 1) {
+            bindAttempts += 1;
             hubLog.warn(
-              { idleMs, idleTimeoutMs: hubIdleTimeoutMs, port },
-              "hub.idle_timeout_shutdown",
+              { port, reason: conflict.cleaned?.reason },
+              "hub.port_in_use_retry_after_stale_pid_cleanup",
             );
-            void stopFn().catch((error) => {
-              hubLog.error(
-                { err: error, idleMs, idleTimeoutMs: hubIdleTimeoutMs, port },
-                "hub.idle_timeout_shutdown_failed",
-              );
-            });
-          }, hubIdleSweepMs);
-          idleTimer.unref();
-        }
+            listenOnce();
+            return;
+          }
 
-        resolveHub({
-          reused: false,
-          external: false,
-          ...info,
-          httpServer,
-          store,
-          router,
-          hitl,
-          pipe,
-          assignCallbacks,
-          delegatorService,
-          delegatorWorker,
-          stop: stopFn,
-        });
-      } catch (error) {
-        void cleanupStartupFailure().finally(() => reject(error));
-      }
-    });
-    httpServer.on("error", (err) => {
-      void cleanupStartupFailure();
-      if (err.code === "EADDRINUSE") {
-        hubLog.error(
-          { port, host },
-          "hub.port_in_use: port already occupied — check for existing hub or other service",
-        );
-        const wrapped = new Error(
-          `Hub 포트 ${port}이(가) 이미 사용 중입니다. 기존 Hub 프로세스를 확인하세요. (PID file: ${PID_FILE})`,
-        );
-        wrapped.code = "EADDRINUSE";
-        reject(wrapped);
-      } else {
-        reject(err);
-      }
-    });
+          await cleanupStartupFailure({ preserveTokenFile: true });
+          if (conflict.action === "reuse") {
+            hubLog.info(
+              {
+                port,
+                pid: conflict.peer?.pid,
+                version: conflict.peer?.version,
+                url: conflict.url,
+              },
+              "hub.already_running",
+            );
+            resolveHub({
+              reused: true,
+              external: true,
+              port,
+              pid: conflict.peer?.pid,
+              url: conflict.url,
+              stop: async () => false,
+            });
+            return;
+          }
+
+          hubLog.error({ port, host }, "hub.port_in_use");
+          const wrapped = new Error(conflict.message);
+          wrapped.code = "EADDRINUSE";
+          reject(wrapped);
+        })();
+      };
+
+      httpServer.once("error", onError);
+      httpServer.listen(port, host, () => {
+        httpServer.off("error", onError);
+        try {
+          let idleTimer = null;
+          let stopPromise = null;
+
+          const info = {
+            port,
+            host,
+            dbPath,
+            pid: process.pid,
+            hubToken: HUB_TOKEN,
+            authMode: HUB_TOKEN ? "token-required" : "localhost-only",
+            url: buildHubUrl(host, port),
+            pipe_path: pipe.path,
+            pipePath: pipe.path,
+            assign_callback_pipe_path: assignCallbacks.path,
+            assignCallbackPipePath: assignCallbacks.path,
+            version,
+            storeType: store.type || "sqlite",
+            idleTimeoutMs: hubIdleTimeoutMs,
+          };
+
+          writeState({
+            pid: process.pid,
+            port,
+            host,
+            auth_mode: HUB_TOKEN ? "token-required" : "localhost-only",
+            url: info.url,
+            pipe_path: pipe.path,
+            pipePath: pipe.path,
+            assign_callback_pipe_path: assignCallbacks.path,
+            assignCallbackPipePath: assignCallbacks.path,
+            authMode: HUB_TOKEN ? "token-required" : "localhost-only",
+            startedAt,
+            started: startedAtMs,
+            version,
+            sessionId,
+            session_id: sessionId,
+          });
+          releaseStartupLock();
+          void syncHubMcpSettingsIfAvailable({ hubUrl: info.url });
+
+          hubLog.info(
+            {
+              url: info.url,
+              pipePath: pipe.path,
+              assignCallbackPath: assignCallbacks.path,
+              pid: process.pid,
+              storeType: info.storeType,
+              version,
+            },
+            "hub.started",
+          );
+          hubLog.debug(
+            {
+              publicDir: PUBLIC_DIR,
+              exists: existsSync(PUBLIC_DIR),
+              hasDashboard: existsSync(resolve(PUBLIC_DIR, "dashboard.html")),
+            },
+            "hub.public_dir",
+          );
+
+          /**
+           * Hub 서버 정지 함수.
+           *
+           * Trade-off (F01 — 영구 poisoning 허용):
+           * 첫 정지 호출에서 cleanup 파이프라인이 실패하면 stopPromise는 실패 상태로
+           * 고정되고, 이후 모든 호출은 동일한 실패 promise를 반환합니다. stopPromise를
+           * null로 리셋하면 재시도가 가능하지만, router sweeper / transports / pipe 등이
+           * 이미 부분 해제된 상태에서 두 번째 close가 실행되면 use-after-close 및
+           * race condition을 유발합니다. 실패한 stopFn은 프로세스 전체 재시작으로 복구해야
+           * 하며, 이 동작은 의도된 설계입니다.
+           */
+          const stopFn = async () => {
+            if (stopPromise) return stopPromise;
+
+            stopPromise = (async () => {
+              router.stopSweeper();
+              clearInterval(hitlTimer);
+              clearInterval(sessionTimer);
+              clearInterval(rateLimitTimer);
+              clearInterval(orphanCleanupTimer);
+              if (idleTimer) {
+                clearInterval(idleTimer);
+              }
+              for (const [, session] of transports) {
+                try {
+                  await session.mcp.close();
+                } catch {}
+                try {
+                  await session.transport.close();
+                } catch {}
+              }
+              transports.clear();
+              await pipe.stop();
+              await assignCallbacks.stop();
+              await delegatorWorker.stop().catch(() => {});
+              try {
+                synapseRegistry.destroy();
+              } catch {}
+              store.close();
+              try {
+                unlinkSync(PID_FILE);
+              } catch {}
+              try {
+                unlinkSync(TOKEN_FILE);
+              } catch {}
+              httpServer.closeAllConnections();
+              await new Promise((resolveClose) =>
+                httpServer.close(resolveClose),
+              );
+            })().catch((error) => {
+              hubLog.error(
+                { err: String(error?.message || error) },
+                "hub.stop_error",
+              );
+              // stopPromise를 null로 리셋하지 않음 — double-close 방지
+            });
+
+            return stopPromise;
+          };
+
+          if (hubIdleTimeoutMs > 0) {
+            idleTimer = setInterval(() => {
+              const idleMs = Date.now() - lastRequestAt;
+              if (idleMs < hubIdleTimeoutMs) return;
+              hubLog.warn(
+                { idleMs, idleTimeoutMs: hubIdleTimeoutMs, port },
+                "hub.idle_timeout_shutdown",
+              );
+              void stopFn().catch((error) => {
+                hubLog.error(
+                  {
+                    err: error,
+                    idleMs,
+                    idleTimeoutMs: hubIdleTimeoutMs,
+                    port,
+                  },
+                  "hub.idle_timeout_shutdown_failed",
+                );
+              });
+            }, hubIdleSweepMs);
+            idleTimer.unref();
+          }
+
+          resolveHub({
+            reused: false,
+            external: false,
+            ...info,
+            httpServer,
+            store,
+            router,
+            hitl,
+            pipe,
+            assignCallbacks,
+            delegatorService,
+            delegatorWorker,
+            stop: stopFn,
+          });
+        } catch (error) {
+          void cleanupStartupFailure().finally(() => reject(error));
+        }
+      });
+    };
+
+    listenOnce();
   });
 }
 
@@ -2016,7 +2211,7 @@ refresh();setInterval(refresh,10000);
 
 const selfRun = process.argv[1]?.replace(/\\/g, "/").endsWith("hub/server.mjs");
 if (selfRun) {
-  const port = parseInt(process.env.TFX_HUB_PORT || "27888", 10);
+  const port = resolveHubPort(process.env);
   const dbPath = process.env.TFX_HUB_DB || undefined;
 
   const cleanupPidFile = () => {
@@ -2038,6 +2233,14 @@ if (selfRun) {
 
   startHub({ port, dbPath })
     .then((info) => {
+      if (info?.reused && info?.external) {
+        hubLog.info(
+          { pid: info.pid, port: info.port, url: info.url },
+          "hub.already_running_exit",
+        );
+        process.exit(0);
+        return;
+      }
       const shutdown = async (signal) => {
         hubLog.info({ signal }, "hub.stopping");
         try {

--- a/scripts/sync-hub-mcp-settings.mjs
+++ b/scripts/sync-hub-mcp-settings.mjs
@@ -1,0 +1,185 @@
+import { constants } from "node:fs";
+import { access, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const TARGET_FILES = [
+  [".gemini", "settings.json"],
+  [".claude", "settings.json"],
+  [".claude", "settings.local.json"],
+];
+const FILE_LOCKS = new Map();
+
+function getSettingsPaths() {
+  const home = process.env.HOME || homedir();
+  return TARGET_FILES.map((segments) => join(home, ...segments));
+}
+
+function getReason(error, fallback) {
+  if (typeof error?.message === "string" && error.message.length > 0) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function log(logger, level, message) {
+  const writer = logger?.[level];
+  if (typeof writer !== "function") {
+    return;
+  }
+
+  try {
+    writer.call(logger, message);
+  } catch {
+    // logging must never break sync flow
+  }
+}
+
+async function withFileLock(filePath, task) {
+  while (FILE_LOCKS.has(filePath)) {
+    await FILE_LOCKS.get(filePath);
+  }
+
+  let release;
+  const lock = new Promise((resolve) => {
+    release = resolve;
+  });
+  FILE_LOCKS.set(filePath, lock);
+
+  try {
+    return await task();
+  } finally {
+    FILE_LOCKS.delete(filePath);
+    release();
+  }
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeJsonAtomic(filePath, value) {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  const payload = `${JSON.stringify(value, null, 2)}\n`;
+
+  try {
+    await writeFile(tmpPath, payload, "utf8");
+
+    try {
+      await rename(tmpPath, filePath);
+    } catch (error) {
+      if (
+        error?.code !== "EEXIST" &&
+        error?.code !== "EPERM" &&
+        error?.code !== "EACCES"
+      ) {
+        throw error;
+      }
+
+      await rm(filePath, { force: true });
+      await rename(tmpPath, filePath);
+    }
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {});
+  }
+}
+
+async function syncSingleFile({ filePath, hubUrl, dryRun, logger }) {
+  return withFileLock(filePath, async () => {
+    if (!(await fileExists(filePath))) {
+      log(logger, "info", `[mcp-sync] skipped: ${filePath}`);
+      return { kind: "skipped", path: filePath };
+    }
+
+    let settings;
+    try {
+      settings = JSON.parse(await readFile(filePath, "utf8"));
+    } catch (error) {
+      const reason =
+        error?.name === "SyntaxError"
+          ? "invalid json"
+          : getReason(error, "read failed");
+      log(logger, "error", `[mcp-sync] error: ${filePath} (${reason})`);
+      return { kind: "error", path: filePath, reason };
+    }
+
+    const servers = settings?.mcpServers;
+    if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+      log(logger, "info", `[mcp-sync] skipped: ${filePath}`);
+      return { kind: "skipped", path: filePath };
+    }
+
+    const hubServer = servers["tfx-hub"];
+    if (hubServer === undefined) {
+      log(logger, "info", `[mcp-sync] skipped: ${filePath}`);
+      return { kind: "skipped", path: filePath };
+    }
+
+    if (
+      !hubServer ||
+      typeof hubServer !== "object" ||
+      Array.isArray(hubServer)
+    ) {
+      const reason = "invalid tfx-hub entry";
+      log(logger, "error", `[mcp-sync] error: ${filePath} (${reason})`);
+      return { kind: "error", path: filePath, reason };
+    }
+
+    if (hubServer.url === hubUrl) {
+      log(logger, "info", `[mcp-sync] skipped: ${filePath}`);
+      return { kind: "skipped", path: filePath };
+    }
+
+    log(
+      logger,
+      "debug",
+      `[mcp-sync] ${filePath} url: ${String(hubServer.url)} -> ${hubUrl}`,
+    );
+
+    if (!dryRun) {
+      try {
+        hubServer.url = hubUrl;
+        await writeJsonAtomic(filePath, settings);
+      } catch (error) {
+        const reason = getReason(error, "write failed");
+        log(logger, "error", `[mcp-sync] error: ${filePath} (${reason})`);
+        return { kind: "error", path: filePath, reason };
+      }
+    }
+
+    log(logger, "info", `[mcp-sync] updated: ${filePath}`);
+    return { kind: "updated", path: filePath };
+  });
+}
+
+export async function syncHubMcpSettings({
+  hubUrl,
+  dryRun = false,
+  logger = console,
+}) {
+  const result = {
+    updated: [],
+    skipped: [],
+    errors: [],
+  };
+
+  for (const filePath of getSettingsPaths()) {
+    const outcome = await syncSingleFile({ filePath, hubUrl, dryRun, logger });
+    if (outcome.kind === "updated") {
+      result.updated.push(outcome.path);
+      continue;
+    }
+    if (outcome.kind === "skipped") {
+      result.skipped.push(outcome.path);
+      continue;
+    }
+    result.errors.push({ path: outcome.path, reason: outcome.reason });
+  }
+
+  return result;
+}

--- a/tests/unit/hub-port-bind.test.mjs
+++ b/tests/unit/hub-port-bind.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  cleanStaleHubPid,
+  detectLivePeer,
+  resolveHubPort,
+} from "../../hub/server.mjs";
+
+const TEMP_DIRS = [];
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-hub-port-bind-"));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+function writeHubPid(payload) {
+  const dir = makeTempDir();
+  const pidFile = join(dir, "hub.pid");
+  writeFileSync(pidFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return pidFile;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    try {
+      rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+describe("hub port bind helpers", () => {
+  it("TFX_HUB_PORT 미지정이면 27888을 사용한다", () => {
+    assert.equal(resolveHubPort({}), 27888);
+    assert.equal(resolveHubPort({ TFX_HUB_PORT: "not-a-number" }), 27888);
+    assert.equal(resolveHubPort({ TFX_HUB_PORT: "30001" }), 30001);
+  });
+
+  it("stale hub.pid 는 자동 정리되고 기본 포트는 27888로 유지된다", () => {
+    const pidFile = writeHubPid({
+      pid: 999999,
+      port: 27888,
+      version: "1.2.3",
+      sessionId: "stale-session",
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = cleanStaleHubPid(pidFile, {
+      killFn() {
+        const error = new Error("ESRCH");
+        error.code = "ESRCH";
+        throw error;
+      },
+    });
+
+    assert.deepEqual(result, {
+      cleaned: true,
+      reason: "stale_pid",
+      pid: 999999,
+    });
+    assert.equal(existsSync(pidFile), false);
+    assert.equal(resolveHubPort({}), 27888);
+  });
+
+  it("live peer 는 signal 0 체크 결과를 반환해 graceful exit 분기를 가능하게 한다", () => {
+    const pidFile = writeHubPid({
+      pid: process.pid,
+      port: 27888,
+      version: "same-version",
+      host: "127.0.0.1",
+      url: "http://127.0.0.1:27888/mcp",
+      sessionId: "live-session",
+      startedAt: new Date().toISOString(),
+    });
+    const killCalls = [];
+
+    const peer = detectLivePeer(pidFile, {
+      killFn(pid, signal) {
+        killCalls.push([pid, signal]);
+      },
+    });
+
+    assert.equal(peer.alive, true);
+    assert.equal(peer.pid, process.pid);
+    assert.equal(peer.port, 27888);
+    assert.equal(peer.version, "same-version");
+    assert.deepEqual(killCalls, [[process.pid, 0]]);
+  });
+});

--- a/tests/unit/sync-hub-mcp-settings.test.mjs
+++ b/tests/unit/sync-hub-mcp-settings.test.mjs
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { syncHubMcpSettings } from "../../scripts/sync-hub-mcp-settings.mjs";
+
+const HUB_URL = "http://127.0.0.1:27888/mcp";
+
+function createLogger() {
+  return {
+    info() {},
+    debug() {},
+    error() {},
+  };
+}
+
+function writeJson(filePath, value) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeRaw(filePath, value) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value, "utf8");
+}
+
+describe("sync-hub-mcp-settings", () => {
+  const originalHome = process.env.HOME;
+  let homeDir;
+
+  function settingsPath(...segments) {
+    return join(homeDir, ...segments);
+  }
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "tfx-mcp-sync-"));
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (homeDir && existsSync(homeDir)) {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("case 1: 대상 settings 파일이 없으면 생성하지 않고 skip한다", async () => {
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, []);
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.skipped, [
+      settingsPath(".gemini", "settings.json"),
+      settingsPath(".claude", "settings.json"),
+      settingsPath(".claude", "settings.local.json"),
+    ]);
+  });
+
+  it("case 2: tfx-hub.url이 이미 일치하면 skipped에 포함한다", async () => {
+    const geminiPath = settingsPath(".gemini", "settings.json");
+    writeJson(geminiPath, {
+      mcpServers: {
+        "tfx-hub": {
+          url: HUB_URL,
+          enabled: false,
+        },
+      },
+    });
+
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, []);
+    assert.deepEqual(result.errors, []);
+    assert.ok(result.skipped.includes(geminiPath));
+    assert.equal(
+      JSON.parse(readFileSync(geminiPath, "utf8")).mcpServers["tfx-hub"].url,
+      HUB_URL,
+    );
+  });
+
+  it("case 3: tfx-hub.url이 다르면 updated에 포함되고 파일이 실제로 바뀐다", async () => {
+    const geminiPath = settingsPath(".gemini", "settings.json");
+    writeJson(geminiPath, {
+      mcpServers: {
+        "tfx-hub": {
+          url: "http://127.0.0.1:39999/mcp",
+        },
+      },
+    });
+
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, [geminiPath]);
+    assert.deepEqual(result.errors, []);
+    assert.equal(
+      JSON.parse(readFileSync(geminiPath, "utf8")).mcpServers["tfx-hub"].url,
+      HUB_URL,
+    );
+    assert.ok(readFileSync(geminiPath, "utf8").endsWith("\n"));
+  });
+
+  it("case 4: 다른 MCP 서버가 있어도 tfx-hub만 수정하고 나머지는 보존한다", async () => {
+    const claudePath = settingsPath(".claude", "settings.json");
+    writeJson(claudePath, {
+      mcpServers: {
+        other: {
+          url: "http://127.0.0.1:4000/mcp",
+          enabled: true,
+        },
+        "tfx-hub": {
+          url: "http://127.0.0.1:49999/mcp",
+          enabled: false,
+        },
+      },
+      profile: "keep-me",
+    });
+
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.ok(result.updated.includes(claudePath));
+    const next = JSON.parse(readFileSync(claudePath, "utf8"));
+    assert.deepEqual(next.mcpServers.other, {
+      url: "http://127.0.0.1:4000/mcp",
+      enabled: true,
+    });
+    assert.equal(next.mcpServers["tfx-hub"].url, HUB_URL);
+    assert.equal(next.profile, "keep-me");
+  });
+
+  it("case 5: invalid JSON이면 errors에 기록하고 원본 파일을 보존한다", async () => {
+    const claudePath = settingsPath(".claude", "settings.json");
+    const original = "{ invalid json\n";
+    writeRaw(claudePath, original);
+
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, []);
+    assert.deepEqual(result.errors, [
+      { path: claudePath, reason: "invalid json" },
+    ]);
+    assert.equal(readFileSync(claudePath, "utf8"), original);
+  });
+
+  it("case 6: dryRun=true면 updated에는 포함되지만 파일은 실제로 바뀌지 않는다", async () => {
+    const claudeLocalPath = settingsPath(".claude", "settings.local.json");
+    writeJson(claudeLocalPath, {
+      mcpServers: {
+        "tfx-hub": {
+          url: "http://127.0.0.1:18888/mcp",
+        },
+      },
+    });
+
+    const before = readFileSync(claudeLocalPath, "utf8");
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      dryRun: true,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, [claudeLocalPath]);
+    assert.equal(readFileSync(claudeLocalPath, "utf8"), before);
+  });
+
+  it("case 7: mcpServers는 있지만 tfx-hub 엔트리가 없으면 생성하지 않고 skip한다", async () => {
+    const geminiPath = settingsPath(".gemini", "settings.json");
+    writeJson(geminiPath, {
+      mcpServers: {
+        other: {
+          url: "http://127.0.0.1:3000/mcp",
+        },
+      },
+    });
+
+    const before = readFileSync(geminiPath, "utf8");
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, []);
+    assert.deepEqual(result.errors, []);
+    assert.ok(result.skipped.includes(geminiPath));
+    assert.equal(readFileSync(geminiPath, "utf8"), before);
+  });
+
+  it("case 8: tfx-hub의 다른 필드(enabled, trust 등)는 보존한다", async () => {
+    const claudePath = settingsPath(".claude", "settings.json");
+    writeJson(claudePath, {
+      mcpServers: {
+        "tfx-hub": {
+          url: "http://127.0.0.1:45555/mcp",
+          enabled: true,
+          trust: ["project-a"],
+          timeout: 15000,
+        },
+      },
+    });
+
+    const result = await syncHubMcpSettings({
+      hubUrl: HUB_URL,
+      logger: createLogger(),
+    });
+
+    assert.deepEqual(result.updated, [claudePath]);
+    assert.deepEqual(result.errors, []);
+
+    const next = JSON.parse(readFileSync(claudePath, "utf8"));
+    assert.deepEqual(next.mcpServers["tfx-hub"], {
+      url: HUB_URL,
+      enabled: true,
+      trust: ["project-a"],
+      timeout: 15000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **PRD-A**: Hub가 반드시 포트 27888에 고정 바인딩되도록 수정. EADDRINUSE 시 `~/.claude/cache/tfx-hub/hub.pid` 검사 → stale 자동 정리 또는 명확한 에러로 실패. `resolveHubPort`/`cleanStaleHubPid`/`detectLivePeer` 헬퍼 함수 분리 export.
- **PRD-B**: `scripts/sync-hub-mcp-settings.mjs` 신규 모듈 — `~/.gemini/settings.json`, `~/.claude/settings.json`, `~/.claude/settings.local.json`의 `mcpServers.tfx-hub.url`을 현재 Hub URL로 자동 동기화. 파일/키 없으면 생성하지 않음(사용자 의도 존중).
- Hub listen 직후 optional dynamic import로 sync 호출 — 모듈 부재/실패 시 warning만 남기고 Hub 정상 실행.

## Test plan
- [ ] `node --test tests/unit/hub-port-bind.test.mjs` 통과
- [ ] `node --test tests/unit/sync-hub-mcp-settings.test.mjs` 통과
- [ ] 기존 Hub 종료 후 재시작 시 27888로 떠짐 확인
- [ ] Gemini/Claude settings.json의 stale URL이 자동 갱신되는지 확인

## Follow-up
- Codex `~/.codex/config.toml` 동기화는 별도 이슈 #81 (TOML 파서 필요)

Closes #79