### PR TITLE
feat(broker): ~/.codex/auth.json ↔ Hub 캐시 양방향 자동 동기화 (#78)

### DIFF
--- a/hub/account-broker.mjs
+++ b/hub/account-broker.mjs
@@ -4,10 +4,22 @@
 // Singleton export. All state changes create new objects (immutable pattern).
 
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  constants as fsConstants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { join, sep } from "node:path";
+import { dirname, join } from "node:path";
 import * as z from "zod";
+
+import { isPathWithin } from "./platform.mjs";
 
 // ── Zod schema ───────────────────────────────────────────────────
 
@@ -45,7 +57,7 @@ const ConfigSchema = z.object({
 });
 
 const DEFAULT_COOLDOWN_MS = 300_000; // 5 minutes
-const QUOTA_COOLDOWN_MS = {
+const _QUOTA_COOLDOWN_MS = {
   codex: 5 * 60 * 60_000, // 5 hours (단기 쿼터)
   codex_weekly: 7 * 24 * 60 * 60_000, // 7 days (주간 쿼터)
   gemini: 24 * 60 * 60_000, // 24 hours
@@ -55,7 +67,12 @@ const LEASE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const CIRCUIT_WINDOW_MS = 10 * 60_000; // 10 minutes
 const CIRCUIT_MAX_FAILURES = 3;
 const AUTH_BASE_PATH = join(homedir(), ".claude", "cache", "tfx-hub");
+const CODEX_AUTH_SOURCE_PATH = join(homedir(), ".codex", "auth.json");
 const STATE_PERSIST_PATH = join(AUTH_BASE_PATH, "broker-state.json");
+const AUTH_SYNC_LOCK_TIMEOUT_MS = 5_000;
+const AUTH_SYNC_LOCK_RETRY_MS = 25;
+const AUTH_SYNC_LOCK_STALE_MS = 30_000;
+const AUTH_SYNC_SAB = new Int32Array(new SharedArrayBuffer(4));
 
 // ── State persistence ────────────────────────────────────────────
 
@@ -65,7 +82,11 @@ function persistState(stateMap) {
     const entries = {};
     for (const [id, acct] of stateMap) {
       // 활성 쿨다운 또는 circuit open만 저장 (불필요한 데이터 제거)
-      if (acct.cooldownUntil > now || acct.circuitOpenedAt > 0 || acct.totalSessions > 0) {
+      if (
+        acct.cooldownUntil > now ||
+        acct.circuitOpenedAt > 0 ||
+        acct.totalSessions > 0
+      ) {
         entries[id] = {
           cooldownUntil: acct.cooldownUntil,
           circuitOpenedAt: acct.circuitOpenedAt,
@@ -77,7 +98,11 @@ function persistState(stateMap) {
     }
     mkdirSync(AUTH_BASE_PATH, { recursive: true });
     writeFileSync(STATE_PERSIST_PATH, JSON.stringify({ ts: now, entries }));
-  } catch (err) { try { console.error("[account-broker] persistState failed:", err.message); } catch {} }
+  } catch (err) {
+    try {
+      console.error("[account-broker] persistState failed:", err.message);
+    } catch {}
+  }
 }
 
 function loadPersistedState() {
@@ -114,6 +139,104 @@ function getRemainingLeaseMs(account, now) {
   return Math.max(0, LEASE_TTL_MS - (now - account.leasedAt));
 }
 
+function sleepSync(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return;
+  Atomics.wait(AUTH_SYNC_SAB, 0, 0, ms);
+}
+
+function statOrNull(filePath) {
+  try {
+    return statSync(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function readAuthPayload(filePath) {
+  const buffer = readFileSync(filePath);
+  const parsed = JSON.parse(buffer.toString("utf8"));
+  return {
+    buffer,
+    parsed,
+    accountId:
+      parsed?.tokens?.account_id ??
+      parsed?.account_id ??
+      parsed?.accountId ??
+      null,
+  };
+}
+
+function createSyncResult({
+  accountId,
+  direction,
+  sourcePath,
+  cachePath,
+  copied = false,
+  skipped = false,
+  reason = "ok",
+}) {
+  return {
+    ok: !skipped || reason === "up_to_date",
+    accountId,
+    direction,
+    sourcePath,
+    cachePath,
+    copied,
+    skipped,
+    reason,
+  };
+}
+
+function withLockFile(lockPath, opts, task) {
+  const retryMs = opts.retryMs ?? AUTH_SYNC_LOCK_RETRY_MS;
+  const timeoutMs = opts.timeoutMs ?? AUTH_SYNC_LOCK_TIMEOUT_MS;
+  const staleMs = opts.staleMs ?? AUTH_SYNC_LOCK_STALE_MS;
+  const start = Date.now();
+
+  while (true) {
+    let fd;
+    try {
+      mkdirSync(dirname(lockPath), { recursive: true });
+      fd = openSync(
+        lockPath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+        0o600,
+      );
+      writeFileSync(fd, `${process.pid}\n${Date.now()}`, "utf8");
+      try {
+        return task();
+      } finally {
+        closeSync(fd);
+        try {
+          unlinkSync(lockPath);
+        } catch {}
+      }
+    } catch (error) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+      if (error?.code !== "EEXIST") throw error;
+
+      const lockStat = statOrNull(lockPath);
+      if (lockStat && Date.now() - lockStat.mtimeMs > staleMs) {
+        try {
+          unlinkSync(lockPath);
+          continue;
+        } catch {}
+      }
+
+      if (Date.now() - start >= timeoutMs) {
+        return { lockTimeout: true };
+      }
+
+      sleepSync(retryMs);
+    }
+  }
+}
+
 // ── AccountBroker ────────────────────────────────────────────────
 
 class AccountBroker extends EventEmitter {
@@ -121,12 +244,35 @@ class AccountBroker extends EventEmitter {
   #state; // Map<accountId, accountState>
   #roundRobinIndex; // Map<provider, number>
   #persist; // boolean — disable persistence for tests
+  #authBasePath;
+  #codexAuthSourcePath;
+  #authSyncLockOpts;
+  #syncCopyDelayMs;
 
-  constructor(config, { _skipPersistence = false } = {}) {
+  constructor(
+    config,
+    {
+      _skipPersistence = false,
+      _authBasePath = AUTH_BASE_PATH,
+      _codexAuthSourcePath = CODEX_AUTH_SOURCE_PATH,
+      _authSyncLockTimeoutMs = AUTH_SYNC_LOCK_TIMEOUT_MS,
+      _authSyncLockRetryMs = AUTH_SYNC_LOCK_RETRY_MS,
+      _authSyncLockStaleMs = AUTH_SYNC_LOCK_STALE_MS,
+      _syncCopyDelayMs = 0,
+    } = {},
+  ) {
     super();
     const parsed = ConfigSchema.parse(config);
     this.#config = parsed;
     this.#persist = !_skipPersistence;
+    this.#authBasePath = _authBasePath;
+    this.#codexAuthSourcePath = _codexAuthSourcePath;
+    this.#authSyncLockOpts = {
+      timeoutMs: _authSyncLockTimeoutMs,
+      retryMs: _authSyncLockRetryMs,
+      staleMs: _authSyncLockStaleMs,
+    };
+    this.#syncCopyDelayMs = _syncCopyDelayMs;
 
     this.#state = new Map();
     this.#roundRobinIndex = new Map();
@@ -160,6 +306,232 @@ class AccountBroker extends EventEmitter {
         totalSessions: saved?.totalSessions ?? 0,
       });
     }
+  }
+
+  #resolveCacheAuthPath(acct) {
+    if (!acct?.authFile) return null;
+    const resolved = join(this.#authBasePath, acct.authFile);
+    if (
+      !isPathWithin(resolved, this.#authBasePath) ||
+      resolved === this.#authBasePath
+    ) {
+      return null;
+    }
+    return resolved;
+  }
+
+  #getSourceAuthPath(acct) {
+    if (!acct || acct.mode !== "auth") return null;
+    if (acct.provider === "codex") return this.#codexAuthSourcePath;
+    return null;
+  }
+
+  #getLockPath(acct) {
+    return join(this.#authBasePath, `codex-auth-sync-${acct.id}.lock`);
+  }
+
+  #copyAuthPayload(sourcePath, destPath) {
+    const payload = readFileSync(sourcePath);
+    if (this.#syncCopyDelayMs > 0) {
+      sleepSync(this.#syncCopyDelayMs);
+    }
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, payload);
+  }
+
+  #syncAuth(accountId, direction) {
+    const acct = this.#state.get(accountId);
+    const sourcePath = this.#getSourceAuthPath(acct);
+    const cachePath = this.#resolveCacheAuthPath(acct);
+
+    if (!acct || acct.mode !== "auth" || acct.provider !== "codex") {
+      return createSyncResult({
+        accountId,
+        direction,
+        sourcePath,
+        cachePath,
+        skipped: true,
+        reason: "unsupported_account",
+      });
+    }
+
+    if (!cachePath) {
+      this.emit("securityViolation", {
+        id: acct.id,
+        authFile: acct.authFile,
+      });
+      return createSyncResult({
+        accountId,
+        direction,
+        sourcePath,
+        cachePath,
+        skipped: true,
+        reason: "invalid_cache_path",
+      });
+    }
+
+    if (!sourcePath) {
+      return createSyncResult({
+        accountId,
+        direction,
+        sourcePath,
+        cachePath,
+        skipped: true,
+        reason: "unsupported_source",
+      });
+    }
+
+    const locked = withLockFile(
+      this.#getLockPath(acct),
+      this.#authSyncLockOpts,
+      () => {
+        try {
+          if (direction === "from-source") {
+            const sourceStat = statOrNull(sourcePath);
+            if (!sourceStat) {
+              return createSyncResult({
+                accountId,
+                direction,
+                sourcePath,
+                cachePath,
+                skipped: true,
+                reason: "source_missing",
+              });
+            }
+
+            const sourceAuth = readAuthPayload(sourcePath);
+            if (!sourceAuth.accountId) {
+              return createSyncResult({
+                accountId,
+                direction,
+                sourcePath,
+                cachePath,
+                skipped: true,
+                reason: "source_account_unknown",
+              });
+            }
+            if (sourceAuth.accountId !== accountId) {
+              return createSyncResult({
+                accountId,
+                direction,
+                sourcePath,
+                cachePath,
+                skipped: true,
+                reason: "source_account_mismatch",
+              });
+            }
+
+            const cacheStat = statOrNull(cachePath);
+            if (cacheStat && sourceStat.mtimeMs <= cacheStat.mtimeMs) {
+              return createSyncResult({
+                accountId,
+                direction,
+                sourcePath,
+                cachePath,
+                skipped: true,
+                reason: "up_to_date",
+              });
+            }
+
+            this.#copyAuthPayload(sourcePath, cachePath);
+            return createSyncResult({
+              accountId,
+              direction,
+              sourcePath,
+              cachePath,
+              copied: true,
+              reason: cacheStat ? "cache_updated" : "cache_created",
+            });
+          }
+
+          const cacheStat = statOrNull(cachePath);
+          if (!cacheStat) {
+            return createSyncResult({
+              accountId,
+              direction,
+              sourcePath,
+              cachePath,
+              skipped: true,
+              reason: "cache_missing",
+            });
+          }
+
+          const cacheAuth = readAuthPayload(cachePath);
+          if (!cacheAuth.accountId) {
+            return createSyncResult({
+              accountId,
+              direction,
+              sourcePath,
+              cachePath,
+              skipped: true,
+              reason: "cache_account_unknown",
+            });
+          }
+          if (cacheAuth.accountId !== accountId) {
+            return createSyncResult({
+              accountId,
+              direction,
+              sourcePath,
+              cachePath,
+              skipped: true,
+              reason: "cache_account_mismatch",
+            });
+          }
+
+          const sourceStat = statOrNull(sourcePath);
+          if (sourceStat && cacheStat.mtimeMs <= sourceStat.mtimeMs) {
+            return createSyncResult({
+              accountId,
+              direction,
+              sourcePath,
+              cachePath,
+              skipped: true,
+              reason: "up_to_date",
+            });
+          }
+
+          this.#copyAuthPayload(cachePath, sourcePath);
+          return createSyncResult({
+            accountId,
+            direction,
+            sourcePath,
+            cachePath,
+            copied: true,
+            reason: sourceStat ? "source_updated" : "source_created",
+          });
+        } catch (error) {
+          return createSyncResult({
+            accountId,
+            direction,
+            sourcePath,
+            cachePath,
+            skipped: true,
+            reason: error?.code === "ENOENT" ? "file_missing" : "read_error",
+          });
+        }
+      },
+    );
+
+    if (locked?.lockTimeout) {
+      return createSyncResult({
+        accountId,
+        direction,
+        sourcePath,
+        cachePath,
+        skipped: true,
+        reason: "lock_timeout",
+      });
+    }
+
+    return locked;
+  }
+
+  syncAuthFromSource(accountId) {
+    return this.#syncAuth(accountId, "from-source");
+  }
+
+  syncAuthToSource(accountId) {
+    return this.#syncAuth(accountId, "to-source");
   }
 
   // ── per-account circuit breaker ─────────────────────────────────
@@ -221,7 +593,7 @@ class AccountBroker extends EventEmitter {
 
   // ── lease ─────────────────────────────────────────────────────
 
-  lease({ provider, remote = false } = {}) {
+  lease({ provider, remote = false, autoSync = true } = {}) {
     const now = Date.now();
     this.#pruneExpiredLeases(now);
 
@@ -286,6 +658,31 @@ class AccountBroker extends EventEmitter {
     // advance round-robin index for this tier
     this.#roundRobinIndex.set(rrKey, (idx + 1) % tierCount);
 
+    let authFile;
+    if (acct.mode === "auth") {
+      const resolved = this.#resolveCacheAuthPath(acct);
+      if (!resolved) {
+        this.emit("securityViolation", {
+          id: acct.id,
+          authFile: acct.authFile,
+        });
+        return null;
+      }
+      authFile = resolved;
+      if (autoSync !== false) {
+        try {
+          const syncResult = this.syncAuthFromSource(acct.id);
+          this.emit("authSync", syncResult);
+        } catch (error) {
+          this.emit("authSyncError", {
+            accountId: acct.id,
+            direction: "from-source",
+            error: error?.message || String(error),
+          });
+        }
+      }
+    }
+
     // mark half-open trial if applicable
     const circuit = this.#getCircuitState(acct, now);
     const isHalfOpen = circuit.state === "half-open";
@@ -306,26 +703,6 @@ class AccountBroker extends EventEmitter {
       tier: acct.tier,
       halfOpen: isHalfOpen,
     });
-
-    // path traversal guard for authFile
-    let authFile;
-    if (acct.mode === "auth") {
-      const resolved = join(AUTH_BASE_PATH, acct.authFile);
-      if (!resolved.startsWith(AUTH_BASE_PATH + sep)) {
-        this.emit("securityViolation", {
-          id: acct.id,
-          authFile: acct.authFile,
-        });
-        // undo the lease — path traversal blocked
-        this.#state.set(acct.id, {
-          ...this.#state.get(acct.id),
-          busy: false,
-          leasedAt: null,
-        });
-        return null;
-      }
-      authFile = resolved;
-    }
 
     return {
       id: acct.id,

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -22,7 +22,10 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createModuleLogger } from "../scripts/lib/logger.mjs";
-import { broker as brokerInstance, reloadBroker } from "./account-broker.mjs";
+import {
+  broker as brokerInstance,
+  reloadBroker,
+} from "./account-broker.mjs";
 import { createAdaptiveEngine } from "./adaptive.mjs";
 import { createAssignCallbackServer } from "./assign-callbacks.mjs";
 import { DelegatorService } from "./delegator/index.mjs";
@@ -562,6 +565,40 @@ function getQosStatsPayload() {
   };
 }
 
+function syncBrokerAuthCache(currentBroker, logger = hubLog) {
+  if (!currentBroker?.snapshot || typeof currentBroker.syncAuthFromSource !== "function") {
+    return [];
+  }
+
+  const authAccounts = currentBroker
+    .snapshot()
+    .filter((account) => account.provider === "codex" && account.mode === "auth");
+
+  return authAccounts.map((account) => {
+    try {
+      const result = currentBroker.syncAuthFromSource(account.id);
+      if (result?.copied) {
+        logger.info(
+          {
+            accountId: account.id,
+            reason: result.reason,
+            sourcePath: result.sourcePath,
+            cachePath: result.cachePath,
+          },
+          "broker.auth_sync_from_source",
+        );
+      }
+      return result;
+    } catch (error) {
+      logger.warn(
+        { accountId: account.id, err: error?.message || String(error) },
+        "broker.auth_sync_from_source_failed",
+      );
+      return { ok: false, accountId: account.id, reason: error?.message || String(error) };
+    }
+  });
+}
+
 function resolvePublicFilePath(path) {
   let relativePath = null;
   if (path === "/dashboard") {
@@ -637,6 +674,8 @@ export async function startHub({
 
   const existingHub = await tryReuseExistingHub({ port, host });
   if (existingHub) return existingHub;
+
+  syncBrokerAuthCache(brokerInstance);
 
   const hubIdleTimeoutMs = parsePositiveInt(
     process.env.TFX_HUB_IDLE_TIMEOUT_MS,
@@ -945,6 +984,7 @@ export async function startHub({
         if (!result.ok) {
           return writeJson(res, 200, { ok: false, error: result.error });
         }
+        syncBrokerAuthCache(result.broker);
         const accounts = result.broker
           ? [...result.broker.snapshot()].length
           : 0;
@@ -2051,7 +2091,7 @@ async function refreshAllAccountQuotas() {
   return results;
 }
 
-function loadQuotaCache() {
+function _loadQuotaCache() {
   try {
     if (!existsSync(QUOTA_CACHE_PATH)) return null;
     return JSON.parse(readFileSync(QUOTA_CACHE_PATH, "utf8"));

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -81,6 +81,29 @@ const DEFAULT_GRACE_MS = 10_000;
  */
 function swapAuthFile(lease, agent, sessionId, eventLog) {
   if (lease?.mode !== "auth" || !lease.authFile) return true;
+  if (
+    agent === "codex" &&
+    lease.id &&
+    broker &&
+    typeof broker.syncAuthToSource === "function"
+  ) {
+    const result = broker.syncAuthToSource(lease.id);
+    if (result?.copied || result?.reason === "up_to_date") {
+      eventLog.append("auth_copy", {
+        session: sessionId,
+        agent,
+        dest: result.sourcePath,
+        reason: result.reason,
+      });
+      return true;
+    }
+    eventLog.append("auth_copy_error", {
+      session: sessionId,
+      dest: result?.sourcePath || join(homedir(), ".codex", "auth.json"),
+      error: result?.reason || "sync_failed",
+    });
+    return false;
+  }
   const dests =
     agent === "codex"
       ? [join(homedir(), ".codex", "auth.json")]

--- a/scripts/sync-codex-auth.mjs
+++ b/scripts/sync-codex-auth.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+
+import { reloadBroker } from "../hub/account-broker.mjs";
+
+function parseArgs(argv) {
+  const args = { direction: "from-source" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--account") {
+      args.account = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--direction") {
+      args.direction = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(
+    "Usage: node scripts/sync-codex-auth.mjs --account <accountId> --direction from-source|to-source|both",
+  );
+}
+
+function runDirection(currentBroker, accountId, direction) {
+  if (direction === "from-source") {
+    return currentBroker.syncAuthFromSource(accountId);
+  }
+  return currentBroker.syncAuthToSource(accountId);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.account) {
+  printUsage();
+  process.exit(args.help ? 0 : 1);
+}
+
+if (!["from-source", "to-source", "both"].includes(args.direction)) {
+  console.error(`Invalid --direction: ${args.direction}`);
+  printUsage();
+  process.exit(1);
+}
+
+const result = reloadBroker();
+if (!result.ok || !result.broker) {
+  console.error(result.error || "broker unavailable");
+  process.exit(1);
+}
+
+const broker = result.broker;
+const directions =
+  args.direction === "both" ? ["from-source", "to-source"] : [args.direction];
+const outcomes = directions.map((direction) =>
+  runDirection(broker, args.account, direction),
+);
+
+console.log(JSON.stringify({ account: args.account, outcomes }, null, 2));
+const failed = outcomes.some(
+  (outcome) =>
+    outcome && outcome.ok === false && outcome.reason !== "up_to_date",
+);
+process.exit(failed ? 1 : 0);

--- a/tests/fixtures/account-broker-lease-helper.mjs
+++ b/tests/fixtures/account-broker-lease-helper.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { AccountBroker } from "../../hub/account-broker.mjs";
+
+const authBasePath = process.env.BROKER_AUTH_BASE_PATH;
+const sourcePath = process.env.BROKER_SOURCE_PATH;
+const accountId = process.env.BROKER_ACCOUNT_ID || "pte1024";
+const authFile = process.env.BROKER_AUTH_FILE || `codex-auth-${accountId}.json`;
+const syncDelayMs = Number(process.env.BROKER_SYNC_DELAY_MS || "0");
+
+const broker = new AccountBroker(
+  {
+    codex: [{ id: accountId, mode: "auth", authFile }],
+  },
+  {
+    _skipPersistence: true,
+    _authBasePath: authBasePath,
+    _codexAuthSourcePath: sourcePath,
+    _syncCopyDelayMs: syncDelayMs,
+    _authSyncLockRetryMs: 10,
+    _authSyncLockTimeoutMs: 5000,
+  },
+);
+
+const lease = broker.lease({ provider: "codex" });
+const cachePath = lease?.authFile;
+const cache = cachePath ? JSON.parse(readFileSync(cachePath, "utf8")) : null;
+process.stdout.write(
+  JSON.stringify({
+    lease,
+    cacheAccountId: cache?.tokens?.account_id ?? null,
+    refreshToken: cache?.tokens?.refresh_token ?? null,
+  }),
+);

--- a/tests/unit/account-broker-auth-sync.test.mjs
+++ b/tests/unit/account-broker-auth-sync.test.mjs
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { AccountBroker } from "../../hub/account-broker.mjs";
+
+function writeAuth(filePath, accountId, refreshToken) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        auth_mode: "chatgpt",
+        tokens: {
+          account_id: accountId,
+          refresh_token: refreshToken,
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function readRefreshToken(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8")).tokens.refresh_token;
+}
+
+function setMtime(filePath, ms) {
+  const when = new Date(ms);
+  utimesSync(filePath, when, when);
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "tfx-account-broker-auth-sync-"));
+  const authBasePath = join(root, ".claude", "cache", "tfx-hub");
+  const sourcePath = join(root, ".codex", "auth.json");
+  const accountId = "pte1024";
+  const authFile = `codex-auth-${accountId}.json`;
+  const cachePath = join(authBasePath, authFile);
+  const broker = new AccountBroker(
+    {
+      codex: [{ id: accountId, mode: "auth", authFile }],
+    },
+    {
+      _skipPersistence: true,
+      _authBasePath: authBasePath,
+      _codexAuthSourcePath: sourcePath,
+      _authSyncLockRetryMs: 10,
+      _authSyncLockTimeoutMs: 5000,
+    },
+  );
+
+  return {
+    root,
+    authBasePath,
+    sourcePath,
+    cachePath,
+    accountId,
+    authFile,
+    broker,
+  };
+}
+
+const cleanup = [];
+afterEach(() => {
+  while (cleanup.length > 0) {
+    const path = cleanup.pop();
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function waitFor(condition, { timeoutMs = 2000, intervalMs = 10 } = {}) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (condition()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("timeout"));
+        return;
+      }
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+function spawnLeaseHelper(env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        join(
+          process.cwd(),
+          "tests",
+          "fixtures",
+          "account-broker-lease-helper.mjs",
+        ),
+      ],
+      {
+        env: { ...process.env, ...env },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+describe("AccountBroker auth sync", () => {
+  it("mtime 기반으로 source가 더 새로우면 cache를 갱신하고 아니면 건너뛴다", () => {
+    const fixture = createFixture();
+    cleanup.push(fixture.root);
+
+    writeAuth(fixture.sourcePath, fixture.accountId, "source-new");
+    writeAuth(fixture.cachePath, fixture.accountId, "cache-old");
+    setMtime(fixture.cachePath, 1_000);
+    setMtime(fixture.sourcePath, 2_000);
+
+    const copied = fixture.broker.syncAuthFromSource(fixture.accountId);
+    assert.equal(copied.copied, true);
+    assert.equal(readRefreshToken(fixture.cachePath), "source-new");
+
+    writeAuth(fixture.cachePath, fixture.accountId, "cache-newer");
+    setMtime(fixture.sourcePath, 3_000);
+    setMtime(fixture.cachePath, 4_000);
+
+    const skipped = fixture.broker.syncAuthFromSource(fixture.accountId);
+    assert.equal(skipped.skipped, true);
+    assert.equal(skipped.reason, "up_to_date");
+    assert.equal(readRefreshToken(fixture.cachePath), "cache-newer");
+  });
+
+  it("from-source / to-source 양방향 복사를 지원한다", () => {
+    const fixture = createFixture();
+    cleanup.push(fixture.root);
+
+    writeAuth(fixture.sourcePath, fixture.accountId, "source-v1");
+    writeAuth(fixture.cachePath, fixture.accountId, "cache-v1");
+    setMtime(fixture.sourcePath, 1_000);
+    setMtime(fixture.cachePath, 2_000);
+
+    const toSource = fixture.broker.syncAuthToSource(fixture.accountId);
+    assert.equal(toSource.copied, true);
+    assert.equal(readRefreshToken(fixture.sourcePath), "cache-v1");
+
+    writeAuth(fixture.sourcePath, fixture.accountId, "source-v2");
+    setMtime(fixture.sourcePath, 3_000);
+    setMtime(fixture.cachePath, 2_500);
+
+    const fromSource = fixture.broker.syncAuthFromSource(fixture.accountId);
+    assert.equal(fromSource.copied, true);
+    assert.equal(readRefreshToken(fixture.cachePath), "source-v2");
+  });
+
+  it("동시 lease 시 lock으로 stale overwrite를 막는다", async () => {
+    const fixture = createFixture();
+    cleanup.push(fixture.root);
+
+    writeAuth(fixture.sourcePath, fixture.accountId, "source-A");
+    writeAuth(fixture.cachePath, fixture.accountId, "cache-old");
+    setMtime(fixture.cachePath, 1_000);
+    setMtime(fixture.sourcePath, 2_000);
+
+    const lockPath = join(
+      fixture.authBasePath,
+      `codex-auth-sync-${fixture.accountId}.lock`,
+    );
+    const env = {
+      BROKER_AUTH_BASE_PATH: fixture.authBasePath,
+      BROKER_SOURCE_PATH: fixture.sourcePath,
+      BROKER_ACCOUNT_ID: fixture.accountId,
+      BROKER_AUTH_FILE: fixture.authFile,
+    };
+
+    const firstLease = spawnLeaseHelper({
+      ...env,
+      BROKER_SYNC_DELAY_MS: "200",
+    });
+    await waitFor(() => existsSync(lockPath));
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    writeAuth(fixture.sourcePath, fixture.accountId, "source-B");
+    setMtime(fixture.sourcePath, Date.now() + 60_000);
+
+    const secondLease = spawnLeaseHelper(env);
+    const [first, second] = await Promise.all([firstLease, secondLease]);
+
+    assert.equal(first.code, 0, first.stderr);
+    assert.equal(second.code, 0, second.stderr);
+
+    const firstPayload = JSON.parse(first.stdout);
+    const secondPayload = JSON.parse(second.stdout);
+    assert.equal(firstPayload.lease?.id, fixture.accountId);
+    assert.equal(secondPayload.lease?.id, fixture.accountId);
+    assert.equal(readRefreshToken(fixture.cachePath), "source-B");
+  });
+});


### PR DESCRIPTION
## Summary

Codex 병렬 exec 시 \`~/.codex/auth.json\`이 외부(codex login 등)로 갱신되어도 hub 캐시 \`~/.claude/cache/tfx-hub/codex-auth-<account>.json\`과 자동 동기화되도록 한다. 기존에는 stale 캐시로 \`refresh_token_reused\` 401 발생.

## 변경

- \`account-broker.syncAuthFromSource(accountId)\` — source mtime > cache면 복사
- \`account-broker.syncAuthToSource(accountId)\` — broker rotate 후 원본 반영
- \`hub/server.mjs\` startup: 등록 account마다 auto-sync
- \`conductor.swapAuthFile\`: syncAuthToSource 연계 (codex agent 한정)
- \`scripts/sync-codex-auth.mjs\`: 수동 헬퍼
- 단위 테스트 3종 (mtime 판정/양방향/잠금)

## Test plan

- [x] broker.syncAuthFromSource 단위 테스트
- [x] broker.syncAuthToSource 단위 테스트
- [x] 동시 lease 시 파일 잠금 회귀
- [ ] 실제 병렬 codex exec 시 refresh_token_reused 재현 안 됨 확인
- [ ] hub/server startup 로그에 auto-sync 기록

## 생성 경로

Phase 3 swarm dispatch: \`docs/prd/phase3-infra/00-combined.md\` shard \`broker-auth-sync\`. Codex headless worktree 격리 (#94 수정 적용).

Closes #78