### PR TITLE
fix(tfx-route): BUG-H _codex_config_swap fail-safe + doctor orphan cleanup (#132)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -12,6 +12,7 @@ import {
   readdirSync,
   readFileSync,
   readSync,
+  renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -3417,15 +3418,44 @@ async function cmdDoctor(options = {}) {
         warn(`orphan config swap backup 감지: ${formatPathForDisplay(orphanBackup)}`);
         info("이전 Codex 실행의 config swap 이 restore 에 실패했습니다.");
         if (fix) {
+          // BUG-H (#132) ownership-claim + atomic rename:
+          // 1) orphan → claim (rename 으로 소유권 확보 — 동시 codex worker 가 건드릴 수 없음)
+          // 2) claim 읽어 tmp 로 write
+          // 3) tmp → codexConfig 로 atomic rename
+          // 4) claim 삭제
+          // 중간 실패 시 claim 을 orphan 경로로 되돌려 수동 복구 가능하게 한다.
+          const claimPath = `${orphanBackup}.doctor-claim-${process.pid}`;
+          const tmpPath = `${codexConfig}.doctor-tmp-${process.pid}`;
           try {
-            const backupContent = readFileSync(orphanBackup, "utf8");
-            writeFileSync(codexConfig, backupContent);
-            unlinkSync(orphanBackup);
-            ok("config.toml 을 backup 에서 복원 + orphan 제거 완료");
+            renameSync(orphanBackup, claimPath);
           } catch (error) {
-            fail(`복원 실패: ${error.message}`);
-            info(`수동 복구: mv "${orphanBackup}" "${codexConfig}"`);
+            fail(`복원 실패 (ownership claim): ${error.message}`);
+            info(`다른 프로세스가 backup 을 사용 중이거나 이미 정리됨: ${orphanBackup}`);
             issues++;
+          }
+          if (existsSync(claimPath)) {
+            try {
+              const backupContent = readFileSync(claimPath, "utf8");
+              writeFileSync(tmpPath, backupContent);
+              renameSync(tmpPath, codexConfig);
+              unlinkSync(claimPath);
+              ok("config.toml 을 backup 에서 복원 + orphan 제거 완료");
+            } catch (error) {
+              fail(`복원 실패: ${error.message}`);
+              // 실패 시 claim 을 orphan 경로로 되돌려 사용자가 재시도 가능하게.
+              try {
+                renameSync(claimPath, orphanBackup);
+              } catch {
+                // claim 롤백 실패 — claim 그대로 남음. 경로 알려줌.
+                info(`claim 경로 보존: ${claimPath} (수동으로 ${orphanBackup} 로 이동 가능)`);
+              }
+              try {
+                unlinkSync(tmpPath);
+              } catch {
+                // tmp 가 아직 안 만들어진 경우 무시
+              }
+              issues++;
+            }
           }
         } else {
           info("복원하려면 `tfx doctor --fix` 를 실행하세요.");

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -3399,6 +3399,47 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // ── Codex Config Health (BUG-H #132) ──
+    // _codex_config_swap 의 restore 가 Windows lock/ACL 로 실패하면
+    // ~/.codex/config.toml.pre-exec 가 남아 [mcp_servers.*] 섹션이 영구 손실된다.
+    // orphan backup 을 감지하고 --fix 로 자동 복원한다.
+    section("Codex Config Health");
+    {
+      const codexConfig = join(CODEX_DIR, "config.toml");
+      const orphanBackup = `${codexConfig}.pre-exec`;
+      if (existsSync(orphanBackup)) {
+        addDoctorCheck(report, {
+          name: "codex-config-orphan-backup",
+          status: "issues",
+          path: orphanBackup,
+          fix: "tfx doctor --fix",
+        });
+        warn(`orphan config swap backup 감지: ${formatPathForDisplay(orphanBackup)}`);
+        info("이전 Codex 실행의 config swap 이 restore 에 실패했습니다.");
+        if (fix) {
+          try {
+            const backupContent = readFileSync(orphanBackup, "utf8");
+            writeFileSync(codexConfig, backupContent);
+            unlinkSync(orphanBackup);
+            ok("config.toml 을 backup 에서 복원 + orphan 제거 완료");
+          } catch (error) {
+            fail(`복원 실패: ${error.message}`);
+            info(`수동 복구: mv "${orphanBackup}" "${codexConfig}"`);
+            issues++;
+          }
+        } else {
+          info("복원하려면 `tfx doctor --fix` 를 실행하세요.");
+          issues++;
+        }
+      } else {
+        addDoctorCheck(report, {
+          name: "codex-config-orphan-backup",
+          status: "ok",
+        });
+        ok("orphan config swap backup 없음");
+      }
+    }
+
     // ── Route Script 정합성 ──
     section("Route Script Sync");
     {

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1436,31 +1436,50 @@ _codex_config_swap() {
       fi
     done
 
+    # BUG-H (#132) fail-safe: allowed_pat 이 비면 swap 스킵.
+    # 과거에는 awk 가 keep="" 에서 모든 [mcp_servers.*] 섹션을 제거하고
+    # restore 시 Windows mv 실패 → config.toml 영구 손상이 재발했다.
+    # 비허용 서버 비활성화는 mcp-filter.mjs 의 enabled=false override 가 담당한다.
+    if [[ -z "$allowed_pat" ]]; then
+      echo "[tfx-route] config.toml swap 스킵: 허용 서버 패턴 없음 (fail-safe)" >&2
+      return 0
+    fi
+
     # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 건드리지 않음)
     if [[ -f "$backup" ]]; then
-      echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중" >&2
+      echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 ($backup)" >&2
       return 0
     fi
     cp "$config" "$backup"
 
-    # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지
+    # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지.
+    # keep="" 은 진입 가드에서 return 됐지만 defense-in-depth 유지.
     awk -v keep="$allowed_pat" '
       BEGIN { skip=0 }
       /^\[mcp_servers\./ {
+        if (keep == "") { skip=0; print; next }
         name=$0; gsub(/^\[mcp_servers\./, "", name); gsub(/[\].].*/, "", name)
-        if (keep == "" || name !~ "^(" keep ")$") { skip=1; next }
+        if (name !~ "^(" keep ")$") { skip=1; next }
         else { skip=0 }
       }
       /^\[/ && !/^\[mcp_servers\./ { skip=0 }
       !skip { print }
     ' "$backup" > "$config"
 
-    local kept=0
-    [[ -n "$allowed_pat" ]] && kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
+    local kept
+    kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
     echo "[tfx-route] config.toml swap: ${kept}개 MCP 서버만 활성" >&2
 
   elif [[ "$action" == "restore" && -f "$backup" ]]; then
-    mv "$backup" "$config" 2>/dev/null
+    # BUG-H (#132): mv 는 Windows lock/ACL 상황에서 조용히 실패할 수 있음.
+    # cat+rm 2단계로 나눠 복원 실패 시 backup 보존 → 다음 시도/수동 복구 가능.
+    if ! cat "$backup" > "$config"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (write error). backup 보존: $backup" >&2
+      return 1
+    fi
+    if ! rm -f "$backup"; then
+      echo "[tfx-route] 경고: backup 삭제 실패: $backup (수동 정리 필요)" >&2
+    fi
     echo "[tfx-route] config.toml 복원 완료" >&2
   fi
 }

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1471,10 +1471,19 @@ _codex_config_swap() {
     echo "[tfx-route] config.toml swap: ${kept}개 MCP 서버만 활성" >&2
 
   elif [[ "$action" == "restore" && -f "$backup" ]]; then
-    # BUG-H (#132): mv 는 Windows lock/ACL 상황에서 조용히 실패할 수 있음.
-    # cat+rm 2단계로 나눠 복원 실패 시 backup 보존 → 다음 시도/수동 복구 가능.
-    if ! cat "$backup" > "$config"; then
-      echo "[tfx-route] 경고: config.toml 복원 실패 (write error). backup 보존: $backup" >&2
+    # BUG-H (#132) atomic rename: cp→tmp→mv 로 중간 실패 시 config 손상 방지.
+    # `cat > $config` 는 cat 실행 전에 dest 가 truncate 되어 mid-stream 실패 시
+    # 빈/부분 파일이 남는다. 같은 디렉토리 내 mv 는 POSIX 상 atomic 이므로
+    # 실패해도 기존 config 와 backup 모두 보존된다.
+    local tmp="${config}.restore.$$"
+    if ! cp "$backup" "$tmp"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (temp copy). backup 보존: $backup" >&2
+      rm -f "$tmp" 2>/dev/null
+      return 1
+    fi
+    if ! mv "$tmp" "$config"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (atomic rename). backup 보존: $backup" >&2
+      rm -f "$tmp" 2>/dev/null
       return 1
     fi
     if ! rm -f "$backup"; then

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1436,31 +1436,50 @@ _codex_config_swap() {
       fi
     done
 
+    # BUG-H (#132) fail-safe: allowed_pat 이 비면 swap 스킵.
+    # 과거에는 awk 가 keep="" 에서 모든 [mcp_servers.*] 섹션을 제거하고
+    # restore 시 Windows mv 실패 → config.toml 영구 손상이 재발했다.
+    # 비허용 서버 비활성화는 mcp-filter.mjs 의 enabled=false override 가 담당한다.
+    if [[ -z "$allowed_pat" ]]; then
+      echo "[tfx-route] config.toml swap 스킵: 허용 서버 패턴 없음 (fail-safe)" >&2
+      return 0
+    fi
+
     # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 건드리지 않음)
     if [[ -f "$backup" ]]; then
-      echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중" >&2
+      echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 ($backup)" >&2
       return 0
     fi
     cp "$config" "$backup"
 
-    # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지
+    # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지.
+    # keep="" 은 진입 가드에서 return 됐지만 defense-in-depth 유지.
     awk -v keep="$allowed_pat" '
       BEGIN { skip=0 }
       /^\[mcp_servers\./ {
+        if (keep == "") { skip=0; print; next }
         name=$0; gsub(/^\[mcp_servers\./, "", name); gsub(/[\].].*/, "", name)
-        if (keep == "" || name !~ "^(" keep ")$") { skip=1; next }
+        if (name !~ "^(" keep ")$") { skip=1; next }
         else { skip=0 }
       }
       /^\[/ && !/^\[mcp_servers\./ { skip=0 }
       !skip { print }
     ' "$backup" > "$config"
 
-    local kept=0
-    [[ -n "$allowed_pat" ]] && kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
+    local kept
+    kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
     echo "[tfx-route] config.toml swap: ${kept}개 MCP 서버만 활성" >&2
 
   elif [[ "$action" == "restore" && -f "$backup" ]]; then
-    mv "$backup" "$config" 2>/dev/null
+    # BUG-H (#132): mv 는 Windows lock/ACL 상황에서 조용히 실패할 수 있음.
+    # cat+rm 2단계로 나눠 복원 실패 시 backup 보존 → 다음 시도/수동 복구 가능.
+    if ! cat "$backup" > "$config"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (write error). backup 보존: $backup" >&2
+      return 1
+    fi
+    if ! rm -f "$backup"; then
+      echo "[tfx-route] 경고: backup 삭제 실패: $backup (수동 정리 필요)" >&2
+    fi
     echo "[tfx-route] config.toml 복원 완료" >&2
   fi
 }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1471,10 +1471,19 @@ _codex_config_swap() {
     echo "[tfx-route] config.toml swap: ${kept}개 MCP 서버만 활성" >&2
 
   elif [[ "$action" == "restore" && -f "$backup" ]]; then
-    # BUG-H (#132): mv 는 Windows lock/ACL 상황에서 조용히 실패할 수 있음.
-    # cat+rm 2단계로 나눠 복원 실패 시 backup 보존 → 다음 시도/수동 복구 가능.
-    if ! cat "$backup" > "$config"; then
-      echo "[tfx-route] 경고: config.toml 복원 실패 (write error). backup 보존: $backup" >&2
+    # BUG-H (#132) atomic rename: cp→tmp→mv 로 중간 실패 시 config 손상 방지.
+    # `cat > $config` 는 cat 실행 전에 dest 가 truncate 되어 mid-stream 실패 시
+    # 빈/부분 파일이 남는다. 같은 디렉토리 내 mv 는 POSIX 상 atomic 이므로
+    # 실패해도 기존 config 와 backup 모두 보존된다.
+    local tmp="${config}.restore.$$"
+    if ! cp "$backup" "$tmp"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (temp copy). backup 보존: $backup" >&2
+      rm -f "$tmp" 2>/dev/null
+      return 1
+    fi
+    if ! mv "$tmp" "$config"; then
+      echo "[tfx-route] 경고: config.toml 복원 실패 (atomic rename). backup 보존: $backup" >&2
+      rm -f "$tmp" 2>/dev/null
       return 1
     fi
     if ! rm -f "$backup"; then

--- a/tests/unit/tfx-route-config-swap.test.mjs
+++ b/tests/unit/tfx-route-config-swap.test.mjs
@@ -1,0 +1,190 @@
+// tests/unit/tfx-route-config-swap.test.mjs
+// BUG-H (#132): _codex_config_swap fail-safe 동작 검증.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, before, after } from "node:test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", "tfx-route.sh");
+
+// tfx-route.sh 에서 _codex_config_swap 함수 정의만 추출해서 subshell 에 주입.
+function extractSwapFunction() {
+  const source = readFileSync(SCRIPT_PATH, "utf8");
+  const start = source.indexOf("_codex_config_swap() {");
+  assert.ok(start >= 0, "_codex_config_swap 정의를 찾을 수 없음");
+  let depth = 0;
+  let end = start;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  return source.slice(start, end);
+}
+
+function runSwap({ action, configContent, flags = [] }) {
+  const dir = mkdtempSync(path.join(tmpdir(), "tfx-swap-"));
+  const config = path.join(dir, "config.toml");
+  writeFileSync(config, configContent);
+  const backup = `${config}.pre-exec`;
+  const flagsLiteral = flags.map((f) => `'${f}'`).join(" ");
+  const funcDef = extractSwapFunction();
+
+  const script = `
+set -u
+_CODEX_CONFIG='${config}'
+CODEX_CONFIG_FLAGS=(${flagsLiteral})
+${funcDef}
+_codex_config_swap ${action}
+`;
+  const result = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+  });
+  const output = {
+    exitCode: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+    config: existsSync(config) ? readFileSync(config, "utf8") : null,
+    backup: existsSync(backup) ? readFileSync(backup, "utf8") : null,
+    backupExists: existsSync(backup),
+    dir,
+  };
+  return output;
+}
+
+describe("BUG-H _codex_config_swap fail-safe", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  const baseToml = [
+    "model = \"gpt-5.3\"",
+    "",
+    "[mcp_servers.tfx-hub]",
+    'url = "http://127.0.0.1:27888/mcp"',
+    "",
+    "[mcp_servers.context7]",
+    'command = "npx"',
+    "",
+    "[profiles.codex53_high]",
+    'model = "gpt-5.3-codex"',
+    "",
+  ].join("\n");
+
+  it("filter: allowed_pat 이 비면 config.toml 을 건드리지 않는다 (주요 버그 회귀 방지)", () => {
+    const r = runSwap({
+      action: "filter",
+      configContent: baseToml,
+      flags: [],
+    });
+    cleanupDirs.push(r.dir);
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.config, baseToml, "config.toml 이 원본 그대로여야 함");
+    assert.equal(r.backupExists, false, "swap 스킵 시 backup 도 생성하지 않음");
+    assert.match(r.stderr, /fail-safe/);
+  });
+
+  it("filter: 허용 서버 패턴이 있으면 해당 서버만 남기고 나머지 제거", () => {
+    const r = runSwap({
+      action: "filter",
+      configContent: baseToml,
+      flags: ["mcp_servers.tfx-hub.enabled=true"],
+    });
+    cleanupDirs.push(r.dir);
+    assert.equal(r.exitCode, 0);
+    assert.match(r.config, /\[mcp_servers\.tfx-hub\]/);
+    assert.doesNotMatch(
+      r.config,
+      /\[mcp_servers\.context7\]/,
+      "비허용 서버는 제거되어야 함",
+    );
+    assert.match(r.config, /\[profiles\.codex53_high\]/, "프로필은 유지");
+    assert.equal(r.backup, baseToml, "backup 은 원본 그대로");
+  });
+
+  it("restore: backup 이 있으면 config 를 원본으로 복원하고 backup 삭제", () => {
+    // 먼저 filter 로 backup 생성
+    const filter = runSwap({
+      action: "filter",
+      configContent: baseToml,
+      flags: ["mcp_servers.tfx-hub.enabled=true"],
+    });
+    cleanupDirs.push(filter.dir);
+    assert.equal(filter.exitCode, 0);
+    // 그 다음 restore 를 동일 디렉토리에 적용
+    const restoreScript = `
+set -u
+_CODEX_CONFIG='${path.join(filter.dir, "config.toml")}'
+${extractSwapFunction()}
+_codex_config_swap restore
+`;
+    const restored = spawnSync("bash", ["-c", restoreScript], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    assert.equal(restored.status, 0);
+    const after = readFileSync(path.join(filter.dir, "config.toml"), "utf8");
+    assert.equal(after, baseToml, "restore 후 원본과 동일");
+    assert.equal(
+      existsSync(path.join(filter.dir, "config.toml.pre-exec")),
+      false,
+      "restore 후 backup 은 삭제되어야 함",
+    );
+    assert.match(restored.stderr, /복원 완료/);
+  });
+
+  it("filter: backup 이 이미 있으면 swap 을 스킵한다 (double-swap 방지)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-swap-"));
+    cleanupDirs.push(dir);
+    const config = path.join(dir, "config.toml");
+    const backup = `${config}.pre-exec`;
+    writeFileSync(config, baseToml);
+    writeFileSync(backup, "existing-backup");
+
+    const script = `
+set -u
+_CODEX_CONFIG='${config}'
+CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
+${extractSwapFunction()}
+_codex_config_swap filter
+`;
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(
+      readFileSync(config, "utf8"),
+      baseToml,
+      "backup 존재 시 config 건드리지 않음",
+    );
+    assert.equal(
+      readFileSync(backup, "utf8"),
+      "existing-backup",
+      "기존 backup 보존",
+    );
+    assert.match(result.stderr, /다른 워커가 사용 중/);
+  });
+});


### PR DESCRIPTION
## Summary
- `_codex_config_swap filter` 이 `allowed_pat=""` 상태에서 awk 로 `[mcp_servers.*]` 섹션을 전부 제거하던 회귀를 차단 (#132).
- restore 의 `mv` 를 `cat + rm` 로 분리해 Windows lock/ACL 에서 조용히 실패하던 경로를 가시화 + backup 보존.
- `tfx doctor` 에 Codex Config Health 섹션 추가. orphan `~/.codex/config.toml.pre-exec` 감지 시 `--fix` 로 자동 복원.
- awk defense-in-depth + packages/triflux 동기화 + 단위 테스트 4개.

## Root cause
`_codex_config_swap filter` 는 현재 CODEX_CONFIG_FLAGS 의 `mcp_servers.X.enabled=true` 만 패턴에 넣는다. profile 이 `none` 이거나 flag 가 비었을 때 `allowed_pat=""` 이 되고, awk 의 `keep==""` 분기가 모든 `[mcp_servers.*]` 를 제거한다. restore 가 Windows `mv` 실패로 조용히 넘어가면 config.toml 은 MCP 섹션이 사라진 채 남는다. 즉 "codex 설정이 자꾸 날아가는" 증상의 구조적 원인.

## Test plan
- [x] `node --test tests/unit/tfx-route-config-swap.test.mjs` — 4/4 pass
- [x] `node --test tests/unit/mcp-filter.test.mjs tests/unit/tfx-route-args.test.mjs tests/unit/tfx-route-config-swap.test.mjs` — 38/38 pass (regression 없음)
- [x] `tfx doctor` — orphan 없음 → `✓ orphan config swap backup 없음`
- [x] `cp config.toml config.toml.pre-exec && tfx doctor` — `⚠ orphan config swap backup 감지`
- [x] `tfx doctor --fix` — `✓ config.toml 을 backup 에서 복원 + orphan 제거 완료`

Closes #132