### PR TITLE
fix(setup): recursive hub/workers/**/*.mjs sync (codex app-server worker 복구)

### DIFF
--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -87,7 +87,7 @@ function scanLibFiles(pluginRoot, claudeDir) {
  * 누락 방지. 2026-04-20 `workers/lib/jsonrpc-stdio.mjs` 가 top-level 전용
  * 스캔 때문에 누락되어 codex app-server worker 기동 실패 → 수정.
  */
-function scanHubWorkerFiles(pluginRoot, claudeDir) {
+export function scanHubWorkerFiles(pluginRoot, claudeDir) {
   const results = [];
   const hubRoot = join(pluginRoot, "hub");
   if (!existsSync(hubRoot)) return results;

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -82,25 +82,39 @@ function scanLibFiles(pluginRoot, claudeDir) {
 }
 
 /**
- * hub/workers/*.mjs + hub/ 루트의 worker 의존성 파일을 자동 스캔.
- * 수동 리스트 대신 glob으로 탐색하여 파일 추가 시 sync 누락 방지.
+ * hub/workers/**\/*.mjs + hub/ 루트의 worker 의존성 파일을 자동 스캔.
+ * 수동 리스트 대신 재귀 walk로 탐색하여 파일/서브디렉토리 추가 시 sync
+ * 누락 방지. 2026-04-20 `workers/lib/jsonrpc-stdio.mjs` 가 top-level 전용
+ * 스캔 때문에 누락되어 codex app-server worker 기동 실패 → 수정.
  */
 function scanHubWorkerFiles(pluginRoot, claudeDir) {
   const results = [];
   const hubRoot = join(pluginRoot, "hub");
   if (!existsSync(hubRoot)) return results;
 
-  // hub/workers/*.mjs 전체
+  // hub/workers/**/*.mjs 전체 (서브디렉토리 포함)
   const workersDir = join(hubRoot, "workers");
   if (existsSync(workersDir)) {
-    for (const f of readdirSync(workersDir).sort()) {
-      if (!f.endsWith(".mjs")) continue;
-      results.push({
-        src: join(workersDir, f),
-        dst: join(claudeDir, "scripts", "hub", "workers", f),
-        label: `hub/workers/${f}`,
-      });
-    }
+    const walkWorkers = (currentDir) => {
+      const entries = readdirSync(currentDir, { withFileTypes: true }).sort(
+        (l, r) => l.name.localeCompare(r.name),
+      );
+      for (const entry of entries) {
+        const absPath = join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          walkWorkers(absPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".mjs")) continue;
+        const rel = relative(workersDir, absPath).replace(/\\/g, "/");
+        results.push({
+          src: absPath,
+          dst: join(claudeDir, "scripts", "hub", "workers", rel),
+          label: `hub/workers/${rel}`,
+        });
+      }
+    };
+    walkWorkers(workersDir);
   }
 
   // hub/ 루트: worker가 import하는 의존성 (cli-adapter-base, platform 등)

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -87,7 +87,7 @@ function scanLibFiles(pluginRoot, claudeDir) {
  * 누락 방지. 2026-04-20 `workers/lib/jsonrpc-stdio.mjs` 가 top-level 전용
  * 스캔 때문에 누락되어 codex app-server worker 기동 실패 → 수정.
  */
-function scanHubWorkerFiles(pluginRoot, claudeDir) {
+export function scanHubWorkerFiles(pluginRoot, claudeDir) {
   const results = [];
   const hubRoot = join(pluginRoot, "hub");
   if (!existsSync(hubRoot)) return results;

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -82,25 +82,39 @@ function scanLibFiles(pluginRoot, claudeDir) {
 }
 
 /**
- * hub/workers/*.mjs + hub/ 루트의 worker 의존성 파일을 자동 스캔.
- * 수동 리스트 대신 glob으로 탐색하여 파일 추가 시 sync 누락 방지.
+ * hub/workers/**\/*.mjs + hub/ 루트의 worker 의존성 파일을 자동 스캔.
+ * 수동 리스트 대신 재귀 walk로 탐색하여 파일/서브디렉토리 추가 시 sync
+ * 누락 방지. 2026-04-20 `workers/lib/jsonrpc-stdio.mjs` 가 top-level 전용
+ * 스캔 때문에 누락되어 codex app-server worker 기동 실패 → 수정.
  */
 function scanHubWorkerFiles(pluginRoot, claudeDir) {
   const results = [];
   const hubRoot = join(pluginRoot, "hub");
   if (!existsSync(hubRoot)) return results;
 
-  // hub/workers/*.mjs 전체
+  // hub/workers/**/*.mjs 전체 (서브디렉토리 포함)
   const workersDir = join(hubRoot, "workers");
   if (existsSync(workersDir)) {
-    for (const f of readdirSync(workersDir).sort()) {
-      if (!f.endsWith(".mjs")) continue;
-      results.push({
-        src: join(workersDir, f),
-        dst: join(claudeDir, "scripts", "hub", "workers", f),
-        label: `hub/workers/${f}`,
-      });
-    }
+    const walkWorkers = (currentDir) => {
+      const entries = readdirSync(currentDir, { withFileTypes: true }).sort(
+        (l, r) => l.name.localeCompare(r.name),
+      );
+      for (const entry of entries) {
+        const absPath = join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          walkWorkers(absPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".mjs")) continue;
+        const rel = relative(workersDir, absPath).replace(/\\/g, "/");
+        results.push({
+          src: absPath,
+          dst: join(claudeDir, "scripts", "hub", "workers", rel),
+          label: `hub/workers/${rel}`,
+        });
+      }
+    };
+    walkWorkers(workersDir);
   }
 
   // hub/ 루트: worker가 import하는 의존성 (cli-adapter-base, platform 등)

--- a/tests/unit/setup-scan-workers.test.mjs
+++ b/tests/unit/setup-scan-workers.test.mjs
@@ -146,10 +146,48 @@ test("scanHubWorkerFiles: dst path preserves nested structure under claudeDir", 
   }
 });
 
-test("scanHubWorkerFiles: empty hub/ returns empty array, no throw", () => {
+test("scanHubWorkerFiles: includes hub-root deps (cli-adapter-base, platform)", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const labels = results.map((r) => r.label);
+    assert.ok(
+      labels.includes("hub/cli-adapter-base.mjs"),
+      `expected hub/cli-adapter-base.mjs, got: ${labels.join(", ")}`,
+    );
+    assert.ok(
+      labels.includes("hub/platform.mjs"),
+      `expected hub/platform.mjs, got: ${labels.join(", ")}`,
+    );
+    const base = results.find((r) => r.label === "hub/cli-adapter-base.mjs");
+    assert.ok(
+      base.dst.endsWith(join("scripts", "hub", "cli-adapter-base.mjs")),
+      `hub-root dep dst must land under scripts/hub/, got: ${base.dst}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: missing hub/ returns empty array, no throw", () => {
+  // plugin root has no hub/ subtree at all (e.g. brand-new clone, pruned
+  // dist). Must degrade cleanly — not throw, not crash setup.
   const claude = mkdtempSync(join(tmpdir(), "tfx-scan-empty-"));
   const root = mkdtempSync(join(tmpdir(), "tfx-scan-noroot-"));
   try {
+    assert.deepEqual(scanHubWorkerFiles(root, claude), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: existing but empty hub/ returns empty array", () => {
+  const root = mkdtempSync(join(tmpdir(), "tfx-scan-emptyhub-"));
+  const claude = mkdtempSync(join(tmpdir(), "tfx-scan-emptyhub-c-"));
+  try {
+    mkdirSync(join(root, "hub"), { recursive: true });
     assert.deepEqual(scanHubWorkerFiles(root, claude), []);
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/tests/unit/setup-scan-workers.test.mjs
+++ b/tests/unit/setup-scan-workers.test.mjs
@@ -1,0 +1,158 @@
+// scanHubWorkerFiles — recursive sync regression guard.
+//
+// PR #139 fixed a silent sync gap where `hub/workers/lib/jsonrpc-stdio.mjs`
+// was never copied to `~/.claude/scripts/` because the scanner only walked
+// top-level `hub/workers/*.mjs`. This suite pins the recursive behavior so
+// a future refactor cannot silently re-break nested worker deps.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { scanHubWorkerFiles } from "../../scripts/setup.mjs";
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "tfx-scan-test-"));
+  const claude = mkdtempSync(join(tmpdir(), "tfx-scan-claude-"));
+  mkdirSync(join(root, "hub", "workers", "lib"), { recursive: true });
+  mkdirSync(join(root, "hub", "workers", "deep", "nested"), { recursive: true });
+  // top-level workers
+  writeFileSync(join(root, "hub", "workers", "factory.mjs"), "// factory");
+  writeFileSync(
+    join(root, "hub", "workers", "codex-app-server-worker.mjs"),
+    "// codex app",
+  );
+  // nested lib — the exact regression case
+  writeFileSync(
+    join(root, "hub", "workers", "lib", "jsonrpc-stdio.mjs"),
+    "// jsonrpc",
+  );
+  // deeper nested
+  writeFileSync(
+    join(root, "hub", "workers", "deep", "nested", "inner.mjs"),
+    "// deep",
+  );
+  // non-mjs (should be skipped)
+  writeFileSync(
+    join(root, "hub", "workers", "README.md"),
+    "# readme",
+  );
+  writeFileSync(
+    join(root, "hub", "workers", "lib", "data.json"),
+    "{}",
+  );
+  // hub-root deps (test covers the existing branch too)
+  writeFileSync(join(root, "hub", "cli-adapter-base.mjs"), "// base");
+  writeFileSync(join(root, "hub", "platform.mjs"), "// platform");
+  return { root, claude };
+}
+
+test("scanHubWorkerFiles: includes top-level .mjs workers", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const labels = results.map((r) => r.label);
+    assert.ok(labels.includes("hub/workers/factory.mjs"));
+    assert.ok(labels.includes("hub/workers/codex-app-server-worker.mjs"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: includes nested lib/*.mjs (PR #139 regression)", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const labels = results.map((r) => r.label);
+    assert.ok(
+      labels.includes("hub/workers/lib/jsonrpc-stdio.mjs"),
+      `expected nested lib path, got: ${labels.join(", ")}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: walks arbitrarily deep subdirectories", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const labels = results.map((r) => r.label);
+    assert.ok(labels.includes("hub/workers/deep/nested/inner.mjs"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: skips non-.mjs files", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const labels = results.map((r) => r.label);
+    assert.ok(!labels.some((l) => l.endsWith(".md")));
+    assert.ok(!labels.some((l) => l.endsWith(".json")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: dst labels use forward slashes regardless of platform", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    for (const r of results) {
+      if (r.label.startsWith("hub/workers/")) {
+        assert.ok(
+          !r.label.includes("\\"),
+          `label must use forward slashes, got: ${r.label}`,
+        );
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: dst path preserves nested structure under claudeDir", () => {
+  const { root, claude } = makeFixture();
+  try {
+    const results = scanHubWorkerFiles(root, claude);
+    const nested = results.find(
+      (r) => r.label === "hub/workers/lib/jsonrpc-stdio.mjs",
+    );
+    assert.ok(nested, "nested entry must exist");
+    const expectedTail = join(
+      "scripts",
+      "hub",
+      "workers",
+      "lib",
+      "jsonrpc-stdio.mjs",
+    );
+    assert.ok(
+      nested.dst.endsWith(expectedTail),
+      `dst must end with ${expectedTail}, got: ${nested.dst}`,
+    );
+    assert.ok(nested.dst.startsWith(claude), "dst must live under claudeDir");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});
+
+test("scanHubWorkerFiles: empty hub/ returns empty array, no throw", () => {
+  const claude = mkdtempSync(join(tmpdir(), "tfx-scan-empty-"));
+  const root = mkdtempSync(join(tmpdir(), "tfx-scan-noroot-"));
+  try {
+    assert.deepEqual(scanHubWorkerFiles(root, claude), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(claude, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

다른 세션에서 보고된 증상:
- `~/.claude/scripts/tfx-route.sh` 는 존재
- 하지만 `~/.claude/scripts/hub/workers/lib/` 디렉토리 자체가 없음 → `codex-app-server-worker.mjs:19` 가 import 하는 `./lib/jsonrpc-stdio.mjs` 모듈 미존재
- 결과: tfx 가 codex app-server 로 라우팅할 때 worker 기동 실패 → claude-native fallback. 기능 손실이 silent 해서 worker가 안 뜬다는 걸 의식하지 않으면 감지 불가.

## Root cause

`scripts/setup.mjs` 의 `scanHubWorkerFiles()` 가 `hub/workers/*.mjs` top-level 만 `readdirSync` 로 훑고 서브디렉토리는 무시. HUD 쪽은 `scanHudFiles()` 에서 재귀 walk 를 쓰는데 workers 는 누락.

session 11 부근 PR 로 `hub/workers/lib/jsonrpc-stdio.mjs` 가 추가됐으나 setup sync 경로에 반영 안 됨.

## Fix

- `scanHubWorkerFiles` 를 재귀 walk 로 전환 (HUD 패턴 복제)
- `relative(workersDir, absPath)` 로 path 보존 + `\` → `/` 정규화
- 새 서브디렉토리 추가 시에도 수동 리스트 수정 불필요

## Verification

- `node scripts/setup.mjs --force` 실행 → `~/.claude/scripts/hub/workers/lib/jsonrpc-stdio.mjs` 15323 bytes 로 생성됨
- `node --test tests/unit/jsonrpc-stdio.test.mjs tests/unit/codex-review.test.mjs tests/unit/packages-mirror.test.mjs` → 48/48 pass
- `npm run release:check-mirror` → Mirror OK

## Test plan

- [x] unit tests 48/48 pass
- [x] mirror byte-identical
- [x] 실제 `~/.claude/scripts/hub/workers/lib/` 생성 확인
- [ ] 향후: `workers/__tests__/` 같은 배포 불필요 폴더가 생기면 exclude 필요 (YAGNI, 발생 시점에 추가)

## Related

- 원인 방치 시 codex app-server 경로 silent degrade
- 세션 13 extended, task from cross-session handoff