### PR TITLE
fix(swarm): BUG-I worktree intentional deletions vs F6 no_commit_guard

### DIFF
--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -25,7 +25,9 @@ import { createSwarmLocks } from "./swarm-locks.mjs";
 import { validateWorkerCompletion } from "./worker-completion-validator.mjs";
 import {
   cleanupWorktree,
+  EXPECTED_WORKTREE_DELETIONS,
   ensureWorktree,
+  extractDirtyFiles,
   fetchRemoteShard,
   prepareIntegrationBranch,
   pruneWorktree,
@@ -408,12 +410,12 @@ export function createSwarmHypervisor(opts) {
     if (worker?.worktreePath && !worker?.shardConfig?.host) {
       try {
         const rawStatus = await git(["status", "--short"], worker.worktreePath);
-        evidence.dirtyFiles = rawStatus
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .map((line) => line.slice(2).trim())
-          .filter(Boolean);
+        // BUG-I: prepareWorktree 가 #34 L2 의도로 rm 한 tracked paths
+        // (EXPECTED_WORKTREE_DELETIONS) 는 dirty 판정에서 제외한다.
+        evidence.dirtyFiles = extractDirtyFiles(
+          rawStatus,
+          EXPECTED_WORKTREE_DELETIONS,
+        );
         evidence.dirty = evidence.dirtyFiles.length > 0;
       } catch (err) {
         evidence.error = evidence.error || err.message;

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -20,12 +20,19 @@ export const EXPECTED_WORKTREE_DELETIONS = Object.freeze([
 ]);
 
 /**
- * Parse `git status --short` output into a dirty-file list, filtering out
- * EXPECTED_WORKTREE_DELETIONS (paths the swarm intentionally removes from each
- * worktree — see prepareWorktree #34 L2). Pure function for unit-testability.
+ * Parse `git status --short` output into a dirty-file list. Filters out paths
+ * in `expectedDeletions` only when the XY status code indicates a deletion
+ * (X='D' or Y='D'). Modifications / additions / untracked of the same paths
+ * remain dirty — otherwise a worker could silently corrupt those files and
+ * bypass F6 no_commit_guard (Codex review #134 round 2).
+ *
+ * git status --short XY codes reference:
+ *   ' D' unstaged delete, 'D ' staged delete, 'DD' both — filtered if path
+ *     is in expectedDeletions.
+ *   ' M'/'M '/'MM' modify, '??' untracked, 'A ' add, 'R ' rename — kept.
  *
  * @param {string} rawStatus — stdout of `git status --short`
- * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths to skip
+ * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths eligible for deletion-only skip
  * @returns {string[]} — remaining dirty paths after filtering
  */
 export function extractDirtyFiles(
@@ -33,13 +40,17 @@ export function extractDirtyFiles(
   expectedDeletions = EXPECTED_WORKTREE_DELETIONS,
 ) {
   const skip = new Set(expectedDeletions);
-  return String(rawStatus ?? "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => line.slice(2).trim())
-    .filter(Boolean)
-    .filter((path) => !skip.has(path));
+  const out = [];
+  for (const raw of String(rawStatus ?? "").split(/\r?\n/)) {
+    if (raw.length < 3) continue;
+    const xy = raw.slice(0, 2);
+    const path = raw.slice(2).trim();
+    if (!path) continue;
+    const isDeletion = xy.includes("D");
+    if (isDeletion && skip.has(path)) continue;
+    out.push(path);
+  }
+  return out;
 }
 
 function git(args, cwd) {

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -11,6 +11,37 @@ import { remoteGit, validateHost } from "./remote-session.mjs";
 const SWARM_ROOT = ".codex-swarm";
 const SLEEP_MS = 2000; // WT race-guard (MEMORY.md: wt-attach-spacing)
 
+// BUG-I: prepareWorktree 가 #34 L2 의도로 worktree 에서 rm 하는 tracked paths.
+// swarm-hypervisor 의 commit_evidence dirty 판정에서 이 경로들을 filter 해야
+// "의도된 삭제" 가 F6 no_commit_guard 를 잘못 trip 하는 것을 막을 수 있다.
+export const EXPECTED_WORKTREE_DELETIONS = Object.freeze([
+  ".claude-plugin/marketplace.json",
+  ".claude-plugin/plugin.json",
+]);
+
+/**
+ * Parse `git status --short` output into a dirty-file list, filtering out
+ * EXPECTED_WORKTREE_DELETIONS (paths the swarm intentionally removes from each
+ * worktree — see prepareWorktree #34 L2). Pure function for unit-testability.
+ *
+ * @param {string} rawStatus — stdout of `git status --short`
+ * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths to skip
+ * @returns {string[]} — remaining dirty paths after filtering
+ */
+export function extractDirtyFiles(
+  rawStatus,
+  expectedDeletions = EXPECTED_WORKTREE_DELETIONS,
+) {
+  const skip = new Set(expectedDeletions);
+  return String(rawStatus ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean)
+    .filter((path) => !skip.has(path));
+}
+
 function git(args, cwd) {
   return new Promise((res, rej) => {
     execFile(

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -15,6 +15,7 @@ import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getHostConfig } from "../lib/ssh-command.mjs";
+import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
 import { ensureConductorRegistry } from "./conductor-registry.mjs";
 import { createEventLog } from "./event-log.mjs";
@@ -24,7 +25,9 @@ import { createSwarmLocks } from "./swarm-locks.mjs";
 import { validateWorkerCompletion } from "./worker-completion-validator.mjs";
 import {
   cleanupWorktree,
+  EXPECTED_WORKTREE_DELETIONS,
   ensureWorktree,
+  extractDirtyFiles,
   fetchRemoteShard,
   prepareIntegrationBranch,
   pruneWorktree,
@@ -407,12 +410,12 @@ export function createSwarmHypervisor(opts) {
     if (worker?.worktreePath && !worker?.shardConfig?.host) {
       try {
         const rawStatus = await git(["status", "--short"], worker.worktreePath);
-        evidence.dirtyFiles = rawStatus
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .map((line) => line.slice(2).trim())
-          .filter(Boolean);
+        // BUG-I: prepareWorktree 가 #34 L2 의도로 rm 한 tracked paths
+        // (EXPECTED_WORKTREE_DELETIONS) 는 dirty 판정에서 제외한다.
+        evidence.dirtyFiles = extractDirtyFiles(
+          rawStatus,
+          EXPECTED_WORKTREE_DELETIONS,
+        );
         evidence.dirty = evidence.dirtyFiles.length > 0;
       } catch (err) {
         evidence.error = evidence.error || err.message;
@@ -430,7 +433,9 @@ export function createSwarmHypervisor(opts) {
     const config = {
       id: `swarm-${shard.name}-${Date.now()}`,
       agent: shard.agent,
-      prompt: shard.prompt,
+      // #125: append Completion Protocol appendix so workers emit a
+      // sentinel-framed JSON payload that conductor can reliably capture.
+      prompt: buildWorkerPrompt(shard.prompt),
       workdir: shard.worktreePath || workdir,
       mcpServers: shard.mcp,
       worktreePath: shard.worktreePath || null,

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -11,6 +11,37 @@ import { remoteGit, validateHost } from "./remote-session.mjs";
 const SWARM_ROOT = ".codex-swarm";
 const SLEEP_MS = 2000; // WT race-guard (MEMORY.md: wt-attach-spacing)
 
+// BUG-I: prepareWorktree 가 #34 L2 의도로 worktree 에서 rm 하는 tracked paths.
+// swarm-hypervisor 의 commit_evidence dirty 판정에서 이 경로들을 filter 해야
+// "의도된 삭제" 가 F6 no_commit_guard 를 잘못 trip 하는 것을 막을 수 있다.
+export const EXPECTED_WORKTREE_DELETIONS = Object.freeze([
+  ".claude-plugin/marketplace.json",
+  ".claude-plugin/plugin.json",
+]);
+
+/**
+ * Parse `git status --short` output into a dirty-file list, filtering out
+ * EXPECTED_WORKTREE_DELETIONS (paths the swarm intentionally removes from each
+ * worktree — see prepareWorktree #34 L2). Pure function for unit-testability.
+ *
+ * @param {string} rawStatus — stdout of `git status --short`
+ * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths to skip
+ * @returns {string[]} — remaining dirty paths after filtering
+ */
+export function extractDirtyFiles(
+  rawStatus,
+  expectedDeletions = EXPECTED_WORKTREE_DELETIONS,
+) {
+  const skip = new Set(expectedDeletions);
+  return String(rawStatus ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean)
+    .filter((path) => !skip.has(path));
+}
+
 function git(args, cwd) {
   return new Promise((res, rej) => {
     execFile(
@@ -252,23 +283,44 @@ export async function rebaseShardOntoIntegration({
     }
   }
 
+  // #127 BUG-E: capture caller's branch BEFORE any checkout. Without
+  // restoring it in finally, this function leaks main repo HEAD onto
+  // integrationBranch and every subsequent Edit/commit lands on the swarm
+  // temp branch silently (observed 2026-04-20: probe + edits + commits all
+  // ended up on swarm/.../merge while user thought they were on main).
+  let originalBranch = null;
+  try {
+    const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
+    if (head && head !== "HEAD") originalBranch = head;
+  } catch {
+    /* detached HEAD or unknown — skip restore */
+  }
+
   // Backup integration HEAD for rollback
   const backupCommit = await git(["rev-parse", integrationBranch], rootDir);
 
+  // #127: cherry-pick instead of rebase. Rebase fails when shardBranch is
+  // already checked out by a swarm worktree ("branch already used by worktree").
+  // Cherry-pick reads the shard's commits without touching its branch ref,
+  // so worktree contention disappears. Memory: feedback_swarm_cherry_pick.
   try {
-    // Rebase shard onto integration
-    await git(["rebase", integrationBranch, shardBranch], rootDir);
+    const log = await git(
+      ["log", "--reverse", "--format=%H", `${integrationBranch}..${shardBranch}`],
+      rootDir,
+    );
+    const shaList = log.split("\n").map((s) => s.trim()).filter(Boolean);
 
-    // Fast-forward integration to include shard changes
     await git(["checkout", integrationBranch], rootDir);
-    await git(["merge", "--ff-only", shardBranch], rootDir);
+
+    for (const sha of shaList) {
+      await git(["cherry-pick", sha], rootDir);
+    }
 
     const headCommit = await git(["rev-parse", "HEAD"], rootDir);
     return { ok: true, headCommit };
   } catch (err) {
-    // Abort rebase and restore integration branch
     try {
-      await git(["rebase", "--abort"], rootDir);
+      await git(["cherry-pick", "--abort"], rootDir);
     } catch {
       /* already clean */
     }
@@ -284,6 +336,16 @@ export async function rebaseShardOntoIntegration({
     }
 
     return { ok: false, error: err.message };
+  } finally {
+    // Always restore caller's branch. Skip if originalBranch is null
+    // (detached HEAD case) or already on target.
+    if (originalBranch) {
+      try {
+        await git(["checkout", originalBranch], rootDir);
+      } catch {
+        /* best-effort — caller will see HEAD on integrationBranch */
+      }
+    }
   }
 }
 

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -20,12 +20,19 @@ export const EXPECTED_WORKTREE_DELETIONS = Object.freeze([
 ]);
 
 /**
- * Parse `git status --short` output into a dirty-file list, filtering out
- * EXPECTED_WORKTREE_DELETIONS (paths the swarm intentionally removes from each
- * worktree — see prepareWorktree #34 L2). Pure function for unit-testability.
+ * Parse `git status --short` output into a dirty-file list. Filters out paths
+ * in `expectedDeletions` only when the XY status code indicates a deletion
+ * (X='D' or Y='D'). Modifications / additions / untracked of the same paths
+ * remain dirty — otherwise a worker could silently corrupt those files and
+ * bypass F6 no_commit_guard (Codex review #134 round 2).
+ *
+ * git status --short XY codes reference:
+ *   ' D' unstaged delete, 'D ' staged delete, 'DD' both — filtered if path
+ *     is in expectedDeletions.
+ *   ' M'/'M '/'MM' modify, '??' untracked, 'A ' add, 'R ' rename — kept.
  *
  * @param {string} rawStatus — stdout of `git status --short`
- * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths to skip
+ * @param {string[]} [expectedDeletions=EXPECTED_WORKTREE_DELETIONS] — paths eligible for deletion-only skip
  * @returns {string[]} — remaining dirty paths after filtering
  */
 export function extractDirtyFiles(
@@ -33,13 +40,17 @@ export function extractDirtyFiles(
   expectedDeletions = EXPECTED_WORKTREE_DELETIONS,
 ) {
   const skip = new Set(expectedDeletions);
-  return String(rawStatus ?? "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => line.slice(2).trim())
-    .filter(Boolean)
-    .filter((path) => !skip.has(path));
+  const out = [];
+  for (const raw of String(rawStatus ?? "").split(/\r?\n/)) {
+    if (raw.length < 3) continue;
+    const xy = raw.slice(0, 2);
+    const path = raw.slice(2).trim();
+    if (!path) continue;
+    const isDeletion = xy.includes("D");
+    if (isDeletion && skip.has(path)) continue;
+    out.push(path);
+  }
+  return out;
 }
 
 function git(args, cwd) {

--- a/tests/unit/swarm-dirty-filter.test.mjs
+++ b/tests/unit/swarm-dirty-filter.test.mjs
@@ -42,3 +42,35 @@ test("extractDirtyFiles: mixed input — only expected deletions filtered", () =
     ["hub/team/foo.mjs", "untracked.md"],
   );
 });
+
+test("extractDirtyFiles: expected path MODIFIED is NOT filtered (Codex review #134)", () => {
+  const raw = " M .claude-plugin/plugin.json";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    [".claude-plugin/plugin.json"],
+  );
+});
+
+test("extractDirtyFiles: expected path UNTRACKED is NOT filtered (Codex review #134)", () => {
+  const raw = "?? .claude-plugin/plugin.json";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    [".claude-plugin/plugin.json"],
+  );
+});
+
+test("extractDirtyFiles: rename 'R  old -> new' passes through (edge case)", () => {
+  const raw = "R  old/file.md -> new/file.md\n M submodule";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    ["old/file.md -> new/file.md", "submodule"],
+  );
+});
+
+test("extractDirtyFiles: staged deletion 'D ' of expected path IS filtered", () => {
+  const raw = "D  .claude-plugin/marketplace.json";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    [],
+  );
+});

--- a/tests/unit/swarm-dirty-filter.test.mjs
+++ b/tests/unit/swarm-dirty-filter.test.mjs
@@ -1,0 +1,44 @@
+// BUG-I regression — extractDirtyFiles filters EXPECTED_WORKTREE_DELETIONS
+// so F6 no_commit_guard does not trip on #34 L2 intentional .claude-plugin
+// removal. See hub/team/worktree-lifecycle.mjs prepareWorktree.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractDirtyFiles,
+  EXPECTED_WORKTREE_DELETIONS,
+} from "../../hub/team/worktree-lifecycle.mjs";
+
+test("extractDirtyFiles: empty/null/undefined input returns empty array", () => {
+  assert.deepStrictEqual(extractDirtyFiles(""), []);
+  assert.deepStrictEqual(extractDirtyFiles(null), []);
+  assert.deepStrictEqual(extractDirtyFiles(undefined), []);
+});
+
+test("extractDirtyFiles: filters EXPECTED_WORKTREE_DELETIONS (BUG-I #129)", () => {
+  const raw =
+    " D .claude-plugin/marketplace.json\n D .claude-plugin/plugin.json";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    [],
+  );
+});
+
+test("extractDirtyFiles: passes through genuine dirty paths", () => {
+  const raw = " M src/foo.js\n?? new.txt";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    ["src/foo.js", "new.txt"],
+  );
+});
+
+test("extractDirtyFiles: mixed input — only expected deletions filtered", () => {
+  const raw =
+    " D .claude-plugin/marketplace.json\n" +
+    " M hub/team/foo.mjs\n" +
+    " D .claude-plugin/plugin.json\n" +
+    "?? untracked.md";
+  assert.deepStrictEqual(
+    extractDirtyFiles(raw, EXPECTED_WORKTREE_DELETIONS),
+    ["hub/team/foo.mjs", "untracked.md"],
+  );
+});


### PR DESCRIPTION
## 배경

세션 11 에서 BUG-F (#129 Codex LLM self-abort) 재현 probe 실행 중 **신규 BUG-I 발견**. BUG-F 증상은 재현 안 됐지만 (worker `status=ok` emit), probe 과정에서 모든 swarm shard 가 integration 단계에서 실패하는 별개 회귀 관찰.

## 증상

```
shard_completed: hasPayload=true
commit_evidence: dirty=true, dirtyFiles=[".claude-plugin/marketplace.json", ".claude-plugin/plugin.json"]
no_commit_guard_failed
integration_failures=1
```

## 원인

`hub/team/worktree-lifecycle.mjs:174-180` 의 `prepareWorktree` 가 #34 L2 의도 ("하네스가 PLUGIN_ROOT 를 오인하는 것 방지") 로 worktree 에서 `.claude-plugin/` 디렉토리를 `rm -rf`.

하지만 `.claude-plugin/{marketplace,plugin}.json` 은 HEAD tree 에 blob 이 있는 **tracked files**. 삭제 후 `git status --short` 가 ` D` (unstaged deletion) 반환.

`swarm-hypervisor.mjs:410-417` F6 guard 는 `dirtyFiles.length > 0` 이면 worker 미완료 작업으로 간주 → integration reject. 의도된 cleanup 을 미완료 작업으로 오판.

세션 10 BUG-H (PR #133) 와 구조 유사: "의도된 infra cleanup 이 side-effect 로 swarm 전체 깨뜨림".

## Fix

Single source of truth 접근:

1. `worktree-lifecycle.mjs` 에 `EXPECTED_WORKTREE_DELETIONS` frozen list + `extractDirtyFiles` pure helper export. prepareWorktree 의 rm 로직은 유지 (#34 L2 의도 보존).
2. `swarm-hypervisor.mjs` 의 commit_evidence dirtyFiles 계산을 `extractDirtyFiles(rawStatus, EXPECTED_WORKTREE_DELETIONS)` 호출로 교체.
3. `packages/triflux/hub/team/` 동일 sync (세션 10 패턴).

## 단위 테스트 (4/4 pass)

`tests/unit/swarm-dirty-filter.test.mjs`:
- empty/null/undefined input returns []
- EXPECTED deletions filtered (BUG-I regression)
- genuine dirty paths passthrough
- mixed input — only expected filtered

## 회귀 증명 (probe 재실행)

**Before** (main HEAD `dc04c35`):
```
state=failed completed=1/1 failed=1 integrated=0 integration_failures=1
```

**After** (이 PR):
```
state=completed completed=1/1 failed=0 integrated=1 integration_failures=0
```

## BUG-F (#129) 상태

BUG-F (Codex LLM self-abort status=failed emit) 은 이번 probe 에서 재현되지 않음 (worker 정상 `status=ok` payload emit). BUG-I fix 후 재시도 필요 (세션 12 이월).

## 관련

- 세션 10 BUG-H (#132 / PR #133) 와 구조 유사
- #34 L2 (worktree `.claude-plugin/` 제거 의도 유지됨)
- BUG-F (#129) 는 미해결, probe 인프라 먼저 복구 후 재시도