### PR TITLE
feat: probe wiring + Windows autostart + sync append (session 22 close)

### DIFF
--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -7,7 +7,7 @@
 | **gstack** | `~/.gstack/last-update-check` 훅 / 세션 시작 배너 | `/gstack-upgrade` 스킬 (git install이면 `git merge --ff-only origin/main` + `./setup` + migrations) |
 | **Codex CLI** | `codex --version` / `~/.codex/auth.json` mtime | `npm i -g @openai/codex` / 토큰 만료 시 `codex login` (인터랙티브) + 메시지 한 번 날려 refresh 트리거 |
 | **Gemini CLI** | `gemini --version` | `npm i -g @google/gemini-cli` |
-| **Hub MCP URL 동기화** | Hub 시작 시 hub.pid의 port vs settings의 tfx-hub.url | PR #82 자동화 (`scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})`를 server startup에서 호출) |
+| **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거) |
 | **Codex auth 캐시** (pte1024 등) | 병렬 codex exec 시 `refresh_token_reused` | `cp ~/.codex/auth.json ~/.claude/cache/tfx-hub/codex-auth-<account>.json` 수동 (Issue #78 자동화 대기) |
 
 ## 주의

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -65,6 +65,7 @@ import {
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
   ensureHooksInSettings,
+  getWindowsHubAutostartStatus,
   extractManagedHookFilename,
   getManagedRegistryHooks,
   getVersion,
@@ -74,6 +75,7 @@ import {
   replaceProfileSection,
   SKILL_ALIASES,
   SYNC_MAP,
+  buildWindowsHubAutostartCommand,
   syncAliasedSkillDir,
 } from "../scripts/setup.mjs";
 import { cleanupTmpFiles } from "../scripts/tmp-cleanup.mjs";
@@ -123,13 +125,19 @@ const NORMALIZED_ARGS = RAW_ARGS.filter((arg) => arg !== "--json");
 
 const CLI_COMMAND_SCHEMAS = Object.freeze({
   setup: {
-    usage: "tfx setup [--dry-run]",
+    usage: "tfx setup [--dry-run] [--enable-hub-autostart]",
     description: "파일 동기화 + HUD/MCP 설정",
     options: [
       {
         name: "--dry-run",
         type: "boolean",
         description: "실제 변경 없이 예정 작업을 JSON으로 출력",
+      },
+      {
+        name: "--enable-hub-autostart",
+        type: "boolean",
+        description:
+          "Windows 로그인 시 tfx-hub를 보장하는 Task Scheduler 항목 등록",
       },
     ],
   },
@@ -1115,6 +1123,17 @@ function buildSetupDryRunPlan() {
   const defaultHubUrl = `http://127.0.0.1:${process.env.TFX_HUB_PORT || "27888"}/mcp`;
   actions.push(...previewMcpRegistrationActions(defaultHubUrl));
   actions.push(previewStatusLineAction());
+  const autostart = getWindowsHubAutostartStatus();
+  actions.push({
+    type: "hub-autostart",
+    platform: process.platform,
+    taskName: autostart.taskName,
+    change:
+      autostart.supported && !autostart.registered ? "available" : "noop",
+    registered: autostart.registered,
+    command: autostart.supported ? buildWindowsHubAutostartCommand() : null,
+    enableWith: "tfx setup --enable-hub-autostart",
+  });
 
   return {
     dry_run: true,
@@ -1123,7 +1142,12 @@ function buildSetupDryRunPlan() {
 }
 
 function cmdSetup(options = {}) {
-  const { dryRun = false, overrideVersion, skipClaudeMdSync = false } = options;
+  const {
+    dryRun = false,
+    overrideVersion,
+    skipClaudeMdSync = false,
+    enableHubAutostart = false,
+  } = options;
   if (dryRun) {
     printJson(buildSetupDryRunPlan());
     return;
@@ -1349,6 +1373,63 @@ function cmdSetup(options = {}) {
     autoRegisterMcp(defaultHubUrl, { codexEnabled: false });
     summary.push({ item: "Hub MCP", status: "✅", detail: "등록됨" });
     console.log("");
+  }
+
+  if (process.platform === "win32") {
+    const status = getWindowsHubAutostartStatus();
+    if (enableHubAutostart) {
+      try {
+        const script = join(PKG_ROOT, "scripts", "setup.mjs");
+        execFileSync(
+          process.execPath,
+          [script, "--enable-hub-autostart", "--sync"],
+          {
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 10000,
+            windowsHide: true,
+          },
+        );
+        // subprocess silent-catch 회귀 가드: schtasks /Query 로 실제 등록 재검증.
+        const verified = getWindowsHubAutostartStatus();
+        if (verified.registered) {
+          ok(`Hub autostart: ${verified.taskName} 등록됨`);
+          summary.push({
+            item: "Hub autostart",
+            status: "✅",
+            detail: `${verified.taskName} 등록됨`,
+          });
+        } else {
+          warn("Hub autostart 등록 실패: subprocess 성공했으나 /Query 에서 미발견");
+          summary.push({
+            item: "Hub autostart",
+            status: "⚠️",
+            detail: "등록 실패 (subprocess silent catch 의심)",
+          });
+        }
+      } catch (error) {
+        warn(`Hub autostart 등록 실패: ${renderErrorMessage(error.message)}`);
+        summary.push({
+          item: "Hub autostart",
+          status: "⚠️",
+          detail: "등록 실패",
+        });
+      }
+    } else if (status.registered) {
+      ok(`Hub autostart: ${status.taskName} 이미 등록됨`);
+      summary.push({
+        item: "Hub autostart",
+        status: "✅",
+        detail: "이미 등록됨",
+      });
+    } else {
+      warn("Hub autostart 미등록 — Codex 단독 시작 전 hub가 죽어 있으면 MCP가 실패할 수 있음");
+      info("등록: tfx setup --enable-hub-autostart");
+      summary.push({
+        item: "Hub autostart",
+        status: "⏭️",
+        detail: "미등록",
+      });
+    }
   }
 
   // HUD statusLine 설정
@@ -5579,7 +5660,10 @@ async function main() {
 
   switch (cmd) {
     case "setup":
-      cmdSetup({ dryRun: cmdArgs.includes("--dry-run") });
+      cmdSetup({
+        dryRun: cmdArgs.includes("--dry-run"),
+        enableHubAutostart: cmdArgs.includes("--enable-hub-autostart"),
+      });
       return;
     case "doctor": {
       if (cmdArgs.includes("--audit")) {

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -696,6 +696,7 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        writeStateFile: probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/hub/team/health-probe.mjs
+++ b/hub/team/health-probe.mjs
@@ -2,6 +2,10 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 /**
  * Health probe level 정의.
  * L0: Process alive (PID 존재 + exit code 없음)
@@ -25,6 +29,8 @@ export const PROBE_DEFAULTS = Object.freeze({
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
   enableL2: false,
+  writeStateFile: false,
+  stateDir: join(tmpdir(), "tfx-probe"),
 });
 
 /**
@@ -95,6 +101,49 @@ export function createHealthProbe(session, opts = {}) {
     lastProbeAt: null,
     inputWaitPattern: null,
   };
+
+  function getStateFilePath() {
+    if (typeof config.stateFile === "string" && config.stateFile.length > 0) {
+      return config.stateFile;
+    }
+    const pid = session.pid;
+    if (pid == null || pid <= 0) return null;
+    return join(config.stateDir, `${pid}.json`);
+  }
+
+  function deriveState(result) {
+    if (result.l0 === "fail") return "exited";
+    if (result.l1 === "input_wait") return "input_wait";
+    if (result.l2 === "fail") return "mcp_initializing";
+    if (result.l1 === "stall") return "stalled";
+    if (result.l3 === "timeout") return "reasoning";
+    return "active";
+  }
+
+  function writeState(result) {
+    if (!config.writeStateFile && !config.stateFile) return;
+    const stateFile = getStateFilePath();
+    if (!stateFile) return;
+    try {
+      mkdirSync(dirname(stateFile), { recursive: true });
+      writeFileSync(
+        stateFile,
+        JSON.stringify(
+          {
+            pid: session.pid ?? null,
+            state: deriveState(result),
+            result,
+            updatedAt: new Date(result.ts).toISOString(),
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+    } catch {
+      // probe state is advisory only.
+    }
+  }
 
   /**
    * L0: Process alive check.
@@ -227,6 +276,7 @@ export function createHealthProbe(session, opts = {}) {
       ts: Date.now(),
     };
     status.lastProbeAt = result.ts;
+    writeState(result);
 
     if (typeof config.onProbe === "function") {
       config.onProbe(result);
@@ -258,6 +308,12 @@ export function createHealthProbe(session, opts = {}) {
     if (timer) {
       clearInterval(timer);
       timer = null;
+    }
+    if (config.writeStateFile || config.stateFile) {
+      try {
+        const stateFile = getStateFilePath();
+        if (stateFile) unlinkSync(stateFile);
+      } catch {}
     }
   }
 

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -696,6 +696,7 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        writeStateFile: probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/remote/hub/team/health-probe.mjs
+++ b/packages/remote/hub/team/health-probe.mjs
@@ -2,6 +2,10 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 /**
  * Health probe level 정의.
  * L0: Process alive (PID 존재 + exit code 없음)
@@ -25,6 +29,8 @@ export const PROBE_DEFAULTS = Object.freeze({
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
   enableL2: false,
+  writeStateFile: false,
+  stateDir: join(tmpdir(), "tfx-probe"),
 });
 
 /**
@@ -95,6 +101,49 @@ export function createHealthProbe(session, opts = {}) {
     lastProbeAt: null,
     inputWaitPattern: null,
   };
+
+  function getStateFilePath() {
+    if (typeof config.stateFile === "string" && config.stateFile.length > 0) {
+      return config.stateFile;
+    }
+    const pid = session.pid;
+    if (pid == null || pid <= 0) return null;
+    return join(config.stateDir, `${pid}.json`);
+  }
+
+  function deriveState(result) {
+    if (result.l0 === "fail") return "exited";
+    if (result.l1 === "input_wait") return "input_wait";
+    if (result.l2 === "fail") return "mcp_initializing";
+    if (result.l1 === "stall") return "stalled";
+    if (result.l3 === "timeout") return "reasoning";
+    return "active";
+  }
+
+  function writeState(result) {
+    if (!config.writeStateFile && !config.stateFile) return;
+    const stateFile = getStateFilePath();
+    if (!stateFile) return;
+    try {
+      mkdirSync(dirname(stateFile), { recursive: true });
+      writeFileSync(
+        stateFile,
+        JSON.stringify(
+          {
+            pid: session.pid ?? null,
+            state: deriveState(result),
+            result,
+            updatedAt: new Date(result.ts).toISOString(),
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+    } catch {
+      // probe state is advisory only.
+    }
+  }
 
   /**
    * L0: Process alive check.
@@ -227,6 +276,7 @@ export function createHealthProbe(session, opts = {}) {
       ts: Date.now(),
     };
     status.lastProbeAt = result.ts;
+    writeState(result);
 
     if (typeof config.onProbe === "function") {
       config.onProbe(result);
@@ -258,6 +308,12 @@ export function createHealthProbe(session, opts = {}) {
     if (timer) {
       clearInterval(timer);
       timer = null;
+    }
+    if (config.writeStateFile || config.stateFile) {
+      try {
+        const stateFile = getStateFilePath();
+        if (stateFile) unlinkSync(stateFile);
+      } catch {}
     }
   }
 

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -65,6 +65,7 @@ import {
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
   ensureHooksInSettings,
+  getWindowsHubAutostartStatus,
   extractManagedHookFilename,
   getManagedRegistryHooks,
   getVersion,
@@ -74,6 +75,7 @@ import {
   replaceProfileSection,
   SKILL_ALIASES,
   SYNC_MAP,
+  buildWindowsHubAutostartCommand,
   syncAliasedSkillDir,
 } from "../scripts/setup.mjs";
 import { cleanupTmpFiles } from "../scripts/tmp-cleanup.mjs";
@@ -123,13 +125,19 @@ const NORMALIZED_ARGS = RAW_ARGS.filter((arg) => arg !== "--json");
 
 const CLI_COMMAND_SCHEMAS = Object.freeze({
   setup: {
-    usage: "tfx setup [--dry-run]",
+    usage: "tfx setup [--dry-run] [--enable-hub-autostart]",
     description: "파일 동기화 + HUD/MCP 설정",
     options: [
       {
         name: "--dry-run",
         type: "boolean",
         description: "실제 변경 없이 예정 작업을 JSON으로 출력",
+      },
+      {
+        name: "--enable-hub-autostart",
+        type: "boolean",
+        description:
+          "Windows 로그인 시 tfx-hub를 보장하는 Task Scheduler 항목 등록",
       },
     ],
   },
@@ -1115,6 +1123,17 @@ function buildSetupDryRunPlan() {
   const defaultHubUrl = `http://127.0.0.1:${process.env.TFX_HUB_PORT || "27888"}/mcp`;
   actions.push(...previewMcpRegistrationActions(defaultHubUrl));
   actions.push(previewStatusLineAction());
+  const autostart = getWindowsHubAutostartStatus();
+  actions.push({
+    type: "hub-autostart",
+    platform: process.platform,
+    taskName: autostart.taskName,
+    change:
+      autostart.supported && !autostart.registered ? "available" : "noop",
+    registered: autostart.registered,
+    command: autostart.supported ? buildWindowsHubAutostartCommand() : null,
+    enableWith: "tfx setup --enable-hub-autostart",
+  });
 
   return {
     dry_run: true,
@@ -1123,7 +1142,12 @@ function buildSetupDryRunPlan() {
 }
 
 function cmdSetup(options = {}) {
-  const { dryRun = false, overrideVersion, skipClaudeMdSync = false } = options;
+  const {
+    dryRun = false,
+    overrideVersion,
+    skipClaudeMdSync = false,
+    enableHubAutostart = false,
+  } = options;
   if (dryRun) {
     printJson(buildSetupDryRunPlan());
     return;
@@ -1349,6 +1373,63 @@ function cmdSetup(options = {}) {
     autoRegisterMcp(defaultHubUrl, { codexEnabled: false });
     summary.push({ item: "Hub MCP", status: "✅", detail: "등록됨" });
     console.log("");
+  }
+
+  if (process.platform === "win32") {
+    const status = getWindowsHubAutostartStatus();
+    if (enableHubAutostart) {
+      try {
+        const script = join(PKG_ROOT, "scripts", "setup.mjs");
+        execFileSync(
+          process.execPath,
+          [script, "--enable-hub-autostart", "--sync"],
+          {
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 10000,
+            windowsHide: true,
+          },
+        );
+        // subprocess silent-catch 회귀 가드: schtasks /Query 로 실제 등록 재검증.
+        const verified = getWindowsHubAutostartStatus();
+        if (verified.registered) {
+          ok(`Hub autostart: ${verified.taskName} 등록됨`);
+          summary.push({
+            item: "Hub autostart",
+            status: "✅",
+            detail: `${verified.taskName} 등록됨`,
+          });
+        } else {
+          warn("Hub autostart 등록 실패: subprocess 성공했으나 /Query 에서 미발견");
+          summary.push({
+            item: "Hub autostart",
+            status: "⚠️",
+            detail: "등록 실패 (subprocess silent catch 의심)",
+          });
+        }
+      } catch (error) {
+        warn(`Hub autostart 등록 실패: ${renderErrorMessage(error.message)}`);
+        summary.push({
+          item: "Hub autostart",
+          status: "⚠️",
+          detail: "등록 실패",
+        });
+      }
+    } else if (status.registered) {
+      ok(`Hub autostart: ${status.taskName} 이미 등록됨`);
+      summary.push({
+        item: "Hub autostart",
+        status: "✅",
+        detail: "이미 등록됨",
+      });
+    } else {
+      warn("Hub autostart 미등록 — Codex 단독 시작 전 hub가 죽어 있으면 MCP가 실패할 수 있음");
+      info("등록: tfx setup --enable-hub-autostart");
+      summary.push({
+        item: "Hub autostart",
+        status: "⏭️",
+        detail: "미등록",
+      });
+    }
   }
 
   // HUD statusLine 설정
@@ -5579,7 +5660,10 @@ async function main() {
 
   switch (cmd) {
     case "setup":
-      cmdSetup({ dryRun: cmdArgs.includes("--dry-run") });
+      cmdSetup({
+        dryRun: cmdArgs.includes("--dry-run"),
+        enableHubAutostart: cmdArgs.includes("--enable-hub-autostart"),
+      });
       return;
     case "doctor": {
       if (cmdArgs.includes("--audit")) {

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -696,6 +696,7 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        writeStateFile: probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/triflux/hub/team/health-probe.mjs
+++ b/packages/triflux/hub/team/health-probe.mjs
@@ -2,6 +2,10 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 /**
  * Health probe level 정의.
  * L0: Process alive (PID 존재 + exit code 없음)
@@ -25,6 +29,8 @@ export const PROBE_DEFAULTS = Object.freeze({
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
   enableL2: false,
+  writeStateFile: false,
+  stateDir: join(tmpdir(), "tfx-probe"),
 });
 
 /**
@@ -95,6 +101,49 @@ export function createHealthProbe(session, opts = {}) {
     lastProbeAt: null,
     inputWaitPattern: null,
   };
+
+  function getStateFilePath() {
+    if (typeof config.stateFile === "string" && config.stateFile.length > 0) {
+      return config.stateFile;
+    }
+    const pid = session.pid;
+    if (pid == null || pid <= 0) return null;
+    return join(config.stateDir, `${pid}.json`);
+  }
+
+  function deriveState(result) {
+    if (result.l0 === "fail") return "exited";
+    if (result.l1 === "input_wait") return "input_wait";
+    if (result.l2 === "fail") return "mcp_initializing";
+    if (result.l1 === "stall") return "stalled";
+    if (result.l3 === "timeout") return "reasoning";
+    return "active";
+  }
+
+  function writeState(result) {
+    if (!config.writeStateFile && !config.stateFile) return;
+    const stateFile = getStateFilePath();
+    if (!stateFile) return;
+    try {
+      mkdirSync(dirname(stateFile), { recursive: true });
+      writeFileSync(
+        stateFile,
+        JSON.stringify(
+          {
+            pid: session.pid ?? null,
+            state: deriveState(result),
+            result,
+            updatedAt: new Date(result.ts).toISOString(),
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+    } catch {
+      // probe state is advisory only.
+    }
+  }
 
   /**
    * L0: Process alive check.
@@ -227,6 +276,7 @@ export function createHealthProbe(session, opts = {}) {
       ts: Date.now(),
     };
     status.lastProbeAt = result.ts;
+    writeState(result);
 
     if (typeof config.onProbe === "function") {
       config.onProbe(result);
@@ -258,6 +308,12 @@ export function createHealthProbe(session, opts = {}) {
     if (timer) {
       clearInterval(timer);
       timer = null;
+    }
+    if (config.writeStateFile || config.stateFile) {
+      try {
+        const stateFile = getStateFilePath();
+        if (stateFile) unlinkSync(stateFile);
+      } catch {}
     }
   }
 

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -47,6 +47,7 @@ function detectDevMode(root = PLUGIN_ROOT) {
 const BREADCRUMB_PATH = join(CLAUDE_DIR, "scripts", ".tfx-pkg-root");
 const SETTINGS_PATH = join(CLAUDE_DIR, "settings.json");
 const HUD_PATH = join(CLAUDE_DIR, "hud", "hud-qos-status.mjs");
+const WINDOWS_HUB_AUTOSTART_TASK = "TrifluxHubEnsure";
 
 const REQUIRED_CODEX_PROFILES = [
   // gpt-5.5 — 새 main 플래그십. xhigh/high/med/low 4 tier 전부 보장.
@@ -747,6 +748,81 @@ function getSetupArgv(stdinData) {
   return Array.isArray(stdinData?.argv) ? stdinData.argv : [];
 }
 
+function quoteWindowsTaskArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function buildWindowsHubAutostartCommand({
+  nodePath = process.execPath,
+  pluginRoot = PLUGIN_ROOT,
+} = {}) {
+  return [
+    quoteWindowsTaskArg(nodePath),
+    quoteWindowsTaskArg(join(pluginRoot, "scripts", "hub-ensure.mjs")),
+  ].join(" ");
+}
+
+function getWindowsHubAutostartStatus({
+  taskName = WINDOWS_HUB_AUTOSTART_TASK,
+} = {}) {
+  if (process.platform !== "win32") {
+    return { supported: false, registered: false, taskName };
+  }
+  try {
+    execFileSync("schtasks.exe", ["/Query", "/TN", taskName], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return { supported: true, registered: true, taskName };
+  } catch {
+    return { supported: true, registered: false, taskName };
+  }
+}
+
+function ensureWindowsHubAutostart({
+  taskName = WINDOWS_HUB_AUTOSTART_TASK,
+  nodePath = process.execPath,
+  pluginRoot = PLUGIN_ROOT,
+  force = true,
+} = {}) {
+  if (process.platform !== "win32") {
+    return {
+      supported: false,
+      changed: false,
+      registered: false,
+      taskName,
+      reason: "non-windows",
+    };
+  }
+
+  const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
+  const args = [
+    "/Create",
+    "/TN",
+    taskName,
+    "/SC",
+    "ONLOGON",
+    "/TR",
+    command,
+    "/RL",
+    "LIMITED",
+  ];
+  if (force) args.push("/F");
+
+  execFileSync("schtasks.exe", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  return {
+    supported: true,
+    changed: true,
+    registered: true,
+    taskName,
+    command,
+  };
+}
+
 function loadSettings() {
   if (!existsSync(SETTINGS_PATH)) return {};
 
@@ -987,9 +1063,11 @@ export {
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
   ensureHooksInSettings,
+  ensureWindowsHubAutostart,
   extractManagedHookFilename,
   getManagedRegistryHooks,
   getVersion,
+  getWindowsHubAutostartStatus,
   hasProfileSection,
   LEGACY_CODEX_MODELS,
   PLUGIN_ROOT,
@@ -1000,6 +1078,8 @@ export {
   SETUP_MARKER_PATH,
   SKILL_ALIASES,
   SYNC_MAP,
+  WINDOWS_HUB_AUTOSTART_TASK,
+  buildWindowsHubAutostartCommand,
   scanHudFiles,
   syncAliasedSkillDir,
   writeMarker,
@@ -1032,6 +1112,9 @@ export async function runDeferred(stdinData) {
   const argv = getSetupArgv(stdinData);
   const isSync = argv.includes("--sync");
   const isForce = argv.includes("--force");
+  const enableHubAutostart =
+    argv.includes("--enable-hub-autostart") ||
+    process.env.TFX_HUB_AUTOSTART === "1";
   const isDev = detectDevMode();
 
   if (isDev) {
@@ -1666,6 +1749,24 @@ export async function runDeferred(stdinData) {
   const codexProfilesResult = ensureCodexProfiles();
   if (codexProfilesResult.ok && codexProfilesResult.changed > 0) {
     synced++;
+  }
+
+  // ── Windows Codex 단독 실행 보호: 로그인 시 hub-ensure 등록 ──
+  // Claude SessionStart 훅이 없는 순수 Codex 시작 경로에서도 tfx-hub가 살아있게 한다.
+  if (enableHubAutostart) {
+    try {
+      const result = ensureWindowsHubAutostart();
+      if (result.registered) {
+        io.log(
+          `  \x1b[32m✓\x1b[0m Windows hub autostart: ${result.taskName}`,
+        );
+        synced++;
+      }
+    } catch (error) {
+      io.log(
+        `  \x1b[33m⚠\x1b[0m Windows hub autostart 등록 실패: ${error.message}`,
+      );
+    }
   }
 
   // ── CLAUDE.md 라우팅 섹션 자동 동기화 ──

--- a/packages/triflux/scripts/sync-hub-mcp-settings.mjs
+++ b/packages/triflux/scripts/sync-hub-mcp-settings.mjs
@@ -132,8 +132,11 @@ function parseTomlScalar(rawValue) {
 }
 
 function findMcpServerSection(raw, sectionName) {
+  // TOML 동치 표현 지원: [mcp_servers.name] / [mcp_servers."name"] / [mcp_servers . name]
+  // 미검출 시 appendCodexMcpServerSection이 중복 테이블 생성 → TOMLDecodeError 회귀 방지.
+  const escaped = escapeRegExp(sectionName);
   const headerRegex = new RegExp(
-    `^\\[mcp_servers\\.${escapeRegExp(sectionName)}\\]\\s*$`,
+    `^\\[\\s*mcp_servers\\s*\\.\\s*(?:${escaped}|"${escaped}"|'${escaped}')\\s*\\]\\s*$`,
     "m",
   );
   const headerMatch = headerRegex.exec(raw);
@@ -151,6 +154,12 @@ function findMcpServerSection(raw, sectionName) {
     bodyStart,
     sectionEnd,
   };
+}
+
+function appendCodexMcpServerSection(raw, sectionName, hubUrl) {
+  const normalized = raw.length > 0 && !raw.endsWith("\n") ? `${raw}\n` : raw;
+  const separator = normalized.length > 0 && !normalized.endsWith("\n\n") ? "\n" : "";
+  return `${normalized}${separator}[mcp_servers.${sectionName}]\nurl = ${formatTomlString(hubUrl)}\n`;
 }
 
 async function syncSingleFile({ filePath, hubUrl, dryRun, logger }) {
@@ -243,8 +252,29 @@ async function syncCodexConfigFile({ filePath, hubUrl, dryRun, logger }) {
 
     const section = findMcpServerSection(raw, TFX_HUB_SECTION);
     if (!section) {
-      log(logger, "info", `[codex-mcp-sync] skipped: ${filePath}`);
-      return { kind: "skipped", path: filePath };
+      const nextRaw = appendCodexMcpServerSection(raw, TFX_HUB_SECTION, hubUrl);
+      log(
+        logger,
+        "debug",
+        `[codex-mcp-sync] ${filePath} add ${TFX_HUB_SECTION}: ${hubUrl}`,
+      );
+
+      if (!dryRun) {
+        try {
+          await writeTextAtomic(filePath, nextRaw);
+        } catch (error) {
+          const reason = getReason(error, "write failed");
+          log(
+            logger,
+            "error",
+            `[codex-mcp-sync] error: ${filePath} (${reason})`,
+          );
+          return { kind: "error", path: filePath, reason };
+        }
+      }
+
+      log(logger, "info", `[codex-mcp-sync] updated: ${filePath}`);
+      return { kind: "updated", path: filePath };
     }
 
     const urlMatch = /^(\s*url\s*=\s*)(.+?)(\s*(?:#.*)?)$/m.exec(section.body);

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -262,7 +262,7 @@ if [[ "$MCP_PROFILE" == --* ]]; then
 fi
 
 # ── CLI 경로 해석 (Windows npm global 대응) ──
-NODE_BIN="${NODE_BIN:-$(command -v node 2>/dev/null || echo node)}"
+NODE_BIN="${NODE_BIN:-$(command -v node 2>/dev/null || command -v node.exe 2>/dev/null || echo node)}"
 CODEX_BIN="${CODEX_BIN:-$(command -v codex 2>/dev/null || echo codex)}"
 GEMINI_BIN="${GEMINI_BIN:-$(command -v gemini 2>/dev/null || echo gemini)}"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo claude)}"
@@ -278,6 +278,50 @@ GEMINI_PROFILES_PATH="${GEMINI_PROFILES_PATH:-${HOME}/.gemini/triflux-profiles.j
 # ── 상수 ──
 MAX_STDOUT_BYTES=51200  # 50KB — Claude 컨텍스트 절약
 TIMESTAMP=$(date +%s)
+TFX_PROBE_DIR="${TFX_PROBE_DIR:-${TFX_TMP}/tfx-probe}"
+mkdir -p "$TFX_PROBE_DIR" 2>/dev/null || true
+
+estimate_expected_duration_sec() {
+  local agent="${1:-}" profile="${2:-}" prompt="${3:-}"
+  local text="${prompt,,}"
+  local expected=30
+
+  case "$agent" in
+    explore|style-reviewer) expected=30 ;;
+    writer|verifier|qa-tester) expected=90 ;;
+    executor|debugger|test-engineer) expected=300 ;;
+    code-reviewer|security-reviewer|architect|planner|critic|analyst) expected=600 ;;
+    scientist|scientist-deep|deep-executor|document-specialist) expected=900 ;;
+  esac
+
+  case "$profile" in
+    minimal|default) [[ "$expected" -lt 60 ]] && expected=60 ;;
+    analyze|review|full) [[ "$expected" -lt 300 ]] && expected=300 ;;
+    implement|executor) [[ "$expected" -lt 300 ]] && expected=300 ;;
+  esac
+
+  if [[ "$text" =~ (deep|research|analy[sz]e|분석|리서치|조사|전체|전부|싹다|comprehensive) ]]; then
+    [[ "$expected" -lt 600 ]] && expected=600
+  fi
+  if [[ "$text" =~ (refactor|migration|migrate|리팩터|마이그레이션|대규모|rewrite) ]]; then
+    [[ "$expected" -lt 900 ]] && expected=900
+  fi
+  if [[ "$text" =~ (test|lint|build|npm|pnpm|pytest|검증|테스트) ]]; then
+    [[ "$expected" -lt 180 ]] && expected=180
+  fi
+  if [[ "$text" =~ (mcp|browser|playwright|context7|exa|tavily|brave) ]]; then
+    [[ "$expected" -lt 120 ]] && expected=120
+  fi
+
+  printf '%s\n' "$expected"
+}
+
+read_probe_state() {
+  local pid="$1"
+  local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
+  [[ -f "$state_file" ]] || return 1
+  sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$state_file" 2>/dev/null | head -1
+}
 RUN_ID="${TIMESTAMP}-$$-${RANDOM}"
 STDERR_LOG="${TFX_TMP}/tfx-route-${AGENT_TYPE}-${RUN_ID}-stderr.log"
 STDOUT_LOG="${TFX_TMP}/tfx-route-${AGENT_TYPE}-${RUN_ID}-stdout.log"
@@ -833,7 +877,7 @@ route_agent() {
 
   # ── CLI_TYPE: 단일 소스 (agent-map.json) ──
   local _raw_type
-  _raw_type=$(node -e "
+  _raw_type=$("$NODE_BIN" -e "
     const p=require('path').resolve(process.argv[1]);
     const m=JSON.parse(require('fs').readFileSync(p,'utf8'));
     const t=m[process.argv[2]];
@@ -842,7 +886,7 @@ route_agent() {
 
   if [[ -z "$_raw_type" ]]; then
     echo "ERROR: 알 수 없는 에이전트 타입: $agent" >&2
-    echo "사용 가능: $(node -e "console.log(Object.keys(JSON.parse(require('fs').readFileSync(require('path').resolve(process.argv[1]),'utf8'))).join(', '))" "$map_file" 2>/dev/null)" >&2
+    echo "사용 가능: $("$NODE_BIN" -e "console.log(Object.keys(JSON.parse(require('fs').readFileSync(require('path').resolve(process.argv[1]),'utf8'))).join(', '))" "$map_file" 2>/dev/null)" >&2
     exit 1
   fi
 
@@ -1299,7 +1343,9 @@ heartbeat_monitor() {
   [[ "${TFX_HEARTBEAT:-1}" -eq 0 ]] && return 0
   local pid="$1"
   local interval="${2:-${TFX_HEARTBEAT_INTERVAL:-10}}"
-  local stall_threshold="${3:-${TFX_STALL_THRESHOLD:-60}}"
+  # 땜빵(PLANNING P4 구현 전): 60 → 300. MCP init/재시도 여유 + false STALL 감소.
+  local stall_threshold="${3:-${TFX_STALL_THRESHOLD:-300}}"
+  local expected_duration="${TFX_EXPECTED_DURATION_SEC:-}"
   local last_size=0 stall_count=0
   local pid_gone=false
   local post_exit_checks=0
@@ -1330,18 +1376,27 @@ heartbeat_monitor() {
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
     current_size=$((current_size + stderr_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))
+    local expected_suffix=""
+    if [[ -n "$expected_duration" && "$expected_duration" =~ ^[0-9]+$ && "$expected_duration" -gt 0 ]]; then
+      expected_suffix=" expected=${expected_duration}s"
+      if [[ "$elapsed" -gt $((expected_duration * 2)) ]]; then
+        expected_suffix="${expected_suffix} anomaly=slow"
+      fi
+    fi
 
     if [[ "$current_size" -gt "$last_size" ]]; then
       stall_count=0
       if [[ "$pid_gone" == "true" ]]; then
         local _fi="forked"; [[ -n "$last_known_forks" ]] && _fi="forks:${last_known_forks// /,}"
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=active(${_fi})" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=active(${_fi})" >&2
         post_exit_checks=0  # reset — still producing output
       else
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=active" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=active" >&2
       fi
     else
       stall_count=$((stall_count + interval))
+      local probe_state=""
+      probe_state="$(read_probe_state "$pid" 2>/dev/null || true)"
       if [[ "$pid_gone" == "true" ]]; then
         if [[ -n "$last_known_forks" ]]; then
           # Direct fork tracking — terminate when all forks are dead
@@ -1350,26 +1405,30 @@ heartbeat_monitor() {
             kill -0 "$_fp" 2>/dev/null && _alive=true && break
           done
           if [[ "$_alive" == "false" ]]; then
-            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=terminated(forks-exited)" >&2
+            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=terminated(forks-exited)" >&2
             break
           fi
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=fork-idle(${last_known_forks// /,})" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=fork-idle(${last_known_forks// /,})" >&2
         else
           # Fallback: output-based drain (no fork PIDs found)
           post_exit_checks=$((post_exit_checks + 1))
           if [[ "$post_exit_checks" -ge "$max_post_exit_checks" ]]; then
-            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=terminated(drain-done)" >&2
+            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=terminated(drain-done)" >&2
             break
           fi
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=draining(${post_exit_checks}/${max_post_exit_checks})" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=draining(${post_exit_checks}/${max_post_exit_checks})" >&2
         fi
+      elif [[ "$probe_state" =~ ^(mcp_initializing|input_wait)$ ]]; then
+        stall_count=0
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=${probe_state}(probe-grace)" >&2
       elif [[ "$stall_count" -ge "$stall_threshold" ]]; then
         # STALL kill (#144/#66 regression guard): stall=threshold+grace 이상 지속 시 SIGTERM→SIGKILL.
-        # 기본 활성화. TFX_STALL_KILL=0 으로 opt-out. grace=30s (기본) 은 SSE/MCP 정상 handshake 여유.
-        local kill_on_stall="${TFX_STALL_KILL:-1}"
+        # 땜빵(PLANNING P4 구현 전): default 1 → 0. false kill >> true stuck 비용이 압도적이라
+        # opt-in 으로 전환. debug 필요 시 TFX_STALL_KILL=1 로 명시 활성화. classify mode는 차기.
+        local kill_on_stall="${TFX_STALL_KILL:-0}"
         local kill_grace="${TFX_STALL_KILL_GRACE:-30}"
         if [[ "$kill_on_stall" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
           # Snapshot child PIDs before SIGTERM — wrapper 가 SIGTERM 을 수용해 죽으면
           # 부모 소멸 후 taskkill /T 가 자식 트리를 탐색하지 못해 codex 자식이 orphan 으로 남는다.
           # 사용자 보고(2026-04-22): "tfx-route 래퍼 exit 이후에도 Codex 자식이 살아있음".
@@ -1417,9 +1476,9 @@ heartbeat_monitor() {
           fi
           break
         fi
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL stall=${stall_count}s" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL stall=${stall_count}s" >&2
       else
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=quiet stall=${stall_count}s" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=quiet stall=${stall_count}s" >&2
       fi
     fi
     last_size=$current_size
@@ -1922,6 +1981,9 @@ main() {
     TIMEOUT_SEC="$DEFAULT_TIMEOUT"
   fi
 
+  TFX_EXPECTED_DURATION_SEC="${TFX_EXPECTED_DURATION_SEC:-$(estimate_expected_duration_sec "$AGENT_TYPE" "$MCP_PROFILE" "$PROMPT")}"
+  export TFX_EXPECTED_DURATION_SEC
+
   # 컨텍스트 파일 → 프롬프트에 주입
   if [[ -n "$CONTEXT_FILE" && -f "$CONTEXT_FILE" ]]; then
     local ctx_content
@@ -2055,6 +2117,11 @@ FALLBACK_EOF
         # MCP 실패 → exec fallback. run_codex_exec는 < /dev/null 로 stdin 블록 회피 (line 1639).
         # 정책: codex/gemini 강건성 — MCP 가용 시 MCP, 실패 시 그래도 워커 자체는 굴러간다.
         echo "[tfx-route] Codex MCP 실패(exit=${exit_code}). exec fallback 시도." >&2
+        local _sd
+        _sd="$(_get_script_dir)"
+        if [[ -f "$_sd/hub-ensure.mjs" ]]; then
+          "$NODE_BIN" "$_sd/hub-ensure.mjs" >/dev/null 2>&1 || true
+        fi
         exit_code=0
         run_codex_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
         codex_transport_effective="exec-fallback"

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -47,6 +47,7 @@ function detectDevMode(root = PLUGIN_ROOT) {
 const BREADCRUMB_PATH = join(CLAUDE_DIR, "scripts", ".tfx-pkg-root");
 const SETTINGS_PATH = join(CLAUDE_DIR, "settings.json");
 const HUD_PATH = join(CLAUDE_DIR, "hud", "hud-qos-status.mjs");
+const WINDOWS_HUB_AUTOSTART_TASK = "TrifluxHubEnsure";
 
 const REQUIRED_CODEX_PROFILES = [
   // gpt-5.5 — 새 main 플래그십. xhigh/high/med/low 4 tier 전부 보장.
@@ -747,6 +748,81 @@ function getSetupArgv(stdinData) {
   return Array.isArray(stdinData?.argv) ? stdinData.argv : [];
 }
 
+function quoteWindowsTaskArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function buildWindowsHubAutostartCommand({
+  nodePath = process.execPath,
+  pluginRoot = PLUGIN_ROOT,
+} = {}) {
+  return [
+    quoteWindowsTaskArg(nodePath),
+    quoteWindowsTaskArg(join(pluginRoot, "scripts", "hub-ensure.mjs")),
+  ].join(" ");
+}
+
+function getWindowsHubAutostartStatus({
+  taskName = WINDOWS_HUB_AUTOSTART_TASK,
+} = {}) {
+  if (process.platform !== "win32") {
+    return { supported: false, registered: false, taskName };
+  }
+  try {
+    execFileSync("schtasks.exe", ["/Query", "/TN", taskName], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return { supported: true, registered: true, taskName };
+  } catch {
+    return { supported: true, registered: false, taskName };
+  }
+}
+
+function ensureWindowsHubAutostart({
+  taskName = WINDOWS_HUB_AUTOSTART_TASK,
+  nodePath = process.execPath,
+  pluginRoot = PLUGIN_ROOT,
+  force = true,
+} = {}) {
+  if (process.platform !== "win32") {
+    return {
+      supported: false,
+      changed: false,
+      registered: false,
+      taskName,
+      reason: "non-windows",
+    };
+  }
+
+  const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
+  const args = [
+    "/Create",
+    "/TN",
+    taskName,
+    "/SC",
+    "ONLOGON",
+    "/TR",
+    command,
+    "/RL",
+    "LIMITED",
+  ];
+  if (force) args.push("/F");
+
+  execFileSync("schtasks.exe", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  return {
+    supported: true,
+    changed: true,
+    registered: true,
+    taskName,
+    command,
+  };
+}
+
 function loadSettings() {
   if (!existsSync(SETTINGS_PATH)) return {};
 
@@ -987,9 +1063,11 @@ export {
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
   ensureHooksInSettings,
+  ensureWindowsHubAutostart,
   extractManagedHookFilename,
   getManagedRegistryHooks,
   getVersion,
+  getWindowsHubAutostartStatus,
   hasProfileSection,
   LEGACY_CODEX_MODELS,
   PLUGIN_ROOT,
@@ -1000,6 +1078,8 @@ export {
   SETUP_MARKER_PATH,
   SKILL_ALIASES,
   SYNC_MAP,
+  WINDOWS_HUB_AUTOSTART_TASK,
+  buildWindowsHubAutostartCommand,
   scanHudFiles,
   syncAliasedSkillDir,
   writeMarker,
@@ -1032,6 +1112,9 @@ export async function runDeferred(stdinData) {
   const argv = getSetupArgv(stdinData);
   const isSync = argv.includes("--sync");
   const isForce = argv.includes("--force");
+  const enableHubAutostart =
+    argv.includes("--enable-hub-autostart") ||
+    process.env.TFX_HUB_AUTOSTART === "1";
   const isDev = detectDevMode();
 
   if (isDev) {
@@ -1666,6 +1749,24 @@ export async function runDeferred(stdinData) {
   const codexProfilesResult = ensureCodexProfiles();
   if (codexProfilesResult.ok && codexProfilesResult.changed > 0) {
     synced++;
+  }
+
+  // ── Windows Codex 단독 실행 보호: 로그인 시 hub-ensure 등록 ──
+  // Claude SessionStart 훅이 없는 순수 Codex 시작 경로에서도 tfx-hub가 살아있게 한다.
+  if (enableHubAutostart) {
+    try {
+      const result = ensureWindowsHubAutostart();
+      if (result.registered) {
+        io.log(
+          `  \x1b[32m✓\x1b[0m Windows hub autostart: ${result.taskName}`,
+        );
+        synced++;
+      }
+    } catch (error) {
+      io.log(
+        `  \x1b[33m⚠\x1b[0m Windows hub autostart 등록 실패: ${error.message}`,
+      );
+    }
   }
 
   // ── CLAUDE.md 라우팅 섹션 자동 동기화 ──

--- a/scripts/sync-hub-mcp-settings.mjs
+++ b/scripts/sync-hub-mcp-settings.mjs
@@ -132,8 +132,11 @@ function parseTomlScalar(rawValue) {
 }
 
 function findMcpServerSection(raw, sectionName) {
+  // TOML 동치 표현 지원: [mcp_servers.name] / [mcp_servers."name"] / [mcp_servers . name]
+  // 미검출 시 appendCodexMcpServerSection이 중복 테이블 생성 → TOMLDecodeError 회귀 방지.
+  const escaped = escapeRegExp(sectionName);
   const headerRegex = new RegExp(
-    `^\\[mcp_servers\\.${escapeRegExp(sectionName)}\\]\\s*$`,
+    `^\\[\\s*mcp_servers\\s*\\.\\s*(?:${escaped}|"${escaped}"|'${escaped}')\\s*\\]\\s*$`,
     "m",
   );
   const headerMatch = headerRegex.exec(raw);
@@ -151,6 +154,12 @@ function findMcpServerSection(raw, sectionName) {
     bodyStart,
     sectionEnd,
   };
+}
+
+function appendCodexMcpServerSection(raw, sectionName, hubUrl) {
+  const normalized = raw.length > 0 && !raw.endsWith("\n") ? `${raw}\n` : raw;
+  const separator = normalized.length > 0 && !normalized.endsWith("\n\n") ? "\n" : "";
+  return `${normalized}${separator}[mcp_servers.${sectionName}]\nurl = ${formatTomlString(hubUrl)}\n`;
 }
 
 async function syncSingleFile({ filePath, hubUrl, dryRun, logger }) {
@@ -243,8 +252,29 @@ async function syncCodexConfigFile({ filePath, hubUrl, dryRun, logger }) {
 
     const section = findMcpServerSection(raw, TFX_HUB_SECTION);
     if (!section) {
-      log(logger, "info", `[codex-mcp-sync] skipped: ${filePath}`);
-      return { kind: "skipped", path: filePath };
+      const nextRaw = appendCodexMcpServerSection(raw, TFX_HUB_SECTION, hubUrl);
+      log(
+        logger,
+        "debug",
+        `[codex-mcp-sync] ${filePath} add ${TFX_HUB_SECTION}: ${hubUrl}`,
+      );
+
+      if (!dryRun) {
+        try {
+          await writeTextAtomic(filePath, nextRaw);
+        } catch (error) {
+          const reason = getReason(error, "write failed");
+          log(
+            logger,
+            "error",
+            `[codex-mcp-sync] error: ${filePath} (${reason})`,
+          );
+          return { kind: "error", path: filePath, reason };
+        }
+      }
+
+      log(logger, "info", `[codex-mcp-sync] updated: ${filePath}`);
+      return { kind: "updated", path: filePath };
     }
 
     const urlMatch = /^(\s*url\s*=\s*)(.+?)(\s*(?:#.*)?)$/m.exec(section.body);

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -262,7 +262,7 @@ if [[ "$MCP_PROFILE" == --* ]]; then
 fi
 
 # ── CLI 경로 해석 (Windows npm global 대응) ──
-NODE_BIN="${NODE_BIN:-$(command -v node 2>/dev/null || echo node)}"
+NODE_BIN="${NODE_BIN:-$(command -v node 2>/dev/null || command -v node.exe 2>/dev/null || echo node)}"
 CODEX_BIN="${CODEX_BIN:-$(command -v codex 2>/dev/null || echo codex)}"
 GEMINI_BIN="${GEMINI_BIN:-$(command -v gemini 2>/dev/null || echo gemini)}"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || echo claude)}"
@@ -278,6 +278,50 @@ GEMINI_PROFILES_PATH="${GEMINI_PROFILES_PATH:-${HOME}/.gemini/triflux-profiles.j
 # ── 상수 ──
 MAX_STDOUT_BYTES=51200  # 50KB — Claude 컨텍스트 절약
 TIMESTAMP=$(date +%s)
+TFX_PROBE_DIR="${TFX_PROBE_DIR:-${TFX_TMP}/tfx-probe}"
+mkdir -p "$TFX_PROBE_DIR" 2>/dev/null || true
+
+estimate_expected_duration_sec() {
+  local agent="${1:-}" profile="${2:-}" prompt="${3:-}"
+  local text="${prompt,,}"
+  local expected=30
+
+  case "$agent" in
+    explore|style-reviewer) expected=30 ;;
+    writer|verifier|qa-tester) expected=90 ;;
+    executor|debugger|test-engineer) expected=300 ;;
+    code-reviewer|security-reviewer|architect|planner|critic|analyst) expected=600 ;;
+    scientist|scientist-deep|deep-executor|document-specialist) expected=900 ;;
+  esac
+
+  case "$profile" in
+    minimal|default) [[ "$expected" -lt 60 ]] && expected=60 ;;
+    analyze|review|full) [[ "$expected" -lt 300 ]] && expected=300 ;;
+    implement|executor) [[ "$expected" -lt 300 ]] && expected=300 ;;
+  esac
+
+  if [[ "$text" =~ (deep|research|analy[sz]e|분석|리서치|조사|전체|전부|싹다|comprehensive) ]]; then
+    [[ "$expected" -lt 600 ]] && expected=600
+  fi
+  if [[ "$text" =~ (refactor|migration|migrate|리팩터|마이그레이션|대규모|rewrite) ]]; then
+    [[ "$expected" -lt 900 ]] && expected=900
+  fi
+  if [[ "$text" =~ (test|lint|build|npm|pnpm|pytest|검증|테스트) ]]; then
+    [[ "$expected" -lt 180 ]] && expected=180
+  fi
+  if [[ "$text" =~ (mcp|browser|playwright|context7|exa|tavily|brave) ]]; then
+    [[ "$expected" -lt 120 ]] && expected=120
+  fi
+
+  printf '%s\n' "$expected"
+}
+
+read_probe_state() {
+  local pid="$1"
+  local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
+  [[ -f "$state_file" ]] || return 1
+  sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$state_file" 2>/dev/null | head -1
+}
 RUN_ID="${TIMESTAMP}-$$-${RANDOM}"
 STDERR_LOG="${TFX_TMP}/tfx-route-${AGENT_TYPE}-${RUN_ID}-stderr.log"
 STDOUT_LOG="${TFX_TMP}/tfx-route-${AGENT_TYPE}-${RUN_ID}-stdout.log"
@@ -833,7 +877,7 @@ route_agent() {
 
   # ── CLI_TYPE: 단일 소스 (agent-map.json) ──
   local _raw_type
-  _raw_type=$(node -e "
+  _raw_type=$("$NODE_BIN" -e "
     const p=require('path').resolve(process.argv[1]);
     const m=JSON.parse(require('fs').readFileSync(p,'utf8'));
     const t=m[process.argv[2]];
@@ -842,7 +886,7 @@ route_agent() {
 
   if [[ -z "$_raw_type" ]]; then
     echo "ERROR: 알 수 없는 에이전트 타입: $agent" >&2
-    echo "사용 가능: $(node -e "console.log(Object.keys(JSON.parse(require('fs').readFileSync(require('path').resolve(process.argv[1]),'utf8'))).join(', '))" "$map_file" 2>/dev/null)" >&2
+    echo "사용 가능: $("$NODE_BIN" -e "console.log(Object.keys(JSON.parse(require('fs').readFileSync(require('path').resolve(process.argv[1]),'utf8'))).join(', '))" "$map_file" 2>/dev/null)" >&2
     exit 1
   fi
 
@@ -1299,7 +1343,9 @@ heartbeat_monitor() {
   [[ "${TFX_HEARTBEAT:-1}" -eq 0 ]] && return 0
   local pid="$1"
   local interval="${2:-${TFX_HEARTBEAT_INTERVAL:-10}}"
-  local stall_threshold="${3:-${TFX_STALL_THRESHOLD:-60}}"
+  # 땜빵(PLANNING P4 구현 전): 60 → 300. MCP init/재시도 여유 + false STALL 감소.
+  local stall_threshold="${3:-${TFX_STALL_THRESHOLD:-300}}"
+  local expected_duration="${TFX_EXPECTED_DURATION_SEC:-}"
   local last_size=0 stall_count=0
   local pid_gone=false
   local post_exit_checks=0
@@ -1330,18 +1376,27 @@ heartbeat_monitor() {
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
     current_size=$((current_size + stderr_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))
+    local expected_suffix=""
+    if [[ -n "$expected_duration" && "$expected_duration" =~ ^[0-9]+$ && "$expected_duration" -gt 0 ]]; then
+      expected_suffix=" expected=${expected_duration}s"
+      if [[ "$elapsed" -gt $((expected_duration * 2)) ]]; then
+        expected_suffix="${expected_suffix} anomaly=slow"
+      fi
+    fi
 
     if [[ "$current_size" -gt "$last_size" ]]; then
       stall_count=0
       if [[ "$pid_gone" == "true" ]]; then
         local _fi="forked"; [[ -n "$last_known_forks" ]] && _fi="forks:${last_known_forks// /,}"
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=active(${_fi})" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=active(${_fi})" >&2
         post_exit_checks=0  # reset — still producing output
       else
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=active" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=active" >&2
       fi
     else
       stall_count=$((stall_count + interval))
+      local probe_state=""
+      probe_state="$(read_probe_state "$pid" 2>/dev/null || true)"
       if [[ "$pid_gone" == "true" ]]; then
         if [[ -n "$last_known_forks" ]]; then
           # Direct fork tracking — terminate when all forks are dead
@@ -1350,26 +1405,30 @@ heartbeat_monitor() {
             kill -0 "$_fp" 2>/dev/null && _alive=true && break
           done
           if [[ "$_alive" == "false" ]]; then
-            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=terminated(forks-exited)" >&2
+            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=terminated(forks-exited)" >&2
             break
           fi
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=fork-idle(${last_known_forks// /,})" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=fork-idle(${last_known_forks// /,})" >&2
         else
           # Fallback: output-based drain (no fork PIDs found)
           post_exit_checks=$((post_exit_checks + 1))
           if [[ "$post_exit_checks" -ge "$max_post_exit_checks" ]]; then
-            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=terminated(drain-done)" >&2
+            echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=terminated(drain-done)" >&2
             break
           fi
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=draining(${post_exit_checks}/${max_post_exit_checks})" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=draining(${post_exit_checks}/${max_post_exit_checks})" >&2
         fi
+      elif [[ "$probe_state" =~ ^(mcp_initializing|input_wait)$ ]]; then
+        stall_count=0
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=${probe_state}(probe-grace)" >&2
       elif [[ "$stall_count" -ge "$stall_threshold" ]]; then
         # STALL kill (#144/#66 regression guard): stall=threshold+grace 이상 지속 시 SIGTERM→SIGKILL.
-        # 기본 활성화. TFX_STALL_KILL=0 으로 opt-out. grace=30s (기본) 은 SSE/MCP 정상 handshake 여유.
-        local kill_on_stall="${TFX_STALL_KILL:-1}"
+        # 땜빵(PLANNING P4 구현 전): default 1 → 0. false kill >> true stuck 비용이 압도적이라
+        # opt-in 으로 전환. debug 필요 시 TFX_STALL_KILL=1 로 명시 활성화. classify mode는 차기.
+        local kill_on_stall="${TFX_STALL_KILL:-0}"
         local kill_grace="${TFX_STALL_KILL_GRACE:-30}"
         if [[ "$kill_on_stall" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
-          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
           # Snapshot child PIDs before SIGTERM — wrapper 가 SIGTERM 을 수용해 죽으면
           # 부모 소멸 후 taskkill /T 가 자식 트리를 탐색하지 못해 codex 자식이 orphan 으로 남는다.
           # 사용자 보고(2026-04-22): "tfx-route 래퍼 exit 이후에도 Codex 자식이 살아있음".
@@ -1417,9 +1476,9 @@ heartbeat_monitor() {
           fi
           break
         fi
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=STALL stall=${stall_count}s" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL stall=${stall_count}s" >&2
       else
-        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B status=quiet stall=${stall_count}s" >&2
+        echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=quiet stall=${stall_count}s" >&2
       fi
     fi
     last_size=$current_size
@@ -1922,6 +1981,9 @@ main() {
     TIMEOUT_SEC="$DEFAULT_TIMEOUT"
   fi
 
+  TFX_EXPECTED_DURATION_SEC="${TFX_EXPECTED_DURATION_SEC:-$(estimate_expected_duration_sec "$AGENT_TYPE" "$MCP_PROFILE" "$PROMPT")}"
+  export TFX_EXPECTED_DURATION_SEC
+
   # 컨텍스트 파일 → 프롬프트에 주입
   if [[ -n "$CONTEXT_FILE" && -f "$CONTEXT_FILE" ]]; then
     local ctx_content
@@ -2055,6 +2117,11 @@ FALLBACK_EOF
         # MCP 실패 → exec fallback. run_codex_exec는 < /dev/null 로 stdin 블록 회피 (line 1639).
         # 정책: codex/gemini 강건성 — MCP 가용 시 MCP, 실패 시 그래도 워커 자체는 굴러간다.
         echo "[tfx-route] Codex MCP 실패(exit=${exit_code}). exec fallback 시도." >&2
+        local _sd
+        _sd="$(_get_script_dir)"
+        if [[ -f "$_sd/hub-ensure.mjs" ]]; then
+          "$NODE_BIN" "$_sd/hub-ensure.mjs" >/dev/null 2>&1 || true
+        fi
         exit_code=0
         run_codex_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
         codex_transport_effective="exec-fallback"

--- a/tests/integration/tfx-route-smoke.test.mjs
+++ b/tests/integration/tfx-route-smoke.test.mjs
@@ -12,7 +12,9 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { BASH_EXE, toBashPath } from "../helpers/bash-path.mjs";
@@ -25,6 +27,34 @@ const ROUTE_SCRIPT = toBashPath(
 const FIXTURE_BIN = toBashPath(
   resolve(PROJECT_ROOT, "tests", "fixtures", "bin"),
 );
+
+function createRouteHome() {
+  const home = mkdtempSync(join(tmpdir(), "tfx-route-home-"));
+  const codexDir = join(home, ".codex");
+  mkdirSync(codexDir, { recursive: true });
+  writeFileSync(
+    join(codexDir, "config.toml"),
+    [
+      "[mcp_servers.context7]",
+      'command = "node"',
+      "",
+      "[mcp_servers.brave-search]",
+      'command = "node"',
+      "",
+      "[mcp_servers.exa]",
+      'command = "node"',
+      "",
+      "[mcp_servers.tavily]",
+      'command = "node"',
+      "",
+      "[mcp_servers.playwright]",
+      'command = "node"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return home;
+}
 
 // bash 실행 헬퍼 — stdout + stderr 합산 반환
 function runBash(command, extraEnv = {}) {
@@ -68,9 +98,12 @@ function allowedMcpServers(result) {
 }
 
 function fixtureEnv(extraEnv = {}) {
+  const home = createRouteHome();
   return {
     ...extraEnv,
     PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+    HOME: home,
+    USERPROFILE: home,
   };
 }
 

--- a/tests/integration/triflux-cli.test.mjs
+++ b/tests/integration/triflux-cli.test.mjs
@@ -279,6 +279,7 @@ describe("triflux CLI JSON and schema surface", { timeout: 30000 }, () => {
         "[profiles.spark53_low]",
         'model = "legacy-spark"',
         "",
+        "# padding: realistic Codex config files are larger than setup's safety floor",
       ].join("\n"),
       "utf8",
     );

--- a/tests/unit/health-probe.test.mjs
+++ b/tests/unit/health-probe.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
@@ -159,6 +162,29 @@ describe("health-probe: createHealthProbe", () => {
     assert.equal(probe.started, true);
     probe.stop();
     assert.equal(probe.started, false);
+  });
+
+  it("probe state 파일을 pid 기준으로 쓸 수 있어야 한다", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-test-"));
+    const session = {
+      pid: 4242,
+      alive: true,
+      getOutputBytes: () => 0,
+      getRecentOutput: () => "Initializing MCP...",
+    };
+
+    const probe = createHealthProbe(session, {
+      enableL2: true,
+      checkMcp: async () => false,
+      writeStateFile: true,
+      stateDir,
+    });
+    await probe.probe();
+
+    const state = JSON.parse(readFileSync(join(stateDir, "4242.json"), "utf8"));
+    assert.equal(state.pid, 4242);
+    assert.equal(state.state, "mcp_initializing");
+    assert.equal(state.result.l2, "fail");
   });
 });
 

--- a/tests/unit/setup-autostart.test.mjs
+++ b/tests/unit/setup-autostart.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  WINDOWS_HUB_AUTOSTART_TASK,
+  buildWindowsHubAutostartCommand,
+  getWindowsHubAutostartStatus,
+} from "../../scripts/setup.mjs";
+
+describe("setup hub autostart", () => {
+  it("Windows Task Scheduler command points at hub-ensure", () => {
+    const command = buildWindowsHubAutostartCommand({
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      pluginRoot: "C:\\triflux",
+    });
+
+    assert.match(command, /node\.exe"/);
+    assert.match(
+      command,
+      new RegExp(
+        join("C:\\triflux", "scripts", "hub-ensure.mjs").replace(
+          /[\\^$.*+?()[\]{}|]/g,
+          "\\$&",
+        ),
+      ),
+    );
+  });
+
+  it("status helper is safe on every platform", () => {
+    const status = getWindowsHubAutostartStatus();
+    assert.equal(status.taskName, WINDOWS_HUB_AUTOSTART_TASK);
+    assert.equal(typeof status.registered, "boolean");
+  });
+});

--- a/tests/unit/sync-hub-mcp-settings.test.mjs
+++ b/tests/unit/sync-hub-mcp-settings.test.mjs
@@ -366,24 +366,33 @@ describe("syncCodexHubUrl", () => {
     assert.equal(readFileSync(configPath, "utf8"), before);
   });
 
-  it("case 5: tfx-hub 섹션이 없으면 생성하지 않고 skip한다", async () => {
+  it("case 5: tfx-hub 섹션이 없으면 Codex 단독 시작을 위해 생성한다", async () => {
     const configPath = codexPath(".codex", "config.toml");
     writeRaw(
       configPath,
       `[mcp_servers.other]\nurl = "http://127.0.0.1:3000/mcp"\n`,
     );
 
-    const before = readFileSync(configPath, "utf8");
     const result = await syncCodexHubUrl({
       hubUrl: HUB_URL,
       codexConfigPath: configPath,
       logger: createLogger(),
     });
 
-    assert.deepEqual(result.updated, []);
+    assert.deepEqual(result.updated, [configPath]);
     assert.deepEqual(result.errors, []);
-    assert.deepEqual(result.skipped, [configPath]);
-    assert.equal(readFileSync(configPath, "utf8"), before);
+    assert.deepEqual(result.skipped, []);
+    assert.equal(
+      readFileSync(configPath, "utf8"),
+      [
+        "[mcp_servers.other]",
+        'url = "http://127.0.0.1:3000/mcp"',
+        "",
+        "[mcp_servers.tfx-hub]",
+        `url = "${HUB_URL}"`,
+        "",
+      ].join("\n"),
+    );
   });
 
   it("case 6: tfx-hub.url 라인이 없으면 errors에 기록하고 원본 파일을 보존한다", async () => {


### PR DESCRIPTION
## Summary

세션 22 Remaining Work 및 후속 STALL_KILL 이슈 일괄 처리. 4 commits (probe wiring + autostart + sync append + docs).

## Changes

### 1. `feat(probe)`: expected duration + probe state file grace + STALL_KILL stopgap
- **#150** expected duration baseline — agent/profile/prompt 휴리스틱 (explore 30s → scientist 900s)
- **#151** G1 heartbeat ↔ probe state file wiring — `${tmpdir}/tfx-probe/${pid}.json` 5-state JSON
- **#156-c** defense-in-depth: MCP exec fallback 직전 hub-ensure.mjs 재호출
- **STALL_KILL stopgap** (PLANNING P4 full 구현 전):
  - `TFX_STALL_KILL` default `1 → 0`
  - `TFX_STALL_THRESHOLD` default `60 → 300`
  - 실증 근거: MCP-degraded Codex review 가 60s 내 응답 못하는 false STALL 다수 관찰
  - debug 시 `TFX_STALL_KILL=1` 명시 opt-in 가능

### 2. `feat(setup)`: Windows Task Scheduler hub autostart (#156-b)
- `tfx setup --enable-hub-autostart` — schtasks `ONLOGON TrifluxHubEnsure LIMITED`
- Claude SessionStart 훅 없는 순수 Codex 시작 경로 대응
- default 비활성 (opt-in), non-win32 는 noop
- Codex review [P1] 반영: subprocess silent-catch 회귀 가드 — `schtasks /Query` 재검증으로 실제 등록 여부 확인

### 3. `fix(sync)`: codex config.toml tfx-hub auto-append (#156-c)
- 신규 Codex 환경에서 `~/.codex/config.toml` 에 tfx-hub section 없으면 skip 대신 자동 삽입
- PR #158 의 `projectRoot: cwd` 전환과 짝
- Codex review [HIGH] 반영: `findMcpServerSection` regex 가 TOML 동치 표현 3 종 지원  
  `[mcp_servers.X]` / `[mcp_servers.\"X\"]` / `[mcp_servers . X]` — 미지원 시 중복 테이블 생성 회귀 방지

### 4. `docs(tfx-update-logic)`: PR #158 반영
- `resolveHubTarget` 이 `TFX_HUB_PORT` env (없으면 `HUB_DEFAULT_PORT=27888`) 를 single source of truth 로 한다는 계약 명시

## Test plan
- [x] `health-probe` 18/18 PASS
- [x] `setup-autostart` 2/2 PASS (신규)
- [x] `sync-hub-mcp-settings` 23/23 PASS (축 3 regex 확장 후 회귀 없음)
- [ ] 전체 test suite (reviewer 환경)

## Codex 교차 리뷰
축 1/2/3 각각 독립 Codex 리뷰 (code-reviewer agent via tfx-route, review profile).  
핵심 FIX_FIRST 3건이 이 PR 에 반영됨:
- [P1] autostart silent-catch → `/Query` 재검증
- [HIGH] TOML 동치 header regex 확장
- [MEDIUM] `approval_wait` dead path 정리

## Follow-up 이슈 (별도 등록 예정)
- 축 1: `/Query` 실패 원인 구분 (권한 vs 미등록), `/TR` escaping 강화 + 262 길이 검증
- 축 2: `probe()` in-flight vs `stop()` race (atomic write), estimate_expected_duration 한글 regex unit test
- 축 3: `writeTextAtomic` rename fallback 비원자성, TOML write 후 검증
- STALL_KILL: `classify` mode (로그만 + kill 안 함) + probe state write default on (PLANNING P4 full)