### PR TITLE
fix(conductor-test): spawn deps 주입으로 claude CLI 쓰레기 세션 차단

### DIFF
--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -116,7 +116,15 @@ function swapAuthFile(lease, agent, sessionId, eventLog) {
  * @param {object} [opts.broker] — AccountBroker 인스턴스 (tierFallback 구독용)
  * @returns {Conductor}
  */
+/**
+ * Conductor 생성.
+ * @param {object} [opts]
+ * @param {object} [opts.deps] — 의존성 주입 (테스트용 mock 지원)
+ * @param {Function} [opts.deps.execFile] — execFile 오버라이드
+ * @param {Function} [opts.deps.spawn] — spawn 오버라이드 (로컬/원격 child process 모두)
+ */
 export function createConductor(opts = {}) {
+  const spawnFn = opts.deps?.spawn || spawn;
   const {
     logsDir,
     maxRestarts = DEFAULT_MAX_RESTARTS,
@@ -492,7 +500,7 @@ export function createConductor(opts = {}) {
 
     let child;
     try {
-      child = spawn(launcher.command, {
+      child = spawnFn(launcher.command, {
         shell: true,
         cwd: spawnCwd,
         env: {
@@ -682,7 +690,7 @@ export function createConductor(opts = {}) {
 
     let child;
     try {
-      child = spawn("ssh", sshArgs, {
+      child = spawnFn("ssh", sshArgs, {
         env: process.env,
         reason: `conductor:remoteSession:${session.id}`,
         stdio: ["pipe", "pipe", "pipe"],

--- a/tests/unit/conductor.test.mjs
+++ b/tests/unit/conductor.test.mjs
@@ -1,9 +1,11 @@
 // tests/unit/conductor.test.mjs — conductor.mjs 상태 머신 유닛 테스트
 
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import { createConductor, STATES } from "../../hub/team/conductor.mjs";
@@ -23,8 +25,39 @@ function makeTmpDir() {
   return dir;
 }
 
-/** 테스트 conductor 팩토리 — grace/probe 값을 짧게 설정해 빠른 종료 보장 */
-function makeConductor(logsDir) {
+/**
+ * 실제 claude/codex CLI를 호출하지 않는 spawn mock.
+ * ~/.claude/projects에 세션 jsonl 쓰레기 생성을 차단한다.
+ * 기본: spawn 직후 setImmediate로 즉시 exit(0) — "claude -p echo_test 빠르게 종료"와 동일 타이밍.
+ */
+function makeMockSpawn({ exitCode = 0, exitSignal = null, exitDelayMs = 0 } = {}) {
+  return function mockSpawn() {
+    const child = new EventEmitter();
+    child.pid = Math.floor(Math.random() * 1_000_000) + 1;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = () => {
+      setImmediate(() => {
+        child.stdout.end();
+        child.stderr.end();
+        child.emit("exit", null, "SIGTERM");
+      });
+      return true;
+    };
+    const fire = () => {
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("exit", exitCode, exitSignal);
+    };
+    if (exitDelayMs > 0) setTimeout(fire, exitDelayMs);
+    else setImmediate(fire);
+    return child;
+  };
+}
+
+/** 테스트 conductor 팩토리 — grace/probe 값을 짧게 + spawn mock 기본 주입 */
+function makeConductor(logsDir, overrides = {}) {
   return createConductor({
     logsDir,
     maxRestarts: 1,
@@ -34,10 +67,15 @@ function makeConductor(logsDir) {
       l1ThresholdMs: 999_999,
       l3ThresholdMs: 999_999,
     },
+    ...overrides,
+    deps: {
+      spawn: makeMockSpawn(),
+      ...(overrides.deps || {}),
+    },
   });
 }
 
-/** spawnSession에 사용하는 최소 유효 config (claude -p "x"는 빠르게 실패/종료) */
+/** spawnSession에 사용하는 최소 유효 config (mock spawn이 즉시 exit(0)) */
 function minConfig(overrides = {}) {
   return {
     id: `test-session-${Date.now()}-${Math.random().toString(36).slice(2)}`,


### PR DESCRIPTION
## Summary

`tests/unit/conductor.test.mjs`가 `prompt: 'echo_test'`로 **실제 claude CLI spawn**하면서 `~/.claude/projects/<slug>/` 에 세션 jsonl 쓰레기가 대량 누적되는 문제 해결.

- 2026-04-17 기준 누적: **1112개 / 22.8MB**
- 세션 UI에서 `echo_test` 제목으로 매번 노출

## 변경

### hub/team/conductor.mjs
- `createConductor` opts.deps.spawn 지원 (기존 `opts.deps.execFile` 패턴과 동일)
- `respawnSession` (로컬) + `startRemoteSession` (SSH) 모두 `spawnFn` 경유

### tests/unit/conductor.test.mjs
- `makeMockSpawn()` 추가: EventEmitter 기반 mock child + `setImmediate` 즉시 exit
- `makeConductor`에 기본 `deps.spawn = mock` 주입
- 기존 47 테스트 **전부 pass 유지** (세션 jsonl 생성 0)

## 검증

- [x] 테스트 실행 후 echo_test 세션 파일 수 = 0 (이전 1112개)
- [x] 47 tests pass, 0 fail
- [x] 원격 세션 (SSH) spawn 경로도 mock 주입 가능
- [ ] production 코드에서 기존 spawn 경로 회귀 없음 (실제 swarm 스모크 후 확인)

## 관련

사용자 직접 리포트 (2026-04-17): `echo_test` 제목의 쓰레기 세션이 세션 UI에 반복 노출. 1112개 일괄 삭제 완료 후 이 PR로 재발 차단.