### PR TITLE
feat(swarm): 실패 shard worktree 자동 cleanup (#80)

### DIFF
--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -21,6 +21,7 @@ import { createEventLog } from "./event-log.mjs";
 import { probeRemoteEnv, resolveRemoteDir } from "./remote-session.mjs";
 import { createSwarmLocks } from "./swarm-locks.mjs";
 import {
+  cleanupWorktree,
   ensureWorktree,
   fetchRemoteShard,
   prepareIntegrationBranch,
@@ -123,6 +124,7 @@ function createSharedRegistry(factory) {
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
+ * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
  * @param {object} [opts.probeOpts] — health probe overrides
  * @param {object} [opts.deps] — dependency injection for testing
  * @returns {SwarmHypervisor}
@@ -135,6 +137,7 @@ export function createSwarmHypervisor(opts) {
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
     graceMs = 10_000,
+    keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
     probeOpts = {},
     _deps = {},
@@ -153,7 +156,8 @@ export function createSwarmHypervisor(opts) {
     _deps.prepareIntegrationBranch || prepareIntegrationBranch;
   const rebaseShardOntoIntegrationImpl =
     _deps.rebaseShardOntoIntegration || rebaseShardOntoIntegration;
-  const cleanupWorktreeImpl = _deps.cleanupWorktree || pruneWorktree;
+  const cleanupWorktreeImpl =
+    _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const emitter = new EventEmitter();
   const eventLog = createEventLog(join(logsDir, "swarm-events.jsonl"));
   const { registry: sharedRegistry, fallbackReason: meshRegistryFallback } =
@@ -171,6 +175,7 @@ export function createSwarmHypervisor(opts) {
 
   /** @type {Set<string>} shards that have fully completed (not just launched) */
   const completedShards = new Set();
+  const cleanedWorktreePaths = new Set();
 
   const results = new Map(); // shardName → validated result
   const failures = new Map(); // shardName → failure info
@@ -563,16 +568,19 @@ export function createSwarmHypervisor(opts) {
         lockManager.release(shard.name);
       }
       if (shard.worktreePath) {
-        try {
-          await cleanupWorktreeImpl({
+        await maybeCleanupWorktree(
+          shard.name,
+          {
             worktreePath: shard.worktreePath,
             branchName: shard.branchName,
-            rootDir: workdir,
+          },
+          shard,
+          {
+            branchName: shard.branchName,
             force: true,
-          });
-        } catch {
-          /* best-effort */
-        }
+            failureReason: `launch_failed:${err.message}`,
+          },
+        );
       }
       return null;
     }
@@ -754,7 +762,10 @@ export function createSwarmHypervisor(opts) {
               shard: shardName,
               error: fetchResult.error,
             });
-            await maybeCleanupWorktree(shardName, worker, shard);
+            await maybeCleanupWorktree(shardName, worker, shard, {
+              force: true,
+              failureReason: "remote_fetch_failed",
+            });
             integrationFailures.push(shardName);
             continue;
           }
@@ -791,7 +802,10 @@ export function createSwarmHypervisor(opts) {
             shard: shardName,
             ...commitEvidence,
           });
-          await maybeCleanupWorktree(shardName, worker, shard);
+          await maybeCleanupWorktree(shardName, worker, shard, {
+            force: true,
+            failureReason: failures.get(shardName)?.mode || "no_commit_evidence",
+          });
           integrationFailures.push(shardName);
           continue;
         }
@@ -810,7 +824,11 @@ export function createSwarmHypervisor(opts) {
             shard: shardName,
             violations: validation.violations,
           });
-          await maybeCleanupWorktree(shardName, worker, shard);
+          await maybeCleanupWorktree(shardName, worker, shard, {
+            force: true,
+            failureReason:
+              failures.get(shardName)?.mode || "lease_violation_revert",
+          });
           integrationFailures.push(shardName);
           continue;
         }
@@ -828,7 +846,10 @@ export function createSwarmHypervisor(opts) {
             integrationBranch,
             error: rebaseResult.error,
           });
-          await maybeCleanupWorktree(shardName, worker, shard);
+          await maybeCleanupWorktree(shardName, worker, shard, {
+            force: true,
+            failureReason: rebaseResult.error || FAILURE_MODES.F5_MERGE_CONFLICT,
+          });
           integrationFailures.push(shardName);
           continue;
         }
@@ -844,7 +865,9 @@ export function createSwarmHypervisor(opts) {
         });
         integrated.push(shardName);
 
-        await maybeCleanupWorktree(shardName, worker, shard, shardBranch);
+        await maybeCleanupWorktree(shardName, worker, shard, {
+          branchName: shardBranch,
+        });
       }
     } catch (err) {
       const unresolved = plan.mergeOrder.filter(
@@ -927,19 +950,35 @@ export function createSwarmHypervisor(opts) {
     shardName,
     worker,
     shard,
-    branchName = worker?.branchName,
+    {
+      branchName = worker?.branchName,
+      force = false,
+      failureReason = null,
+    } = {},
   ) {
     if (!worker?.worktreePath || shard?.host) return;
+    if (failureReason && keepFailedWorktrees) return;
+    if (cleanedWorktreePaths.has(worker.worktreePath)) return;
     try {
       await cleanupWorktreeImpl({
         worktreePath: worker.worktreePath,
         branchName,
         rootDir: workdir,
+        force,
       });
+      cleanedWorktreePaths.add(worker.worktreePath);
+      if (failureReason) {
+        eventLog.append("worktree_auto_cleanup", {
+          shard: shardName,
+          worktreePath: worker.worktreePath,
+          reason: failureReason,
+        });
+      }
     } catch (err) {
       eventLog.append("worktree_cleanup_failed", {
         shard: shardName,
         worktreePath: worker.worktreePath,
+        reason: failureReason || null,
         error: err.message,
       });
     }
@@ -1207,6 +1246,18 @@ export function createSwarmHypervisor(opts) {
     }
 
     await Promise.allSettled(shutdowns);
+
+    if (!keepFailedWorktrees) {
+      for (const [shardName, failureInfo] of failures) {
+        const worker = workers.get(shardName);
+        const shard =
+          worker?.shardConfig || plan?.shards.find((item) => item.name === shardName);
+        await maybeCleanupWorktree(shardName, worker, shard, {
+          force: true,
+          failureReason: failureInfo?.mode || failureInfo?.reason || reason,
+        });
+      }
+    }
 
     sharedRegistry.clear();
     lockManager?.releaseAll();

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -5,7 +5,7 @@
 
 import { execFile } from "node:child_process";
 import { access, mkdir, readdir, rm } from "node:fs/promises";
-import { join, normalize, resolve } from "node:path";
+import { join, normalize, relative, resolve } from "node:path";
 import { remoteGit, validateHost } from "./remote-session.mjs";
 
 const SWARM_ROOT = ".codex-swarm";
@@ -36,6 +36,50 @@ function sleep(ms) {
 /** Normalize path for Windows compatibility. */
 function normPath(p) {
   return normalize(p).replace(/\\/g, "/");
+}
+
+function resolveCleanupTarget(worktreePath, rootDir) {
+  const resolvedRoot = resolve(rootDir);
+  const resolvedWorktree = resolve(worktreePath);
+  const normalizedRoot = normPath(resolvedRoot).replace(/\/+$/u, "");
+  const normalizedWorktree = normPath(resolvedWorktree).replace(/\/+$/u, "");
+
+  if (normalizedWorktree === normalizedRoot) {
+    throw new Error("refusing to cleanup the main working tree");
+  }
+
+  const rel = normPath(relative(resolvedRoot, resolvedWorktree));
+  if (
+    !rel ||
+    rel === "." ||
+    rel === ".." ||
+    rel.startsWith("../") ||
+    rel.includes("/../")
+  ) {
+    throw new Error(`refusing to cleanup path outside rootDir: ${worktreePath}`);
+  }
+
+  const allowed =
+    rel.startsWith(".codex-swarm/wt-") || rel.startsWith(".triflux/");
+  if (!allowed) {
+    throw new Error(`refusing to cleanup unsafe path: ${worktreePath}`);
+  }
+
+  return {
+    resolvedRoot,
+    resolvedWorktree,
+    normalizedWorktree,
+  };
+}
+
+async function branchExists(branchName, rootDir) {
+  if (!branchName) return false;
+  try {
+    const listed = await git(["branch", "--list", branchName], rootDir);
+    return listed.trim().length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -242,6 +286,60 @@ export async function rebaseShardOntoIntegration({
 }
 
 /**
+ * Safely remove a worktree directory and delete its branch.
+ * Refuses to touch the main working tree or paths outside known swarm state.
+ *
+ * @param {object} opts
+ * @param {string} opts.worktreePath
+ * @param {string} [opts.branchName]
+ * @param {string} [opts.rootDir=process.cwd()]
+ * @param {boolean} [opts.force=false]
+ */
+export async function cleanupWorktree({
+  worktreePath,
+  branchName,
+  rootDir = process.cwd(),
+  force = false,
+}) {
+  const { resolvedWorktree } = resolveCleanupTarget(worktreePath, rootDir);
+  const forceArgs = force ? ["--force"] : [];
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await git(
+        ["worktree", "remove", ...forceArgs, resolvedWorktree],
+        rootDir,
+      );
+      break;
+    } catch (_err) {
+      if (attempt === 2) {
+        try {
+          await rm(resolvedWorktree, { recursive: true, force: true });
+        } catch {
+          /* ignore */
+        }
+      }
+      await sleep(SLEEP_MS);
+    }
+  }
+
+  await sleep(SLEEP_MS);
+  try {
+    await git(["worktree", "prune"], rootDir);
+  } catch {
+    /* best-effort */
+  }
+
+  if (branchName && (await branchExists(branchName, rootDir))) {
+    try {
+      await git(["branch", "-D", branchName], rootDir);
+    } catch {
+      /* branch may already be gone */
+    }
+  }
+}
+
+/**
  * Remove a worktree and its branch.
  * Follows WT race-guard: sleep between operations.
  *
@@ -279,45 +377,14 @@ export async function pruneWorktree({
     }
   }
 
-  const forceFlag = force ? "--force" : "";
+  await cleanupWorktree({
+    worktreePath,
+    branchName,
+    rootDir,
+    force,
+  });
 
-  // Remove worktree (with retry for Windows file handle issues — E5)
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      await git(
-        ["worktree", "remove", worktreePath, ...(forceFlag ? [forceFlag] : [])],
-        rootDir,
-      );
-      break;
-    } catch (_err) {
-      if (attempt === 2) {
-        // Last resort: rm the directory and prune
-        try {
-          await rm(worktreePath, { recursive: true, force: true });
-        } catch {
-          /* ignore */
-        }
-      }
-      await sleep(SLEEP_MS);
-    }
-  }
-
-  // Prune stale worktree references
-  await sleep(SLEEP_MS);
-  try {
-    await git(["worktree", "prune"], rootDir);
-  } catch {
-    /* best-effort */
-  }
-
-  // Delete branch if specified
-  if (branchName) {
-    try {
-      await git(["branch", "-D", branchName], rootDir);
-    } catch {
-      /* may not exist */
-    }
-  }
+  return { ok: true };
 }
 
 /**

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -167,6 +167,13 @@ function createTestHypervisor(workdir, logsDir, overrides = {}) {
     },
   });
   return { hv, conductors };
+}
+
+function readEventLog(filePath) {
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
 }
 
 async function waitForCondition(check, timeoutMs = 1000) {
@@ -518,6 +525,7 @@ describe("swarm-hypervisor", () => {
           worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
           branchName: "swarm/issue-4/worker-a",
           rootDir: workdir,
+          force: false,
         },
       ]);
     });
@@ -711,6 +719,98 @@ describe("swarm-hypervisor", () => {
   });
 
   describe("shutdown", () => {
+    it("auto-cleans failed shard worktrees on shutdown by default", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+      const cleanupCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "failed-cleanup",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          cleanupWorktree: async (opts) => {
+            cleanupCalls.push(opts);
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].fail("worker crashed");
+      await waitForCondition(() => hv.getStatus().failedShards === 1);
+      await hv.shutdown("test_failure_cleanup");
+
+      assert.deepEqual(cleanupCalls, [
+        {
+          worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
+          branchName: "swarm/failed-cleanup/worker-a",
+          rootDir: workdir,
+          force: true,
+        },
+      ]);
+
+      const autoCleanupEvent = readEventLog(hv.eventLogPath).find(
+        (entry) => entry.event === "worktree_auto_cleanup",
+      );
+      assert.deepEqual(
+        autoCleanupEvent && {
+          shard: autoCleanupEvent.shard,
+          worktreePath: autoCleanupEvent.worktreePath,
+          reason: autoCleanupEvent.reason,
+        },
+        {
+          shard: "worker-a",
+          worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
+          reason: "F1_crash",
+        },
+      );
+
+      hv = null;
+    });
+
+    it("preserves failed shard worktrees when keepFailedWorktrees=true", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+      const cleanupCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "failed-keep",
+        keepFailedWorktrees: true,
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          cleanupWorktree: async (opts) => {
+            cleanupCalls.push(opts);
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].fail("worker crashed");
+      await waitForCondition(() => hv.getStatus().failedShards === 1);
+      await hv.shutdown("test_keep_failed");
+
+      assert.deepEqual(cleanupCalls, []);
+      assert.equal(
+        readEventLog(hv.eventLogPath).some(
+          (entry) => entry.event === "worktree_auto_cleanup",
+        ),
+        false,
+      );
+
+      hv = null;
+    });
+
     it("transitions to FAILED state on early shutdown", async () => {
       const plan = planSwarm(null, { content: SIMPLE_PRD });
       ({ hv } = createTestHypervisor(workdir, logsDir));

--- a/tests/unit/worktree-lifecycle.test.mjs
+++ b/tests/unit/worktree-lifecycle.test.mjs
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
+  cleanupWorktree,
   ensureWorktree,
   prepareIntegrationBranch,
   pruneOrphanWorktrees,
@@ -203,5 +204,18 @@ describe("worktree-lifecycle", () => {
   it("W-06: pruneOrphanWorktrees — .codex-swarm 없으면 빈 배열 반환", async () => {
     const removed = await pruneOrphanWorktrees({ rootDir: repoDir });
     assert.deepEqual(removed, []);
+  });
+
+  it("W-07: cleanupWorktree — main working tree 삭제를 차단한다", async () => {
+    await assert.rejects(
+      () =>
+        cleanupWorktree({
+          worktreePath: repoDir,
+          branchName: "main",
+          rootDir: repoDir,
+          force: true,
+        }),
+      /main working tree/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

swarm shard가 F1_crash / F2_ratelimit / F3_stall로 실패하면 `.codex-swarm/wt-<shard>` worktree와 브랜치를 자동 제거. 성공 shard는 유지 (merge 경로). `keepFailedWorktrees` 옵션으로 보존 가능.

## 변경

- `worktree-lifecycle.cleanupWorktree` 신규 (path prefix 안전 검증, 메인 tree 차단)
- `swarm-hypervisor` shutdown/cleanup: 실패 shard 자동 제거 + `worktree_auto_cleanup` 이벤트
- `createSwarmHypervisor` `opts.keepFailedWorktrees?: boolean` (기본 false)
- 단위 테스트 3종

## Test plan

- [x] 실패 shard 종료 → .codex-swarm/wt-<shard> 제거 + branch delete
- [x] keepFailedWorktrees=true면 보존 (디버깅용)
- [x] 메인 working tree 경로는 차단 (절대 안전장치)
- [x] 단위 테스트 3종 pass
- [ ] 실제 shard 실패 시나리오 회귀 확인

## 범위 제한

Phase 3 swarm dispatch 결과. shard Codex가 spec 범위를 넘어 packages/ 미러와 scripts/pack.mjs도 수정했으나 이 PR에서는 **지정 2 파일 + 테스트 2만** 반영 (scope 준수). 미러 동기화는 merge 후 기존 pack 워크플로우로 처리.

Closes #80