### PR TITLE
fix(swarm): BUG-J rebase catch block must not rewind caller branch

### DIFF
--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -335,15 +335,38 @@ export async function rebaseShardOntoIntegration({
     } catch {
       /* already clean */
     }
+
+    // #129 BUG-J: Roll back integrationBranch without mutating whatever
+    // branch HEAD currently points at. The previous implementation did a
+    // blind `reset --hard backupCommit` on current HEAD — if the earlier
+    // `git checkout integrationBranch` inside the try block failed (e.g.
+    // integrationBranch was already checked out by a swarm worktree) the
+    // caller's branch silently rewound to integrationBranch's backup commit.
+    // Observed 2026-04-20: fix branch tree lost to main HEAD during swarm
+    // probe, requiring `git merge --ff-only origin/<branch>` recovery.
+    let currentBranch = null;
     try {
-      await git(["checkout", integrationBranch], rootDir);
+      const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
+      if (head && head !== "HEAD") currentBranch = head;
     } catch {
-      /* best-effort */
+      /* detached — fall through to ref-only update */
     }
-    try {
-      await git(["reset", "--hard", backupCommit], rootDir);
-    } catch {
-      /* best-effort */
+
+    if (currentBranch === integrationBranch) {
+      // HEAD is on integrationBranch — reset advances this branch only.
+      try {
+        await git(["reset", "--hard", backupCommit], rootDir);
+      } catch {
+        /* best-effort */
+      }
+    } else {
+      // HEAD is elsewhere (originalBranch, detached, or another branch).
+      // Update the integrationBranch ref directly; never touch current HEAD.
+      try {
+        await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
+      } catch {
+        /* best-effort: branch may be checked out in another worktree */
+      }
     }
 
     return { ok: false, error: err.message };

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -335,15 +335,38 @@ export async function rebaseShardOntoIntegration({
     } catch {
       /* already clean */
     }
+
+    // #129 BUG-J: Roll back integrationBranch without mutating whatever
+    // branch HEAD currently points at. The previous implementation did a
+    // blind `reset --hard backupCommit` on current HEAD — if the earlier
+    // `git checkout integrationBranch` inside the try block failed (e.g.
+    // integrationBranch was already checked out by a swarm worktree) the
+    // caller's branch silently rewound to integrationBranch's backup commit.
+    // Observed 2026-04-20: fix branch tree lost to main HEAD during swarm
+    // probe, requiring `git merge --ff-only origin/<branch>` recovery.
+    let currentBranch = null;
     try {
-      await git(["checkout", integrationBranch], rootDir);
+      const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
+      if (head && head !== "HEAD") currentBranch = head;
     } catch {
-      /* best-effort */
+      /* detached — fall through to ref-only update */
     }
-    try {
-      await git(["reset", "--hard", backupCommit], rootDir);
-    } catch {
-      /* best-effort */
+
+    if (currentBranch === integrationBranch) {
+      // HEAD is on integrationBranch — reset advances this branch only.
+      try {
+        await git(["reset", "--hard", backupCommit], rootDir);
+      } catch {
+        /* best-effort */
+      }
+    } else {
+      // HEAD is elsewhere (originalBranch, detached, or another branch).
+      // Update the integrationBranch ref directly; never touch current HEAD.
+      try {
+        await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
+      } catch {
+        /* best-effort: branch may be checked out in another worktree */
+      }
     }
 
     return { ok: false, error: err.message };

--- a/tests/unit/rebase-branch-safety.test.mjs
+++ b/tests/unit/rebase-branch-safety.test.mjs
@@ -1,0 +1,193 @@
+// BUG-J regression — rebaseShardOntoIntegration must not mutate the caller's
+// branch when its internal checkout fails. Previous behavior: on checkout
+// failure the catch block ran `git reset --hard backupCommit` on whatever
+// HEAD pointed at, silently rewinding the caller's branch to integrationBranch's
+// backup (observed 2026-04-20 during BUG-F probe).
+//
+// These tests spin up a disposable git repo in tmpdir to exercise the real
+// lifecycle without mocking execFile.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile as execFileCb } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { rebaseShardOntoIntegration } from "../../hub/team/worktree-lifecycle.mjs";
+
+const execFile = promisify(execFileCb);
+
+async function git(cwd, args) {
+  const { stdout } = await execFile("git", args, {
+    cwd,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Triflux Test",
+      GIT_AUTHOR_EMAIL: "test@triflux.local",
+      GIT_COMMITTER_NAME: "Triflux Test",
+      GIT_COMMITTER_EMAIL: "test@triflux.local",
+    },
+  });
+  return stdout.trim();
+}
+
+async function withTempRepo(fn) {
+  const repo = await mkdtemp(join(tmpdir(), "tfx-bug-j-"));
+  const aux = await mkdtemp(join(tmpdir(), "tfx-bug-j-wt-"));
+  try {
+    await git(repo, ["init", "-q", "-b", "main"]);
+    await git(repo, ["commit", "-q", "--allow-empty", "-m", "base"]);
+    await fn({ repo, aux });
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+    await rm(aux, { recursive: true, force: true });
+  }
+}
+
+test("rebaseShardOntoIntegration: checkout failure does not rewind caller branch (BUG-J)", async () => {
+  await withTempRepo(async ({ repo, aux }) => {
+    // Caller branch with a unique commit — this must survive the failure.
+    await git(repo, ["checkout", "-q", "-b", "caller"]);
+    await git(repo, ["commit", "-q", "--allow-empty", "-m", "caller work"]);
+    const callerSha = await git(repo, ["rev-parse", "HEAD"]);
+
+    // integrationBranch held by a separate worktree → main repo cannot
+    // checkout it, forcing the catch block to run while current HEAD is
+    // still on `caller`.
+    await git(repo, [
+      "worktree",
+      "add",
+      "--quiet",
+      aux,
+      "-b",
+      "swarm/r/merge",
+      "main",
+    ]);
+
+    // shardBranch exists but is empty relative to integration (no commits
+    // to pick). The failure we care about is the checkout, not cherry-pick.
+    await git(repo, ["branch", "swarm/r/shard", "main"]);
+
+    const result = await rebaseShardOntoIntegration({
+      shardBranch: "swarm/r/shard",
+      integrationBranch: "swarm/r/merge",
+      rootDir: repo,
+    });
+
+    assert.equal(result.ok, false, "should report failure");
+
+    const afterSha = await git(repo, ["rev-parse", "caller"]);
+    assert.equal(
+      afterSha,
+      callerSha,
+      "caller branch must not be reset to integrationBranch's backup",
+    );
+
+    const currentBranch = await git(repo, [
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
+    assert.equal(
+      currentBranch,
+      "caller",
+      "current HEAD must be restored to caller branch",
+    );
+  });
+});
+
+test("rebaseShardOntoIntegration: ref-only rollback leaves integrationBranch at backup (BUG-J)", async () => {
+  await withTempRepo(async ({ repo, aux }) => {
+    await git(repo, ["checkout", "-q", "-b", "caller"]);
+    await git(repo, ["commit", "-q", "--allow-empty", "-m", "caller work"]);
+
+    await git(repo, [
+      "worktree",
+      "add",
+      "--quiet",
+      aux,
+      "-b",
+      "swarm/r/merge",
+      "main",
+    ]);
+    const backupSha = await git(repo, ["rev-parse", "swarm/r/merge"]);
+
+    await git(repo, ["branch", "swarm/r/shard", "main"]);
+
+    await rebaseShardOntoIntegration({
+      shardBranch: "swarm/r/shard",
+      integrationBranch: "swarm/r/merge",
+      rootDir: repo,
+    });
+
+    // integrationBranch ref should remain at its backup commit (either
+    // unchanged because we never got to mutate it, or explicitly rolled
+    // back via `branch -f`).
+    const afterMergeSha = await git(repo, ["rev-parse", "swarm/r/merge"]);
+    assert.equal(
+      afterMergeSha,
+      backupSha,
+      "integrationBranch must still point at backup commit",
+    );
+  });
+});
+
+test("rebaseShardOntoIntegration: happy path cherry-picks shard commits (regression guard)", async () => {
+  await withTempRepo(async ({ repo }) => {
+    // Shard branch with a real file commit we expect to land on integration.
+    await git(repo, ["checkout", "-q", "-b", "swarm/r/shard", "main"]);
+    await writeFile(join(repo, "shard.txt"), "shard content\n");
+    await git(repo, ["add", "shard.txt"]);
+    await git(repo, ["commit", "-q", "-m", "shard feature"]);
+    const shardSha = await git(repo, ["rev-parse", "HEAD"]);
+
+    await git(repo, ["checkout", "-q", "main"]);
+    await git(repo, ["branch", "swarm/r/merge", "main"]);
+
+    // Caller on main.
+    const callerBefore = await git(repo, ["rev-parse", "main"]);
+
+    const result = await rebaseShardOntoIntegration({
+      shardBranch: "swarm/r/shard",
+      integrationBranch: "swarm/r/merge",
+      rootDir: repo,
+    });
+
+    assert.equal(result.ok, true, "happy path should succeed");
+
+    // integrationBranch advanced past its base by one cherry-picked commit.
+    const mergeSha = await git(repo, ["rev-parse", "swarm/r/merge"]);
+    assert.notEqual(
+      mergeSha,
+      callerBefore,
+      "integrationBranch advanced past base",
+    );
+    const mergeSubject = await git(repo, [
+      "log",
+      "-1",
+      "--format=%s",
+      "swarm/r/merge",
+    ]);
+    assert.equal(mergeSubject, "shard feature");
+
+    // Cherry-pick preserves the tree; sha differs but subject matches.
+    assert.notEqual(
+      await git(repo, ["rev-parse", "swarm/r/merge"]),
+      shardSha,
+      "cherry-pick creates a new commit sha",
+    );
+
+    // Caller branch (main) untouched.
+    assert.equal(
+      await git(repo, ["rev-parse", "main"]),
+      callerBefore,
+      "main stays at base after happy path",
+    );
+    assert.equal(
+      await git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]),
+      "main",
+      "HEAD restored to caller",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `rebaseShardOntoIntegration`의 catch 블록이 `git reset --hard backupCommit`을 current HEAD 검증 없이 실행 → 선행 `git checkout integrationBranch` 실패 시 caller 브랜치를 integrationBranch의 backup commit으로 silently rewind
- catch 블록을 current HEAD 확인 분기로 교체: HEAD가 integrationBranch면 기존 `reset --hard`, 아니면 `git branch -f integrationBranch backupCommit` (ref-only 업데이트, current HEAD 불변)
- E2E 회귀 테스트 3개 추가 (`tests/unit/rebase-branch-safety.test.mjs`)

## Root cause

worktree contention (integrationBranch가 다른 worktree에 checked out) 또는 다른 이유로 `git checkout integrationBranch`가 catch 블록 진입 전/후 모두 실패하면 current HEAD는 여전히 caller의 branch. 기존 코드는 그 상태에서 `reset --hard`를 실행해 caller의 branch ref를 integrationBranch의 base commit으로 덮어씀.

## Observed incident (2026-04-20 세션 11)

BUG-F probe 재실행 중 `fix/bug-i-worktree-plugin-dir-cleanup`의 commit `27272fd`가 main HEAD `dc04c35`로 reset. `origin/fix/bug-i-worktree-plugin-dir-cleanup`에 이미 push되어 있어 `git merge --ff-only`로 복구 가능했지만, push 이전 상태였다면 로컬 작업 소실됐을 수 있음. reflog 증거:

```
HEAD@{7}: commit: fix(swarm): BUG-I worktree intentional deletions...
HEAD@{6}: reset: moving to dc04c35ec452153487331e28b5debaf84b991e86
HEAD@{5}: checkout: moving from fix/bug-i to fix/bug-i (noop)
HEAD@{4}: merge origin/fix/bug-i: Fast-forward (recovery)
```

## Fix approach

```js
if (currentBranch === integrationBranch) {
  // HEAD is on integrationBranch — reset advances this branch only.
  await git(["reset", "--hard", backupCommit], rootDir);
} else {
  // HEAD elsewhere — update integrationBranch ref directly.
  await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
}
```

`git branch -f`는 현재 checked out branch는 건드리지 않음. integrationBranch가 또 다른 worktree에 checked out 된 경우 `branch -f` 자체가 실패할 수 있지만, 이는 catch 블록 내 best-effort 롤백이므로 throw 안 하고 live with it.

## Test plan

- [x] `tests/unit/swarm-dirty-filter.test.mjs` 8개 pass (기존, 회귀 없음)
- [x] `tests/unit/rebase-branch-safety.test.mjs` 3개 pass (신규)
  - checkout 실패 시 caller branch ref 보존
  - integrationBranch ref가 backup commit에 유지
  - happy path cherry-pick 정상 동작
- [ ] BUG-F probe 재시도 시 main repo tree 훼손 없는지 live 확인 (본 PR merge 후)

## Related

- 세션 11 checkpoint: `~/.gstack/projects/tellang-triflux/checkpoints/20260420-180811-session-11-bug-i-fixed-pr134-merged-bug-j-discovered.md`
- BUG-I (선행 fix): #134 (merged a6cc2e6)
- BUG-F (후행 probe 대기): #129