### PR TITLE
fix(hub): quota-refresh 개별 계정 try-catch + 누락 import 수정

### DIFF
--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -1682,9 +1682,9 @@ function cleanupStaleSpawnSessions(log) {
 const QUOTA_CACHE_PATH = join(CACHE_DIR, "broker-quota-cache.json");
 
 async function checkSingleAccountQuota(acct) {
-  const authPath = join(PID_DIR, acct.authFile);
-  if (!existsSync(authPath)) return { id: acct.id, status: "no_auth" };
   try {
+    const authPath = join(PID_DIR, acct.authFile);
+    if (!existsSync(authPath)) return { id: acct.id, status: "no_auth" };
     const auth = JSON.parse(readFileSync(authPath, "utf8"));
     if (acct.provider === "codex") {
       const token = auth.tokens?.access_token || auth.OPENAI_API_KEY || "";
@@ -1712,7 +1712,12 @@ async function checkSingleAccountQuota(acct) {
 async function refreshAllAccountQuotas() {
   const snap = brokerInstance?.snapshot() || [];
   const checks = snap.filter(a => a.authFile).map(a => checkSingleAccountQuota(a));
-  const results = await Promise.all(checks);
+  const settled = await Promise.allSettled(checks);
+  const results = settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : { id: snap.filter(a => a.authFile)[i]?.id ?? "unknown", status: "error", message: String(s.reason?.message || s.reason).substring(0, 60) },
+  );
   // 캐시 저장
   try {
     writeFileSync(QUOTA_CACHE_PATH, JSON.stringify({ ts: Date.now(), results }));

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -1682,9 +1682,9 @@ function cleanupStaleSpawnSessions(log) {
 const QUOTA_CACHE_PATH = join(CACHE_DIR, "broker-quota-cache.json");
 
 async function checkSingleAccountQuota(acct) {
-  const authPath = join(PID_DIR, acct.authFile);
-  if (!existsSync(authPath)) return { id: acct.id, status: "no_auth" };
   try {
+    const authPath = join(PID_DIR, acct.authFile);
+    if (!existsSync(authPath)) return { id: acct.id, status: "no_auth" };
     const auth = JSON.parse(readFileSync(authPath, "utf8"));
     if (acct.provider === "codex") {
       const token = auth.tokens?.access_token || auth.OPENAI_API_KEY || "";
@@ -1712,7 +1712,12 @@ async function checkSingleAccountQuota(acct) {
 async function refreshAllAccountQuotas() {
   const snap = brokerInstance?.snapshot() || [];
   const checks = snap.filter(a => a.authFile).map(a => checkSingleAccountQuota(a));
-  const results = await Promise.all(checks);
+  const settled = await Promise.allSettled(checks);
+  const results = settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : { id: snap.filter(a => a.authFile)[i]?.id ?? "unknown", status: "error", message: String(s.reason?.message || s.reason).substring(0, 60) },
+  );
   // 캐시 저장
   try {
     writeFileSync(QUOTA_CACHE_PATH, JSON.stringify({ ts: Date.now(), results }));


### PR DESCRIPTION
- checkSingleAccountQuota: join(PID_DIR, acct.authFile)을 try-catch 안으로 이동하여
  authFile이 undefined일 때 uncaught throw 방지
- refreshAllAccountQuotas: Promise.all → Promise.allSettled로 변경하여
  한 계정 실패가 전체 엔드포인트를 크래시시키지 않도록 격리
- packages/triflux 미러에도 동일 수정 적용
