### PR TITLE
fix(config): permanent guard against codex config.toml reset

### DIFF
--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -57,8 +57,40 @@ const REQUIRED_CODEX_PROFILES = [
     lines: ['model = "gpt-5.3-codex"', 'model_reasoning_effort = "xhigh"'],
   },
   {
+    name: "codex53_med",
+    lines: ['model = "gpt-5.3-codex"', 'model_reasoning_effort = "medium"'],
+  },
+  {
     name: "spark53_low",
     lines: ['model = "gpt-5.3-codex-spark"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "spark53_med",
+    lines: ['model = "gpt-5.3-codex-spark"', 'model_reasoning_effort = "medium"'],
+  },
+  {
+    name: "gpt54_xhigh",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "xhigh"'],
+  },
+  {
+    name: "gpt54_high",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "high"'],
+  },
+  {
+    name: "gpt54_low",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "mini54_low",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "mini54_med",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "medium"'],
+  },
+  {
+    name: "mini54_high",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "high"'],
   },
 ];
 
@@ -556,6 +588,15 @@ function ensureCodexHubServerConfig({
   }
 }
 
+// Top-level config.toml keys that must exist with these defaults.
+// Only injected when the key is completely absent — existing user values are
+// never overwritten, regardless of what value was set.
+const REQUIRED_TOP_LEVEL_SETTINGS = [
+  { key: "model", value: '"gpt-5.4"' },
+  { key: "model_reasoning_effort", value: '"high"' },
+  { key: "service_tier", value: '"fast"' },
+];
+
 function ensureCodexProfiles() {
   try {
     if (!existsSync(CODEX_DIR)) mkdirSync(CODEX_DIR, { recursive: true });
@@ -564,9 +605,45 @@ function ensureCodexProfiles() {
       ? readFileSync(CODEX_CONFIG_PATH, "utf8")
       : "";
 
+    // Safety guard: if the file exists but is suspiciously small (< 100 bytes)
+    // skip all writes to avoid perpetuating a corrupted state.
+    if (original.length > 0 && original.length < 100) {
+      process.stderr.write(
+        `[tfx-setup] config.toml 크기 이상 (${original.length} bytes) — 쓰기 스킵. 수동 확인 필요: ${CODEX_CONFIG_PATH}\n`,
+      );
+      return { ok: false, changed: 0, message: "config too small, skipped" };
+    }
+
     let updated = original;
     let changed = 0;
 
+    // ── 1. top-level 필수 설정 주입 (없을 때만, 기존 값 보존) ──
+    // 파일 상단 [profiles.*] / [mcp_servers.*] 이전 영역만 검사한다.
+    // 프로필 섹션 내부의 동명 키(예: model = "gpt-5.3-codex")는 무시한다.
+    // 이미 존재하는 키는 절대 덮어쓰지 않는다.
+    for (const { key, value } of REQUIRED_TOP_LEVEL_SETTINGS) {
+      // top-level 영역 = 첫 번째 [profiles.*] / [mcp_servers.*] 헤더 이전
+      const firstSectionIdx = updated.search(/^\[(?:profiles|mcp_servers)\./m);
+      const topLevelRegion =
+        firstSectionIdx === -1 ? updated : updated.slice(0, firstSectionIdx);
+      const topLevelKeyRe = new RegExp(`^${key}\\s*=`, "m");
+      if (!topLevelKeyRe.test(topLevelRegion)) {
+        // firstSectionIdx already computed above for this iteration
+        const line = `${key} = ${value}\n`;
+        if (firstSectionIdx === -1) {
+          // 섹션이 없으면 파일 맨 앞에 추가
+          updated = line + updated;
+        } else {
+          updated =
+            updated.slice(0, firstSectionIdx) +
+            line +
+            updated.slice(firstSectionIdx);
+        }
+        changed++;
+      }
+    }
+
+    // ── 2. 필수 프로필 보장 ──
     for (const profile of REQUIRED_CODEX_PROFILES) {
       const desired = `[profiles.${profile.name}]\n${profile.lines.join("\n")}\n`;
 
@@ -898,6 +975,7 @@ export {
   LEGACY_CODEX_MODELS,
   PLUGIN_ROOT,
   REQUIRED_CODEX_PROFILES,
+  REQUIRED_TOP_LEVEL_SETTINGS,
   readMarker,
   replaceProfileSection,
   SETUP_MARKER_PATH,

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1445,6 +1445,14 @@ _codex_config_swap() {
       return 0
     fi
 
+    # Pre-validation: config.toml이 500 bytes 미만이면 이미 손상된 상태일 수 있음 — 스킵
+    local config_size
+    config_size=$(wc -c < "$config" 2>/dev/null | tr -d ' ') || config_size=0
+    if [[ "$config_size" -lt 500 ]]; then
+      echo "[tfx-route] 경고: config.toml 크기 ${config_size} bytes — 손상 의심, swap 스킵 (수동 확인 필요)" >&2
+      return 0
+    fi
+
     # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 건드리지 않음)
     if [[ -f "$backup" ]]; then
       echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 ($backup)" >&2
@@ -1454,6 +1462,7 @@ _codex_config_swap() {
 
     # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지.
     # keep="" 은 진입 가드에서 return 됐지만 defense-in-depth 유지.
+    local tmp_filtered="${config}.filter.$$"
     awk -v keep="$allowed_pat" '
       BEGIN { skip=0 }
       /^\[mcp_servers\./ {
@@ -1464,7 +1473,26 @@ _codex_config_swap() {
       }
       /^\[/ && !/^\[mcp_servers\./ { skip=0 }
       !skip { print }
-    ' "$backup" > "$config"
+    ' "$backup" > "$tmp_filtered"
+
+    # Output sanity check: 필터 결과가 비었거나 백업의 30% 미만이면 적용 거부
+    local filtered_size backup_size threshold
+    filtered_size=$(wc -c < "$tmp_filtered" 2>/dev/null | tr -d ' ') || filtered_size=0
+    backup_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_size=1
+    threshold=$(( backup_size * 30 / 100 ))
+    if [[ "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ]]; then
+      echo "[tfx-route] 경고: 필터 결과 크기 ${filtered_size} bytes (백업 ${backup_size} bytes의 30% 미만) — 적용 거부, 백업에서 복원" >&2
+      rm -f "$tmp_filtered" 2>/dev/null
+      rm -f "$backup" 2>/dev/null
+      return 1
+    fi
+
+    # 검증 통과 — atomic rename으로 적용
+    if ! mv "$tmp_filtered" "$config"; then
+      echo "[tfx-route] 경고: 필터 결과 적용 실패 (atomic rename), 백업 보존: $backup" >&2
+      rm -f "$tmp_filtered" 2>/dev/null
+      return 1
+    fi
 
     local kept
     kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
@@ -1475,6 +1503,15 @@ _codex_config_swap() {
     # `cat > $config` 는 cat 실행 전에 dest 가 truncate 되어 mid-stream 실패 시
     # 빈/부분 파일이 남는다. 같은 디렉토리 내 mv 는 POSIX 상 atomic 이므로
     # 실패해도 기존 config 와 backup 모두 보존된다.
+
+    # Restore sanity check: 백업 자체가 비었거나 500 bytes 미만이면 복원 중단
+    local backup_restore_size
+    backup_restore_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_size=0
+    if [[ "$backup_restore_size" -lt 500 ]]; then
+      echo "[tfx-route] 경고: backup 크기 ${backup_restore_size} bytes — 손상 의심, 복원 중단. 수동 확인 필요: $backup" >&2
+      return 1
+    fi
+
     local tmp="${config}.restore.$$"
     if ! cp "$backup" "$tmp"; then
       echo "[tfx-route] 경고: config.toml 복원 실패 (temp copy). backup 보존: $backup" >&2

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -57,8 +57,40 @@ const REQUIRED_CODEX_PROFILES = [
     lines: ['model = "gpt-5.3-codex"', 'model_reasoning_effort = "xhigh"'],
   },
   {
+    name: "codex53_med",
+    lines: ['model = "gpt-5.3-codex"', 'model_reasoning_effort = "medium"'],
+  },
+  {
     name: "spark53_low",
     lines: ['model = "gpt-5.3-codex-spark"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "spark53_med",
+    lines: ['model = "gpt-5.3-codex-spark"', 'model_reasoning_effort = "medium"'],
+  },
+  {
+    name: "gpt54_xhigh",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "xhigh"'],
+  },
+  {
+    name: "gpt54_high",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "high"'],
+  },
+  {
+    name: "gpt54_low",
+    lines: ['model = "gpt-5.4"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "mini54_low",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "low"'],
+  },
+  {
+    name: "mini54_med",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "medium"'],
+  },
+  {
+    name: "mini54_high",
+    lines: ['model = "gpt-5.4-mini"', 'model_reasoning_effort = "high"'],
   },
 ];
 
@@ -556,6 +588,15 @@ function ensureCodexHubServerConfig({
   }
 }
 
+// Top-level config.toml keys that must exist with these defaults.
+// Only injected when the key is completely absent — existing user values are
+// never overwritten, regardless of what value was set.
+const REQUIRED_TOP_LEVEL_SETTINGS = [
+  { key: "model", value: '"gpt-5.4"' },
+  { key: "model_reasoning_effort", value: '"high"' },
+  { key: "service_tier", value: '"fast"' },
+];
+
 function ensureCodexProfiles() {
   try {
     if (!existsSync(CODEX_DIR)) mkdirSync(CODEX_DIR, { recursive: true });
@@ -564,9 +605,45 @@ function ensureCodexProfiles() {
       ? readFileSync(CODEX_CONFIG_PATH, "utf8")
       : "";
 
+    // Safety guard: if the file exists but is suspiciously small (< 100 bytes)
+    // skip all writes to avoid perpetuating a corrupted state.
+    if (original.length > 0 && original.length < 100) {
+      process.stderr.write(
+        `[tfx-setup] config.toml 크기 이상 (${original.length} bytes) — 쓰기 스킵. 수동 확인 필요: ${CODEX_CONFIG_PATH}\n`,
+      );
+      return { ok: false, changed: 0, message: "config too small, skipped" };
+    }
+
     let updated = original;
     let changed = 0;
 
+    // ── 1. top-level 필수 설정 주입 (없을 때만, 기존 값 보존) ──
+    // 파일 상단 [profiles.*] / [mcp_servers.*] 이전 영역만 검사한다.
+    // 프로필 섹션 내부의 동명 키(예: model = "gpt-5.3-codex")는 무시한다.
+    // 이미 존재하는 키는 절대 덮어쓰지 않는다.
+    for (const { key, value } of REQUIRED_TOP_LEVEL_SETTINGS) {
+      // top-level 영역 = 첫 번째 [profiles.*] / [mcp_servers.*] 헤더 이전
+      const firstSectionIdx = updated.search(/^\[(?:profiles|mcp_servers)\./m);
+      const topLevelRegion =
+        firstSectionIdx === -1 ? updated : updated.slice(0, firstSectionIdx);
+      const topLevelKeyRe = new RegExp(`^${key}\\s*=`, "m");
+      if (!topLevelKeyRe.test(topLevelRegion)) {
+        // firstSectionIdx already computed above for this iteration
+        const line = `${key} = ${value}\n`;
+        if (firstSectionIdx === -1) {
+          // 섹션이 없으면 파일 맨 앞에 추가
+          updated = line + updated;
+        } else {
+          updated =
+            updated.slice(0, firstSectionIdx) +
+            line +
+            updated.slice(firstSectionIdx);
+        }
+        changed++;
+      }
+    }
+
+    // ── 2. 필수 프로필 보장 ──
     for (const profile of REQUIRED_CODEX_PROFILES) {
       const desired = `[profiles.${profile.name}]\n${profile.lines.join("\n")}\n`;
 
@@ -898,6 +975,7 @@ export {
   LEGACY_CODEX_MODELS,
   PLUGIN_ROOT,
   REQUIRED_CODEX_PROFILES,
+  REQUIRED_TOP_LEVEL_SETTINGS,
   readMarker,
   replaceProfileSection,
   SETUP_MARKER_PATH,

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1445,6 +1445,14 @@ _codex_config_swap() {
       return 0
     fi
 
+    # Pre-validation: config.toml이 500 bytes 미만이면 이미 손상된 상태일 수 있음 — 스킵
+    local config_size
+    config_size=$(wc -c < "$config" 2>/dev/null | tr -d ' ') || config_size=0
+    if [[ "$config_size" -lt 500 ]]; then
+      echo "[tfx-route] 경고: config.toml 크기 ${config_size} bytes — 손상 의심, swap 스킵 (수동 확인 필요)" >&2
+      return 0
+    fi
+
     # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 건드리지 않음)
     if [[ -f "$backup" ]]; then
       echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 ($backup)" >&2
@@ -1454,6 +1462,7 @@ _codex_config_swap() {
 
     # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지.
     # keep="" 은 진입 가드에서 return 됐지만 defense-in-depth 유지.
+    local tmp_filtered="${config}.filter.$$"
     awk -v keep="$allowed_pat" '
       BEGIN { skip=0 }
       /^\[mcp_servers\./ {
@@ -1464,7 +1473,26 @@ _codex_config_swap() {
       }
       /^\[/ && !/^\[mcp_servers\./ { skip=0 }
       !skip { print }
-    ' "$backup" > "$config"
+    ' "$backup" > "$tmp_filtered"
+
+    # Output sanity check: 필터 결과가 비었거나 백업의 30% 미만이면 적용 거부
+    local filtered_size backup_size threshold
+    filtered_size=$(wc -c < "$tmp_filtered" 2>/dev/null | tr -d ' ') || filtered_size=0
+    backup_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_size=1
+    threshold=$(( backup_size * 30 / 100 ))
+    if [[ "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ]]; then
+      echo "[tfx-route] 경고: 필터 결과 크기 ${filtered_size} bytes (백업 ${backup_size} bytes의 30% 미만) — 적용 거부, 백업에서 복원" >&2
+      rm -f "$tmp_filtered" 2>/dev/null
+      rm -f "$backup" 2>/dev/null
+      return 1
+    fi
+
+    # 검증 통과 — atomic rename으로 적용
+    if ! mv "$tmp_filtered" "$config"; then
+      echo "[tfx-route] 경고: 필터 결과 적용 실패 (atomic rename), 백업 보존: $backup" >&2
+      rm -f "$tmp_filtered" 2>/dev/null
+      return 1
+    fi
 
     local kept
     kept=$(echo "$allowed_pat" | tr '|' '\n' | wc -l | tr -d ' ')
@@ -1475,6 +1503,15 @@ _codex_config_swap() {
     # `cat > $config` 는 cat 실행 전에 dest 가 truncate 되어 mid-stream 실패 시
     # 빈/부분 파일이 남는다. 같은 디렉토리 내 mv 는 POSIX 상 atomic 이므로
     # 실패해도 기존 config 와 backup 모두 보존된다.
+
+    # Restore sanity check: 백업 자체가 비었거나 500 bytes 미만이면 복원 중단
+    local backup_restore_size
+    backup_restore_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_size=0
+    if [[ "$backup_restore_size" -lt 500 ]]; then
+      echo "[tfx-route] 경고: backup 크기 ${backup_restore_size} bytes — 손상 의심, 복원 중단. 수동 확인 필요: $backup" >&2
+      return 1
+    fi
+
     local tmp="${config}.restore.$$"
     if ! cp "$backup" "$tmp"; then
       echo "[tfx-route] 경고: config.toml 복원 실패 (temp copy). backup 보존: $backup" >&2

--- a/tests/unit/setup-codex-profiles.test.mjs
+++ b/tests/unit/setup-codex-profiles.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, "..", "..");
+
+const {
+  ensureCodexProfiles,
+  hasProfileSection,
+  REQUIRED_CODEX_PROFILES,
+  REQUIRED_TOP_LEVEL_SETTINGS,
+} = await import("../../scripts/setup.mjs");
+
+// ── helpers ──
+
+const TMP_DIR = join(PROJECT_ROOT, "tests", ".tmp-codex-profiles");
+
+function ensureTmpDir() {
+  if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+}
+
+function cleanTmpDir() {
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true });
+}
+
+/**
+ * Patch the module-level CODEX paths so ensureCodexProfiles writes to a temp
+ * directory instead of the real ~/.codex/config.toml.
+ */
+function withTempCodex(configContent, fn) {
+  const fakeCodexDir = join(TMP_DIR, `codex-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(fakeCodexDir, { recursive: true });
+  const configPath = join(fakeCodexDir, "config.toml");
+  if (configContent !== null) {
+    writeFileSync(configPath, configContent, "utf8");
+  }
+  return { fakeCodexDir, configPath };
+}
+
+// ── REQUIRED_CODEX_PROFILES 확장 확인 ──
+
+describe("REQUIRED_CODEX_PROFILES: 확장된 프로필 목록 검증", () => {
+  const requiredNames = [
+    "codex53_high",
+    "codex53_xhigh",
+    "codex53_med",
+    "spark53_low",
+    "spark53_med",
+    "gpt54_xhigh",
+    "gpt54_high",
+    "gpt54_low",
+    "mini54_low",
+    "mini54_med",
+    "mini54_high",
+  ];
+
+  for (const name of requiredNames) {
+    it(`REQUIRED_CODEX_PROFILES에 ${name} 이 포함되어야 한다`, () => {
+      const found = REQUIRED_CODEX_PROFILES.some((p) => p.name === name);
+      assert.ok(found, `${name} not found in REQUIRED_CODEX_PROFILES`);
+    });
+  }
+
+  it("각 프로필에 name과 lines 필드가 있어야 한다", () => {
+    for (const p of REQUIRED_CODEX_PROFILES) {
+      assert.ok(typeof p.name === "string" && p.name.length > 0, `profile missing name`);
+      assert.ok(Array.isArray(p.lines) && p.lines.length > 0, `profile ${p.name} missing lines`);
+    }
+  });
+});
+
+// ── REQUIRED_TOP_LEVEL_SETTINGS 검증 ──
+
+describe("REQUIRED_TOP_LEVEL_SETTINGS: 필수 top-level 설정 목록", () => {
+  it("model, model_reasoning_effort, service_tier 가 포함되어야 한다", () => {
+    const keys = REQUIRED_TOP_LEVEL_SETTINGS.map((s) => s.key);
+    assert.ok(keys.includes("model"), "model missing");
+    assert.ok(keys.includes("model_reasoning_effort"), "model_reasoning_effort missing");
+    assert.ok(keys.includes("service_tier"), "service_tier missing");
+  });
+
+  it("model 기본값은 gpt-5.4", () => {
+    const entry = REQUIRED_TOP_LEVEL_SETTINGS.find((s) => s.key === "model");
+    assert.ok(entry?.value.includes("gpt-5.4"), `unexpected model default: ${entry?.value}`);
+  });
+
+  it("service_tier 기본값은 fast", () => {
+    const entry = REQUIRED_TOP_LEVEL_SETTINGS.find((s) => s.key === "service_tier");
+    assert.ok(entry?.value.includes("fast"), `unexpected service_tier default: ${entry?.value}`);
+  });
+});
+
+// ── ensureCodexProfiles: top-level 주입 동작 ──
+// Note: ensureCodexProfiles writes to the real CODEX_CONFIG_PATH which is
+// module-level. These tests verify the logic via hasProfileSection on the
+// content that ensureCodexProfiles would produce, using a real temp file
+// approach by temporarily swapping environment via monkey-patching the path.
+// Since the module path is hardcoded, we test the pure helper logic instead.
+
+describe("hasProfileSection: 프로필 섹션 감지", () => {
+  it("존재하는 프로필 섹션을 감지한다", () => {
+    const content = '[profiles.gpt54_high]\nmodel = "gpt-5.4"\nmodel_reasoning_effort = "high"\n';
+    assert.equal(hasProfileSection(content, "gpt54_high"), true);
+  });
+
+  it("존재하지 않는 프로필 섹션은 false를 반환한다", () => {
+    const content = '[profiles.codex53_high]\nmodel = "gpt-5.3-codex"\n';
+    assert.equal(hasProfileSection(content, "gpt54_high"), false);
+  });
+
+  it("부분 일치는 false를 반환한다 (gpt54 vs gpt54_high)", () => {
+    const content = '[profiles.gpt54]\nmodel = "gpt-5.4"\n';
+    assert.equal(hasProfileSection(content, "gpt54_high"), false);
+  });
+});
+
+// ── top-level 주입 로직 검증 (순수 함수 수준) ──
+
+describe("top-level 설정 주입 로직: 없으면 주입, 있으면 보존", () => {
+  it("top-level 영역(첫 섹션 전)에 model이 없으면 주입 대상으로 판정된다", () => {
+    const content = '[profiles.codex53_high]\nmodel = "gpt-5.3-codex"\n';
+    // top-level 영역 = 첫 번째 [profiles.*] 헤더 이전
+    const firstSectionIdx = content.search(/^\[(?:profiles|mcp_servers)\./m);
+    const topLevelRegion = firstSectionIdx === -1 ? content : content.slice(0, firstSectionIdx);
+    const topLevelKeyRe = /^model\s*=/m;
+    assert.equal(topLevelKeyRe.test(topLevelRegion), false,
+      "top-level region before first section should not contain model=");
+  });
+
+  it("top-level model= 이 있으면 보존 대상으로 판정된다", () => {
+    const content = 'model = "gpt-5.4"\nservice_tier = "fast"\n\n[profiles.codex53_high]\nmodel = "gpt-5.3-codex"\n';
+    const topLevelKeyRe = /^model\s*=/m;
+    assert.equal(topLevelKeyRe.test(content), true, "should find top-level model=");
+  });
+
+  it("프로필 내부 model= 은 top-level로 오인되지 않는다", () => {
+    // 프로필 섹션 안의 model=은 top-level key 탐지에서 제외되어야 한다.
+    // 현재 regex는 ^model\s*= (multiline)이므로 섹션 헤더 다음 줄도 매칭될 수 있다.
+    // 이 테스트는 top-level에 model= 이 없고 프로필에만 있는 케이스를 문서화한다.
+    const contentWithoutTopLevel = '[profiles.codex53_high]\nmodel = "gpt-5.3-codex"\n';
+    // regex matches any line starting with "model" — including inside profiles.
+    // The injection logic relies on the caller to check BEFORE the first section header.
+    // Here we just document the known behavior: the regex WILL match the profile-internal model=.
+    // The actual ensureCodexProfiles logic inserts before the first [profiles.*] section,
+    // so if top-level model= is absent, the regex test against the full content may still
+    // return true due to profile-internal lines. This is a known limitation documented here.
+    // The real protection is: inject only if the key is absent from the region BEFORE any section.
+    const topLevelKeyRe = /^model\s*=/m;
+    // This assertion documents that the regex matches inside profiles too (known behavior)
+    assert.equal(topLevelKeyRe.test(contentWithoutTopLevel), true,
+      "regex matches model= inside profiles — known limitation, acceptable since profiles come after top-level region");
+  });
+
+  it("top-level 삽입 로직: 첫 섹션 앞에 키를 삽입한다", () => {
+    const content = '[profiles.codex53_high]\nmodel = "gpt-5.3-codex"\n';
+    const key = "service_tier";
+    const value = '"fast"';
+    const line = `${key} = ${value}\n`;
+    const firstSectionIdx = content.search(/^\[(?:profiles|mcp_servers)\./m);
+    const injected = content.slice(0, firstSectionIdx) + line + content.slice(firstSectionIdx);
+    assert.ok(injected.startsWith(`${key} = ${value}`), "key should be inserted at top");
+    assert.ok(injected.includes('[profiles.codex53_high]'), "profile section preserved");
+  });
+});
+
+// ── config.toml 크기 가드 ──
+
+describe("ensureCodexProfiles: 손상 파일 가드", () => {
+  before(ensureTmpDir);
+  after(cleanTmpDir);
+
+  it("REQUIRED_CODEX_PROFILES 리스트가 비어 있지 않다", () => {
+    assert.ok(REQUIRED_CODEX_PROFILES.length >= 3, "need at least 3 profiles");
+  });
+
+  it("REQUIRED_TOP_LEVEL_SETTINGS 리스트가 비어 있지 않다", () => {
+    assert.ok(REQUIRED_TOP_LEVEL_SETTINGS.length >= 3, "need at least 3 top-level settings");
+  });
+});


### PR DESCRIPTION
## 원인 분석

`SessionStart` 훅 → `session-start-fast.mjs` → `setup.runCritical()` → `ensureCriticalSetup()` → `ensureCodexProfiles()` 경로가 **세션 시작마다** 실행된다.

두 가지 손상 경로가 확인됨:

1. **setup.mjs** (`ensureCodexProfiles`): `REQUIRED_CODEX_PROFILES`에 3개 프로필만 있어서 `gpt54_*`·`mini54_*` 프로필은 재생성되지 않음. 또한 top-level `model`/`service_tier`/`model_reasoning_effort` 키 보호 로직이 없어서, `_codex_config_swap`이 config를 손상시킨 후 다음 세션에 이 값들이 누락된 채 방치됨.

2. **tfx-route.sh** (`_codex_config_swap`): awk 필터 결과를 검증 없이 `> $config`로 직접 write. 결과가 비거나 비정상적으로 작아도 그대로 적용됨 → config 영구 손상.

## 변경 내용

### scripts/setup.mjs + packages/triflux/scripts/setup.mjs

- `REQUIRED_CODEX_PROFILES` 3개 → 11개로 확장: `gpt54_xhigh`, `gpt54_high`, `gpt54_low`, `mini54_low`, `mini54_med`, `mini54_high`, `codex53_med`, `spark53_med` 추가
- `REQUIRED_TOP_LEVEL_SETTINGS` 상수 신설: `model="gpt-5.4"`, `model_reasoning_effort="high"`, `service_tier="fast"` — top-level 영역(첫 섹션 헤더 이전)에 키가 없을 때만 주입, 기존 값은 절대 덮어쓰지 않음
- size guard: config.toml이 100 bytes 미만이면 모든 쓰기 스킵

### scripts/tfx-route.sh + packages/triflux/scripts/tfx-route.sh

- filter 전 pre-validation: config.toml < 500 bytes이면 swap 스킵
- awk 출력을 tmp 파일에 저장 후 크기 검증 (0이거나 백업의 30% 미만이면 적용 거부)
- tmp → config atomic mv로 교체
- restore 시 backup < 500 bytes이면 복원 중단

### tests/unit/setup-codex-profiles.test.mjs (신규)

24/24 tests pass.

## 미결 사항

- `gpt54_med` 프로필 없음 — 필요 시 추가 가능 (`gpt54_high`/`gpt54_low`로 현재 커버)
- `oh-my-codex` 업데이트 후 MCP tool approval_mode 복원 문제는 별도 이슈