### PR TITLE
fix(session-15): packages/remote --yolo + drop stale tfx-autoresearch SKILL test + routing-qa assertion

### DIFF
--- a/packages/remote/hub/team/backend.mjs
+++ b/packages/remote/hub/team/backend.mjs
@@ -6,6 +6,16 @@ import { createRequire } from "node:module";
 import { buildExecArgs } from "@triflux/core/hub/codex-adapter.mjs";
 import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 
+// --yolo is required: without it gemini waits on stdin for tool-call approval
+// even when stdin is redirected, producing a 0-byte 90s+ silent hang.
+// execution-mode.mjs:buildSpawnSpecForMode enforces the same flag.
+export function buildGeminiCommand(prompt, resultFile, { isWindows } = {}) {
+  if (isWindows) {
+    return `$null | gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
+  }
+  return `gemini --yolo --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+}
+
 const _require = createRequire(import.meta.url);
 
 // ── 백엔드 클래스 ──────────────────────────────────────────────────────────
@@ -42,10 +52,7 @@ export class GeminiBackend {
   }
 
   buildArgs(prompt, resultFile, opts = {}) {
-    if (IS_WINDOWS) {
-      return `$null | gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err'`;
-    }
-    return `gemini --prompt ${prompt} --output-format text > '${resultFile}' 2>'${resultFile}.err' < /dev/null`;
+    return buildGeminiCommand(prompt, resultFile, { isWindows: IS_WINDOWS });
   }
 
   env() {

--- a/tests/unit/autoresearch.test.mjs
+++ b/tests/unit/autoresearch.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import {
@@ -9,57 +9,10 @@ import {
   saveReport,
 } from "../../hub/research.mjs";
 
-// ── SKILL.md 구조 검증 ──
-
-const SKILL_PATH = new URL(
-  "../../skills/tfx-autoresearch/SKILL.md",
-  import.meta.url,
-);
-
-describe("tfx-autoresearch SKILL.md — 구조 검증", () => {
-  let content;
-
-  before(async () => {
-    content = await readFile(SKILL_PATH, "utf-8");
-  });
-
-  it("SKILL.md 파일이 존재하고 읽을 수 있어야 한다", () => {
-    assert.ok(content, "content must be non-empty");
-    assert.ok(content.length > 100, "SKILL.md must have substantial content");
-  });
-
-  it("트리거 키워드가 모두 포함되어야 한다", () => {
-    const triggers = [
-      "autoresearch",
-      "리서치",
-      "자동 리서치",
-      "웹 리서치",
-      "조사해",
-      "알아봐",
-      "research this",
-    ];
-    for (const trigger of triggers) {
-      assert.ok(content.includes(trigger), `트리거 "${trigger}" 누락`);
-    }
-  });
-
-  it("마크다운 구조가 유효해야 한다", () => {
-    assert.ok(content.startsWith("---"), "frontmatter 시작 --- 필요");
-    const secondDash = content.indexOf("---", 3);
-    assert.ok(secondDash > 0, "frontmatter 종료 --- 필요");
-
-    const frontmatter = content.substring(0, secondDash);
-    assert.ok(frontmatter.includes("name:"), "frontmatter name 필드 필요");
-    assert.ok(
-      frontmatter.includes("description:"),
-      "frontmatter description 필드 필요",
-    );
-    assert.ok(
-      frontmatter.includes("triggers:"),
-      "frontmatter triggers 필드 필요",
-    );
-  });
-});
+// Phase 5 cleanup (b371043) removed skills/tfx-autoresearch/ as thin alias.
+// tfx-research --auto 가 canonical entrypoint. 이 파일은 hub/research.mjs 의
+// pure helper (generateQueries / normalizeResults / buildReport / saveReport)
+// 만 검증한다.
 
 // ── generateQueries ──
 

--- a/tests/unit/backend.test.mjs
+++ b/tests/unit/backend.test.mjs
@@ -260,7 +260,64 @@ describe("listBackends", () => {
 });
 
 // ========================================================================
-// 5. agent-map.json 정합성 — 모든 에이전트가 유효한 백엔드로 해석됨
+// 5. packages/remote mirror contract — 원격 실행 패키지도 동일 invariant
+//    (세션 15: 세션 14 #140 mirror 누락 회귀가 실제 발생했으므로 contract
+//    test 로 재발 방지)
+// ========================================================================
+describe("packages/remote/hub/team/backend.mjs — mirror contract", () => {
+  const REMOTE_BACKEND = readFileSync(
+    join(ROOT, "packages/remote/hub/team/backend.mjs"),
+    "utf8",
+  );
+
+  it("buildGeminiCommand helper 가 export 되어야 한다", () => {
+    assert.ok(
+      /export\s+function\s+buildGeminiCommand\s*\(/.test(REMOTE_BACKEND),
+      "buildGeminiCommand export 누락 (root backend.mjs 와 sync)",
+    );
+  });
+
+  it("Windows 분기에 --yolo 포함 (silent-hang 회귀 방지)", () => {
+    assert.ok(
+      /\$null\s*\|\s*gemini\s+--yolo\s+--prompt/.test(REMOTE_BACKEND),
+      "Windows 분기 --yolo 누락",
+    );
+  });
+
+  it("Unix 분기에 --yolo 포함 (silent-hang 회귀 방지)", () => {
+    assert.ok(
+      /gemini\s+--yolo\s+--prompt\s+\$\{prompt\}.*<\s*\/dev\/null/s.test(
+        REMOTE_BACKEND,
+      ),
+      "Unix 분기 --yolo 또는 /dev/null redirect 누락",
+    );
+  });
+
+  it("GeminiBackend.buildArgs 가 buildGeminiCommand 를 호출 (wrapper 패턴)", () => {
+    const geminiClass = REMOTE_BACKEND.match(
+      /class\s+GeminiBackend[\s\S]*?^\}/m,
+    );
+    assert.ok(geminiClass, "GeminiBackend class 누락");
+    assert.ok(
+      /buildGeminiCommand\s*\(/.test(geminiClass[0]),
+      "GeminiBackend.buildArgs 가 buildGeminiCommand 호출 안 함",
+    );
+  });
+
+  it("CodexBackend / ClaudeBackend 존재 (registry 계약 유지)", () => {
+    assert.ok(
+      /class\s+CodexBackend\b/.test(REMOTE_BACKEND),
+      "CodexBackend class 누락",
+    );
+    assert.ok(
+      /class\s+ClaudeBackend\b/.test(REMOTE_BACKEND),
+      "ClaudeBackend class 누락",
+    );
+  });
+});
+
+// ========================================================================
+// 6. agent-map.json 정합성 — 모든 에이전트가 유효한 백엔드로 해석됨
 // ========================================================================
 describe("agent-map.json 정합성", () => {
   const agentMap = JSON.parse(

--- a/tests/unit/routing-qa.test.mjs
+++ b/tests/unit/routing-qa.test.mjs
@@ -257,13 +257,16 @@ describe("headless: buildHeadlessCommand", async () => {
     assert.ok(cmd.includes("/tmp/result.txt"));
   });
 
-  it("gemini → gemini --prompt ... --output-format text > result", () => {
+  it("gemini → gemini --yolo --prompt ... --output-format text > result", () => {
     const cmd = buildHeadlessCommand(
       "gemini",
       "test prompt",
       "/tmp/result.txt",
     );
-    assert.ok(cmd.includes("gemini --prompt"), `gemini --prompt 포함: ${cmd}`);
+    assert.ok(
+      cmd.includes("gemini --yolo --prompt"),
+      `gemini --yolo --prompt 포함: ${cmd}`,
+    );
     assert.ok(cmd.includes("--output-format text"));
     assert.ok(cmd.includes("> '/tmp/result.txt'"));
   });


### PR DESCRIPTION
## Summary

세션 15 로드맵/회귀 점검에서 발견한 3건 수정.

### 1. packages/remote --yolo 누락 (세션 14 #140 mirror 공백)

세션 14 PR #140 은 root + \`packages/triflux\` 만 sync (\`release:check-mirror\` 정책). \`packages/remote\` 는 별도 npm package (\`@triflux/core\` import) 라 mirror 자동화가 touch 하지 않음. 결과: \`packages/remote/hub/team/backend.mjs\` 의 GeminiBackend.buildArgs 가 여전히 \`gemini --prompt\` 만 사용 → stdin redirected 상태에서도 90s+ silent-hang 재현.

- \`buildGeminiCommand(prompt, resultFile, { isWindows })\` pure helper 를 root backend.mjs 와 동일 서명으로 packages/remote 에도 추가
- GeminiBackend.buildArgs 는 얇은 wrapper

### 2. tests/unit/autoresearch.test.mjs stale SKILL block 제거

Phase 5 cleanup (\`b371043\`) 에서 \`skills/tfx-autoresearch/\` thin alias 를 제거 (canonical = \`tfx-research --auto\`). \`skill-drift.test.mjs\` 는 주석으로 정리 반영, 그러나 \`autoresearch.test.mjs\` 의 첫 describe (SKILL.md 구조 검증) 은 \`skills/tfx-autoresearch/SKILL.md\` 를 여전히 expect → session 15 full suite 에서 3 테스트 fail.

- SKILL.md describe 블록 + \`readFile\` import 제거
- \`hub/research.mjs\` pure helper tests (generateQueries / normalizeResults / buildReport / saveReport) 는 유지

### 3. tests/unit/routing-qa.test.mjs assertion 갱신

\`buildHeadlessCommand(\"gemini\", ...)\` 이 내부에서 \`GeminiBackend.buildArgs\` 경유 → 세션 14 #140 의 \`--yolo\` 가 자동 반영. 단 테스트 assertion 이 \"gemini --prompt\" substring 을 expect → 실제 출력 \"gemini --yolo --prompt ...\" 로 match 실패.

- assertion 을 \"gemini --yolo --prompt\" 로 업데이트, 동작 변경 없음

## Test plan

- [x] \`node --test tests/unit/backend.test.mjs tests/unit/autoresearch.test.mjs\` 40/40 pass
- [x] \`node --test tests/unit/routing-qa.test.mjs\` 49/49 pass
- [x] 전체 unit suite (swarm-hypervisor 제외) 2307/2310 pass, 0 fail, 3 skipped (\`#110\` hang 은 기존 이슈)
- [x] \`npm run release:check-mirror\` OK
- [ ] \`tfx review HEAD~2..HEAD\` Codex cross-review

Refs: 세션 15 체크포인트 회귀 점검. 다음 단계 release 10.13.0 준비.