### PR TITLE
fix(swarm): F7 validator rejects status=failed worker payload (BUG-G, #130)

### DIFF
--- a/hub/team/worker-completion-validator.mjs
+++ b/hub/team/worker-completion-validator.mjs
@@ -35,11 +35,25 @@ export function validateWorkerCompletion(payload) {
   }
 
   const valid = compiled(payload);
-  if (valid) return { ok: true };
+  if (!valid) {
+    const firstError = compiled.errors?.[0];
+    const reason = formatError(firstError, payload);
+    return { ok: false, reason };
+  }
 
-  const firstError = compiled.errors?.[0];
-  const reason = formatError(firstError, payload);
-  return { ok: false, reason };
+  // BUG-G (#130): the schema's if-then only constrains commits_made when
+  // status='ok', so status='failed' payloads pass AJV vacuously. Without
+  // this guard the hypervisor F7 path treats a worker self-reported failure
+  // as a successful completion and integrates phantom shards.
+  if (payload.status === "failed") {
+    const detail =
+      typeof payload.reason === "string" && payload.reason.length > 0
+        ? payload.reason
+        : "unspecified";
+    return { ok: false, reason: `worker_self_reported_failure:${detail}` };
+  }
+
+  return { ok: true };
 }
 
 function formatError(err, payload) {

--- a/tests/unit/worker-completion-validator.test.mjs
+++ b/tests/unit/worker-completion-validator.test.mjs
@@ -52,4 +52,32 @@ describe("validateWorkerCompletion", () => {
     assert.equal(validateWorkerCompletion("ok").ok, false);
     assert.equal(validateWorkerCompletion(undefined).ok, false);
   });
+
+  it("rejects status=failed payload with a reason (BUG-G #130)", () => {
+    const result = validateWorkerCompletion({
+      status: "failed",
+      reason: "codex stall",
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "worker_self_reported_failure:codex stall");
+  });
+
+  it("rejects status=failed payload with empty commits_made (BUG-G #130)", () => {
+    const result = validateWorkerCompletion({
+      status: "failed",
+      commits_made: [],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "worker_self_reported_failure:unspecified");
+  });
+
+  it("rejects status=failed payload even when commits_made has entries", () => {
+    const result = validateWorkerCompletion({
+      status: "failed",
+      reason: "partial work then abort",
+      commits_made: [{ sha: "abc1234", message: "wip" }],
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /^worker_self_reported_failure:/);
+  });
 });


### PR DESCRIPTION
## Summary

- Worker completion schema's `if-then` only constrained `commits_made` when `status='ok'`, so `status='failed'` payloads passed AJV vacuously.
- Hypervisor F7 guard treated those as successful completions → `completedShards.add()` → `integrateResults()` → phantom `integrated.push()` without real commits.
- Fix adds an explicit post-schema check in `validateWorkerCompletion()` so `status='failed'` is rejected with reason `worker_self_reported_failure:<detail>`, routing the shard to the existing `F7_WORKER_DID_NOT_COMMIT` failure path. No hypervisor change needed.

## Evidence chain

- `hub/team/schemas/worker-completion.json` — `allOf[0]` gates `commits_made.minItems:1` on `status='ok'` only (vacuous `if-then` on `status='failed'`).
- `hub/team/swarm-hypervisor.mjs:661-705` — F7 branch takes `verdict.ok=false`; fix restores that path for self-reported failures without altering the hypervisor.
- `hub/team/swarm-hypervisor.mjs:890-1021` — integration loop skips on `failures.has(shardName)`; with `failures` un-populated, phantom shards were previously `integrated.push()`.

## Test plan

- [x] `node --test tests/unit/worker-completion-validator.test.mjs` — 8/8 pass (5 existing + 3 new)
- [x] Existing `status='ok'` and `status='skipped'` cases unchanged
- [x] New cases cover:
  - `status='failed'` + explicit `reason` (detail propagated)
  - `status='failed'` + empty `commits_made` (original BUG-G payload)
  - `status='failed'` + populated `commits_made` (worker reports partial work then aborts)

## Scope

- No schema change — `status='failed'` remains a legitimate enum value; validator semantics tightened instead.
- No hypervisor change — F7 failure branch was already correct for `verdict.ok=false`.
- No public API change.

Closes #130