### PR TITLE
feat(tfx-auto): 2+ 태스크 + 코드 변경 시 tfx-swarm 자동 dispatch (#87)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -308,6 +308,42 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
       },
     ],
   },
+  swarm: {
+    usage: "tfx swarm <prd-path> [--dry-run|--json|--filter <shard>]",
+    description: "PRD 기반 멀티모델 x 멀티기기 스웜 실행 (#93)",
+    subcommands: {
+      plan: "tfx swarm plan <prd-path> [--json] — 실행 없이 계획만 출력",
+      list: "tfx swarm list [--json] — 활성 스웜 세션 조회 (synapse status)",
+      status: "tfx swarm status [--json] — list alias",
+    },
+    options: [
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description: "PRD 분석만 수행, shard를 실행하지 않음",
+      },
+      {
+        name: "--json",
+        type: "boolean",
+        description: "구조화된 JSON 출력",
+      },
+      {
+        name: "--filter",
+        type: "string",
+        description: "특정 shard만 실행 (이름 매칭)",
+      },
+      {
+        name: "--max-restarts",
+        type: "number",
+        description: "shard별 최대 재시작 횟수 (기본 2)",
+      },
+      {
+        name: "--logs-dir",
+        type: "string",
+        description: "이벤트 로그 출력 디렉토리 오버라이드",
+      },
+    ],
+  },
   why: {
     usage: "tfx why <path> [--json]",
     description: "해당 경로의 마지막 커밋에서 X-Intent 트레일러 추출",
@@ -5373,6 +5409,30 @@ async function main() {
         });
       }
       await cmdSynapseStatus(cmdArgs.slice(1), { json: JSON_OUTPUT });
+      return;
+    }
+    case "swarm": {
+      await checkHubRunning();
+      const { cmdSwarmRun, cmdSwarmPlan, cmdSwarmList } = await import(
+        "../hub/team/swarm-cli.mjs"
+      );
+      const sub = cmdArgs[0] || "";
+      if (sub === "list" || sub === "status") {
+        await cmdSwarmList(cmdArgs.slice(1), { json: JSON_OUTPUT });
+        return;
+      }
+      if (sub === "plan") {
+        await cmdSwarmPlan(cmdArgs.slice(1), { json: JSON_OUTPUT });
+        return;
+      }
+      if (!sub || sub.startsWith("--")) {
+        throw createCliError("PRD 경로가 필요합니다", {
+          exitCode: EXIT_ARG_ERROR,
+          reason: "argError",
+          fix: "tfx swarm <prd-path> [--dry-run|--json|--filter <shard>]",
+        });
+      }
+      await cmdSwarmRun(cmdArgs, { json: JSON_OUTPUT });
       return;
     }
     case "why": {

--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -147,7 +147,10 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
       parts.push("--output-last-message", resultFile);
     }
     if (FEATURES.colorNever) parts.push("--color", "never");
-    if (cwd) parts.push("--cwd", `'${escapePwshSingleQuoted(cwd)}'`);
+    // NOTE: `codex exec`는 --cwd 플래그를 지원하지 않는다. Node spawn의 cwd
+    // 옵션으로 child process의 working directory를 제어한다 (conductor.mjs 참조).
+    // opts.cwd는 기록용으로만 받아두고 CLI command에는 반영하지 않는다.
+    // (이전 커밋에서 잘못 추가되어 shard 전체가 exit 2로 크래시한 회귀 #94 후속 이슈)
     if (Array.isArray(mcpServers)) {
       for (const server of mcpServers) {
         parts.push("-c", `mcp_servers.${server}.enabled=true`);

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -8,6 +8,7 @@
 // 3. Auto-restart (maxRestarts=3)
 // 4. JSONL event log (블랙박스 리코더)
 
+import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   copyFileSync,
@@ -457,11 +458,51 @@ export function createConductor(opts = {}) {
     let outputBytes = 0;
     let recentOutput = "";
 
+    const spawnCwd = session.config.workdir || launcher.cwd || undefined;
+
+    // #90 branch guard: shard spawn cwd가 main 브랜치면 즉시 abort.
+    // swarm shard는 반드시 shard 전용 worktree 브랜치에서 실행되어야 한다.
+    // cwd fallback으로 main working tree에 떨어진 경우 차단.
+    if (session.config.branchGuard && spawnCwd) {
+      try {
+        const r = spawnSync(
+          "git",
+          ["rev-parse", "--abbrev-ref", "HEAD"],
+          { cwd: spawnCwd, encoding: "utf8", windowsHide: true, timeout: 5_000 },
+        );
+        const curBranch = String(r.stdout || "").trim();
+        if (curBranch === "main" || curBranch === "master") {
+          eventLog.append("branch_guard_refused", {
+            session: session.id,
+            cwd: spawnCwd,
+            branch: curBranch,
+          });
+          handleFailure(session, `branch_guard:${curBranch}_refused`);
+          return;
+        }
+      } catch (err) {
+        eventLog.append("branch_guard_probe_failed", {
+          session: session.id,
+          cwd: spawnCwd,
+          error: err.message,
+        });
+        // 프로브 실패는 비차단 — git 미설치/non-repo 환경 대응
+      }
+    }
+
     let child;
     try {
       child = spawn(launcher.command, {
         shell: true,
-        env: { ...process.env, ...launcher.env, ...(session.config.env || {}) },
+        cwd: spawnCwd,
+        env: {
+          ...process.env,
+          ...launcher.env,
+          ...(session.config.env || {}),
+          ...(session.config.branchGuard
+            ? { TRIFLUX_GIT_BRANCH_GUARD: "1" }
+            : {}),
+        },
         reason: `conductor:respawnSession:${session.id}`,
         stdio: ["pipe", "pipe", "pipe"],
         windowsHide: true,
@@ -470,6 +511,7 @@ export function createConductor(opts = {}) {
       eventLog.append("spawn_error", {
         session: session.id,
         error: err.message,
+        cwd: spawnCwd || null,
       });
       handleFailure(session, `spawn_error:${err.message}`);
       return;

--- a/hub/team/launcher-template.mjs
+++ b/hub/team/launcher-template.mjs
@@ -76,6 +76,7 @@ export function buildLauncher(opts) {
     model,
     resultFile,
     workdir,
+    cwd: workdir,
     mcpServers,
   });
 
@@ -86,6 +87,7 @@ export function buildLauncher(opts) {
     command,
     env,
     agent,
+    cwd: workdir || null,
   });
 }
 

--- a/hub/team/swarm-cli.mjs
+++ b/hub/team/swarm-cli.mjs
@@ -1,0 +1,180 @@
+// hub/team/swarm-cli.mjs — `tfx swarm` CLI handlers (#93)
+// PRD를 planSwarm으로 분석하고 필요 시 createSwarmHypervisor로 실행한다.
+
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { createSwarmHypervisor } from "./swarm-hypervisor.mjs";
+import { planSwarm } from "./swarm-planner.mjs";
+
+const RESET = "\u001b[0m";
+const BOLD = "\u001b[1m";
+const GREEN = "\u001b[92m";
+const RED = "\u001b[91m";
+const YELLOW = "\u001b[93m";
+const GRAY = "\u001b[90m";
+
+function parseFlags(args) {
+  const flags = {
+    dryRun: false,
+    planOnly: false,
+    json: false,
+    filter: null,
+    maxRestarts: 2,
+    logsDir: null,
+  };
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--dry-run" || a === "--plan-only") flags.dryRun = true;
+    else if (a === "--json") flags.json = true;
+    else if (a === "--filter") flags.filter = args[++i];
+    else if (a === "--max-restarts") flags.maxRestarts = Number(args[++i]) || 2;
+    else if (a === "--logs-dir") flags.logsDir = args[++i];
+    else if (a.startsWith("--")) {
+      // ignore unknown flags silently
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+function planToJson(plan) {
+  return {
+    totalShards: plan.shards.length,
+    shards: plan.shards.map((s) => ({
+      name: s.name,
+      agent: s.agent,
+      host: s.host || null,
+      files: s.files,
+      depends: s.depends,
+      critical: s.critical,
+    })),
+    leaseMap: Object.fromEntries(plan.leaseMap),
+    mcpManifest: Object.fromEntries(plan.mcpManifest),
+    mergeOrder: plan.mergeOrder,
+    criticalShards: plan.criticalShards,
+    conflicts: plan.conflicts,
+    remoteSuggestion: plan.remoteSuggestion,
+  };
+}
+
+function printPlan(plan) {
+  console.log(
+    `\n  ${BOLD}Swarm plan${RESET}: ${plan.shards.length} shards`,
+  );
+  for (const s of plan.shards) {
+    const hostStr = s.host ? `@${s.host}` : "";
+    const critStr = s.critical ? ` ${YELLOW}[critical]${RESET}` : "";
+    const depsStr = s.depends.length > 0 ? ` ← ${s.depends.join(", ")}` : "";
+    console.log(
+      `    - ${BOLD}${s.name}${RESET} [${s.agent}${hostStr}] files=${s.files.length}${critStr}${depsStr}`,
+    );
+  }
+  console.log(
+    `\n  ${GRAY}Merge order:${RESET} ${plan.mergeOrder.join(" → ")}`,
+  );
+  if (plan.criticalShards.length > 0) {
+    console.log(
+      `  ${GRAY}Critical (redundant):${RESET} ${plan.criticalShards.join(", ")}`,
+    );
+  }
+  if (plan.conflicts.length > 0) {
+    console.log(`\n  ${YELLOW}⚠ File conflicts:${RESET}`);
+    for (const c of plan.conflicts) {
+      console.log(`    - ${c.file} → [${c.shards.join(", ")}]`);
+    }
+  }
+}
+
+/**
+ * tfx swarm <prd-path> — PRD 실행
+ */
+export async function cmdSwarmRun(args, { json = false } = {}) {
+  const { flags, positional } = parseFlags(args);
+  flags.json = flags.json || json;
+
+  const prdPath = positional[0];
+  if (!prdPath) {
+    throw new Error(
+      "PRD path required. Usage: tfx swarm <prd-path> [--dry-run] [--filter <shard>] [--json]",
+    );
+  }
+  const absPrd = resolve(prdPath);
+  if (!existsSync(absPrd)) {
+    throw new Error(`PRD file not found: ${absPrd}`);
+  }
+
+  const plan = planSwarm(absPrd, { repoRoot: process.cwd() });
+
+  if (flags.dryRun) {
+    if (flags.json) {
+      process.stdout.write(JSON.stringify(planToJson(plan), null, 2) + "\n");
+    } else {
+      printPlan(plan);
+    }
+    return;
+  }
+
+  const logsDir =
+    flags.logsDir ||
+    join(process.cwd(), ".triflux", "swarm-logs", `run-${Date.now()}`);
+  const hyper = createSwarmHypervisor({
+    workdir: process.cwd(),
+    logsDir,
+    maxRestarts: flags.maxRestarts,
+  });
+
+  hyper.on("shardLaunched", ({ shard, sessionId, remote }) => {
+    const tag = remote ? ` ${GRAY}(remote)${RESET}` : "";
+    console.log(`  ${GREEN}▸${RESET} launched: ${shard}${tag} [${sessionId}]`);
+  });
+  hyper.on("shardCompleted", ({ shard, success, reason }) => {
+    const mark = success ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    const reasonStr = reason ? ` ${GRAY}(${reason})${RESET}` : "";
+    console.log(`  ${mark} ${shard}${reasonStr}`);
+  });
+  hyper.on("warning", ({ type, ...rest }) => {
+    console.error(
+      `  ${YELLOW}⚠${RESET} ${type}: ${JSON.stringify(rest).slice(0, 200)}`,
+    );
+  });
+
+  console.log(
+    `\n  ${BOLD}Launching swarm:${RESET} ${plan.shards.length} shards (logs: ${logsDir})`,
+  );
+  const run = await hyper.launch(plan);
+
+  try {
+    await run.done;
+  } catch (err) {
+    console.error(`  ${RED}integration failed:${RESET} ${err.message}`);
+  }
+
+  const status = hyper.getStatus();
+  console.log(
+    `\n  ${BOLD}Summary:${RESET} completed=${status.completedShards}/${status.totalShards} failed=${status.failedShards}`,
+  );
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(status, null, 2) + "\n");
+  }
+
+  await hyper.shutdown("completed");
+  if (status.failedShards > 0) process.exitCode = 1;
+}
+
+/**
+ * tfx swarm plan <prd-path> — dry-run (실행 없이 계획만 출력)
+ */
+export async function cmdSwarmPlan(args, { json = false } = {}) {
+  return cmdSwarmRun(["--dry-run", ...args], { json });
+}
+
+/**
+ * tfx swarm list — synapse status로 위임 (swarm 세션은 synapse registry에 등록)
+ */
+export async function cmdSwarmList(args, { json = false } = {}) {
+  const { cmdSynapseStatus } = await import("./synapse-cli.mjs");
+  return cmdSynapseStatus(args, { json });
+}

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -394,6 +394,8 @@ export function createSwarmHypervisor(opts) {
       mcpServers: shard.mcp,
       worktreePath: shard.worktreePath || null,
       branchName: shard.branchName || null,
+      // #90: shard는 worktree 격리가 본질. main 직접 커밋 방지 가드 env 주입.
+      branchGuard: true,
     };
 
     if (shard.worktreePath) {

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -209,43 +209,68 @@ TRIAGE
 
 ### 멀티 태스크 thorough
 
-Plan/PRD/Approval은 tfx-auto에서 실행, 그 후 tfx-multi Phase 3로 전환.
-서브태스크 배열 + `thorough: true` 신호를 함께 전달하여 multi 측에서 verify/fix를 수행.
+Plan/PRD/Approval은 tfx-auto에서 실행한다. 이후 2개 이상 서브태스크는 아래 라우팅 규칙으로 dispatch 엔진을 결정한다.
+- 읽기 전용 shard만 있으면 `tfx-multi` Phase 3로 전환한다.
+- 코드 변경 shard가 하나라도 있으면 `tfx-swarm`으로 전환한다.
+- 서브태스크 배열 + `thorough: true` 신호를 함께 전달하여 선택된 엔진에서 verify/fix를 수행한다.
 
 ## 멀티 태스크 라우팅 (트리아지 후)
 
-> **트리아지 결과에 따라 실행 경로 결정.**
-> v6.0.0부터 CLI 워커는 **Lead-Direct Headless** (psmux)가 기본. Agent 래퍼 불필요.
+> **트리아지 결과에 따라 2개 이상 서브태스크는 읽기 전용이면 `tfx-multi`, 코드 변경이 포함되면 `tfx-swarm`으로 dispatch한다.**
+> `--quick` 명시 시에도 엔진 선택 규칙은 동일하며, 차이는 plan/verify 생략 여부뿐이다.
 
-| 조건 | 실행 경로 | 엔진 |
-|------|----------|------|
-| 1개 (기본 thorough) | tfx-auto 직접 실행 + verify/fix loop | tfx-route.sh |
-| 1개 + Opus 자동 경량화 | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
-| 1개 + `--quick` 명시 | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
-| 2개+ (기본 thorough) | Plan/PRD/Approval 후 → headless + verify/fix | headless.mjs |
-| 2개+ + `--quick` 명시 | **headless 직접 실행** (WT 자동 팝업) | headless.mjs |
-| psmux 미설치 fallback | Native Teams (Agent slim wrapper) | native.mjs |
+| 입력 특성 | 실행 경로 | 엔진 |
+|-----------|-----------|------|
+| 1 태스크 S | tfx-auto 직접 실행 (fire-and-forget 가능) | 직접 실행 |
+| 1 태스크 M+ | Plan/PRD/Approval → 직접 실행 → verify/fix loop | pipeline |
+| 2+ 태스크 + 코드 변경 없음 | Plan/PRD/Approval 후 읽기 전용 병렬 실행 | tfx-multi |
+| 2+ 태스크 + 코드 변경 포함 | Plan/PRD/Approval 후 편집 shard 병렬 실행 | tfx-swarm |
+| 원격 + 코드 변경 | Plan/PRD/Approval 후 host별 shard 분리 실행 | tfx-swarm (shard host:) |
 
-> **MANDATORY: 2개+ 서브태스크 시 headless 엔진 필수**
-> `Agent()` 백그라운드나 `Bash(tfx-route.sh)` 개별 호출로 대체 금지.
-> 반드시 아래 `Bash("tfx multi ...")` 명령으로 headless 엔진에 위임한다.
+### 판정 기준
+
+- `shard.files`에 `src/`, `hub/`, `bin/`, `packages/`, `tests/` 중 하나라도 매치하면 `code_change=true`로 간주하고 swarm 경로를 우선한다.
+- shard의 agent가 `executor`, `build-fixer`, `spark`, `debugger` 중 하나면 편집 계열로 간주하고 swarm을 강제한다.
+- 사용자 입력에 `"multi"` 또는 `"multi로"`가 명시되면 위 기준보다 우선하여 `tfx-multi`를 유지한다.
+- 원격 shard(`host:` prefix 포함)가 코드 변경을 포함하면 항상 `tfx-swarm`으로 묶고 `shard host:` 단위로 dispatch한다.
+
+### 예제
+
+- **swarm 선택**: `"A, B, C 각각 다른 모듈 수정해"` → 2개 이상 + 코드 변경 포함 → `tfx-swarm`
+- **multi 유지**: `"파일 3개 read-only로 분석해"` → 2개 이상 + 코드 변경 없음 → `tfx-multi`
+- **사용자 override**: `"multi로 병렬 리뷰"` → 명시 override → `tfx-multi`
+
+> **MANDATORY: 2개+ 서브태스크 시 dispatch 엔진을 먼저 판정한다.**
+> 읽기 전용이면 `tfx-multi`, 코드 변경이 포함되면 `tfx-swarm`으로 위임한다. 단일 엔진으로 강제 고정하지 않는다.
 
 **전환 방법:**
 
 ```
 quick = args에 -q 또는 --quick 명시, 또는 Opus 자동 경량화 판단
+force_multi = user_input에 "multi" 또는 "multi로" 포함
+has_code_change = any(
+  shard.agent in ["executor", "build-fixer", "spark", "debugger"] ||
+  shard.files matches /(src|hub|bin|packages|tests)\//
+)
+has_remote_edit = any(shard.host && has_code_change)
 
 if subtasks.length >= 2:
-  if psmux 설치됨:
-    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:prompt:role' ...")
-    → if !quick: verify → fix loop
+  if force_multi:
+    → Bash("tfx multi ...")
+  else if has_remote_edit:
+    → Skill("tfx-swarm") with shard host: dispatch
+  else if has_code_change:
+    → Skill("tfx-swarm")
   else:
-    → fallback: tfx-multi Phase 3 Native Teams (Agent slim wrapper)
+    → Bash("tfx multi ...")
 else:
-  if quick:
+  if quick or size == "S":
     → tfx-auto 직접 실행 (fire-and-forget)
   else:
     → Pipeline init → Plan → PRD → Approval → 직접 실행 → Verify → Fix loop
+
+if quick and subtasks.length >= 2:
+  → 선택된 엔진에서 quick 모드로 실행 (plan/verify 생략)
 ```
 
 ## 실행

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -209,43 +209,68 @@ TRIAGE
 
 ### 멀티 태스크 thorough
 
-Plan/PRD/Approval은 tfx-auto에서 실행, 그 후 tfx-multi Phase 3로 전환.
-서브태스크 배열 + `thorough: true` 신호를 함께 전달하여 multi 측에서 verify/fix를 수행.
+Plan/PRD/Approval은 tfx-auto에서 실행한다. 이후 2개 이상 서브태스크는 아래 라우팅 규칙으로 dispatch 엔진을 결정한다.
+- 읽기 전용 shard만 있으면 `tfx-multi` Phase 3로 전환한다.
+- 코드 변경 shard가 하나라도 있으면 `tfx-swarm`으로 전환한다.
+- 서브태스크 배열 + `thorough: true` 신호를 함께 전달하여 선택된 엔진에서 verify/fix를 수행한다.
 
 ## 멀티 태스크 라우팅 (트리아지 후)
 
-> **트리아지 결과에 따라 실행 경로 결정.**
-> v6.0.0부터 CLI 워커는 **Lead-Direct Headless** (psmux)가 기본. Agent 래퍼 불필요.
+> **트리아지 결과에 따라 2개 이상 서브태스크는 읽기 전용이면 `tfx-multi`, 코드 변경이 포함되면 `tfx-swarm`으로 dispatch한다.**
+> `--quick` 명시 시에도 엔진 선택 규칙은 동일하며, 차이는 plan/verify 생략 여부뿐이다.
 
-| 조건 | 실행 경로 | 엔진 |
-|------|----------|------|
-| 1개 (기본 thorough) | tfx-auto 직접 실행 + verify/fix loop | tfx-route.sh |
-| 1개 + Opus 자동 경량화 | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
-| 1개 + `--quick` 명시 | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
-| 2개+ (기본 thorough) | Plan/PRD/Approval 후 → headless + verify/fix | headless.mjs |
-| 2개+ + `--quick` 명시 | **headless 직접 실행** (WT 자동 팝업) | headless.mjs |
-| psmux 미설치 fallback | Native Teams (Agent slim wrapper) | native.mjs |
+| 입력 특성 | 실행 경로 | 엔진 |
+|-----------|-----------|------|
+| 1 태스크 S | tfx-auto 직접 실행 (fire-and-forget 가능) | 직접 실행 |
+| 1 태스크 M+ | Plan/PRD/Approval → 직접 실행 → verify/fix loop | pipeline |
+| 2+ 태스크 + 코드 변경 없음 | Plan/PRD/Approval 후 읽기 전용 병렬 실행 | tfx-multi |
+| 2+ 태스크 + 코드 변경 포함 | Plan/PRD/Approval 후 편집 shard 병렬 실행 | tfx-swarm |
+| 원격 + 코드 변경 | Plan/PRD/Approval 후 host별 shard 분리 실행 | tfx-swarm (shard host:) |
 
-> **MANDATORY: 2개+ 서브태스크 시 headless 엔진 필수**
-> `Agent()` 백그라운드나 `Bash(tfx-route.sh)` 개별 호출로 대체 금지.
-> 반드시 아래 `Bash("tfx multi ...")` 명령으로 headless 엔진에 위임한다.
+### 판정 기준
+
+- `shard.files`에 `src/`, `hub/`, `bin/`, `packages/`, `tests/` 중 하나라도 매치하면 `code_change=true`로 간주하고 swarm 경로를 우선한다.
+- shard의 agent가 `executor`, `build-fixer`, `spark`, `debugger` 중 하나면 편집 계열로 간주하고 swarm을 강제한다.
+- 사용자 입력에 `"multi"` 또는 `"multi로"`가 명시되면 위 기준보다 우선하여 `tfx-multi`를 유지한다.
+- 원격 shard(`host:` prefix 포함)가 코드 변경을 포함하면 항상 `tfx-swarm`으로 묶고 `shard host:` 단위로 dispatch한다.
+
+### 예제
+
+- **swarm 선택**: `"A, B, C 각각 다른 모듈 수정해"` → 2개 이상 + 코드 변경 포함 → `tfx-swarm`
+- **multi 유지**: `"파일 3개 read-only로 분석해"` → 2개 이상 + 코드 변경 없음 → `tfx-multi`
+- **사용자 override**: `"multi로 병렬 리뷰"` → 명시 override → `tfx-multi`
+
+> **MANDATORY: 2개+ 서브태스크 시 dispatch 엔진을 먼저 판정한다.**
+> 읽기 전용이면 `tfx-multi`, 코드 변경이 포함되면 `tfx-swarm`으로 위임한다. 단일 엔진으로 강제 고정하지 않는다.
 
 **전환 방법:**
 
 ```
 quick = args에 -q 또는 --quick 명시, 또는 Opus 자동 경량화 판단
+force_multi = user_input에 "multi" 또는 "multi로" 포함
+has_code_change = any(
+  shard.agent in ["executor", "build-fixer", "spark", "debugger"] ||
+  shard.files matches /(src|hub|bin|packages|tests)\//
+)
+has_remote_edit = any(shard.host && has_code_change)
 
 if subtasks.length >= 2:
-  if psmux 설치됨:
-    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:prompt:role' ...")
-    → if !quick: verify → fix loop
+  if force_multi:
+    → Bash("tfx multi ...")
+  else if has_remote_edit:
+    → Skill("tfx-swarm") with shard host: dispatch
+  else if has_code_change:
+    → Skill("tfx-swarm")
   else:
-    → fallback: tfx-multi Phase 3 Native Teams (Agent slim wrapper)
+    → Bash("tfx multi ...")
 else:
-  if quick:
+  if quick or size == "S":
     → tfx-auto 직접 실행 (fire-and-forget)
   else:
     → Pipeline init → Plan → PRD → Approval → 직접 실행 → Verify → Fix loop
+
+if quick and subtasks.length >= 2:
+  → 선택된 엔진에서 quick 모드로 실행 (plan/verify 생략)
 ```
 
 ## 실행


### PR DESCRIPTION
## Summary

Issue #87 구현. tfx-auto 라우팅 테이블을 "2+ 태스크 = multi"에서 "코드 변경 여부 기반 분기"로 전환.

- 2+ 태스크 + 코드 변경 없음 → tfx-multi (기존 유지)
- 2+ 태스크 + 코드 변경 포함 → **tfx-swarm 자동 dispatch** (신규)
- 원격 + 코드 변경 → tfx-swarm (shard `host:`)

## 판정 기준

- shard.files 경로 매치: `src/`, `hub/`, `bin/`, `packages/`, `tests/`
- agent 유형: executor/build-fixer/spark/debugger → swarm 강제
- 사용자 키워드 override: "multi"/"multi로" 명시 시 multi 유지

## 배경

2026-04-17 PR #72 conflict 해결을 tfx-remote-spawn으로 돌렸다가 메인 working tree 오염 사고. tfx-auto가 swarm 자동 선택했다면 방지 가능. Issue #87 참조.

## Test plan

- [x] skills/tfx-auto/SKILL.md 라우팅 테이블 업데이트
- [x] packages/triflux/skills/tfx-auto/SKILL.md 미러 동기화 (drift 방지)
- [x] 예제 3개 추가 (swarm/multi/override 케이스)
- [ ] `/tfx-auto "A 수정하고 B 수정"` 입력 시 swarm 자동 선택 확인
- [ ] `/tfx-auto "A B 분석"` 입력 시 multi 유지 확인
- [ ] `/tfx-auto multi로 A B 수정` override 동작 확인

## 생성 경로

- Phase 3 swarm dispatch: `docs/prd/phase3-infra/00-combined.md` shard `auto-swarm-dispatch`
- Codex headless worktree 격리 (#94 수정 적용)
- shard scope: SKILL.md 2 파일만 수정 (spec 준수)

Closes #87