### PR TITLE
fix(tfx-route): stale config.toml.pre-exec cleanup + heartbeat stall kill (#144/#66)

### DIFF
--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1361,8 +1361,16 @@ heartbeat_monitor() {
             _grace_waited=$((_grace_waited + 1))
           done
           if kill -0 "$pid" 2>/dev/null; then
-            echo "[tfx-heartbeat] pid=$pid SIGTERM 무시 — SIGKILL 강제" >&2
-            kill -KILL "$pid" 2>/dev/null || true
+            # Windows/MSYS: POSIX SIGKILL 이 Win32 자식 트리까지 닿지 않는다.
+            # cleanup_workers 와 동일하게 taskkill /T /F 로 트리 종료.
+            case "$(uname -s)" in
+              MINGW*|MSYS*)
+                echo "[tfx-heartbeat] pid=$pid SIGTERM 무시 — taskkill /T /F" >&2
+                MSYS_NO_PATHCONV=1 cmd.exe //c "taskkill /T /F /PID $pid" 2>/dev/null || true ;;
+              *)
+                echo "[tfx-heartbeat] pid=$pid SIGTERM 무시 — SIGKILL 강제" >&2
+                kill -KILL "$pid" 2>/dev/null || true ;;
+            esac
           fi
           break
         fi
@@ -1471,27 +1479,51 @@ _codex_config_swap() {
       return 0
     fi
 
-    # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 단, stale lock 은 자동 정리)
+    # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 단, owner-dead + 백업 안전 복원 시 이어받기)
     if [[ -f "$backup" ]]; then
-      # Stale detection (#144/#66 regression guard): crash/stall 로 lock 이 남은 경우,
-      # 후속 워커가 무한정 MCP 없이 돌아가는 것을 막는다. 기본 5분, env override 가능.
-      local stale_min="${TFX_CONFIG_LOCK_STALE_MIN:-5}"
-      local now_epoch backup_mtime age_s
-      now_epoch=$(date +%s)
-      backup_mtime=$(stat -c %Y "$backup" 2>/dev/null || stat -f %m "$backup" 2>/dev/null || echo "$now_epoch")
-      age_s=$((now_epoch - backup_mtime))
-      if [[ "$age_s" -ge $((stale_min * 60)) ]]; then
-        echo "[tfx-route] stale config.toml.pre-exec 감지 (age=${age_s}s ≥ ${stale_min}m) — 자동 제거 후 swap 진행" >&2
-        if ! rm -f "$backup"; then
-          echo "[tfx-route] 경고: stale backup 제거 실패 — swap 스킵" >&2
-          return 0
+      # Owner PID marker (P1 fix): mtime 만으로 stale 을 판정하면 장시간 정상 실행 워커도 오탐.
+      # $backup.owner 에 생성 워커 PID 기록 → kill -0 로 alive 확인. PID 파일 없거나 죽었으면 stale.
+      # mtime 은 신뢰성 낮아 soft 보조 지표로만 사용 (owner 파일 유실 대비 fallback).
+      local owner_file="${backup}.owner"
+      local owner_alive=false
+      local owner_pid=""
+      if [[ -f "$owner_file" ]]; then
+        owner_pid=$(cat "$owner_file" 2>/dev/null | tr -d '[:space:]')
+        if [[ -n "$owner_pid" ]] && kill -0 "$owner_pid" 2>/dev/null; then
+          owner_alive=true
         fi
-      else
-        echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 (age=${age_s}s, $backup)" >&2
+      fi
+
+      if [[ "$owner_alive" == "true" ]]; then
+        echo "[tfx-route] config.toml swap 스킵: 소유 워커 살아있음 (pid=$owner_pid, $backup)" >&2
         return 0
       fi
+
+      # Owner dead or unknown — stale 후보. 다만 backup-loss 방지를 위해 원본 복원 먼저.
+      # P2 fix: `rm -f $backup` 후 현재 config 를 새 backup 으로 cp 하면, 이전 워커가 이미
+      # filter 한 상태에서 crash 했을 때 원본이 영구 소실. 여기서 먼저 restore 를 시도해
+      # backup 이 원본을 담고 있는 한 그것을 살린다.
+      local backup_restore_guard_size
+      backup_restore_guard_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_guard_size=0
+      if [[ "$backup_restore_guard_size" -lt 500 ]]; then
+        # 작은 backup 은 이미 손상된 state. 현재 config 도 필터된 상태일 수 있으므로
+        # 추가 swap 은 상황을 악화시킬 위험. 전체 스킵하고 수동 확인 유도.
+        echo "[tfx-route] stale backup 작음 (size=${backup_restore_guard_size}B, pid=${owner_pid:-?} dead) — swap 스킵, 수동 확인: $backup" >&2
+        return 0
+      fi
+      local stale_tmp="${config}.stale-restore.$$"
+      if cp "$backup" "$stale_tmp" && mv "$stale_tmp" "$config"; then
+        echo "[tfx-route] stale backup 감지 (pid=${owner_pid:-?} dead) — 원본 복원 후 swap 재진행" >&2
+      else
+        echo "[tfx-route] 경고: stale backup 복원 실패, swap 스킵 (수동 확인: $backup)" >&2
+        rm -f "$stale_tmp" 2>/dev/null
+        return 0
+      fi
+      rm -f "$backup" "$owner_file" 2>/dev/null || true
     fi
     cp "$config" "$backup"
+    # Owner marker: 이 워커가 backup 소유자임을 기록. 다음 워커의 stale detection 기준.
+    echo "$$" > "${backup}.owner" 2>/dev/null || true
 
     # awk로 필터링: 비허용 MCP 서버 섹션 제거, 나머지 그대로 유지.
     # keep="" 은 진입 가드에서 return 됐지만 defense-in-depth 유지.
@@ -1559,6 +1591,7 @@ _codex_config_swap() {
     if ! rm -f "$backup"; then
       echo "[tfx-route] 경고: backup 삭제 실패: $backup (수동 정리 필요)" >&2
     fi
+    rm -f "${backup}.owner" 2>/dev/null || true
     echo "[tfx-route] config.toml 복원 완료" >&2
   fi
 }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1348,6 +1348,24 @@ heartbeat_monitor() {
           echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=draining(${post_exit_checks}/${max_post_exit_checks})" >&2
         fi
       elif [[ "$stall_count" -ge "$stall_threshold" ]]; then
+        # STALL kill (#144/#66 regression guard): stall=threshold+grace 이상 지속 시 SIGTERM→SIGKILL.
+        # 기본 활성화. TFX_STALL_KILL=0 으로 opt-out. grace=30s (기본) 은 SSE/MCP 정상 handshake 여유.
+        local kill_on_stall="${TFX_STALL_KILL:-1}"
+        local kill_grace="${TFX_STALL_KILL_GRACE:-30}"
+        if [[ "$kill_on_stall" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
+          kill -TERM "$pid" 2>/dev/null || true
+          local _grace_waited=0
+          while kill -0 "$pid" 2>/dev/null && [[ "$_grace_waited" -lt 5 ]]; do
+            sleep 1
+            _grace_waited=$((_grace_waited + 1))
+          done
+          if kill -0 "$pid" 2>/dev/null; then
+            echo "[tfx-heartbeat] pid=$pid SIGTERM 무시 — SIGKILL 강제" >&2
+            kill -KILL "$pid" 2>/dev/null || true
+          fi
+          break
+        fi
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL stall=${stall_count}s" >&2
       else
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=quiet stall=${stall_count}s" >&2
@@ -1453,10 +1471,25 @@ _codex_config_swap() {
       return 0
     fi
 
-    # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 건드리지 않음)
+    # 백업 생성 (이미 있으면 다른 워커가 swap 중 — 단, stale lock 은 자동 정리)
     if [[ -f "$backup" ]]; then
-      echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 ($backup)" >&2
-      return 0
+      # Stale detection (#144/#66 regression guard): crash/stall 로 lock 이 남은 경우,
+      # 후속 워커가 무한정 MCP 없이 돌아가는 것을 막는다. 기본 5분, env override 가능.
+      local stale_min="${TFX_CONFIG_LOCK_STALE_MIN:-5}"
+      local now_epoch backup_mtime age_s
+      now_epoch=$(date +%s)
+      backup_mtime=$(stat -c %Y "$backup" 2>/dev/null || stat -f %m "$backup" 2>/dev/null || echo "$now_epoch")
+      age_s=$((now_epoch - backup_mtime))
+      if [[ "$age_s" -ge $((stale_min * 60)) ]]; then
+        echo "[tfx-route] stale config.toml.pre-exec 감지 (age=${age_s}s ≥ ${stale_min}m) — 자동 제거 후 swap 진행" >&2
+        if ! rm -f "$backup"; then
+          echo "[tfx-route] 경고: stale backup 제거 실패 — swap 스킵" >&2
+          return 0
+        fi
+      else
+        echo "[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 (age=${age_s}s, $backup)" >&2
+        return 0
+      fi
     fi
     cp "$config" "$backup"
 

--- a/tests/unit/tfx-route-config-swap.test.mjs
+++ b/tests/unit/tfx-route-config-swap.test.mjs
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -79,17 +80,41 @@ describe("BUG-H _codex_config_swap fail-safe", () => {
     }
   });
 
+  // 500 bytes 미만은 'config.toml 손상 의심' 가드에 걸리므로 padding 섹션을 채운 fixture.
+  // (v10.13.0 에서 size guard 가 추가되면서 기존 165 bytes fixture 가 정상 경로를 타지 못함.)
   const baseToml = [
     'model = "gpt-5.3"',
+    'approval_mode = "auto"',
+    'sandbox = "workspace-write"',
     "",
     "[mcp_servers.tfx-hub]",
     'url = "http://127.0.0.1:27888/mcp"',
+    'description = "triflux hub MCP server for cross-CLI messaging"',
     "",
     "[mcp_servers.context7]",
     'command = "npx"',
+    'args = ["-y", "@upstash/context7-mcp@latest"]',
+    "",
+    "[mcp_servers.exa]",
+    'command = "npx"',
+    'args = ["-y", "exa-mcp-server"]',
+    'env = { EXA_API_KEY = "placeholder-key-for-test-fixture-padding" }',
+    "",
+    "[mcp_servers.tavily]",
+    'command = "npx"',
+    'args = ["-y", "@modelcontextprotocol/server-tavily"]',
     "",
     "[profiles.codex53_high]",
     'model = "gpt-5.3-codex"',
+    'model_reasoning_effort = "high"',
+    "",
+    "[profiles.codex53_low]",
+    'model = "gpt-5.3-codex"',
+    'model_reasoning_effort = "low"',
+    "",
+    "[profiles.gpt54_xhigh]",
+    'model = "gpt-5.4"',
+    'model_reasoning_effort = "high"',
     "",
   ].join("\n");
 
@@ -186,5 +211,126 @@ _codex_config_swap filter
       "기존 backup 보존",
     );
     assert.match(result.stderr, /다른 워커가 사용 중/);
+  });
+});
+
+describe("#144/#66 stale lock auto-cleanup", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  // 500 bytes 미만은 'config.toml 손상 의심' 가드에 걸리므로 padding 섹션을 채운 실제 크기의 fixture.
+  const baseToml = [
+    'model = "gpt-5.3"',
+    'approval_mode = "auto"',
+    'sandbox = "workspace-write"',
+    "",
+    "[mcp_servers.tfx-hub]",
+    'url = "http://127.0.0.1:27888/mcp"',
+    'description = "triflux hub MCP server for cross-CLI messaging"',
+    "",
+    "[mcp_servers.context7]",
+    'command = "npx"',
+    'args = ["-y", "@upstash/context7-mcp@latest"]',
+    "",
+    "[mcp_servers.exa]",
+    'command = "npx"',
+    'args = ["-y", "exa-mcp-server"]',
+    'env = { EXA_API_KEY = "placeholder-key-for-test-fixture-padding" }',
+    "",
+    "[mcp_servers.tavily]",
+    'command = "npx"',
+    'args = ["-y", "@modelcontextprotocol/server-tavily"]',
+    "",
+    "[profiles.codex53_high]",
+    'model = "gpt-5.3-codex"',
+    'model_reasoning_effort = "high"',
+    "",
+    "[profiles.codex53_low]",
+    'model = "gpt-5.3-codex"',
+    'model_reasoning_effort = "low"',
+    "",
+    "[profiles.gpt54_xhigh]",
+    'model = "gpt-5.4"',
+    'model_reasoning_effort = "high"',
+    "",
+  ].join("\n");
+
+  function setupStaleBackup({ backupAgeSec }) {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-stale-"));
+    const config = path.join(dir, "config.toml");
+    const backup = `${config}.pre-exec`;
+    writeFileSync(config, baseToml);
+    writeFileSync(backup, "stale-backup-contents");
+    // mtime 을 과거로 강제 조정 (utimesSync sec-granular)
+    const mtimeSec = Math.floor(Date.now() / 1000) - backupAgeSec;
+    utimesSync(backup, mtimeSec, mtimeSec);
+    return { dir, config, backup };
+  }
+
+  function runFilter({ backupAgeSec, envOverride = {} }) {
+    const { dir, config, backup } = setupStaleBackup({ backupAgeSec });
+    cleanupDirs.push(dir);
+    const envExports = Object.entries(envOverride)
+      .map(([k, v]) => `export ${k}='${v}'`)
+      .join("\n");
+    const script = `
+set -u
+${envExports}
+_CODEX_CONFIG='${config}'
+CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
+${extractSwapFunction()}
+_codex_config_swap filter
+`;
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    return {
+      exitCode: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+      config: existsSync(config) ? readFileSync(config, "utf8") : null,
+      backup: existsSync(backup) ? readFileSync(backup, "utf8") : null,
+      backupExists: existsSync(backup),
+      dir,
+    };
+  }
+
+  it("stale lock (age=10분, 기본 5분 threshold 초과) 감지 후 자동 제거하고 swap 진행", () => {
+    const r = runFilter({ backupAgeSec: 600 });
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stderr, /stale config\.toml\.pre-exec 감지/);
+    assert.match(r.stderr, /age=6\d\ds/); // 6xx seconds
+    assert.match(r.stderr, /자동 제거 후 swap 진행/);
+    // 새 backup 은 원본 config 로 재생성됨 (stale 된 "stale-backup-contents" 가 아님)
+    assert.notEqual(r.backup, "stale-backup-contents", "stale backup 은 교체돼야 함");
+    assert.match(r.backup, /\[mcp_servers\.tfx-hub\]/);
+    // config 는 필터링되어 context7 제거됨
+    assert.doesNotMatch(r.config, /\[mcp_servers\.context7\]/);
+  });
+
+  it("fresh lock (age=1분) 은 건드리지 않고 기존 skip 동작 유지 (double-swap 방지)", () => {
+    const r = runFilter({ backupAgeSec: 60 });
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stderr, /다른 워커가 사용 중/);
+    assert.match(r.stderr, /age=6\ds/);
+    // Backup 은 원본 그대로, config 도 건드리지 않음
+    assert.equal(r.backup, "stale-backup-contents");
+    assert.equal(r.config, baseToml);
+    assert.doesNotMatch(r.stderr, /stale config\.toml\.pre-exec 감지/);
+  });
+
+  it("TFX_CONFIG_LOCK_STALE_MIN=1 override: age=90초면 stale 로 간주", () => {
+    const r = runFilter({
+      backupAgeSec: 90,
+      envOverride: { TFX_CONFIG_LOCK_STALE_MIN: "1" },
+    });
+    assert.equal(r.exitCode, 0);
+    assert.match(r.stderr, /stale config\.toml\.pre-exec 감지/);
+    assert.match(r.stderr, /≥ 1m/);
   });
 });

--- a/tests/unit/tfx-route-config-swap.test.mjs
+++ b/tests/unit/tfx-route-config-swap.test.mjs
@@ -8,7 +8,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -180,20 +179,29 @@ _codex_config_swap restore
     assert.match(restored.stderr, /복원 완료/);
   });
 
-  it("filter: backup 이 이미 있으면 swap 을 스킵한다 (double-swap 방지)", () => {
+  it("filter: backup + owner alive → swap 을 스킵한다 (double-swap 방지)", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "tfx-swap-"));
     cleanupDirs.push(dir);
     const config = path.join(dir, "config.toml");
     const backup = `${config}.pre-exec`;
+    const ownerFile = `${backup}.owner`;
     writeFileSync(config, baseToml);
     writeFileSync(backup, "existing-backup");
-
+    // 살아있는 owner: 현재 bash 가 shell 에서 kill -0 성공할 수 있는 PID 를 script 내부에서 확보
+    const bashConfig = config.replace(/\\/g, "/");
+    const bashOwner = ownerFile.replace(/\\/g, "/");
     const script = `
 set -u
-_CODEX_CONFIG='${config}'
+# 살아있는 helper process 를 fork → owner 파일에 그 PID 기록
+sleep 10 &
+OWNER_PID=$!
+echo "$OWNER_PID" > '${bashOwner}'
+_CODEX_CONFIG='${bashConfig}'
 CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
 ${extractSwapFunction()}
 _codex_config_swap filter
+kill "$OWNER_PID" 2>/dev/null || true
+wait "$OWNER_PID" 2>/dev/null || true
 `;
     const result = spawnSync("bash", ["-c", script], {
       encoding: "utf8",
@@ -203,18 +211,18 @@ _codex_config_swap filter
     assert.equal(
       readFileSync(config, "utf8"),
       baseToml,
-      "backup 존재 시 config 건드리지 않음",
+      "owner alive 시 config 건드리지 않음",
     );
     assert.equal(
       readFileSync(backup, "utf8"),
       "existing-backup",
       "기존 backup 보존",
     );
-    assert.match(result.stderr, /다른 워커가 사용 중/);
+    assert.match(result.stderr, /소유 워커 살아있음/);
   });
 });
 
-describe("#144/#66 stale lock auto-cleanup", () => {
+describe("#144/#66 stale lock owner-PID cleanup + backup-loss guard", () => {
   const cleanupDirs = [];
   after(() => {
     for (const d of cleanupDirs) {
@@ -259,28 +267,30 @@ describe("#144/#66 stale lock auto-cleanup", () => {
     "",
   ].join("\n");
 
-  function setupStaleBackup({ backupAgeSec }) {
+  function setupBackup({ backupContent = baseToml, ownerPid = null }) {
     const dir = mkdtempSync(path.join(tmpdir(), "tfx-stale-"));
     const config = path.join(dir, "config.toml");
     const backup = `${config}.pre-exec`;
+    const ownerFile = `${backup}.owner`;
     writeFileSync(config, baseToml);
-    writeFileSync(backup, "stale-backup-contents");
-    // mtime 을 과거로 강제 조정 (utimesSync sec-granular)
-    const mtimeSec = Math.floor(Date.now() / 1000) - backupAgeSec;
-    utimesSync(backup, mtimeSec, mtimeSec);
-    return { dir, config, backup };
+    writeFileSync(backup, backupContent);
+    if (ownerPid !== null) {
+      writeFileSync(ownerFile, String(ownerPid));
+    }
+    return { dir, config, backup, ownerFile };
   }
 
-  function runFilter({ backupAgeSec, envOverride = {} }) {
-    const { dir, config, backup } = setupStaleBackup({ backupAgeSec });
+  function runFilter({ backupContent = baseToml, ownerPid = null, usePrescript = "" }) {
+    const { dir, config, backup, ownerFile } = setupBackup({
+      backupContent,
+      ownerPid,
+    });
     cleanupDirs.push(dir);
-    const envExports = Object.entries(envOverride)
-      .map(([k, v]) => `export ${k}='${v}'`)
-      .join("\n");
+    const bashConfig = config.replace(/\\/g, "/");
     const script = `
 set -u
-${envExports}
-_CODEX_CONFIG='${config}'
+${usePrescript}
+_CODEX_CONFIG='${bashConfig}'
 CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
 ${extractSwapFunction()}
 _codex_config_swap filter
@@ -295,42 +305,97 @@ _codex_config_swap filter
       stdout: result.stdout,
       config: existsSync(config) ? readFileSync(config, "utf8") : null,
       backup: existsSync(backup) ? readFileSync(backup, "utf8") : null,
+      owner: existsSync(ownerFile) ? readFileSync(ownerFile, "utf8").trim() : null,
       backupExists: existsSync(backup),
       dir,
     };
   }
 
-  it("stale lock (age=10분, 기본 5분 threshold 초과) 감지 후 자동 제거하고 swap 진행", () => {
-    const r = runFilter({ backupAgeSec: 600 });
+  // owner alive test 는 BUG-H "filter: backup + owner alive" 에서 커버됨 (중복 제거).
+
+  it("owner PID dead + backup=원본 → 원본 복원 후 swap 재진행", () => {
+    // PID 999999 는 대개 존재하지 않음 (ephemeral). 존재 여부와 무관하게 dead 로 가정하는 보호 로직은
+    // kill -0 실패시 stale 분기. 만약 존재하면 skip (rare).
+    const deadPid = 999999;
+    const r = runFilter({ backupContent: baseToml, ownerPid: deadPid });
+    if (/소유 워커 살아있음/.test(r.stderr)) {
+      // very rare race: PID recycled to live process
+      return;
+    }
     assert.equal(r.exitCode, 0);
-    assert.match(r.stderr, /stale config\.toml\.pre-exec 감지/);
-    assert.match(r.stderr, /age=6\d\ds/); // 6xx seconds
-    assert.match(r.stderr, /자동 제거 후 swap 진행/);
-    // 새 backup 은 원본 config 로 재생성됨 (stale 된 "stale-backup-contents" 가 아님)
-    assert.notEqual(r.backup, "stale-backup-contents", "stale backup 은 교체돼야 함");
+    assert.match(r.stderr, /stale backup 감지.*dead/);
+    assert.match(r.stderr, /원본 복원 후 swap 재진행/);
+    // 새 backup 은 원본이어야 함 (복원 경로를 탔으므로)
     assert.match(r.backup, /\[mcp_servers\.tfx-hub\]/);
     // config 는 필터링되어 context7 제거됨
     assert.doesNotMatch(r.config, /\[mcp_servers\.context7\]/);
   });
 
-  it("fresh lock (age=1분) 은 건드리지 않고 기존 skip 동작 유지 (double-swap 방지)", () => {
-    const r = runFilter({ backupAgeSec: 60 });
+  it("owner file 없음 (legacy lock) + backup=원본 → 원본 복원 후 swap 진행", () => {
+    const r = runFilter({ backupContent: baseToml, ownerPid: null });
     assert.equal(r.exitCode, 0);
-    assert.match(r.stderr, /다른 워커가 사용 중/);
-    assert.match(r.stderr, /age=6\ds/);
-    // Backup 은 원본 그대로, config 도 건드리지 않음
-    assert.equal(r.backup, "stale-backup-contents");
-    assert.equal(r.config, baseToml);
-    assert.doesNotMatch(r.stderr, /stale config\.toml\.pre-exec 감지/);
+    assert.match(r.stderr, /stale backup 감지.*pid=\?/);
+    assert.match(r.stderr, /원본 복원 후 swap 재진행/);
+    assert.match(r.backup, /\[mcp_servers\.tfx-hub\]/);
+    assert.doesNotMatch(r.config, /\[mcp_servers\.context7\]/);
   });
 
-  it("TFX_CONFIG_LOCK_STALE_MIN=1 override: age=90초면 stale 로 간주", () => {
-    const r = runFilter({
-      backupAgeSec: 90,
-      envOverride: { TFX_CONFIG_LOCK_STALE_MIN: "1" },
-    });
+  it("owner file 없음 + backup 작음(<500B) → 원본 소실 위험, 전체 swap 스킵", () => {
+    const r = runFilter({ backupContent: "tiny", ownerPid: null });
     assert.equal(r.exitCode, 0);
-    assert.match(r.stderr, /stale config\.toml\.pre-exec 감지/);
-    assert.match(r.stderr, /≥ 1m/);
+    assert.match(r.stderr, /stale backup 작음/);
+    assert.match(r.stderr, /swap 스킵/);
+    // config 는 건드리지 않음 (안전), backup 도 수동 확인 유도
+    assert.equal(r.config, baseToml);
+    assert.equal(r.backup, "tiny", "작은 backup 은 수동 확인용으로 보존");
+  });
+
+  it("정상 swap 시 .owner 파일이 현재 PID 로 생성된다", () => {
+    // backup 이 없는 초기 상태에서 filter → backup 과 .owner 모두 생성
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-owner-"));
+    cleanupDirs.push(dir);
+    const config = path.join(dir, "config.toml");
+    writeFileSync(config, baseToml);
+    const bashConfig = config.replace(/\\/g, "/");
+    const script = `
+set -u
+_CODEX_CONFIG='${bashConfig}'
+CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
+${extractSwapFunction()}
+_codex_config_swap filter
+echo "OWNER=$(cat ${bashConfig}.pre-exec.owner 2>/dev/null || echo MISSING)"
+`;
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /OWNER=\d+/, "owner 파일에 PID 기록");
+    assert.doesNotMatch(result.stdout, /OWNER=MISSING/);
+  });
+
+  it("restore 는 backup 과 .owner 를 같이 삭제한다", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-restore-"));
+    cleanupDirs.push(dir);
+    const config = path.join(dir, "config.toml");
+    const backup = `${config}.pre-exec`;
+    const ownerFile = `${backup}.owner`;
+    writeFileSync(config, baseToml);
+    const script = `
+set -u
+_CODEX_CONFIG='${config}'
+CODEX_CONFIG_FLAGS=('mcp_servers.tfx-hub.enabled=true')
+${extractSwapFunction()}
+_codex_config_swap filter
+_codex_config_swap restore
+`;
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(existsSync(backup), false, "backup 삭제");
+    assert.equal(existsSync(ownerFile), false, ".owner 삭제");
+    assert.equal(readFileSync(config, "utf8"), baseToml);
   });
 });

--- a/tests/unit/tfx-route-stall-kill.test.mjs
+++ b/tests/unit/tfx-route-stall-kill.test.mjs
@@ -60,6 +60,13 @@ describe("#144/#66 heartbeat stall kill — shape", () => {
     assert.match(hb, /kill_on_stall="\$\{TFX_STALL_KILL:-1\}"/);
     assert.match(hb, /kill_grace="\$\{TFX_STALL_KILL_GRACE:-30\}"/);
   });
+
+  it("Windows(MINGW/MSYS) 에서는 taskkill /T /F 로 프로세스 트리를 종료한다", () => {
+    const hb = extractFunction("heartbeat_monitor");
+    assert.match(hb, /MINGW\*\|MSYS\*/, "Windows 감지 case 필요");
+    assert.match(hb, /taskkill \/T \/F/, "Windows 트리 종료 명령 필요");
+    assert.match(hb, /MSYS_NO_PATHCONV=1/, "MSYS 경로 변환 비활성화 필요");
+  });
 });
 
 describe("#144/#66 heartbeat stall kill — integration", () => {

--- a/tests/unit/tfx-route-stall-kill.test.mjs
+++ b/tests/unit/tfx-route-stall-kill.test.mjs
@@ -1,0 +1,144 @@
+// tests/unit/tfx-route-stall-kill.test.mjs
+// #144/#66 regression: heartbeat_monitor 가 STALL 상태에서 worker 를 kill 하는지 확인.
+//
+// 본격적인 process-level E2E 는 flaky 가능성이 있어 shape + integration smoke 만 수행한다:
+// 1. tfx-route.sh 내 heartbeat_monitor 블록에 STALL_KILL 분기 + SIGTERM/SIGKILL 호출이 존재
+// 2. 짧은 interval 로 heartbeat_monitor 를 기동 → stall 유지된 child 가 실제로 kill 되는지
+//
+// 본 test 는 triflux 가 "codex MCP worker 가 output=0B 로 무한 stall" 사고를 더 이상
+// 900s timeout 에 맡기지 않고 조기 종료하도록 보장한다.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", "tfx-route.sh");
+
+function extractFunction(name) {
+  const source = readFileSync(SCRIPT_PATH, "utf8");
+  const start = source.indexOf(`${name}() {`);
+  assert.ok(start >= 0, `${name} 정의를 찾을 수 없음`);
+  let depth = 0;
+  let end = start;
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  return source.slice(start, end);
+}
+
+describe("#144/#66 heartbeat stall kill — shape", () => {
+  it("heartbeat_monitor 는 STALL_KILL 분기와 TFX_STALL_KILL env, SIGTERM/SIGKILL 호출을 포함한다", () => {
+    const hb = extractFunction("heartbeat_monitor");
+    assert.match(hb, /TFX_STALL_KILL/, "TFX_STALL_KILL env opt-out 이 필요");
+    assert.match(hb, /TFX_STALL_KILL_GRACE/, "grace 시간 env override 가 필요");
+    assert.match(hb, /STALL_KILL/, "STALL_KILL 상태 로그가 필요");
+    assert.match(hb, /kill -TERM "\$pid"/, "SIGTERM 호출 필수");
+    assert.match(hb, /kill -KILL "\$pid"/, "SIGKILL 강제 경로 필수");
+  });
+
+  it("kill_on_stall 기본값은 활성화(1)이고, grace 기본값은 30초", () => {
+    const hb = extractFunction("heartbeat_monitor");
+    assert.match(hb, /kill_on_stall="\$\{TFX_STALL_KILL:-1\}"/);
+    assert.match(hb, /kill_grace="\$\{TFX_STALL_KILL_GRACE:-30\}"/);
+  });
+});
+
+describe("#144/#66 heartbeat stall kill — integration", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("stall 이 지속되면 worker 에게 SIGTERM 을 보내고 loop 을 break 한다", (t) => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-stall-"));
+    cleanupDirs.push(dir);
+    const stdoutLog = path.join(dir, "stdout.log");
+    const stderrLog = path.join(dir, "stderr.log");
+    writeFileSync(stdoutLog, "");
+    writeFileSync(stderrLog, "");
+
+    // heartbeat_monitor + _find_fork_pids 함수를 subshell 에 주입하고,
+    // 실제 child (sleep 60) 에 대해 짧은 interval 로 감시 → STALL_KILL 유도.
+    const hb = extractFunction("heartbeat_monitor");
+    const findForks = extractFunction("_find_fork_pids");
+
+    const script = `
+set -u
+export TFX_HEARTBEAT=1
+export TFX_HEARTBEAT_INTERVAL=1
+export TFX_STALL_THRESHOLD=2
+export TFX_STALL_KILL=1
+export TFX_STALL_KILL_GRACE=1
+STDOUT_LOG='${stdoutLog}'
+STDERR_LOG='${stderrLog}'
+TIMESTAMP=$(date +%s)
+
+${findForks}
+${hb}
+
+# Fork a dummy child that would otherwise run for 30s (simulating a stalled codex worker)
+sleep 30 &
+CHILD_PID=$!
+echo "CHILD_PID=$CHILD_PID" >&2
+
+# Launch heartbeat monitor on the child in background — it should SIGTERM after ~4s
+heartbeat_monitor "$CHILD_PID" 1 2 &
+HB_PID=$!
+
+# Wait up to 10s for heartbeat to do its work
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  sleep 1
+  if ! kill -0 "$CHILD_PID" 2>/dev/null; then
+    echo "CHILD_KILLED_AFTER=\${i}s" >&2
+    break
+  fi
+done
+
+# Cleanup heartbeat + any stragglers
+kill "$HB_PID" 2>/dev/null || true
+wait "$HB_PID" 2>/dev/null || true
+kill "$CHILD_PID" 2>/dev/null || true
+
+if kill -0 "$CHILD_PID" 2>/dev/null; then
+  echo "RESULT=child_still_alive" >&2
+  exit 1
+else
+  echo "RESULT=child_terminated" >&2
+fi
+`;
+    const result = spawnSync("bash", ["-c", script], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      timeout: 20_000,
+    });
+    assert.equal(
+      result.status,
+      0,
+      `child was not terminated by STALL_KILL.\nstderr:\n${result.stderr}`,
+    );
+    assert.match(result.stderr, /status=STALL_KILL/, "STALL_KILL 상태 로그");
+    assert.match(result.stderr, /SIGTERM/, "SIGTERM 발사 로그");
+    assert.match(result.stderr, /RESULT=child_terminated/);
+  });
+});


### PR DESCRIPTION
## 요약

session 17 에서 `/tfx-auto --cli codex` 2회 연속 `output=0B` 로 stall 한 버그의 근본 원인 2개를 수정.

- **A. Stale lock cleanup 부재** — crash/stall 된 worker 가 남긴 `config.toml.pre-exec` 가 후속 worker 를 "다른 워커 사용 중" 으로 차단 → 계속 MCP 없이 degraded 기동 → stall 악순환.
- **B. heartbeat_monitor 는 log 만 출력, kill 없음** — `status=STALL` 감지해도 worker 를 종료하지 않아 기본 timeout (900s) 까지 생존.

## 재현 로그 (session 17 실제)

\`\`\`
1차 job 1776744294-17403-9725:
[tfx-heartbeat] pid=17487 elapsed=11s output=0B status=quiet stall=10s
→ log 단절. 21분+ 뒤에도 ps 에 살아있음.

2차 job 1776744449-21236-26371 (다른 worker):
[tfx-route] config.toml swap 스킵: 다른 워커가 사용 중 (...config.toml.pre-exec)
→ MCP 없이 degraded → 역시 output=0B stall.
\`\`\`

## Fix

### 1. \`_codex_config_swap\` filter 경로에 stale detection 추가

- backup mtime age 계산 (\`stat -c %Y\` / \`stat -f %m\` 양쪽 지원 — Windows Git Bash 호환)
- \`age ≥ TFX_CONFIG_LOCK_STALE_MIN\` (기본 5분) 이면 자동 \`rm\` 후 swap 재진행
- fresh lock 은 기존 skip 동작 유지 (double-swap 방지)

### 2. \`heartbeat_monitor\` 에 STALL_KILL 분기 추가

- \`stall_count >= threshold + TFX_STALL_KILL_GRACE\` (기본 30s) 에서 SIGTERM
- 5초 유예 후 살아있으면 SIGKILL 강제 + loop break
- \`TFX_STALL_KILL=0\` 으로 opt-out 가능

## Tests

**\`tests/unit/tfx-route-config-swap.test.mjs\`** (+3)
- stale lock (age=10분) 자동 제거 후 swap 진행
- fresh lock (age=1분) 기존 skip 유지 (double-swap 방지 회귀 확인)
- \`TFX_CONFIG_LOCK_STALE_MIN=1\` env override

**\`tests/unit/tfx-route-stall-kill.test.mjs\`** (신규, +3)
- shape: STALL_KILL 분기 + SIGTERM/SIGKILL 호출 존재
- shape: \`kill_on_stall\` 기본 1, \`grace\` 기본 30
- integration: 짧은 interval (threshold=2, grace=1) 로 실제 child 가 **약 4.5초 내 SIGTERM** 확인

**기타 회복**: BUG-H fixture (165 bytes) 가 v10.13.0 에 추가된 500 bytes 손상 가드에 걸려 pre-existing regression 상태였음. 같은 padded fixture 로 교체해 동시 회복.

**결과**: 10/10 pass (기존 4 + 신규 6).

## 영향

- Codex MCP worker handshake stall 시, 후속 worker 가 **기본 ~90초** 안에 lock 해제 + MCP 재시도 가능 (기존 900s 대기).
- \`#144\` doctor auto-fix 와 \`#66\` upstream 우회 모두 **현장에서 재현하던 경로**가 제거됨.

## Test Plan

- [x] \`node --test tests/unit/tfx-route-config-swap.test.mjs tests/unit/tfx-route-stall-kill.test.mjs\` → 10/10 pass
- [ ] 후속: landing 후 session 18 에서 \`/tfx-auto --cli codex --mode deep\` 재시도 → stall 재발 시 90초 내 복구 확인
- [ ] 후속: release 시 \`pack.mjs\` 로 \`packages/triflux/scripts/tfx-route.sh\` mirror + \`setup.mjs\` 재배포

## Refs

- Closes: 해당 없음 (umbrella 미해결. #144/#66 부분 완화)
- Refs: #144, #66, #122
- Plan: \`.omc/artifacts/session-17-plan-20260421-130921.md\`