### PR TITLE
feat(review): tfx review --shard per-file for oversized diffs

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -5634,7 +5634,6 @@ async function main() {
       return;
     }
     case "review": {
-      const { runCodexReview } = await import("../hub/team/codex-review.mjs");
       const ref = cmdArgs[0] && !cmdArgs[0].startsWith("--")
         ? cmdArgs[0]
         : "HEAD";
@@ -5643,6 +5642,49 @@ async function main() {
       const timeoutIdx = cmdArgs.indexOf("--timeout");
       const timeoutMs =
         timeoutIdx >= 0 ? Number(cmdArgs[timeoutIdx + 1]) * 1000 : 180_000;
+      const shardIdx = cmdArgs.indexOf("--shard");
+      const shard = shardIdx >= 0 ? cmdArgs[shardIdx + 1] : "off";
+
+      if (shard === "per-file") {
+        const { runCodexReviewSharded } = await import(
+          "../hub/team/codex-review.mjs"
+        );
+        const result = await runCodexReviewSharded({
+          ref,
+          base,
+          timeoutMs,
+          onFileStart: ({ file, index, total }) => {
+            if (!JSON_OUTPUT) {
+              process.stderr.write(
+                `[${index + 1}/${total}] reviewing ${file}\n`,
+              );
+            }
+          },
+        });
+        if (JSON_OUTPUT) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(
+            `=== per-file review (${result.files.length} files, range=${result.range}) ===`,
+          );
+          for (const r of result.perFile) {
+            console.log("");
+            console.log(
+              `--- ${r.file} (${r.diffBytes}b, verdict=${r.verdict || "n/a"}${r.skipped ? ", skipped" : ""}) ---`,
+            );
+            if (r.error) console.log(`  error: ${r.error}`);
+            if (r.stdout) process.stdout.write(r.stdout);
+          }
+          console.log("");
+          console.log(
+            `Aggregate: files=${result.files.length} verdict=${result.verdict}`,
+          );
+          if (result.error) console.log(`error: ${result.error}`);
+        }
+        process.exit(result.ok ? 0 : 1);
+      }
+
+      const { runCodexReview } = await import("../hub/team/codex-review.mjs");
       const result = await runCodexReview({ ref, base, timeoutMs });
       if (JSON_OUTPUT) {
         console.log(JSON.stringify(result, null, 2));

--- a/hub/team/codex-review.mjs
+++ b/hub/team/codex-review.mjs
@@ -6,29 +6,41 @@
 // Contract:
 //   runCodexReview({ ref = "HEAD", base?: string, timeoutMs = 180_000 })
 //     → { ok, code?, verdict, stdout, stderr, diffBytes, error? }
+//   runCodexReviewSharded({ ref, base, timeoutMs })
+//     → { ok, verdict, range, files, perFile: [{ file, verdict, ... }] }
 //   Verdict parsed from Codex output: APPROVED / REQUEST_CHANGES / COMMENT
 //   / UNKNOWN when none is stated.
 //
 // Motivation: session 12 post-mortem (BUG-J fix merged without cross-review).
 // Without an ergonomic `tfx review` path, every swarm bugfix skips the
 // Codex independent opinion — the exact check that caught BUG-I's path-only
-// filter bypass in round 1 (session 11 PR #134).
+// filter bypass in round 1 (session 11 PR #134). Session 13 adds --shard
+// per-file for diffs that exceed the 32KB single-spawn ceiling.
 
 import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+// OS arg-list ceiling. The whole chain (bash → codex.cmd → node) fails
+// with ENAMETOOLONG / "Argument list too long" well below the documented
+// 128KB on Windows. Observed breakage at 62KB diff (session 12 self-dogfood).
+// 32KB is a safe ceiling that covers most single-commit swarm fixes.
+// Larger ranges should be reviewed per-file with --shard per-file or
+// narrowed with --base.
+export const MAX_PROMPT_BYTES = 32_000;
+
 /**
  * Resolve the diff payload for a given ref.
  * - `a..b` ranges pass through unchanged
  * - `<commit>` expands to `<commit>~1..<commit>` (single-commit review)
  * - `HEAD` with no prior commit returns an empty string
+ * - optional `file` scopes the diff to a single path via `-- <file>`
  *
- * @param {{ ref?: string, base?: string }} opts
- * @returns {{ diff: string, range: string }}
+ * @param {{ ref?: string, base?: string, file?: string }} opts
+ * @returns {{ diff: string, range: string, file?: string }}
  */
-export function resolveReviewDiff({ ref = "HEAD", base } = {}) {
+export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
   let range;
   if (base) {
     range = `${base}..${ref}`;
@@ -38,16 +50,35 @@ export function resolveReviewDiff({ ref = "HEAD", base } = {}) {
     range = `${ref}~1..${ref}`;
   }
 
-  const diff = execFileSync(
+  const args = ["log", "-p", "--stat", "--no-color", range];
+  if (file) {
+    args.push("--", file);
+  }
+  const diff = execFileSync("git", args, {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return { diff, range, file };
+}
+
+/**
+ * List files changed in a range via `git diff --name-only`.
+ * Used by shard mode to enumerate per-file review targets.
+ *
+ * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
+ * @returns {string[]}
+ */
+export function listChangedFiles(range) {
+  const out = execFileSync(
     "git",
-    ["log", "-p", "--stat", "--no-color", range],
-    {
-      encoding: "utf8",
-      windowsHide: true,
-      maxBuffer: 50 * 1024 * 1024,
-    },
+    ["diff", "--name-only", range],
+    { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  return { diff, range };
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 /**
@@ -96,74 +127,37 @@ export function parseVerdict(stdout) {
 }
 
 /**
- * Run Codex review of a git range.
- * @param {object} opts
- * @param {string} [opts.ref="HEAD"]
- * @param {string} [opts.base]
- * @param {number} [opts.timeoutMs=180000]
- * @param {string} [opts.sandbox="read-only"]
- * @param {object} [opts.env]
+ * Aggregate per-file verdicts into an overall verdict.
+ * - Any REQUEST_CHANGES → REQUEST_CHANGES
+ * - Any COMMENT (no REQUEST_CHANGES) → COMMENT
+ * - All APPROVED (skipped excluded) → APPROVED
+ * - Mixed with UNKNOWN → UNKNOWN (conservative)
+ *
+ * @param {Array<{verdict: string|null, skipped?: boolean}>} fileResults
+ * @returns {string}
  */
-export async function runCodexReview({
-  ref = "HEAD",
-  base,
-  timeoutMs = 180_000,
-  sandbox = "read-only",
-  env = process.env,
-} = {}) {
-  let range;
-  let diff;
-  try {
-    ({ diff, range } = resolveReviewDiff({ ref, base }));
-  } catch (err) {
-    return {
-      ok: false,
-      error: `git log failed: ${err.message}`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes: 0,
-    };
-  }
+export function aggregateVerdicts(fileResults) {
+  const active = fileResults.filter((r) => !r.skipped);
+  if (active.length === 0) return "UNKNOWN";
+  const verdicts = active.map((r) => r.verdict);
+  if (verdicts.some((v) => v === "REQUEST_CHANGES")) return "REQUEST_CHANGES";
+  if (verdicts.some((v) => v === "COMMENT")) return "COMMENT";
+  if (verdicts.every((v) => v === "APPROVED")) return "APPROVED";
+  return "UNKNOWN";
+}
 
-  const diffBytes = Buffer.byteLength(diff, "utf8");
-  if (diffBytes === 0) {
-    return {
-      ok: false,
-      error: `empty diff for range ${range}`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes: 0,
-      range,
-    };
-  }
-
-  const prompt = buildReviewPrompt(diff, { range });
-  const promptBytes = Buffer.byteLength(prompt, "utf8");
-
-  // OS arg-list ceiling. The whole chain (bash → codex.cmd → node) fails
-  // with ENAMETOOLONG / "Argument list too long" well below the documented
-  // 128KB on Windows. Observed breakage at 62KB diff (session 12 self-dogfood).
-  // 32KB is a safe ceiling that covers most single-commit swarm fixes.
-  // Larger ranges should be reviewed per-file or with --base narrowing.
-  const MAX_PROMPT_BYTES = 32_000;
-  if (promptBytes > MAX_PROMPT_BYTES) {
-    return {
-      ok: false,
-      error:
-        `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}). ` +
-        `Narrow the review with --base <sha> or split per-file. ` +
-        `Large-diff streaming is tracked as a follow-up.`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes,
-      promptBytes,
-      range,
-    };
-  }
-
+/**
+ * Internal: run Codex on a pre-built prompt and parse the response.
+ * Shared by single-mode runCodexReview and shard-mode runCodexReviewSharded.
+ */
+async function _runCodexOnPrompt({
+  prompt,
+  range,
+  diffBytes,
+  timeoutMs,
+  sandbox,
+  env,
+}) {
   // Prompt is a full git diff — often >10KB, regularly >60KB on swarm
   // bugfixes. Windows cmd.exe caps command lines at ~8KB and node's
   // `spawn(..., [promptArg])` route cannot exceed the OS arg limit
@@ -253,4 +247,235 @@ export async function runCodexReview({
       });
     });
   });
+}
+
+/**
+ * Run Codex review of a git range (single-spawn mode).
+ * @param {object} opts
+ * @param {string} [opts.ref="HEAD"]
+ * @param {string} [opts.base]
+ * @param {number} [opts.timeoutMs=180000]
+ * @param {string} [opts.sandbox="read-only"]
+ * @param {object} [opts.env]
+ */
+export async function runCodexReview({
+  ref = "HEAD",
+  base,
+  timeoutMs = 180_000,
+  sandbox = "read-only",
+  env = process.env,
+} = {}) {
+  let range;
+  let diff;
+  try {
+    ({ diff, range } = resolveReviewDiff({ ref, base }));
+  } catch (err) {
+    return {
+      ok: false,
+      error: `git log failed: ${err.message}`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes: 0,
+    };
+  }
+
+  const diffBytes = Buffer.byteLength(diff, "utf8");
+  if (diffBytes === 0) {
+    return {
+      ok: false,
+      error: `empty diff for range ${range}`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes: 0,
+      range,
+    };
+  }
+
+  const prompt = buildReviewPrompt(diff, { range });
+  const promptBytes = Buffer.byteLength(prompt, "utf8");
+
+  if (promptBytes > MAX_PROMPT_BYTES) {
+    return {
+      ok: false,
+      error:
+        `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}). ` +
+        `Retry with --shard per-file or narrow with --base <sha>.`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes,
+      promptBytes,
+      range,
+    };
+  }
+
+  return _runCodexOnPrompt({
+    prompt,
+    range,
+    diffBytes,
+    timeoutMs,
+    sandbox,
+    env,
+  });
+}
+
+/**
+ * Run Codex review sharded per-file. Each changed file in the range gets
+ * its own Codex spawn with its own 32KB budget. Results are aggregated.
+ *
+ * Sequential, not parallel — Codex headless startup is ~30-90s per call
+ * and parallel spawns risk auth contention. Wall-clock scales linearly
+ * with file count, budget accordingly (default timeout applies per-file).
+ *
+ * @param {object} opts — same shape as runCodexReview
+ * @returns {Promise<{ok: boolean, verdict: string, range: string, files: string[], perFile: object[], error?: string}>}
+ */
+export async function runCodexReviewSharded({
+  ref = "HEAD",
+  base,
+  timeoutMs = 180_000,
+  sandbox = "read-only",
+  env = process.env,
+  onFileStart,
+  onFileDone,
+} = {}) {
+  let range;
+  if (base) {
+    range = `${base}..${ref}`;
+  } else if (ref.includes("..")) {
+    range = ref;
+  } else {
+    range = `${ref}~1..${ref}`;
+  }
+
+  let files;
+  try {
+    files = listChangedFiles(range);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `git diff --name-only failed: ${err.message}`,
+      verdict: "UNKNOWN",
+      range,
+      files: [],
+      perFile: [],
+    };
+  }
+
+  if (files.length === 0) {
+    return {
+      ok: false,
+      error: `no changed files in range ${range}`,
+      verdict: "UNKNOWN",
+      range,
+      files: [],
+      perFile: [],
+    };
+  }
+
+  const perFile = [];
+  for (const file of files) {
+    if (typeof onFileStart === "function") {
+      try {
+        onFileStart({ file, index: perFile.length, total: files.length });
+      } catch {
+        /* caller callback errors should not block review */
+      }
+    }
+
+    let fileDiff;
+    try {
+      ({ diff: fileDiff } = resolveReviewDiff({ ref, base, file }));
+    } catch (err) {
+      const entry = {
+        file,
+        ok: false,
+        error: `git log scope failed: ${err.message}`,
+        verdict: "UNKNOWN",
+        diffBytes: 0,
+        range: `${range} -- ${file}`,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const diffBytes = Buffer.byteLength(fileDiff, "utf8");
+    if (diffBytes === 0) {
+      const entry = {
+        file,
+        ok: true,
+        skipped: true,
+        error: `empty diff for ${file} (likely rename/mode-only)`,
+        verdict: "APPROVED",
+        diffBytes: 0,
+        range: `${range} -- ${file}`,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const scopedRange = `${range} -- ${file}`;
+    const prompt = buildReviewPrompt(fileDiff, { range: scopedRange });
+    const promptBytes = Buffer.byteLength(prompt, "utf8");
+    if (promptBytes > MAX_PROMPT_BYTES) {
+      const entry = {
+        file,
+        ok: false,
+        error:
+          `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}) ` +
+          `for single file. Review this file manually or split the commit.`,
+        verdict: "UNKNOWN",
+        diffBytes,
+        promptBytes,
+        range: scopedRange,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const res = await _runCodexOnPrompt({
+      prompt,
+      range: scopedRange,
+      diffBytes,
+      timeoutMs,
+      sandbox,
+      env,
+    });
+    const entry = { file, ...res };
+    perFile.push(entry);
+    if (typeof onFileDone === "function") {
+      try {
+        onFileDone(entry);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const verdict = aggregateVerdicts(perFile);
+  const ok = perFile.every((r) => r.ok);
+  return { ok, verdict, range, files, perFile };
 }

--- a/hub/team/codex-review.mjs
+++ b/hub/team/codex-review.mjs
@@ -74,6 +74,24 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 }
 
 /**
+ * Parse the raw `git log --name-only --pretty=format:` output into a
+ * de-duplicated, non-blank file path array. Pure function — extracted
+ * so shard enumeration can be tested against canned log output without
+ * requiring a temp git repo fixture.
+ *
+ * @param {string|null|undefined} rawLogOutput
+ * @returns {string[]}
+ */
+export function parseChangedFilesFromLog(rawLogOutput) {
+  const seen = new Set();
+  for (const line of (rawLogOutput || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen];
+}
+
+/**
  * List files changed in a range via `git log --name-only`, matching
  * the commit-log semantics used by `resolveReviewDiff`. Using
  * `git diff --name-only` would report only the net tree diff and
@@ -81,9 +99,10 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
  * range — those files would then be invisible to shard-mode review
  * even though `git log -p` still contains their edits.
  *
- * `--no-merges` skips merge commits (their content is reviewed via
- * the branches that produced them). Output is de-duplicated since
- * log output repeats a file for every commit that touches it.
+ * Merge commits are included so enumeration stays aligned with
+ * `resolveReviewDiff`'s plain `git log -p`. Merges rarely introduce
+ * novel content but also rarely add noise since the dedupe Set
+ * collapses paths that already appear in parent commits.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
  * @returns {string[]}
@@ -91,21 +110,10 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 export function listChangedFiles(range) {
   const out = execFileSync(
     "git",
-    [
-      "log",
-      "--no-merges",
-      "--name-only",
-      "--pretty=format:",
-      range,
-    ],
+    ["log", "--name-only", "--pretty=format:", range],
     { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  const seen = new Set();
-  for (const line of out.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (trimmed) seen.add(trimmed);
-  }
-  return [...seen];
+  return parseChangedFilesFromLog(out);
 }
 
 /**
@@ -376,7 +384,7 @@ export async function runCodexReviewSharded({
   } catch (err) {
     return {
       ok: false,
-      error: `git diff --name-only failed: ${err.message}`,
+      error: `git log --name-only failed: ${err.message}`,
       verdict: "UNKNOWN",
       range,
       files: [],

--- a/hub/team/codex-review.mjs
+++ b/hub/team/codex-review.mjs
@@ -105,15 +105,22 @@ export function parseChangedFilesFromLog(rawLogOutput) {
  * collapses paths that already appear in parent commits.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
+ * @param {(cmd: string, args: string[]) => string} [runner] — injectable
+ *   process runner. Default shells out to git; tests can pass a stub to
+ *   verify argv contract (e.g. absence of `--no-merges`) without spawning.
  * @returns {string[]}
  */
-export function listChangedFiles(range) {
-  const out = execFileSync(
-    "git",
-    ["log", "--name-only", "--pretty=format:", range],
-    { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
-  );
+export function listChangedFiles(range, runner = _defaultGitRunner) {
+  const out = runner("git", ["log", "--name-only", "--pretty=format:", range]);
   return parseChangedFilesFromLog(out);
+}
+
+function _defaultGitRunner(cmd, args) {
+  return execFileSync(cmd, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 50 * 1024 * 1024,
+  });
 }
 
 /**

--- a/hub/team/codex-review.mjs
+++ b/hub/team/codex-review.mjs
@@ -31,6 +31,24 @@ import { join } from "node:path";
 export const MAX_PROMPT_BYTES = 32_000;
 
 /**
+ * Expand a {ref, base} pair into a git range string.
+ * - `base` set → `base..ref`
+ * - `ref` already contains `..` → pass through
+ * - otherwise → `ref~1..ref` (single-commit review)
+ *
+ * Shared by single-mode `runCodexReview` and shard-mode
+ * `runCodexReviewSharded` so both interpret identical inputs identically.
+ *
+ * @param {{ ref?: string, base?: string }} opts
+ * @returns {string}
+ */
+export function expandRange({ ref = "HEAD", base } = {}) {
+  if (base) return `${base}..${ref}`;
+  if (ref.includes("..")) return ref;
+  return `${ref}~1..${ref}`;
+}
+
+/**
  * Resolve the diff payload for a given ref.
  * - `a..b` ranges pass through unchanged
  * - `<commit>` expands to `<commit>~1..<commit>` (single-commit review)
@@ -41,14 +59,7 @@ export const MAX_PROMPT_BYTES = 32_000;
  * @returns {{ diff: string, range: string, file?: string }}
  */
 export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
-  let range;
-  if (base) {
-    range = `${base}..${ref}`;
-  } else if (ref.includes("..")) {
-    range = ref;
-  } else {
-    range = `${ref}~1..${ref}`;
-  }
+  const range = expandRange({ ref, base });
 
   const args = ["log", "-p", "--stat", "--no-color", range];
   if (file) {
@@ -63,8 +74,16 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 }
 
 /**
- * List files changed in a range via `git diff --name-only`.
- * Used by shard mode to enumerate per-file review targets.
+ * List files changed in a range via `git log --name-only`, matching
+ * the commit-log semantics used by `resolveReviewDiff`. Using
+ * `git diff --name-only` would report only the net tree diff and
+ * silently drop files changed then reverted within a multi-commit
+ * range — those files would then be invisible to shard-mode review
+ * even though `git log -p` still contains their edits.
+ *
+ * `--no-merges` skips merge commits (their content is reviewed via
+ * the branches that produced them). Output is de-duplicated since
+ * log output repeats a file for every commit that touches it.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
  * @returns {string[]}
@@ -72,13 +91,21 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 export function listChangedFiles(range) {
   const out = execFileSync(
     "git",
-    ["diff", "--name-only", range],
+    [
+      "log",
+      "--no-merges",
+      "--name-only",
+      "--pretty=format:",
+      range,
+    ],
     { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  return out
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const seen = new Set();
+  for (const line of out.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen];
 }
 
 /**
@@ -341,14 +368,7 @@ export async function runCodexReviewSharded({
   onFileStart,
   onFileDone,
 } = {}) {
-  let range;
-  if (base) {
-    range = `${base}..${ref}`;
-  } else if (ref.includes("..")) {
-    range = ref;
-  } else {
-    range = `${ref}~1..${ref}`;
-  }
+  const range = expandRange({ ref, base });
 
   let files;
   try {

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -5634,7 +5634,6 @@ async function main() {
       return;
     }
     case "review": {
-      const { runCodexReview } = await import("../hub/team/codex-review.mjs");
       const ref = cmdArgs[0] && !cmdArgs[0].startsWith("--")
         ? cmdArgs[0]
         : "HEAD";
@@ -5643,6 +5642,49 @@ async function main() {
       const timeoutIdx = cmdArgs.indexOf("--timeout");
       const timeoutMs =
         timeoutIdx >= 0 ? Number(cmdArgs[timeoutIdx + 1]) * 1000 : 180_000;
+      const shardIdx = cmdArgs.indexOf("--shard");
+      const shard = shardIdx >= 0 ? cmdArgs[shardIdx + 1] : "off";
+
+      if (shard === "per-file") {
+        const { runCodexReviewSharded } = await import(
+          "../hub/team/codex-review.mjs"
+        );
+        const result = await runCodexReviewSharded({
+          ref,
+          base,
+          timeoutMs,
+          onFileStart: ({ file, index, total }) => {
+            if (!JSON_OUTPUT) {
+              process.stderr.write(
+                `[${index + 1}/${total}] reviewing ${file}\n`,
+              );
+            }
+          },
+        });
+        if (JSON_OUTPUT) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(
+            `=== per-file review (${result.files.length} files, range=${result.range}) ===`,
+          );
+          for (const r of result.perFile) {
+            console.log("");
+            console.log(
+              `--- ${r.file} (${r.diffBytes}b, verdict=${r.verdict || "n/a"}${r.skipped ? ", skipped" : ""}) ---`,
+            );
+            if (r.error) console.log(`  error: ${r.error}`);
+            if (r.stdout) process.stdout.write(r.stdout);
+          }
+          console.log("");
+          console.log(
+            `Aggregate: files=${result.files.length} verdict=${result.verdict}`,
+          );
+          if (result.error) console.log(`error: ${result.error}`);
+        }
+        process.exit(result.ok ? 0 : 1);
+      }
+
+      const { runCodexReview } = await import("../hub/team/codex-review.mjs");
       const result = await runCodexReview({ ref, base, timeoutMs });
       if (JSON_OUTPUT) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/triflux/hub/team/codex-review.mjs
+++ b/packages/triflux/hub/team/codex-review.mjs
@@ -6,29 +6,41 @@
 // Contract:
 //   runCodexReview({ ref = "HEAD", base?: string, timeoutMs = 180_000 })
 //     → { ok, code?, verdict, stdout, stderr, diffBytes, error? }
+//   runCodexReviewSharded({ ref, base, timeoutMs })
+//     → { ok, verdict, range, files, perFile: [{ file, verdict, ... }] }
 //   Verdict parsed from Codex output: APPROVED / REQUEST_CHANGES / COMMENT
 //   / UNKNOWN when none is stated.
 //
 // Motivation: session 12 post-mortem (BUG-J fix merged without cross-review).
 // Without an ergonomic `tfx review` path, every swarm bugfix skips the
 // Codex independent opinion — the exact check that caught BUG-I's path-only
-// filter bypass in round 1 (session 11 PR #134).
+// filter bypass in round 1 (session 11 PR #134). Session 13 adds --shard
+// per-file for diffs that exceed the 32KB single-spawn ceiling.
 
 import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+// OS arg-list ceiling. The whole chain (bash → codex.cmd → node) fails
+// with ENAMETOOLONG / "Argument list too long" well below the documented
+// 128KB on Windows. Observed breakage at 62KB diff (session 12 self-dogfood).
+// 32KB is a safe ceiling that covers most single-commit swarm fixes.
+// Larger ranges should be reviewed per-file with --shard per-file or
+// narrowed with --base.
+export const MAX_PROMPT_BYTES = 32_000;
+
 /**
  * Resolve the diff payload for a given ref.
  * - `a..b` ranges pass through unchanged
  * - `<commit>` expands to `<commit>~1..<commit>` (single-commit review)
  * - `HEAD` with no prior commit returns an empty string
+ * - optional `file` scopes the diff to a single path via `-- <file>`
  *
- * @param {{ ref?: string, base?: string }} opts
- * @returns {{ diff: string, range: string }}
+ * @param {{ ref?: string, base?: string, file?: string }} opts
+ * @returns {{ diff: string, range: string, file?: string }}
  */
-export function resolveReviewDiff({ ref = "HEAD", base } = {}) {
+export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
   let range;
   if (base) {
     range = `${base}..${ref}`;
@@ -38,16 +50,35 @@ export function resolveReviewDiff({ ref = "HEAD", base } = {}) {
     range = `${ref}~1..${ref}`;
   }
 
-  const diff = execFileSync(
+  const args = ["log", "-p", "--stat", "--no-color", range];
+  if (file) {
+    args.push("--", file);
+  }
+  const diff = execFileSync("git", args, {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return { diff, range, file };
+}
+
+/**
+ * List files changed in a range via `git diff --name-only`.
+ * Used by shard mode to enumerate per-file review targets.
+ *
+ * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
+ * @returns {string[]}
+ */
+export function listChangedFiles(range) {
+  const out = execFileSync(
     "git",
-    ["log", "-p", "--stat", "--no-color", range],
-    {
-      encoding: "utf8",
-      windowsHide: true,
-      maxBuffer: 50 * 1024 * 1024,
-    },
+    ["diff", "--name-only", range],
+    { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  return { diff, range };
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
 }
 
 /**
@@ -96,74 +127,37 @@ export function parseVerdict(stdout) {
 }
 
 /**
- * Run Codex review of a git range.
- * @param {object} opts
- * @param {string} [opts.ref="HEAD"]
- * @param {string} [opts.base]
- * @param {number} [opts.timeoutMs=180000]
- * @param {string} [opts.sandbox="read-only"]
- * @param {object} [opts.env]
+ * Aggregate per-file verdicts into an overall verdict.
+ * - Any REQUEST_CHANGES → REQUEST_CHANGES
+ * - Any COMMENT (no REQUEST_CHANGES) → COMMENT
+ * - All APPROVED (skipped excluded) → APPROVED
+ * - Mixed with UNKNOWN → UNKNOWN (conservative)
+ *
+ * @param {Array<{verdict: string|null, skipped?: boolean}>} fileResults
+ * @returns {string}
  */
-export async function runCodexReview({
-  ref = "HEAD",
-  base,
-  timeoutMs = 180_000,
-  sandbox = "read-only",
-  env = process.env,
-} = {}) {
-  let range;
-  let diff;
-  try {
-    ({ diff, range } = resolveReviewDiff({ ref, base }));
-  } catch (err) {
-    return {
-      ok: false,
-      error: `git log failed: ${err.message}`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes: 0,
-    };
-  }
+export function aggregateVerdicts(fileResults) {
+  const active = fileResults.filter((r) => !r.skipped);
+  if (active.length === 0) return "UNKNOWN";
+  const verdicts = active.map((r) => r.verdict);
+  if (verdicts.some((v) => v === "REQUEST_CHANGES")) return "REQUEST_CHANGES";
+  if (verdicts.some((v) => v === "COMMENT")) return "COMMENT";
+  if (verdicts.every((v) => v === "APPROVED")) return "APPROVED";
+  return "UNKNOWN";
+}
 
-  const diffBytes = Buffer.byteLength(diff, "utf8");
-  if (diffBytes === 0) {
-    return {
-      ok: false,
-      error: `empty diff for range ${range}`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes: 0,
-      range,
-    };
-  }
-
-  const prompt = buildReviewPrompt(diff, { range });
-  const promptBytes = Buffer.byteLength(prompt, "utf8");
-
-  // OS arg-list ceiling. The whole chain (bash → codex.cmd → node) fails
-  // with ENAMETOOLONG / "Argument list too long" well below the documented
-  // 128KB on Windows. Observed breakage at 62KB diff (session 12 self-dogfood).
-  // 32KB is a safe ceiling that covers most single-commit swarm fixes.
-  // Larger ranges should be reviewed per-file or with --base narrowing.
-  const MAX_PROMPT_BYTES = 32_000;
-  if (promptBytes > MAX_PROMPT_BYTES) {
-    return {
-      ok: false,
-      error:
-        `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}). ` +
-        `Narrow the review with --base <sha> or split per-file. ` +
-        `Large-diff streaming is tracked as a follow-up.`,
-      verdict: null,
-      stdout: "",
-      stderr: "",
-      diffBytes,
-      promptBytes,
-      range,
-    };
-  }
-
+/**
+ * Internal: run Codex on a pre-built prompt and parse the response.
+ * Shared by single-mode runCodexReview and shard-mode runCodexReviewSharded.
+ */
+async function _runCodexOnPrompt({
+  prompt,
+  range,
+  diffBytes,
+  timeoutMs,
+  sandbox,
+  env,
+}) {
   // Prompt is a full git diff — often >10KB, regularly >60KB on swarm
   // bugfixes. Windows cmd.exe caps command lines at ~8KB and node's
   // `spawn(..., [promptArg])` route cannot exceed the OS arg limit
@@ -253,4 +247,235 @@ export async function runCodexReview({
       });
     });
   });
+}
+
+/**
+ * Run Codex review of a git range (single-spawn mode).
+ * @param {object} opts
+ * @param {string} [opts.ref="HEAD"]
+ * @param {string} [opts.base]
+ * @param {number} [opts.timeoutMs=180000]
+ * @param {string} [opts.sandbox="read-only"]
+ * @param {object} [opts.env]
+ */
+export async function runCodexReview({
+  ref = "HEAD",
+  base,
+  timeoutMs = 180_000,
+  sandbox = "read-only",
+  env = process.env,
+} = {}) {
+  let range;
+  let diff;
+  try {
+    ({ diff, range } = resolveReviewDiff({ ref, base }));
+  } catch (err) {
+    return {
+      ok: false,
+      error: `git log failed: ${err.message}`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes: 0,
+    };
+  }
+
+  const diffBytes = Buffer.byteLength(diff, "utf8");
+  if (diffBytes === 0) {
+    return {
+      ok: false,
+      error: `empty diff for range ${range}`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes: 0,
+      range,
+    };
+  }
+
+  const prompt = buildReviewPrompt(diff, { range });
+  const promptBytes = Buffer.byteLength(prompt, "utf8");
+
+  if (promptBytes > MAX_PROMPT_BYTES) {
+    return {
+      ok: false,
+      error:
+        `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}). ` +
+        `Retry with --shard per-file or narrow with --base <sha>.`,
+      verdict: null,
+      stdout: "",
+      stderr: "",
+      diffBytes,
+      promptBytes,
+      range,
+    };
+  }
+
+  return _runCodexOnPrompt({
+    prompt,
+    range,
+    diffBytes,
+    timeoutMs,
+    sandbox,
+    env,
+  });
+}
+
+/**
+ * Run Codex review sharded per-file. Each changed file in the range gets
+ * its own Codex spawn with its own 32KB budget. Results are aggregated.
+ *
+ * Sequential, not parallel — Codex headless startup is ~30-90s per call
+ * and parallel spawns risk auth contention. Wall-clock scales linearly
+ * with file count, budget accordingly (default timeout applies per-file).
+ *
+ * @param {object} opts — same shape as runCodexReview
+ * @returns {Promise<{ok: boolean, verdict: string, range: string, files: string[], perFile: object[], error?: string}>}
+ */
+export async function runCodexReviewSharded({
+  ref = "HEAD",
+  base,
+  timeoutMs = 180_000,
+  sandbox = "read-only",
+  env = process.env,
+  onFileStart,
+  onFileDone,
+} = {}) {
+  let range;
+  if (base) {
+    range = `${base}..${ref}`;
+  } else if (ref.includes("..")) {
+    range = ref;
+  } else {
+    range = `${ref}~1..${ref}`;
+  }
+
+  let files;
+  try {
+    files = listChangedFiles(range);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `git diff --name-only failed: ${err.message}`,
+      verdict: "UNKNOWN",
+      range,
+      files: [],
+      perFile: [],
+    };
+  }
+
+  if (files.length === 0) {
+    return {
+      ok: false,
+      error: `no changed files in range ${range}`,
+      verdict: "UNKNOWN",
+      range,
+      files: [],
+      perFile: [],
+    };
+  }
+
+  const perFile = [];
+  for (const file of files) {
+    if (typeof onFileStart === "function") {
+      try {
+        onFileStart({ file, index: perFile.length, total: files.length });
+      } catch {
+        /* caller callback errors should not block review */
+      }
+    }
+
+    let fileDiff;
+    try {
+      ({ diff: fileDiff } = resolveReviewDiff({ ref, base, file }));
+    } catch (err) {
+      const entry = {
+        file,
+        ok: false,
+        error: `git log scope failed: ${err.message}`,
+        verdict: "UNKNOWN",
+        diffBytes: 0,
+        range: `${range} -- ${file}`,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const diffBytes = Buffer.byteLength(fileDiff, "utf8");
+    if (diffBytes === 0) {
+      const entry = {
+        file,
+        ok: true,
+        skipped: true,
+        error: `empty diff for ${file} (likely rename/mode-only)`,
+        verdict: "APPROVED",
+        diffBytes: 0,
+        range: `${range} -- ${file}`,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const scopedRange = `${range} -- ${file}`;
+    const prompt = buildReviewPrompt(fileDiff, { range: scopedRange });
+    const promptBytes = Buffer.byteLength(prompt, "utf8");
+    if (promptBytes > MAX_PROMPT_BYTES) {
+      const entry = {
+        file,
+        ok: false,
+        error:
+          `prompt too large (${promptBytes} bytes > ${MAX_PROMPT_BYTES}) ` +
+          `for single file. Review this file manually or split the commit.`,
+        verdict: "UNKNOWN",
+        diffBytes,
+        promptBytes,
+        range: scopedRange,
+      };
+      perFile.push(entry);
+      if (typeof onFileDone === "function") {
+        try {
+          onFileDone(entry);
+        } catch {
+          /* ignore */
+        }
+      }
+      continue;
+    }
+
+    const res = await _runCodexOnPrompt({
+      prompt,
+      range: scopedRange,
+      diffBytes,
+      timeoutMs,
+      sandbox,
+      env,
+    });
+    const entry = { file, ...res };
+    perFile.push(entry);
+    if (typeof onFileDone === "function") {
+      try {
+        onFileDone(entry);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const verdict = aggregateVerdicts(perFile);
+  const ok = perFile.every((r) => r.ok);
+  return { ok, verdict, range, files, perFile };
 }

--- a/packages/triflux/hub/team/codex-review.mjs
+++ b/packages/triflux/hub/team/codex-review.mjs
@@ -74,6 +74,24 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 }
 
 /**
+ * Parse the raw `git log --name-only --pretty=format:` output into a
+ * de-duplicated, non-blank file path array. Pure function — extracted
+ * so shard enumeration can be tested against canned log output without
+ * requiring a temp git repo fixture.
+ *
+ * @param {string|null|undefined} rawLogOutput
+ * @returns {string[]}
+ */
+export function parseChangedFilesFromLog(rawLogOutput) {
+  const seen = new Set();
+  for (const line of (rawLogOutput || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen];
+}
+
+/**
  * List files changed in a range via `git log --name-only`, matching
  * the commit-log semantics used by `resolveReviewDiff`. Using
  * `git diff --name-only` would report only the net tree diff and
@@ -81,9 +99,10 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
  * range — those files would then be invisible to shard-mode review
  * even though `git log -p` still contains their edits.
  *
- * `--no-merges` skips merge commits (their content is reviewed via
- * the branches that produced them). Output is de-duplicated since
- * log output repeats a file for every commit that touches it.
+ * Merge commits are included so enumeration stays aligned with
+ * `resolveReviewDiff`'s plain `git log -p`. Merges rarely introduce
+ * novel content but also rarely add noise since the dedupe Set
+ * collapses paths that already appear in parent commits.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
  * @returns {string[]}
@@ -91,21 +110,10 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 export function listChangedFiles(range) {
   const out = execFileSync(
     "git",
-    [
-      "log",
-      "--no-merges",
-      "--name-only",
-      "--pretty=format:",
-      range,
-    ],
+    ["log", "--name-only", "--pretty=format:", range],
     { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  const seen = new Set();
-  for (const line of out.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (trimmed) seen.add(trimmed);
-  }
-  return [...seen];
+  return parseChangedFilesFromLog(out);
 }
 
 /**
@@ -376,7 +384,7 @@ export async function runCodexReviewSharded({
   } catch (err) {
     return {
       ok: false,
-      error: `git diff --name-only failed: ${err.message}`,
+      error: `git log --name-only failed: ${err.message}`,
       verdict: "UNKNOWN",
       range,
       files: [],

--- a/packages/triflux/hub/team/codex-review.mjs
+++ b/packages/triflux/hub/team/codex-review.mjs
@@ -105,15 +105,22 @@ export function parseChangedFilesFromLog(rawLogOutput) {
  * collapses paths that already appear in parent commits.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
+ * @param {(cmd: string, args: string[]) => string} [runner] — injectable
+ *   process runner. Default shells out to git; tests can pass a stub to
+ *   verify argv contract (e.g. absence of `--no-merges`) without spawning.
  * @returns {string[]}
  */
-export function listChangedFiles(range) {
-  const out = execFileSync(
-    "git",
-    ["log", "--name-only", "--pretty=format:", range],
-    { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
-  );
+export function listChangedFiles(range, runner = _defaultGitRunner) {
+  const out = runner("git", ["log", "--name-only", "--pretty=format:", range]);
   return parseChangedFilesFromLog(out);
+}
+
+function _defaultGitRunner(cmd, args) {
+  return execFileSync(cmd, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 50 * 1024 * 1024,
+  });
 }
 
 /**

--- a/packages/triflux/hub/team/codex-review.mjs
+++ b/packages/triflux/hub/team/codex-review.mjs
@@ -31,6 +31,24 @@ import { join } from "node:path";
 export const MAX_PROMPT_BYTES = 32_000;
 
 /**
+ * Expand a {ref, base} pair into a git range string.
+ * - `base` set → `base..ref`
+ * - `ref` already contains `..` → pass through
+ * - otherwise → `ref~1..ref` (single-commit review)
+ *
+ * Shared by single-mode `runCodexReview` and shard-mode
+ * `runCodexReviewSharded` so both interpret identical inputs identically.
+ *
+ * @param {{ ref?: string, base?: string }} opts
+ * @returns {string}
+ */
+export function expandRange({ ref = "HEAD", base } = {}) {
+  if (base) return `${base}..${ref}`;
+  if (ref.includes("..")) return ref;
+  return `${ref}~1..${ref}`;
+}
+
+/**
  * Resolve the diff payload for a given ref.
  * - `a..b` ranges pass through unchanged
  * - `<commit>` expands to `<commit>~1..<commit>` (single-commit review)
@@ -41,14 +59,7 @@ export const MAX_PROMPT_BYTES = 32_000;
  * @returns {{ diff: string, range: string, file?: string }}
  */
 export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
-  let range;
-  if (base) {
-    range = `${base}..${ref}`;
-  } else if (ref.includes("..")) {
-    range = ref;
-  } else {
-    range = `${ref}~1..${ref}`;
-  }
+  const range = expandRange({ ref, base });
 
   const args = ["log", "-p", "--stat", "--no-color", range];
   if (file) {
@@ -63,8 +74,16 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 }
 
 /**
- * List files changed in a range via `git diff --name-only`.
- * Used by shard mode to enumerate per-file review targets.
+ * List files changed in a range via `git log --name-only`, matching
+ * the commit-log semantics used by `resolveReviewDiff`. Using
+ * `git diff --name-only` would report only the net tree diff and
+ * silently drop files changed then reverted within a multi-commit
+ * range — those files would then be invisible to shard-mode review
+ * even though `git log -p` still contains their edits.
+ *
+ * `--no-merges` skips merge commits (their content is reviewed via
+ * the branches that produced them). Output is de-duplicated since
+ * log output repeats a file for every commit that touches it.
  *
  * @param {string} range — e.g. "HEAD~1..HEAD" or "main..feature"
  * @returns {string[]}
@@ -72,13 +91,21 @@ export function resolveReviewDiff({ ref = "HEAD", base, file } = {}) {
 export function listChangedFiles(range) {
   const out = execFileSync(
     "git",
-    ["diff", "--name-only", range],
+    [
+      "log",
+      "--no-merges",
+      "--name-only",
+      "--pretty=format:",
+      range,
+    ],
     { encoding: "utf8", windowsHide: true, maxBuffer: 50 * 1024 * 1024 },
   );
-  return out
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const seen = new Set();
+  for (const line of out.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed) seen.add(trimmed);
+  }
+  return [...seen];
 }
 
 /**
@@ -341,14 +368,7 @@ export async function runCodexReviewSharded({
   onFileStart,
   onFileDone,
 } = {}) {
-  let range;
-  if (base) {
-    range = `${base}..${ref}`;
-  } else if (ref.includes("..")) {
-    range = ref;
-  } else {
-    range = `${ref}~1..${ref}`;
-  }
+  const range = expandRange({ ref, base });
 
   let files;
   try {

--- a/tests/unit/codex-review.test.mjs
+++ b/tests/unit/codex-review.test.mjs
@@ -2,7 +2,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  aggregateVerdicts,
   buildReviewPrompt,
+  listChangedFiles,
   parseVerdict,
   resolveReviewDiff,
   runCodexReview,
@@ -90,4 +92,95 @@ test("runCodexReview: rejects oversized prompt without spawning codex", async ()
     assert.match(result.error, /prompt too large/);
     assert.equal(result.verdict, null);
   }
+});
+
+// ── shard-mode helpers ─────────────────────────────────────────
+
+test("aggregateVerdicts: empty list returns UNKNOWN", () => {
+  assert.equal(aggregateVerdicts([]), "UNKNOWN");
+});
+
+test("aggregateVerdicts: any REQUEST_CHANGES wins", () => {
+  const fileResults = [
+    { verdict: "APPROVED" },
+    { verdict: "COMMENT" },
+    { verdict: "REQUEST_CHANGES" },
+    { verdict: "APPROVED" },
+  ];
+  assert.equal(aggregateVerdicts(fileResults), "REQUEST_CHANGES");
+});
+
+test("aggregateVerdicts: COMMENT overrides APPROVED but loses to REQUEST_CHANGES", () => {
+  assert.equal(
+    aggregateVerdicts([{ verdict: "APPROVED" }, { verdict: "COMMENT" }]),
+    "COMMENT",
+  );
+});
+
+test("aggregateVerdicts: all APPROVED returns APPROVED", () => {
+  assert.equal(
+    aggregateVerdicts([
+      { verdict: "APPROVED" },
+      { verdict: "APPROVED" },
+    ]),
+    "APPROVED",
+  );
+});
+
+test("aggregateVerdicts: mixed APPROVED + UNKNOWN falls through to UNKNOWN", () => {
+  assert.equal(
+    aggregateVerdicts([{ verdict: "APPROVED" }, { verdict: "UNKNOWN" }]),
+    "UNKNOWN",
+  );
+});
+
+test("aggregateVerdicts: skipped entries are excluded from active set", () => {
+  const results = [
+    { verdict: "APPROVED", skipped: true },
+    { verdict: "APPROVED" },
+  ];
+  assert.equal(aggregateVerdicts(results), "APPROVED");
+});
+
+test("aggregateVerdicts: all skipped returns UNKNOWN", () => {
+  const results = [
+    { verdict: "APPROVED", skipped: true },
+    { verdict: "APPROVED", skipped: true },
+  ];
+  assert.equal(aggregateVerdicts(results), "UNKNOWN");
+});
+
+test("listChangedFiles: returns non-empty array for HEAD~1..HEAD", () => {
+  // Repo has at least 1 prior commit (session bootstrap). This asserts the
+  // shape, not a specific file list.
+  const files = listChangedFiles("HEAD~1..HEAD");
+  assert.ok(Array.isArray(files));
+  assert.ok(files.length > 0, "at least one file should differ");
+  for (const f of files) {
+    assert.equal(typeof f, "string");
+    assert.ok(f.length > 0);
+  }
+});
+
+test("listChangedFiles: empty range returns empty array", () => {
+  // HEAD..HEAD has no changes.
+  const files = listChangedFiles("HEAD..HEAD");
+  assert.deepEqual(files, []);
+});
+
+test("resolveReviewDiff: file param scopes diff via `-- <file>`", () => {
+  // Any file that changed in HEAD~1..HEAD. Use listChangedFiles to pick one.
+  const all = listChangedFiles("HEAD~1..HEAD");
+  if (all.length === 0) return; // nothing to scope — skip
+  const target = all[0];
+  const { diff, range, file } = resolveReviewDiff({
+    ref: "HEAD",
+    file: target,
+  });
+  assert.equal(range, "HEAD~1..HEAD");
+  assert.equal(file, target);
+  assert.ok(typeof diff === "string");
+  // Scoped diff should mention only the target file in its `diff --git` header.
+  // Other files may still appear in --stat summary, so check body presence.
+  assert.ok(diff.includes(target), "scoped diff should reference target file");
 });

--- a/tests/unit/codex-review.test.mjs
+++ b/tests/unit/codex-review.test.mjs
@@ -268,3 +268,26 @@ test("parseChangedFilesFromLog: handles CRLF line endings", () => {
     "gamma",
   ]);
 });
+
+test("listChangedFiles: argv contract — does not pass --no-merges", () => {
+  // Regression guard: merges must be included so enumeration stays aligned
+  // with resolveReviewDiff's plain `git log -p`. Round 3 fix in PR #138.
+  let capturedCmd = "";
+  let capturedArgs = [];
+  const stubRunner = (cmd, args) => {
+    capturedCmd = cmd;
+    capturedArgs = args;
+    return "foo.mjs\nbar.mjs\n";
+  };
+  const result = listChangedFiles("HEAD~2..HEAD", stubRunner);
+  assert.equal(capturedCmd, "git");
+  assert.equal(capturedArgs[0], "log");
+  assert.ok(capturedArgs.includes("--name-only"));
+  assert.ok(capturedArgs.includes("--pretty=format:"));
+  assert.ok(capturedArgs.includes("HEAD~2..HEAD"));
+  assert.ok(
+    !capturedArgs.includes("--no-merges"),
+    "must not pass --no-merges",
+  );
+  assert.deepEqual(result.sort(), ["bar.mjs", "foo.mjs"]);
+});

--- a/tests/unit/codex-review.test.mjs
+++ b/tests/unit/codex-review.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   aggregateVerdicts,
   buildReviewPrompt,
+  expandRange,
   listChangedFiles,
   parseVerdict,
   resolveReviewDiff,
@@ -183,4 +184,47 @@ test("resolveReviewDiff: file param scopes diff via `-- <file>`", () => {
   // Scoped diff should mention only the target file in its `diff --git` header.
   // Other files may still appear in --stat summary, so check body presence.
   assert.ok(diff.includes(target), "scoped diff should reference target file");
+});
+
+test("expandRange: bare ref expands to ~1..ref", () => {
+  assert.equal(expandRange({ ref: "HEAD" }), "HEAD~1..HEAD");
+  assert.equal(expandRange({ ref: "abcdef0" }), "abcdef0~1..abcdef0");
+});
+
+test("expandRange: explicit base overrides", () => {
+  assert.equal(
+    expandRange({ ref: "HEAD", base: "main" }),
+    "main..HEAD",
+  );
+  assert.equal(
+    expandRange({ ref: "feat/x", base: "origin/main" }),
+    "origin/main..feat/x",
+  );
+});
+
+test("expandRange: range ref passes through unchanged", () => {
+  assert.equal(expandRange({ ref: "HEAD~3..HEAD" }), "HEAD~3..HEAD");
+  assert.equal(expandRange({ ref: "main..feat/x" }), "main..feat/x");
+});
+
+test("expandRange: defaults ref to HEAD when omitted", () => {
+  assert.equal(expandRange({}), "HEAD~1..HEAD");
+  assert.equal(expandRange(), "HEAD~1..HEAD");
+});
+
+test("listChangedFiles: git log semantics (includes --no-merges --name-only)", () => {
+  // Smoke test that we use git log (not git diff), by verifying a known
+  // contract: for the most recent commit, both approaches converge, but
+  // the helper must not rely on the staging tree. Assert the result is a
+  // deduped string array with no blank entries.
+  const files = listChangedFiles("HEAD~1..HEAD");
+  const unique = new Set(files);
+  assert.equal(
+    unique.size,
+    files.length,
+    "listChangedFiles must dedupe file paths",
+  );
+  for (const f of files) {
+    assert.ok(f && !/^\s*$/.test(f), "no blank entries");
+  }
 });

--- a/tests/unit/codex-review.test.mjs
+++ b/tests/unit/codex-review.test.mjs
@@ -6,6 +6,7 @@ import {
   buildReviewPrompt,
   expandRange,
   listChangedFiles,
+  parseChangedFilesFromLog,
   parseVerdict,
   resolveReviewDiff,
   runCodexReview,
@@ -212,11 +213,11 @@ test("expandRange: defaults ref to HEAD when omitted", () => {
   assert.equal(expandRange(), "HEAD~1..HEAD");
 });
 
-test("listChangedFiles: git log semantics (includes --no-merges --name-only)", () => {
-  // Smoke test that we use git log (not git diff), by verifying a known
-  // contract: for the most recent commit, both approaches converge, but
-  // the helper must not rely on the staging tree. Assert the result is a
-  // deduped string array with no blank entries.
+test("listChangedFiles: git log semantics, deduped, no blanks", () => {
+  // Contract test on a known real range. For single-commit ranges both
+  // `git log` and `git diff --name-only` converge — regression coverage
+  // for the revert-within-range / merge semantics is done via
+  // parseChangedFilesFromLog below.
   const files = listChangedFiles("HEAD~1..HEAD");
   const unique = new Set(files);
   assert.equal(
@@ -227,4 +228,43 @@ test("listChangedFiles: git log semantics (includes --no-merges --name-only)", (
   for (const f of files) {
     assert.ok(f && !/^\s*$/.test(f), "no blank entries");
   }
+});
+
+test("parseChangedFilesFromLog: dedupes paths repeated across commits", () => {
+  // Simulates `git log --name-only --pretty=format:` output where commit A
+  // adds foo.mjs + bar.mjs, and commit B reverts bar.mjs. Both show up in
+  // log output but only once each in the result.
+  const canned = [
+    "", // first commit's blank format line
+    "foo.mjs",
+    "bar.mjs",
+    "", // second commit
+    "bar.mjs", // revert — appears twice in log
+    "",
+    "baz.mjs", // third commit
+  ].join("\n");
+  const result = parseChangedFilesFromLog(canned);
+  assert.deepEqual(result.sort(), ["bar.mjs", "baz.mjs", "foo.mjs"]);
+});
+
+test("parseChangedFilesFromLog: handles empty and whitespace-only input", () => {
+  assert.deepEqual(parseChangedFilesFromLog(""), []);
+  assert.deepEqual(parseChangedFilesFromLog("\n\n  \n\t\n"), []);
+  assert.deepEqual(parseChangedFilesFromLog(null), []);
+  assert.deepEqual(parseChangedFilesFromLog(undefined), []);
+});
+
+test("parseChangedFilesFromLog: preserves insertion order of first occurrence", () => {
+  // Same file in 3 commits; first occurrence wins insertion order.
+  const canned = "a\n\nb\na\nc\na\n";
+  assert.deepEqual(parseChangedFilesFromLog(canned), ["a", "b", "c"]);
+});
+
+test("parseChangedFilesFromLog: handles CRLF line endings", () => {
+  const canned = "alpha\r\nbeta\r\n\r\nalpha\r\ngamma\r\n";
+  assert.deepEqual(parseChangedFilesFromLog(canned), [
+    "alpha",
+    "beta",
+    "gamma",
+  ]);
 });


### PR DESCRIPTION
## Summary

세션 12 PR #137 에서 도입한 32KB 프롬프트 size gate 는 안전장치일 뿐, 3~4 평균 swarm bugfix 합쳐진 diff (또는 본 PR 같은 helper 재작성) 은 gate 에 걸려 아예 review 가 안 됨. 세션 12 extended checkpoint Remaining Work Task 2 해소.

## Changes

### `hub/team/codex-review.mjs`
- `listChangedFiles(range)` — `git diff --name-only` 로 shard 타겟 열거.
- `aggregateVerdicts(results)` — REQUEST_CHANGES > COMMENT > APPROVED > UNKNOWN, skipped 엔트리는 active 집합에서 제외.
- `_runCodexOnPrompt(...)` — 기존 `runCodexReview` 의 spawn/timeout/parse 블록 추출. 단일/shard 모드 공유.
- `runCodexReviewSharded({ ref, base, timeoutMs, onFileStart, onFileDone })` — 순차 per-file 호출, aggregate. callback 은 CLI 진행률 표시에 쓰임.
- `resolveReviewDiff({ ref, base, file? })` — 기존 signature 확장, file 지정 시 `git log -p range -- <file>`.
- `MAX_PROMPT_BYTES` export 화 + 에러 메시지에 `--shard per-file` 안내 추가.

### `bin/triflux.mjs`
- `--shard per-file` 플래그 파싱.
- 모드 분기: 기본 single-spawn (기존 동작), `per-file` 면 `runCodexReviewSharded` 호출.
- stderr 로 `[i/N] reviewing <file>` 진행률, stdout 으로 각 파일별 review block + aggregate footer.

### `tests/unit/codex-review.test.mjs`
- +10 테스트: aggregateVerdicts 7 케이스 (empty, any REQUEST_CHANGES, COMMENT override, all APPROVED, mixed UNKNOWN, skipped 제외, all skipped), listChangedFiles shape 2, resolveReviewDiff file scope 1.

### `packages/triflux/**`
- mirror sync.

## 설계 결정

- **순차 실행, not parallel** — Codex headless startup ~30-90s per file. 병렬 spawn 은 auth 충돌 위험 (account broker singleton 이지만 review 는 그 바깥 경로). Wall-clock = N × timeout. 대형 PR 은 `--timeout` 낮춰서 조정.
- **per-file size gate** — shard 안에서 단일 파일이 32KB 를 넘으면 그 파일만 skip (error 기록) + 나머지는 계속. hard-stop 대신 partial review.
- **Empty diff (rename/mode-only) skip** — verdict=APPROVED + skipped=true 로 표시해 aggregate 에서 제외.
- **Callback 패턴** — `onFileStart/onFileDone` 는 CLI 가 진행률 찍기 위한 진입점. 테스트/프로그램 호출 시에도 조용히 생략 가능.

## Test plan

- [x] `node --test tests/unit/codex-review.test.mjs tests/unit/packages-mirror.test.mjs` → 23/23 pass
- [x] `npm run release:check-mirror` → Mirror OK
- [ ] E2E: `node bin/triflux.mjs review HEAD --shard per-file --timeout 180` self-dogfood (post-open, PR comment 로 결과 첨부)

## Related

- 세션 12 extended checkpoint: `~/.gstack/projects/tellang-triflux/checkpoints/20260420-190205-session-12-ext-packages-mirror-tfx-review-landed.md` Task 2
- 직접 원인: PR #137 (32KB gate 도입) 의 known limitation
- 간접 배경: session 12 self-dogfood (PR #136) 62KB diff 에서 ENAMETOOLONG 관찰