### PR TITLE
fix(#144): doctor auto-fix gap — stale skills recursive + mcp url sync + psmux guidance + TTL

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -134,7 +134,8 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     ],
   },
   doctor: {
-    usage: "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--json]",
+    usage:
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -157,6 +158,12 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "진단 번들(zip) 생성: spawn-trace + hook timing + system info",
+      },
+      {
+        name: "--purge-logs",
+        type: "boolean",
+        description:
+          "--fix 와 함께 사용. cli-issues.jsonl 에서 7일 초과 항목 물리 삭제 (#144)",
       },
       {
         name: "--json",
@@ -1742,7 +1749,8 @@ function ensureValidRegistryState() {
 }
 
 async function cmdDoctor(options = {}) {
-  const { fix = false, reset = false, json = false } = options;
+  const { fix = false, reset = false, purgeLogs = false, json = false } =
+    options;
   const report = {
     status: "ok",
     mode: reset ? "reset" : fix ? "fix" : "check",
@@ -2357,9 +2365,20 @@ async function cmdDoctor(options = {}) {
           info(`업데이트 권장:\n${formatPsmuxUpdateGuidance("  ")}`);
         }
         if (psmuxSupport.missingOptionalCommands?.length > 0) {
+          // #144: 단순히 "detach-first hardening 경로에서만 사용" 만으로는 사용자가
+          // 영향 범위와 해결 방법을 알 수 없다. 각 capability 별 영향과 업그레이드 명령을 명시.
           info(
-            `선택 capability 미지원: ${psmuxSupport.missingOptionalCommands.join(", ")} (detach-first hardening 경로에서만 사용)`,
+            `선택 capability 미지원: ${psmuxSupport.missingOptionalCommands.join(", ")}`,
           );
+          if (psmuxSupport.missingOptionalCommands.includes("detach-client")) {
+            info(
+              "  detach-client: WT 1.24 ConPTY close-race 회피용. WT 기반 병렬 실행(swarm dashboard, tfx-multi wt 모드) 에서 pane freeze/ConPTY hang 위험 증가.",
+            );
+            info(
+              "  해결: psmux v3.4+ 로 업그레이드. 현재 psmux 업그레이드 명령:",
+            );
+            info(`${formatPsmuxUpdateGuidance("    ")}`);
+          }
         }
 
         // 기본 셸 확인: psmux 세션의 기본 셸이 PowerShell인지 cmd.exe인지
@@ -2771,6 +2790,10 @@ async function cmdDoctor(options = {}) {
           ).version;
           let cleaned = 0;
 
+          // #144: 오래된 로그 노이즈 완화 — 7일 초과 항목은 INFO 레벨로 downgrade.
+          // --fix --purge-logs 플래그가 있으면 해당 오래된 항목은 실제 삭제.
+          const STALE_AGE_MS = 7 * 24 * 3600 * 1000;
+          let purged = 0;
           for (const [key, g] of Object.entries(groups)) {
             const fixVer = KNOWN_FIXES[key];
             if (fixVer && semverGte(currentVer, fixVer)) {
@@ -2785,15 +2808,47 @@ async function cmdDoctor(options = {}) {
                 : age < 86400000
                   ? `${Math.round(age / 3600000)}시간 전`
                   : `${Math.round(age / 86400000)}일 전`;
-            const sev =
-              g.severity === "error"
+            const isStale = age >= STALE_AGE_MS;
+            if (isStale && fix && purgeLogs) {
+              purged += g.count;
+              continue;
+            }
+            const sev = isStale
+              ? `${CYAN}INFO${RESET}`
+              : g.severity === "error"
                 ? `${RED}ERROR${RESET}`
                 : `${YELLOW}WARN${RESET}`;
-            warn(`[${sev}] ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            const staleTag = isStale ? " [STALE]" : "";
+            if (isStale) {
+              info(`[${sev}]${staleTag} ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            } else {
+              warn(`[${sev}] ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            }
             if (g.snippet) info(`  ${g.snippet.substring(0, 120)}`);
             if (fixVer)
               info(`  해결: triflux >= v${fixVer} (npm update -g triflux)`);
-            issues++;
+            if (isStale && !purgeLogs) {
+              info(`  7일 초과 — 삭제: tfx doctor --fix --purge-logs`);
+            }
+            if (!isStale) issues++;
+          }
+
+          // --fix --purge-logs 로 stale 항목 물리 삭제
+          if (purged > 0) {
+            const remaining = entries.filter(
+              (e) => Date.now() - e.ts < STALE_AGE_MS,
+            );
+            writeFileSync(
+              issuesFile,
+              remaining.map((e) => JSON.stringify(e)).join("\n") +
+                (remaining.length ? "\n" : ""),
+            );
+            ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
+            report.actions.push({
+              name: "purge-stale-logs",
+              status: "applied",
+              count: purged,
+            });
           }
 
           // 해결된 이슈 자동 정리
@@ -3371,6 +3426,43 @@ async function cmdDoctor(options = {}) {
           warn(`${row.label}: ${row.name} URL 불일치`);
           info(`expected ${row.expectedUrl}`);
           if (row.actualUrl) info(`actual   ${row.actualUrl}`);
+        }
+
+        // #144: --fix 모드에서 tfx-hub URL 불일치를 hub status 기준으로 자동 갱신.
+        // Project MCP (.mcp.json) 와 Codex/Claude/Gemini settings 모두 대상.
+        if (fix && mismatchRows.some((r) => r.name === "tfx-hub")) {
+          try {
+            const hubUrl = mismatchRows.find((r) => r.name === "tfx-hub")?.expectedUrl;
+            if (hubUrl) {
+              const { syncHubMcpSettings, syncProjectMcpJson } = await import(
+                "../scripts/sync-hub-mcp-settings.mjs"
+              );
+              const settingsResult = await syncHubMcpSettings({ hubUrl, logger: { log() {}, warn() {}, error() {} } });
+              const projectResult = await syncProjectMcpJson({
+                hubUrl,
+                projectRoot: process.cwd(),
+                logger: { log() {}, warn() {}, error() {} },
+              });
+              const totalUpdated =
+                (settingsResult?.updated?.length || 0) +
+                (projectResult?.updated?.length || 0);
+              if (totalUpdated > 0) {
+                ok(`tfx-hub URL ${totalUpdated}개 파일 자동 갱신 (${hubUrl})`);
+                report.actions.push({
+                  name: "sync-hub-url",
+                  status: "applied",
+                  files: [
+                    ...(settingsResult?.updated || []),
+                    ...(projectResult?.updated || []),
+                  ],
+                });
+              } else {
+                info("tfx-hub URL 자동 갱신: 대상 파일 없음");
+              }
+            }
+          } catch (e) {
+            warn(`tfx-hub URL 자동 갱신 실패: ${e?.message?.split(/\r?\n/)[0] || e}`);
+          }
         }
 
         for (const row of missingFileRows) {
@@ -5508,7 +5600,8 @@ async function main() {
       }
       const fix = cmdArgs.includes("--fix");
       const reset = cmdArgs.includes("--reset");
-      await cmdDoctor({ fix, reset, json: JSON_OUTPUT });
+      const purgeLogs = cmdArgs.includes("--purge-logs");
+      await cmdDoctor({ fix, reset, purgeLogs, json: JSON_OUTPUT });
       return;
     }
     case "mcp":

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -2833,37 +2833,35 @@ async function cmdDoctor(options = {}) {
             if (!isStale) issues++;
           }
 
-          // --fix --purge-logs 로 stale 항목 물리 삭제
-          if (purged > 0) {
-            const remaining = entries.filter(
-              (e) => Date.now() - e.ts < STALE_AGE_MS,
-            );
-            writeFileSync(
-              issuesFile,
-              remaining.map((e) => JSON.stringify(e)).join("\n") +
-                (remaining.length ? "\n" : ""),
-            );
-            ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
-            report.actions.push({
-              name: "purge-stale-logs",
-              status: "applied",
-              count: purged,
-            });
-          }
-
-          // 해결된 이슈 자동 정리
-          if (cleaned > 0) {
+          // #144 Codex review P2: 두 filter (stale purge + KNOWN_FIXES) 가 각각 원본 entries 로
+          // write 하면 두 번째 write 가 첫 번째 결과를 되살린다. 단일 통합 필터로 한 번만 저장.
+          if (purged > 0 || cleaned > 0) {
+            const now = Date.now();
             const remaining = entries.filter((e) => {
+              // purge-logs 로 물리 삭제 대상: 7일 초과
+              if (purged > 0 && now - e.ts >= STALE_AGE_MS) return false;
+              // KNOWN_FIXES 해결된 이슈 제거
               const key = `${e.cli}:${e.pattern}`;
               const fixVer = KNOWN_FIXES[key];
-              return !(fixVer && semverGte(currentVer, fixVer));
+              if (fixVer && semverGte(currentVer, fixVer)) return false;
+              return true;
             });
             writeFileSync(
               issuesFile,
               remaining.map((e) => JSON.stringify(e)).join("\n") +
                 (remaining.length ? "\n" : ""),
             );
-            ok(`${cleaned}개 해결된 이슈 자동 정리됨`);
+            if (purged > 0) {
+              ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
+              report.actions.push({
+                name: "purge-stale-logs",
+                status: "applied",
+                count: purged,
+              });
+            }
+            if (cleaned > 0) {
+              ok(`${cleaned}개 해결된 이슈 자동 정리됨`);
+            }
           }
           addDoctorCheck(report, {
             name: "cli-issues",
@@ -3430,6 +3428,8 @@ async function cmdDoctor(options = {}) {
 
         // #144: --fix 모드에서 tfx-hub URL 불일치를 hub status 기준으로 자동 갱신.
         // Project MCP (.mcp.json) 와 Codex/Claude/Gemini settings 모두 대상.
+        // Codex review P2: fix 성공 시 issues 집계에서 차감해야 doctor 결과가 ok 로 반영됨.
+        let autoFixedMismatches = 0;
         if (fix && mismatchRows.some((r) => r.name === "tfx-hub")) {
           try {
             const hubUrl = mismatchRows.find((r) => r.name === "tfx-hub")?.expectedUrl;
@@ -3456,6 +3456,10 @@ async function cmdDoctor(options = {}) {
                     ...(projectResult?.updated || []),
                   ],
                 });
+                // fix 성공 — mismatchRows 중 tfx-hub 엔트리는 해결된 것으로 집계
+                autoFixedMismatches = mismatchRows.filter(
+                  (r) => r.name === "tfx-hub",
+                ).length;
               } else {
                 info("tfx-hub URL 자동 갱신: 대상 파일 없음");
               }
@@ -3487,7 +3491,7 @@ async function cmdDoctor(options = {}) {
         }
 
         issues += invalidConfigs.length;
-        issues += mismatchRows.length;
+        issues += Math.max(0, mismatchRows.length - autoFixedMismatches);
         issues += stdioRows.length;
       }
     }

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -134,7 +134,8 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     ],
   },
   doctor: {
-    usage: "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--json]",
+    usage:
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -157,6 +158,12 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "진단 번들(zip) 생성: spawn-trace + hook timing + system info",
+      },
+      {
+        name: "--purge-logs",
+        type: "boolean",
+        description:
+          "--fix 와 함께 사용. cli-issues.jsonl 에서 7일 초과 항목 물리 삭제 (#144)",
       },
       {
         name: "--json",
@@ -1742,7 +1749,8 @@ function ensureValidRegistryState() {
 }
 
 async function cmdDoctor(options = {}) {
-  const { fix = false, reset = false, json = false } = options;
+  const { fix = false, reset = false, purgeLogs = false, json = false } =
+    options;
   const report = {
     status: "ok",
     mode: reset ? "reset" : fix ? "fix" : "check",
@@ -2357,9 +2365,20 @@ async function cmdDoctor(options = {}) {
           info(`업데이트 권장:\n${formatPsmuxUpdateGuidance("  ")}`);
         }
         if (psmuxSupport.missingOptionalCommands?.length > 0) {
+          // #144: 단순히 "detach-first hardening 경로에서만 사용" 만으로는 사용자가
+          // 영향 범위와 해결 방법을 알 수 없다. 각 capability 별 영향과 업그레이드 명령을 명시.
           info(
-            `선택 capability 미지원: ${psmuxSupport.missingOptionalCommands.join(", ")} (detach-first hardening 경로에서만 사용)`,
+            `선택 capability 미지원: ${psmuxSupport.missingOptionalCommands.join(", ")}`,
           );
+          if (psmuxSupport.missingOptionalCommands.includes("detach-client")) {
+            info(
+              "  detach-client: WT 1.24 ConPTY close-race 회피용. WT 기반 병렬 실행(swarm dashboard, tfx-multi wt 모드) 에서 pane freeze/ConPTY hang 위험 증가.",
+            );
+            info(
+              "  해결: psmux v3.4+ 로 업그레이드. 현재 psmux 업그레이드 명령:",
+            );
+            info(`${formatPsmuxUpdateGuidance("    ")}`);
+          }
         }
 
         // 기본 셸 확인: psmux 세션의 기본 셸이 PowerShell인지 cmd.exe인지
@@ -2771,6 +2790,10 @@ async function cmdDoctor(options = {}) {
           ).version;
           let cleaned = 0;
 
+          // #144: 오래된 로그 노이즈 완화 — 7일 초과 항목은 INFO 레벨로 downgrade.
+          // --fix --purge-logs 플래그가 있으면 해당 오래된 항목은 실제 삭제.
+          const STALE_AGE_MS = 7 * 24 * 3600 * 1000;
+          let purged = 0;
           for (const [key, g] of Object.entries(groups)) {
             const fixVer = KNOWN_FIXES[key];
             if (fixVer && semverGte(currentVer, fixVer)) {
@@ -2785,15 +2808,47 @@ async function cmdDoctor(options = {}) {
                 : age < 86400000
                   ? `${Math.round(age / 3600000)}시간 전`
                   : `${Math.round(age / 86400000)}일 전`;
-            const sev =
-              g.severity === "error"
+            const isStale = age >= STALE_AGE_MS;
+            if (isStale && fix && purgeLogs) {
+              purged += g.count;
+              continue;
+            }
+            const sev = isStale
+              ? `${CYAN}INFO${RESET}`
+              : g.severity === "error"
                 ? `${RED}ERROR${RESET}`
                 : `${YELLOW}WARN${RESET}`;
-            warn(`[${sev}] ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            const staleTag = isStale ? " [STALE]" : "";
+            if (isStale) {
+              info(`[${sev}]${staleTag} ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            } else {
+              warn(`[${sev}] ${g.cli}/${g.pattern} x${g.count} (최근: ${ago})`);
+            }
             if (g.snippet) info(`  ${g.snippet.substring(0, 120)}`);
             if (fixVer)
               info(`  해결: triflux >= v${fixVer} (npm update -g triflux)`);
-            issues++;
+            if (isStale && !purgeLogs) {
+              info(`  7일 초과 — 삭제: tfx doctor --fix --purge-logs`);
+            }
+            if (!isStale) issues++;
+          }
+
+          // --fix --purge-logs 로 stale 항목 물리 삭제
+          if (purged > 0) {
+            const remaining = entries.filter(
+              (e) => Date.now() - e.ts < STALE_AGE_MS,
+            );
+            writeFileSync(
+              issuesFile,
+              remaining.map((e) => JSON.stringify(e)).join("\n") +
+                (remaining.length ? "\n" : ""),
+            );
+            ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
+            report.actions.push({
+              name: "purge-stale-logs",
+              status: "applied",
+              count: purged,
+            });
           }
 
           // 해결된 이슈 자동 정리
@@ -3371,6 +3426,43 @@ async function cmdDoctor(options = {}) {
           warn(`${row.label}: ${row.name} URL 불일치`);
           info(`expected ${row.expectedUrl}`);
           if (row.actualUrl) info(`actual   ${row.actualUrl}`);
+        }
+
+        // #144: --fix 모드에서 tfx-hub URL 불일치를 hub status 기준으로 자동 갱신.
+        // Project MCP (.mcp.json) 와 Codex/Claude/Gemini settings 모두 대상.
+        if (fix && mismatchRows.some((r) => r.name === "tfx-hub")) {
+          try {
+            const hubUrl = mismatchRows.find((r) => r.name === "tfx-hub")?.expectedUrl;
+            if (hubUrl) {
+              const { syncHubMcpSettings, syncProjectMcpJson } = await import(
+                "../scripts/sync-hub-mcp-settings.mjs"
+              );
+              const settingsResult = await syncHubMcpSettings({ hubUrl, logger: { log() {}, warn() {}, error() {} } });
+              const projectResult = await syncProjectMcpJson({
+                hubUrl,
+                projectRoot: process.cwd(),
+                logger: { log() {}, warn() {}, error() {} },
+              });
+              const totalUpdated =
+                (settingsResult?.updated?.length || 0) +
+                (projectResult?.updated?.length || 0);
+              if (totalUpdated > 0) {
+                ok(`tfx-hub URL ${totalUpdated}개 파일 자동 갱신 (${hubUrl})`);
+                report.actions.push({
+                  name: "sync-hub-url",
+                  status: "applied",
+                  files: [
+                    ...(settingsResult?.updated || []),
+                    ...(projectResult?.updated || []),
+                  ],
+                });
+              } else {
+                info("tfx-hub URL 자동 갱신: 대상 파일 없음");
+              }
+            }
+          } catch (e) {
+            warn(`tfx-hub URL 자동 갱신 실패: ${e?.message?.split(/\r?\n/)[0] || e}`);
+          }
         }
 
         for (const row of missingFileRows) {
@@ -5508,7 +5600,8 @@ async function main() {
       }
       const fix = cmdArgs.includes("--fix");
       const reset = cmdArgs.includes("--reset");
-      await cmdDoctor({ fix, reset, json: JSON_OUTPUT });
+      const purgeLogs = cmdArgs.includes("--purge-logs");
+      await cmdDoctor({ fix, reset, purgeLogs, json: JSON_OUTPUT });
       return;
     }
     case "mcp":

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -2833,37 +2833,35 @@ async function cmdDoctor(options = {}) {
             if (!isStale) issues++;
           }
 
-          // --fix --purge-logs 로 stale 항목 물리 삭제
-          if (purged > 0) {
-            const remaining = entries.filter(
-              (e) => Date.now() - e.ts < STALE_AGE_MS,
-            );
-            writeFileSync(
-              issuesFile,
-              remaining.map((e) => JSON.stringify(e)).join("\n") +
-                (remaining.length ? "\n" : ""),
-            );
-            ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
-            report.actions.push({
-              name: "purge-stale-logs",
-              status: "applied",
-              count: purged,
-            });
-          }
-
-          // 해결된 이슈 자동 정리
-          if (cleaned > 0) {
+          // #144 Codex review P2: 두 filter (stale purge + KNOWN_FIXES) 가 각각 원본 entries 로
+          // write 하면 두 번째 write 가 첫 번째 결과를 되살린다. 단일 통합 필터로 한 번만 저장.
+          if (purged > 0 || cleaned > 0) {
+            const now = Date.now();
             const remaining = entries.filter((e) => {
+              // purge-logs 로 물리 삭제 대상: 7일 초과
+              if (purged > 0 && now - e.ts >= STALE_AGE_MS) return false;
+              // KNOWN_FIXES 해결된 이슈 제거
               const key = `${e.cli}:${e.pattern}`;
               const fixVer = KNOWN_FIXES[key];
-              return !(fixVer && semverGte(currentVer, fixVer));
+              if (fixVer && semverGte(currentVer, fixVer)) return false;
+              return true;
             });
             writeFileSync(
               issuesFile,
               remaining.map((e) => JSON.stringify(e)).join("\n") +
                 (remaining.length ? "\n" : ""),
             );
-            ok(`${cleaned}개 해결된 이슈 자동 정리됨`);
+            if (purged > 0) {
+              ok(`${purged}개 stale 로그 항목 삭제 (7일 초과)`);
+              report.actions.push({
+                name: "purge-stale-logs",
+                status: "applied",
+                count: purged,
+              });
+            }
+            if (cleaned > 0) {
+              ok(`${cleaned}개 해결된 이슈 자동 정리됨`);
+            }
           }
           addDoctorCheck(report, {
             name: "cli-issues",
@@ -3430,6 +3428,8 @@ async function cmdDoctor(options = {}) {
 
         // #144: --fix 모드에서 tfx-hub URL 불일치를 hub status 기준으로 자동 갱신.
         // Project MCP (.mcp.json) 와 Codex/Claude/Gemini settings 모두 대상.
+        // Codex review P2: fix 성공 시 issues 집계에서 차감해야 doctor 결과가 ok 로 반영됨.
+        let autoFixedMismatches = 0;
         if (fix && mismatchRows.some((r) => r.name === "tfx-hub")) {
           try {
             const hubUrl = mismatchRows.find((r) => r.name === "tfx-hub")?.expectedUrl;
@@ -3456,6 +3456,10 @@ async function cmdDoctor(options = {}) {
                     ...(projectResult?.updated || []),
                   ],
                 });
+                // fix 성공 — mismatchRows 중 tfx-hub 엔트리는 해결된 것으로 집계
+                autoFixedMismatches = mismatchRows.filter(
+                  (r) => r.name === "tfx-hub",
+                ).length;
               } else {
                 info("tfx-hub URL 자동 갱신: 대상 파일 없음");
               }
@@ -3487,7 +3491,7 @@ async function cmdDoctor(options = {}) {
         }
 
         issues += invalidConfigs.length;
-        issues += mismatchRows.length;
+        issues += Math.max(0, mismatchRows.length - autoFixedMismatches);
         issues += stdioRows.length;
       }
     }

--- a/packages/triflux/scripts/__tests__/setup-cleanup-stale-skills.test.mjs
+++ b/packages/triflux/scripts/__tests__/setup-cleanup-stale-skills.test.mjs
@@ -1,0 +1,102 @@
+// scripts/__tests__/setup-cleanup-stale-skills.test.mjs
+// #144: cleanupStaleSkills 가 nested directory 를 가진 stale 스킬도 재귀 삭제하는지 확인.
+//
+// 이전 구현은 top-level 파일만 unlinkSync → 하위 폴더 있는 과거 스킬
+// (tfx-deep-*, tfx-codex-swarm 등) 은 제거 실패 → "triflux update 돌려도 13개 그대로" UX bug.
+
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+const SETUP_MJS_URL = new URL("../setup.mjs", import.meta.url).href;
+const { cleanupStaleSkills } = await import(SETUP_MJS_URL);
+
+describe("#144 cleanupStaleSkills — 재귀 삭제", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) rmSync(d, { recursive: true, force: true });
+  });
+
+  function setupFixture() {
+    const root = mkdtempSync(path.join(tmpdir(), "tfx-cleanup-"));
+    cleanupDirs.push(root);
+    const installedDir = path.join(root, "installed");
+    const pkgDir = path.join(root, "pkg");
+    mkdirSync(installedDir, { recursive: true });
+    mkdirSync(pkgDir, { recursive: true });
+    // pkg 에는 tfx-auto 만 있음 (나머지는 installed 에서 stale 로 감지)
+    mkdirSync(path.join(pkgDir, "tfx-auto"), { recursive: true });
+    return { installedDir, pkgDir };
+  }
+
+  it("nested directory 가 있는 stale 스킬도 전부 제거된다 (과거 회귀 bug)", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    // stale 스킬: top-level 파일 + nested 디렉토리
+    const staleSkill = path.join(installedDir, "tfx-deep-review");
+    mkdirSync(staleSkill, { recursive: true });
+    writeFileSync(path.join(staleSkill, "SKILL.md"), "# deprecated");
+    const nested = path.join(staleSkill, "snapshot");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, "data.json"), "{}");
+    mkdirSync(path.join(nested, "sub"), { recursive: true });
+    writeFileSync(path.join(nested, "sub", "more.txt"), "xxx");
+
+    // 유지해야 할 스킬 (pkg 에 있음)
+    mkdirSync(path.join(installedDir, "tfx-auto"), { recursive: true });
+    writeFileSync(path.join(installedDir, "tfx-auto", "SKILL.md"), "# ok");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 1);
+    assert.deepEqual(result.removed, ["tfx-deep-review"]);
+    assert.equal(existsSync(staleSkill), false, "nested dir 포함 전부 삭제");
+    assert.equal(
+      existsSync(path.join(installedDir, "tfx-auto")),
+      true,
+      "pkg 에 있는 스킬은 보존",
+    );
+  });
+
+  it("top-level 파일만 있는 stale 스킬도 제거된다 (legacy behavior 회귀 방지)", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    const staleSkill = path.join(installedDir, "tfx-autoresearch");
+    mkdirSync(staleSkill, { recursive: true });
+    writeFileSync(path.join(staleSkill, "SKILL.md"), "# deprecated");
+    writeFileSync(path.join(staleSkill, "config.json"), "{}");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 1);
+    assert.equal(existsSync(staleSkill), false);
+  });
+
+  it("SKILL_ALIASES 에 있는 alias 는 유지된다", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    // alias (tfx-autopilot) 는 SKILL_ALIASES 에 있으므로 pkgNames 에 자동 포함
+    mkdirSync(path.join(installedDir, "tfx-autopilot"), { recursive: true });
+    writeFileSync(
+      path.join(installedDir, "tfx-autopilot", "SKILL.md"),
+      "# alias",
+    );
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 0);
+    assert.equal(existsSync(path.join(installedDir, "tfx-autopilot")), true);
+  });
+
+  it("tfx- 접두사 없는 디렉토리는 건드리지 않음", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    mkdirSync(path.join(installedDir, "other-skill"), { recursive: true });
+    writeFileSync(path.join(installedDir, "other-skill", "SKILL.md"), "# other");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 0);
+    assert.equal(existsSync(path.join(installedDir, "other-skill")), true);
+  });
+});

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -430,17 +431,15 @@ function cleanupStaleSkills(installedDir, pkgDir) {
     if (pkgNames.has(name)) continue;
 
     const skillPath = join(installedDir, name);
+    // #144: 재귀 삭제 필요 — 과거 구현은 파일만 unlink 하여 nested 디렉토리가 있는 스킬을
+    // 온전히 제거하지 못했다. `tfx-deep-*`, `tfx-codex-swarm` 같은 과거 잔재 디렉토리는
+    // workspace/snapshot 같은 하위 폴더를 가지므로 rmSync recursive 가 필수.
     try {
-      const entries = readdirSync(skillPath);
-      for (const f of entries) unlinkSync(join(skillPath, f));
-      // rmdir only works on empty dirs; ignore errors for nested
-      try {
-        readdirSync(skillPath).length === 0 && unlinkSync(skillPath);
-      } catch {}
+      rmSync(skillPath, { recursive: true, force: true });
+      removed.push(name);
     } catch {
-      /* best effort */
+      /* best effort — next setup/update cycle 에서 재시도 */
     }
-    removed.push(name);
   }
   return { count: removed.length, removed };
 }

--- a/scripts/__tests__/setup-cleanup-stale-skills.test.mjs
+++ b/scripts/__tests__/setup-cleanup-stale-skills.test.mjs
@@ -1,0 +1,102 @@
+// scripts/__tests__/setup-cleanup-stale-skills.test.mjs
+// #144: cleanupStaleSkills 가 nested directory 를 가진 stale 스킬도 재귀 삭제하는지 확인.
+//
+// 이전 구현은 top-level 파일만 unlinkSync → 하위 폴더 있는 과거 스킬
+// (tfx-deep-*, tfx-codex-swarm 등) 은 제거 실패 → "triflux update 돌려도 13개 그대로" UX bug.
+
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+const SETUP_MJS_URL = new URL("../setup.mjs", import.meta.url).href;
+const { cleanupStaleSkills } = await import(SETUP_MJS_URL);
+
+describe("#144 cleanupStaleSkills — 재귀 삭제", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) rmSync(d, { recursive: true, force: true });
+  });
+
+  function setupFixture() {
+    const root = mkdtempSync(path.join(tmpdir(), "tfx-cleanup-"));
+    cleanupDirs.push(root);
+    const installedDir = path.join(root, "installed");
+    const pkgDir = path.join(root, "pkg");
+    mkdirSync(installedDir, { recursive: true });
+    mkdirSync(pkgDir, { recursive: true });
+    // pkg 에는 tfx-auto 만 있음 (나머지는 installed 에서 stale 로 감지)
+    mkdirSync(path.join(pkgDir, "tfx-auto"), { recursive: true });
+    return { installedDir, pkgDir };
+  }
+
+  it("nested directory 가 있는 stale 스킬도 전부 제거된다 (과거 회귀 bug)", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    // stale 스킬: top-level 파일 + nested 디렉토리
+    const staleSkill = path.join(installedDir, "tfx-deep-review");
+    mkdirSync(staleSkill, { recursive: true });
+    writeFileSync(path.join(staleSkill, "SKILL.md"), "# deprecated");
+    const nested = path.join(staleSkill, "snapshot");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, "data.json"), "{}");
+    mkdirSync(path.join(nested, "sub"), { recursive: true });
+    writeFileSync(path.join(nested, "sub", "more.txt"), "xxx");
+
+    // 유지해야 할 스킬 (pkg 에 있음)
+    mkdirSync(path.join(installedDir, "tfx-auto"), { recursive: true });
+    writeFileSync(path.join(installedDir, "tfx-auto", "SKILL.md"), "# ok");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 1);
+    assert.deepEqual(result.removed, ["tfx-deep-review"]);
+    assert.equal(existsSync(staleSkill), false, "nested dir 포함 전부 삭제");
+    assert.equal(
+      existsSync(path.join(installedDir, "tfx-auto")),
+      true,
+      "pkg 에 있는 스킬은 보존",
+    );
+  });
+
+  it("top-level 파일만 있는 stale 스킬도 제거된다 (legacy behavior 회귀 방지)", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    const staleSkill = path.join(installedDir, "tfx-autoresearch");
+    mkdirSync(staleSkill, { recursive: true });
+    writeFileSync(path.join(staleSkill, "SKILL.md"), "# deprecated");
+    writeFileSync(path.join(staleSkill, "config.json"), "{}");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 1);
+    assert.equal(existsSync(staleSkill), false);
+  });
+
+  it("SKILL_ALIASES 에 있는 alias 는 유지된다", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    // alias (tfx-autopilot) 는 SKILL_ALIASES 에 있으므로 pkgNames 에 자동 포함
+    mkdirSync(path.join(installedDir, "tfx-autopilot"), { recursive: true });
+    writeFileSync(
+      path.join(installedDir, "tfx-autopilot", "SKILL.md"),
+      "# alias",
+    );
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 0);
+    assert.equal(existsSync(path.join(installedDir, "tfx-autopilot")), true);
+  });
+
+  it("tfx- 접두사 없는 디렉토리는 건드리지 않음", () => {
+    const { installedDir, pkgDir } = setupFixture();
+    mkdirSync(path.join(installedDir, "other-skill"), { recursive: true });
+    writeFileSync(path.join(installedDir, "other-skill", "SKILL.md"), "# other");
+
+    const result = cleanupStaleSkills(installedDir, pkgDir);
+    assert.equal(result.count, 0);
+    assert.equal(existsSync(path.join(installedDir, "other-skill")), true);
+  });
+});

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -430,17 +431,15 @@ function cleanupStaleSkills(installedDir, pkgDir) {
     if (pkgNames.has(name)) continue;
 
     const skillPath = join(installedDir, name);
+    // #144: 재귀 삭제 필요 — 과거 구현은 파일만 unlink 하여 nested 디렉토리가 있는 스킬을
+    // 온전히 제거하지 못했다. `tfx-deep-*`, `tfx-codex-swarm` 같은 과거 잔재 디렉토리는
+    // workspace/snapshot 같은 하위 폴더를 가지므로 rmSync recursive 가 필수.
     try {
-      const entries = readdirSync(skillPath);
-      for (const f of entries) unlinkSync(join(skillPath, f));
-      // rmdir only works on empty dirs; ignore errors for nested
-      try {
-        readdirSync(skillPath).length === 0 && unlinkSync(skillPath);
-      } catch {}
+      rmSync(skillPath, { recursive: true, force: true });
+      removed.push(name);
     } catch {
-      /* best effort */
+      /* best effort — next setup/update cycle 에서 재시도 */
     }
-    removed.push(name);
   }
   return { count: removed.length, removed };
 }


### PR DESCRIPTION
## 요약

\`triflux doctor --fix\` / \`tfx update\` 가 안내한 대로 항목을 자동 해결하지 않는 4개 gap 을 단일 PR 로 fix (#144 Batch A).

## 근본 원인

\`cleanupStaleSkills()\` 가 **top-level 파일만 unlinkSync** 하고 **nested directory 를 재귀 삭제하지 않았다**. \`tfx-deep-*\`, \`tfx-codex-swarm\` 같은 과거 잔재는 workspace/skill-snapshot 서브폴더를 가지므로 setup/update 가 아무리 실행돼도 디렉토리가 남아 "13개 영구 감지" UX bug.

## Sub-fix 4건

| # | 파일 | 변경 |
|---|------|------|
| 1 | \`scripts/setup.mjs\` | \`cleanupStaleSkills\` 를 \`rmSync({recursive:true, force:true})\` 로 교체. \`rmSync\` import 추가 |
| 2 | \`bin/triflux.mjs\` | \`doctor --fix\` 에서 \`tfx-hub\` URL 불일치 감지 시 \`syncHubMcpSettings\` + \`syncProjectMcpJson\` 호출 → \`.mcp.json\` + settings 일괄 갱신 |
| 3 | \`bin/triflux.mjs\` | psmux detach-client 미지원 메시지 강화 — 영향(WT 1.24 ConPTY 회피) + 해결(psmux v3.4+ 업그레이드) + 업그레이드 명령 명시 |
| 4 | \`bin/triflux.mjs\` | cli-issues 7일 TTL — stale 항목 INFO downgrade + issues++ 제외. \`--purge-logs\` 플래그로 물리 삭제 |

## Tests

\`scripts/__tests__/setup-cleanup-stale-skills.test.mjs\` (신규, **4/4 pass**):
- nested directory 가 있는 stale 스킬 재귀 삭제 (bug 회귀 방지)
- top-level 파일만 있는 스킬 (legacy behavior) 유지
- \`SKILL_ALIASES\` (tfx-autopilot 등) 보존
- \`tfx-\` 접두사 없는 디렉토리 무시

## Mirror 동기화

Source (\`scripts/setup.mjs\`, \`bin/triflux.mjs\`) → Mirror (\`packages/triflux/\`) 양쪽 반영. pack.mjs 경로와 일치. release 시 추가 동기화 불필요.

## 영향

- \`tfx update\` 한 번으로 13개 deprecated 스킬 잔재 실제 제거
- hub URL drift 시 \`--fix\` 로 \`.mcp.json\` + settings.json 일괄 자동 복구
- psmux v3.4 미만 사용자에게 구체적 업그레이드 경로 제시
- 12일+ 묵은 CLI 로그가 WARN 노이즈로 쌓이지 않음

## Test Plan

- [x] \`node --test scripts/__tests__/setup-cleanup-stale-skills.test.mjs\` → 4/4 pass
- [ ] Codex review (\`TFX_CODEX_TRANSPORT=exec\` 경로로 재검증)
- [ ] landing 후 v10.13.2 patch release

## Refs

Closes #144
Follow-up from #145 (\`tfx-route.sh\` stale lock, session 17)