### PR TITLE
fix(gemini): add --yolo to GeminiBackend to prevent headless silent-hang

### DIFF
--- a/hub/team/backend.mjs
+++ b/hub/team/backend.mjs
@@ -6,6 +6,16 @@ import { createRequire } from "node:module";
 import { buildExecArgs } from "../codex-adapter.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 
+// --yolo is required: without it gemini waits on stdin for tool-call approval
+// even when stdin is redirected, producing a 0-byte 90s+ silent hang.
+// execution-mode.mjs:buildSpawnSpecForMode enforces the same flag.
+export function buildGeminiCommand(prompt, resultFile, { isWindows } = {}) {
+  if (isWindows) {
+    return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+  }
+  return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+}
+
 const _require = createRequire(import.meta.url);
 
 // ── 백엔드 클래스 ──────────────────────────────────────────────────────────
@@ -42,12 +52,7 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    // --yolo is required: without it gemini waits on stdin for tool-call approval
-    // even when stdin is redirected, producing a 0-byte 90s+ silent hang.
-    if (IS_WINDOWS) {
-      return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
-    }
-    return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+    return buildGeminiCommand(prompt, resultFile, { isWindows: IS_WINDOWS });
   }
 
   env() {

--- a/hub/team/backend.mjs
+++ b/hub/team/backend.mjs
@@ -42,10 +42,12 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
+    // --yolo is required: without it gemini waits on stdin for tool-call approval
+    // even when stdin is redirected, producing a 0-byte 90s+ silent hang.
     if (IS_WINDOWS) {
-      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+      return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
     }
-    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+    return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
   }
 
   env() {

--- a/packages/triflux/hub/team/backend.mjs
+++ b/packages/triflux/hub/team/backend.mjs
@@ -6,6 +6,16 @@ import { createRequire } from "node:module";
 import { buildExecArgs } from "../codex-adapter.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 
+// --yolo is required: without it gemini waits on stdin for tool-call approval
+// even when stdin is redirected, producing a 0-byte 90s+ silent hang.
+// execution-mode.mjs:buildSpawnSpecForMode enforces the same flag.
+export function buildGeminiCommand(prompt, resultFile, { isWindows } = {}) {
+  if (isWindows) {
+    return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+  }
+  return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+}
+
 const _require = createRequire(import.meta.url);
 
 // ── 백엔드 클래스 ──────────────────────────────────────────────────────────
@@ -42,12 +52,7 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    // --yolo is required: without it gemini waits on stdin for tool-call approval
-    // even when stdin is redirected, producing a 0-byte 90s+ silent hang.
-    if (IS_WINDOWS) {
-      return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
-    }
-    return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+    return buildGeminiCommand(prompt, resultFile, { isWindows: IS_WINDOWS });
   }
 
   env() {

--- a/packages/triflux/hub/team/backend.mjs
+++ b/packages/triflux/hub/team/backend.mjs
@@ -42,10 +42,12 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
+    // --yolo is required: without it gemini waits on stdin for tool-call approval
+    // even when stdin is redirected, producing a 0-byte 90s+ silent hang.
     if (IS_WINDOWS) {
-      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+      return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
     }
-    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+    return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
   }
 
   env() {

--- a/tests/unit/backend.test.mjs
+++ b/tests/unit/backend.test.mjs
@@ -58,17 +58,35 @@ describe("GeminiBackend", () => {
     assert.equal(backend.command(), "gemini");
   });
 
-  it("buildArgs — gemini --prompt ... --output-format text > result 포함", () => {
+  it("buildArgs — gemini --yolo --prompt ... --output-format text > result 포함", () => {
     const cmd = backend.buildArgs(
       "(Get-Content -Raw '/tmp/p.txt')",
       "/tmp/r.txt",
     );
-    assert.ok(cmd.includes("gemini --prompt"), `gemini --prompt 포함: ${cmd}`);
+    assert.ok(
+      cmd.includes("gemini --yolo --prompt"),
+      `gemini --yolo --prompt 포함: ${cmd}`,
+    );
     assert.ok(
       cmd.includes("--output-format text"),
       `--output-format text 포함: ${cmd}`,
     );
     assert.ok(cmd.includes("> '/tmp/r.txt'"), `> result 포함: ${cmd}`);
+  });
+
+  it("buildArgs — --yolo 플래그 누락 금지 (silent-hang 회귀 방지)", () => {
+    const cmd = backend.buildArgs(
+      "(Get-Content -Raw '/tmp/p.txt')",
+      "/tmp/r.txt",
+    );
+    assert.ok(
+      /\bgemini\s+--yolo\b/.test(cmd),
+      `--yolo 플래그 필수: ${cmd}`,
+    );
+    assert.ok(
+      cmd.indexOf("--yolo") < cmd.indexOf("--prompt"),
+      `--yolo 는 --prompt 앞에 위치: ${cmd}`,
+    );
   });
 
   it("env() — 빈 객체 반환", () => {

--- a/tests/unit/backend.test.mjs
+++ b/tests/unit/backend.test.mjs
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildGeminiCommand,
   ClaudeBackend,
   CodexBackend,
   GeminiBackend,
@@ -74,23 +75,68 @@ describe("GeminiBackend", () => {
     assert.ok(cmd.includes("> '/tmp/r.txt'"), `> result 포함: ${cmd}`);
   });
 
-  it("buildArgs — --yolo 플래그 누락 금지 (silent-hang 회귀 방지)", () => {
-    const cmd = backend.buildArgs(
-      "(Get-Content -Raw '/tmp/p.txt')",
-      "/tmp/r.txt",
-    );
-    assert.ok(
-      /\bgemini\s+--yolo\b/.test(cmd),
-      `--yolo 플래그 필수: ${cmd}`,
-    );
-    assert.ok(
-      cmd.indexOf("--yolo") < cmd.indexOf("--prompt"),
-      `--yolo 는 --prompt 앞에 위치: ${cmd}`,
-    );
-  });
-
   it("env() — 빈 객체 반환", () => {
     assert.deepEqual(backend.env(), {});
+  });
+});
+
+// ========================================================================
+// GeminiBackend — buildGeminiCommand pure helper (Windows/Unix 양 분기)
+// ========================================================================
+describe("buildGeminiCommand: platform-specific formatting", () => {
+  const prompt = "(Get-Content -Raw '/tmp/p.txt')";
+  const resultFile = "/tmp/r.txt";
+
+  it("Windows 분기 — $null | gemini --yolo --prompt ... (silent-hang 회귀 방지)", () => {
+    const cmd = buildGeminiCommand(prompt, resultFile, { isWindows: true });
+    assert.ok(
+      cmd.startsWith("$null | gemini --yolo --prompt "),
+      `Windows 분기 시작 prefix: ${cmd}`,
+    );
+    assert.ok(
+      /\bgemini\s+--yolo\s+--prompt\b/.test(cmd),
+      `--yolo 가 --prompt 앞에 위치: ${cmd}`,
+    );
+    assert.ok(
+      cmd.includes(`> '${resultFile}' 2>'${resultFile}.err'`),
+      `result/err 리다이렉트: ${cmd}`,
+    );
+    assert.ok(!cmd.includes("< /dev/null"), `Windows 는 /dev/null 미사용: ${cmd}`);
+  });
+
+  it("Unix 분기 — gemini --yolo --prompt ... < /dev/null (silent-hang 회귀 방지)", () => {
+    const cmd = buildGeminiCommand(prompt, resultFile, { isWindows: false });
+    assert.ok(
+      cmd.startsWith("gemini --yolo --prompt "),
+      `Unix 분기 시작 prefix: ${cmd}`,
+    );
+    assert.ok(
+      /\bgemini\s+--yolo\s+--prompt\b/.test(cmd),
+      `--yolo 가 --prompt 앞에 위치: ${cmd}`,
+    );
+    assert.ok(cmd.endsWith("< /dev/null"), `stdin redirect suffix: ${cmd}`);
+    assert.ok(!cmd.startsWith("$null"), `Unix 는 $null prefix 미사용: ${cmd}`);
+  });
+
+  it("양 분기 모두 --yolo 플래그 필수 (미누락 invariant)", () => {
+    const win = buildGeminiCommand(prompt, resultFile, { isWindows: true });
+    const unix = buildGeminiCommand(prompt, resultFile, { isWindows: false });
+    for (const cmd of [win, unix]) {
+      assert.ok(
+        /\bgemini\s+--yolo\b/.test(cmd),
+        `--yolo 플래그 누락: ${cmd}`,
+      );
+      assert.ok(
+        cmd.indexOf("--yolo") < cmd.indexOf("--prompt"),
+        `--yolo 는 --prompt 앞: ${cmd}`,
+      );
+    }
+  });
+
+  it("isWindows 생략 시 Unix 분기로 기본 동작", () => {
+    const cmd = buildGeminiCommand(prompt, resultFile);
+    assert.ok(cmd.startsWith("gemini --yolo"), `기본 Unix 포맷: ${cmd}`);
+    assert.ok(cmd.endsWith("< /dev/null"), `기본 /dev/null: ${cmd}`);
   });
 });
 


### PR DESCRIPTION
## Summary

- \`hub/team/backend.mjs\` GeminiBackend.buildArgs 에 \`--yolo\` 추가. \`--prompt\` + stdin 닫힘 조합만으로는 gemini 가 tool-call 승인 대기로 90s+ silent-hang 발생.
- 세션 12 \`tfx-multi-fpfw92gj-worker-2\` 에서 관측된 0 bytes 증상의 근본원인. \`execution-mode.mjs:112\` 의 \`buildSpawnSpecForMode\` 는 이미 \`--yolo\` 포함, backend.mjs 경로만 누락.
- Node subprocess probe (yolo-short, yolo-json, yolo-positional) 로 확증: \`--yolo\` 없으면 90s TIMEOUT 0 bytes, 추가시 ~12s exit 0 정상 응답.

## Changes

- \`hub/team/backend.mjs\`: Windows / Unix 양 분기에 \`--yolo\` 추가 + short WHY comment
- \`packages/triflux/hub/team/backend.mjs\`: mirror sync
- \`tests/unit/backend.test.mjs\`: 기존 assertion 업데이트 + regression test 1건 (--yolo 필수 + 순서 검증)

## Test plan

- [x] \`node --test tests/unit/backend.test.mjs tests/unit/gemini-*.test.mjs tests/unit/codex-review.test.mjs tests/unit/setup-scan-workers.test.mjs tests/unit/packages-mirror.test.mjs tests/unit/jsonrpc-stdio.test.mjs\` — 104/104 pass
- [x] \`npm run release:check-mirror\` — OK
- [x] probe 확증: \`node gemini-probe.mjs yolo-short/yolo-json/yolo-positional\` 전부 ~11s exit 0
- [ ] \`tfx review HEAD\` Codex cross-review (PR 후 run)

Refs: session 13 checkpoint Remaining Work Task 1.