### PR TITLE
fix(probe): atomic write + stop() race (#162)

### DIFF
--- a/hub/team/health-probe.mjs
+++ b/hub/team/health-probe.mjs
@@ -2,12 +2,7 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import {
-  mkdirSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -92,7 +87,13 @@ export function createHealthProbe(session, opts = {}) {
   // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
   // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
   let stopped = false;
-  let inFlightProbe = null;
+  // P0 (#167 review): start() 마다 증가. probe() 가 시작 시 캡처 → writeState() 가 epoch
+  // 비교로 stop()→start() 사이의 in-flight 가 새 run 의 state 를 덮는 race 차단.
+  // stopped flag 만으로는 start() 가 stopped=false 로 reset 한 직후 race 못 막음.
+  let runEpoch = 0;
+  // P1-1 (#167 review): Set 으로 모든 in-flight probe 추적. interval 이 빨라 N+1 이 N 끝나기
+  // 전에 시작되면 단일 var 는 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+  const inFlightProbes = new Set();
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -129,8 +130,12 @@ export function createHealthProbe(session, opts = {}) {
     return "active";
   }
 
-  function writeState(result) {
-    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
+  function writeState(result, probeEpoch) {
+    // stop() 직후 in-flight probe()의 재생성 방지.
+    // P0 (#167): probeEpoch !== runEpoch 면 이전 run 의 stale probe 가 새 run 의 state 를
+    // 덮으려는 시도 → skip.
+    if (stopped) return;
+    if (probeEpoch !== undefined && probeEpoch !== runEpoch) return;
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
@@ -154,16 +159,38 @@ export function createHealthProbe(session, opts = {}) {
       try {
         renameSync(tmpPath, stateFile);
       } catch (renameErr) {
-        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        // Windows: 대상이 존재할 때 EPERM/EACCES.
+        // P1-2 (#167 review): backup-then-swap 으로 기존 파일 보존. 옛 unlinkSync→renameSync
+        // 패턴은 1차 unlink 후 2차 rename 실패 시 기존 파일과 tmp 둘 다 잃었다.
         if (
           renameErr?.code === "EEXIST" ||
           renameErr?.code === "EPERM" ||
           renameErr?.code === "EACCES"
         ) {
+          const backupPath = `${stateFile}.old-${process.pid}-${Date.now()}`;
+          let backupCreated = false;
           try {
-            unlinkSync(stateFile);
-          } catch {}
-          renameSync(tmpPath, stateFile);
+            renameSync(stateFile, backupPath);
+            backupCreated = true;
+          } catch {
+            // backup 실패 (대상 없음/잠김) — 그래도 진행 (tmp→stateFile 시도)
+          }
+          try {
+            renameSync(tmpPath, stateFile);
+            if (backupCreated) {
+              try {
+                unlinkSync(backupPath);
+              } catch {}
+            }
+          } catch (secondErr) {
+            // 2차도 실패 → backup 복구해서 기존 파일 보존
+            if (backupCreated) {
+              try {
+                renameSync(backupPath, stateFile);
+              } catch {}
+            }
+            throw secondErr;
+          }
         } else {
           throw renameErr;
         }
@@ -299,6 +326,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function probe() {
     if (stopped) return null;
+    // P0 (#167): probe 시작 시 epoch 캡처. start() 가 새 epoch 로 바꾸면 이 probe 의
+    // writeState 는 stale 로 판정 → skip.
+    const probeEpoch = runEpoch;
     const promise = (async () => {
       const result = {
         l0: probeL0(),
@@ -309,7 +339,7 @@ export function createHealthProbe(session, opts = {}) {
         ts: Date.now(),
       };
       status.lastProbeAt = result.ts;
-      writeState(result);
+      writeState(result, probeEpoch);
 
       if (typeof config.onProbe === "function") {
         config.onProbe(result);
@@ -317,9 +347,10 @@ export function createHealthProbe(session, opts = {}) {
 
       return result;
     })();
-    inFlightProbe = promise.finally(() => {
-      if (inFlightProbe === promise) inFlightProbe = null;
-    });
+    // P1-1 (#167): Set 으로 모든 in-flight 추적. 단일 var 패턴은 N+1 이 N 끝나기 전에
+    // 시작되면 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+    inFlightProbes.add(promise);
+    promise.finally(() => inFlightProbes.delete(promise));
     return promise;
   }
 
@@ -327,6 +358,8 @@ export function createHealthProbe(session, opts = {}) {
     if (started) return;
     started = true;
     stopped = false;
+    // P0 (#167): epoch 증가 — 이전 run 의 in-flight probe 가 새 run 의 state 를 덮지 못하게.
+    runEpoch += 1;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -366,10 +399,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function stopAndDrain() {
     stop();
-    if (inFlightProbe) {
-      try {
-        await inFlightProbe;
-      } catch {}
+    // P1-1 (#167): 모든 in-flight probe 대기. allSettled 로 unhandled rejection 방지.
+    if (inFlightProbes.size > 0) {
+      await Promise.allSettled(Array.from(inFlightProbes));
     }
   }
 

--- a/hub/team/health-probe.mjs
+++ b/hub/team/health-probe.mjs
@@ -2,7 +2,12 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -84,6 +89,10 @@ export function createHealthProbe(session, opts = {}) {
   const config = { ...PROBE_DEFAULTS, ...opts };
   let timer = null;
   let started = false;
+  // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
+  // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
+  let stopped = false;
+  let inFlightProbe = null;
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -121,27 +130,49 @@ export function createHealthProbe(session, opts = {}) {
   }
 
   function writeState(result) {
+    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
+    const payload =
+      JSON.stringify(
+        {
+          pid: session.pid ?? null,
+          state: deriveState(result),
+          result,
+          updatedAt: new Date(result.ts).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n";
+    // tmp+rename 으로 atomic write — heartbeat 의 sed 가 부분 파일을 읽는 race 제거.
+    // tmp 는 같은 디렉토리에 둬야 EXDEV (cross-device link) 가 안 난다.
+    const tmpPath = `${stateFile}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
       mkdirSync(dirname(stateFile), { recursive: true });
-      writeFileSync(
-        stateFile,
-        JSON.stringify(
-          {
-            pid: session.pid ?? null,
-            state: deriveState(result),
-            result,
-            updatedAt: new Date(result.ts).toISOString(),
-          },
-          null,
-          2,
-        ) + "\n",
-        "utf8",
-      );
+      writeFileSync(tmpPath, payload, "utf8");
+      try {
+        renameSync(tmpPath, stateFile);
+      } catch (renameErr) {
+        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        if (
+          renameErr?.code === "EEXIST" ||
+          renameErr?.code === "EPERM" ||
+          renameErr?.code === "EACCES"
+        ) {
+          try {
+            unlinkSync(stateFile);
+          } catch {}
+          renameSync(tmpPath, stateFile);
+        } else {
+          throw renameErr;
+        }
+      }
     } catch {
-      // probe state is advisory only.
+      // probe state is advisory only — tmp cleanup
+      try {
+        unlinkSync(tmpPath);
+      } catch {}
     }
   }
 
@@ -264,30 +295,38 @@ export function createHealthProbe(session, opts = {}) {
 
   /**
    * 전체 probe 실행 (L0→L1→L2→L3).
-   * @returns {Promise<object>} probe 결과
+   * @returns {Promise<object|null>} probe 결과. stop() 이후 호출이면 null.
    */
   async function probe() {
-    const result = {
-      l0: probeL0(),
-      l1: probeL1(),
-      l2: await probeL2(),
-      l3: probeL3(),
-      inputWaitPattern: status.inputWaitPattern,
-      ts: Date.now(),
-    };
-    status.lastProbeAt = result.ts;
-    writeState(result);
+    if (stopped) return null;
+    const promise = (async () => {
+      const result = {
+        l0: probeL0(),
+        l1: probeL1(),
+        l2: await probeL2(),
+        l3: probeL3(),
+        inputWaitPattern: status.inputWaitPattern,
+        ts: Date.now(),
+      };
+      status.lastProbeAt = result.ts;
+      writeState(result);
 
-    if (typeof config.onProbe === "function") {
-      config.onProbe(result);
-    }
+      if (typeof config.onProbe === "function") {
+        config.onProbe(result);
+      }
 
-    return result;
+      return result;
+    })();
+    inFlightProbe = promise.finally(() => {
+      if (inFlightProbe === promise) inFlightProbe = null;
+    });
+    return promise;
   }
 
   function start() {
     if (started) return;
     started = true;
+    stopped = false;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -305,6 +344,9 @@ export function createHealthProbe(session, opts = {}) {
   function stop() {
     if (!started) return;
     started = false;
+    // stopped 를 먼저 set 해야 in-flight probe()의 writeState() 가 skip 된다.
+    // 이후 unlink — in-flight 가 끝나도 writeState 가 no-op 이므로 재생성 없음.
+    stopped = true;
     if (timer) {
       clearInterval(timer);
       timer = null;
@@ -313,6 +355,20 @@ export function createHealthProbe(session, opts = {}) {
       try {
         const stateFile = getStateFilePath();
         if (stateFile) unlinkSync(stateFile);
+      } catch {}
+    }
+  }
+
+  /**
+   * stop() 후 in-flight probe() 가 완료될 때까지 대기.
+   * 결정적 종료가 필요한 테스트/teardown 용. conductor 의 sync stop() 호출자는
+   * 그대로 stop() 만 호출하면 stopped flag 가 race 를 막는다.
+   */
+  async function stopAndDrain() {
+    stop();
+    if (inFlightProbe) {
+      try {
+        await inFlightProbe;
       } catch {}
     }
   }
@@ -333,6 +389,7 @@ export function createHealthProbe(session, opts = {}) {
   return Object.freeze({
     start,
     stop,
+    stopAndDrain,
     probe,
     resetTracking,
     getStatus: () => ({ ...status }),

--- a/packages/remote/hub/team/health-probe.mjs
+++ b/packages/remote/hub/team/health-probe.mjs
@@ -2,12 +2,7 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import {
-  mkdirSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -92,7 +87,13 @@ export function createHealthProbe(session, opts = {}) {
   // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
   // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
   let stopped = false;
-  let inFlightProbe = null;
+  // P0 (#167 review): start() 마다 증가. probe() 가 시작 시 캡처 → writeState() 가 epoch
+  // 비교로 stop()→start() 사이의 in-flight 가 새 run 의 state 를 덮는 race 차단.
+  // stopped flag 만으로는 start() 가 stopped=false 로 reset 한 직후 race 못 막음.
+  let runEpoch = 0;
+  // P1-1 (#167 review): Set 으로 모든 in-flight probe 추적. interval 이 빨라 N+1 이 N 끝나기
+  // 전에 시작되면 단일 var 는 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+  const inFlightProbes = new Set();
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -129,8 +130,12 @@ export function createHealthProbe(session, opts = {}) {
     return "active";
   }
 
-  function writeState(result) {
-    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
+  function writeState(result, probeEpoch) {
+    // stop() 직후 in-flight probe()의 재생성 방지.
+    // P0 (#167): probeEpoch !== runEpoch 면 이전 run 의 stale probe 가 새 run 의 state 를
+    // 덮으려는 시도 → skip.
+    if (stopped) return;
+    if (probeEpoch !== undefined && probeEpoch !== runEpoch) return;
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
@@ -154,16 +159,38 @@ export function createHealthProbe(session, opts = {}) {
       try {
         renameSync(tmpPath, stateFile);
       } catch (renameErr) {
-        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        // Windows: 대상이 존재할 때 EPERM/EACCES.
+        // P1-2 (#167 review): backup-then-swap 으로 기존 파일 보존. 옛 unlinkSync→renameSync
+        // 패턴은 1차 unlink 후 2차 rename 실패 시 기존 파일과 tmp 둘 다 잃었다.
         if (
           renameErr?.code === "EEXIST" ||
           renameErr?.code === "EPERM" ||
           renameErr?.code === "EACCES"
         ) {
+          const backupPath = `${stateFile}.old-${process.pid}-${Date.now()}`;
+          let backupCreated = false;
           try {
-            unlinkSync(stateFile);
-          } catch {}
-          renameSync(tmpPath, stateFile);
+            renameSync(stateFile, backupPath);
+            backupCreated = true;
+          } catch {
+            // backup 실패 (대상 없음/잠김) — 그래도 진행 (tmp→stateFile 시도)
+          }
+          try {
+            renameSync(tmpPath, stateFile);
+            if (backupCreated) {
+              try {
+                unlinkSync(backupPath);
+              } catch {}
+            }
+          } catch (secondErr) {
+            // 2차도 실패 → backup 복구해서 기존 파일 보존
+            if (backupCreated) {
+              try {
+                renameSync(backupPath, stateFile);
+              } catch {}
+            }
+            throw secondErr;
+          }
         } else {
           throw renameErr;
         }
@@ -299,6 +326,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function probe() {
     if (stopped) return null;
+    // P0 (#167): probe 시작 시 epoch 캡처. start() 가 새 epoch 로 바꾸면 이 probe 의
+    // writeState 는 stale 로 판정 → skip.
+    const probeEpoch = runEpoch;
     const promise = (async () => {
       const result = {
         l0: probeL0(),
@@ -309,7 +339,7 @@ export function createHealthProbe(session, opts = {}) {
         ts: Date.now(),
       };
       status.lastProbeAt = result.ts;
-      writeState(result);
+      writeState(result, probeEpoch);
 
       if (typeof config.onProbe === "function") {
         config.onProbe(result);
@@ -317,9 +347,10 @@ export function createHealthProbe(session, opts = {}) {
 
       return result;
     })();
-    inFlightProbe = promise.finally(() => {
-      if (inFlightProbe === promise) inFlightProbe = null;
-    });
+    // P1-1 (#167): Set 으로 모든 in-flight 추적. 단일 var 패턴은 N+1 이 N 끝나기 전에
+    // 시작되면 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+    inFlightProbes.add(promise);
+    promise.finally(() => inFlightProbes.delete(promise));
     return promise;
   }
 
@@ -327,6 +358,8 @@ export function createHealthProbe(session, opts = {}) {
     if (started) return;
     started = true;
     stopped = false;
+    // P0 (#167): epoch 증가 — 이전 run 의 in-flight probe 가 새 run 의 state 를 덮지 못하게.
+    runEpoch += 1;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -366,10 +399,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function stopAndDrain() {
     stop();
-    if (inFlightProbe) {
-      try {
-        await inFlightProbe;
-      } catch {}
+    // P1-1 (#167): 모든 in-flight probe 대기. allSettled 로 unhandled rejection 방지.
+    if (inFlightProbes.size > 0) {
+      await Promise.allSettled(Array.from(inFlightProbes));
     }
   }
 

--- a/packages/remote/hub/team/health-probe.mjs
+++ b/packages/remote/hub/team/health-probe.mjs
@@ -2,7 +2,12 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -84,6 +89,10 @@ export function createHealthProbe(session, opts = {}) {
   const config = { ...PROBE_DEFAULTS, ...opts };
   let timer = null;
   let started = false;
+  // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
+  // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
+  let stopped = false;
+  let inFlightProbe = null;
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -121,27 +130,49 @@ export function createHealthProbe(session, opts = {}) {
   }
 
   function writeState(result) {
+    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
+    const payload =
+      JSON.stringify(
+        {
+          pid: session.pid ?? null,
+          state: deriveState(result),
+          result,
+          updatedAt: new Date(result.ts).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n";
+    // tmp+rename 으로 atomic write — heartbeat 의 sed 가 부분 파일을 읽는 race 제거.
+    // tmp 는 같은 디렉토리에 둬야 EXDEV (cross-device link) 가 안 난다.
+    const tmpPath = `${stateFile}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
       mkdirSync(dirname(stateFile), { recursive: true });
-      writeFileSync(
-        stateFile,
-        JSON.stringify(
-          {
-            pid: session.pid ?? null,
-            state: deriveState(result),
-            result,
-            updatedAt: new Date(result.ts).toISOString(),
-          },
-          null,
-          2,
-        ) + "\n",
-        "utf8",
-      );
+      writeFileSync(tmpPath, payload, "utf8");
+      try {
+        renameSync(tmpPath, stateFile);
+      } catch (renameErr) {
+        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        if (
+          renameErr?.code === "EEXIST" ||
+          renameErr?.code === "EPERM" ||
+          renameErr?.code === "EACCES"
+        ) {
+          try {
+            unlinkSync(stateFile);
+          } catch {}
+          renameSync(tmpPath, stateFile);
+        } else {
+          throw renameErr;
+        }
+      }
     } catch {
-      // probe state is advisory only.
+      // probe state is advisory only — tmp cleanup
+      try {
+        unlinkSync(tmpPath);
+      } catch {}
     }
   }
 
@@ -264,30 +295,38 @@ export function createHealthProbe(session, opts = {}) {
 
   /**
    * 전체 probe 실행 (L0→L1→L2→L3).
-   * @returns {Promise<object>} probe 결과
+   * @returns {Promise<object|null>} probe 결과. stop() 이후 호출이면 null.
    */
   async function probe() {
-    const result = {
-      l0: probeL0(),
-      l1: probeL1(),
-      l2: await probeL2(),
-      l3: probeL3(),
-      inputWaitPattern: status.inputWaitPattern,
-      ts: Date.now(),
-    };
-    status.lastProbeAt = result.ts;
-    writeState(result);
+    if (stopped) return null;
+    const promise = (async () => {
+      const result = {
+        l0: probeL0(),
+        l1: probeL1(),
+        l2: await probeL2(),
+        l3: probeL3(),
+        inputWaitPattern: status.inputWaitPattern,
+        ts: Date.now(),
+      };
+      status.lastProbeAt = result.ts;
+      writeState(result);
 
-    if (typeof config.onProbe === "function") {
-      config.onProbe(result);
-    }
+      if (typeof config.onProbe === "function") {
+        config.onProbe(result);
+      }
 
-    return result;
+      return result;
+    })();
+    inFlightProbe = promise.finally(() => {
+      if (inFlightProbe === promise) inFlightProbe = null;
+    });
+    return promise;
   }
 
   function start() {
     if (started) return;
     started = true;
+    stopped = false;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -305,6 +344,9 @@ export function createHealthProbe(session, opts = {}) {
   function stop() {
     if (!started) return;
     started = false;
+    // stopped 를 먼저 set 해야 in-flight probe()의 writeState() 가 skip 된다.
+    // 이후 unlink — in-flight 가 끝나도 writeState 가 no-op 이므로 재생성 없음.
+    stopped = true;
     if (timer) {
       clearInterval(timer);
       timer = null;
@@ -313,6 +355,20 @@ export function createHealthProbe(session, opts = {}) {
       try {
         const stateFile = getStateFilePath();
         if (stateFile) unlinkSync(stateFile);
+      } catch {}
+    }
+  }
+
+  /**
+   * stop() 후 in-flight probe() 가 완료될 때까지 대기.
+   * 결정적 종료가 필요한 테스트/teardown 용. conductor 의 sync stop() 호출자는
+   * 그대로 stop() 만 호출하면 stopped flag 가 race 를 막는다.
+   */
+  async function stopAndDrain() {
+    stop();
+    if (inFlightProbe) {
+      try {
+        await inFlightProbe;
       } catch {}
     }
   }
@@ -333,6 +389,7 @@ export function createHealthProbe(session, opts = {}) {
   return Object.freeze({
     start,
     stop,
+    stopAndDrain,
     probe,
     resetTracking,
     getStatus: () => ({ ...status }),

--- a/packages/triflux/hub/team/health-probe.mjs
+++ b/packages/triflux/hub/team/health-probe.mjs
@@ -2,12 +2,7 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import {
-  mkdirSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -92,7 +87,13 @@ export function createHealthProbe(session, opts = {}) {
   // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
   // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
   let stopped = false;
-  let inFlightProbe = null;
+  // P0 (#167 review): start() 마다 증가. probe() 가 시작 시 캡처 → writeState() 가 epoch
+  // 비교로 stop()→start() 사이의 in-flight 가 새 run 의 state 를 덮는 race 차단.
+  // stopped flag 만으로는 start() 가 stopped=false 로 reset 한 직후 race 못 막음.
+  let runEpoch = 0;
+  // P1-1 (#167 review): Set 으로 모든 in-flight probe 추적. interval 이 빨라 N+1 이 N 끝나기
+  // 전에 시작되면 단일 var 는 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+  const inFlightProbes = new Set();
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -129,8 +130,12 @@ export function createHealthProbe(session, opts = {}) {
     return "active";
   }
 
-  function writeState(result) {
-    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
+  function writeState(result, probeEpoch) {
+    // stop() 직후 in-flight probe()의 재생성 방지.
+    // P0 (#167): probeEpoch !== runEpoch 면 이전 run 의 stale probe 가 새 run 의 state 를
+    // 덮으려는 시도 → skip.
+    if (stopped) return;
+    if (probeEpoch !== undefined && probeEpoch !== runEpoch) return;
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
@@ -154,16 +159,38 @@ export function createHealthProbe(session, opts = {}) {
       try {
         renameSync(tmpPath, stateFile);
       } catch (renameErr) {
-        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        // Windows: 대상이 존재할 때 EPERM/EACCES.
+        // P1-2 (#167 review): backup-then-swap 으로 기존 파일 보존. 옛 unlinkSync→renameSync
+        // 패턴은 1차 unlink 후 2차 rename 실패 시 기존 파일과 tmp 둘 다 잃었다.
         if (
           renameErr?.code === "EEXIST" ||
           renameErr?.code === "EPERM" ||
           renameErr?.code === "EACCES"
         ) {
+          const backupPath = `${stateFile}.old-${process.pid}-${Date.now()}`;
+          let backupCreated = false;
           try {
-            unlinkSync(stateFile);
-          } catch {}
-          renameSync(tmpPath, stateFile);
+            renameSync(stateFile, backupPath);
+            backupCreated = true;
+          } catch {
+            // backup 실패 (대상 없음/잠김) — 그래도 진행 (tmp→stateFile 시도)
+          }
+          try {
+            renameSync(tmpPath, stateFile);
+            if (backupCreated) {
+              try {
+                unlinkSync(backupPath);
+              } catch {}
+            }
+          } catch (secondErr) {
+            // 2차도 실패 → backup 복구해서 기존 파일 보존
+            if (backupCreated) {
+              try {
+                renameSync(backupPath, stateFile);
+              } catch {}
+            }
+            throw secondErr;
+          }
         } else {
           throw renameErr;
         }
@@ -299,6 +326,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function probe() {
     if (stopped) return null;
+    // P0 (#167): probe 시작 시 epoch 캡처. start() 가 새 epoch 로 바꾸면 이 probe 의
+    // writeState 는 stale 로 판정 → skip.
+    const probeEpoch = runEpoch;
     const promise = (async () => {
       const result = {
         l0: probeL0(),
@@ -309,7 +339,7 @@ export function createHealthProbe(session, opts = {}) {
         ts: Date.now(),
       };
       status.lastProbeAt = result.ts;
-      writeState(result);
+      writeState(result, probeEpoch);
 
       if (typeof config.onProbe === "function") {
         config.onProbe(result);
@@ -317,9 +347,10 @@ export function createHealthProbe(session, opts = {}) {
 
       return result;
     })();
-    inFlightProbe = promise.finally(() => {
-      if (inFlightProbe === promise) inFlightProbe = null;
-    });
+    // P1-1 (#167): Set 으로 모든 in-flight 추적. 단일 var 패턴은 N+1 이 N 끝나기 전에
+    // 시작되면 N 을 덮어써 stopAndDrain() 시 N 이 누락된다.
+    inFlightProbes.add(promise);
+    promise.finally(() => inFlightProbes.delete(promise));
     return promise;
   }
 
@@ -327,6 +358,8 @@ export function createHealthProbe(session, opts = {}) {
     if (started) return;
     started = true;
     stopped = false;
+    // P0 (#167): epoch 증가 — 이전 run 의 in-flight probe 가 새 run 의 state 를 덮지 못하게.
+    runEpoch += 1;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -366,10 +399,9 @@ export function createHealthProbe(session, opts = {}) {
    */
   async function stopAndDrain() {
     stop();
-    if (inFlightProbe) {
-      try {
-        await inFlightProbe;
-      } catch {}
+    // P1-1 (#167): 모든 in-flight probe 대기. allSettled 로 unhandled rejection 방지.
+    if (inFlightProbes.size > 0) {
+      await Promise.allSettled(Array.from(inFlightProbes));
     }
   }
 

--- a/packages/triflux/hub/team/health-probe.mjs
+++ b/packages/triflux/hub/team/health-probe.mjs
@@ -2,7 +2,12 @@
 // 기존 cli-adapter-base.mjs:stallThresholdMs(30s)와 headless.mjs:STALL_DEFAULTS(120s)를
 // 4단계 probe 모델로 교체. stdout+stderr 통합 스트림으로 평가 (F3 해결).
 
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -84,6 +89,10 @@ export function createHealthProbe(session, opts = {}) {
   const config = { ...PROBE_DEFAULTS, ...opts };
   let timer = null;
   let started = false;
+  // stopped flag는 in-flight probe()가 stop() 사이의 await 점에서
+  // writeState/unlink 와 race 하는 것을 막는다. start() 시 false 로 reset.
+  let stopped = false;
+  let inFlightProbe = null;
 
   // L1 tracking
   let lastOutputBytes = 0;
@@ -121,27 +130,49 @@ export function createHealthProbe(session, opts = {}) {
   }
 
   function writeState(result) {
+    if (stopped) return; // stop() 직후 in-flight probe()의 재생성 방지
     if (!config.writeStateFile && !config.stateFile) return;
     const stateFile = getStateFilePath();
     if (!stateFile) return;
+    const payload =
+      JSON.stringify(
+        {
+          pid: session.pid ?? null,
+          state: deriveState(result),
+          result,
+          updatedAt: new Date(result.ts).toISOString(),
+        },
+        null,
+        2,
+      ) + "\n";
+    // tmp+rename 으로 atomic write — heartbeat 의 sed 가 부분 파일을 읽는 race 제거.
+    // tmp 는 같은 디렉토리에 둬야 EXDEV (cross-device link) 가 안 난다.
+    const tmpPath = `${stateFile}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
       mkdirSync(dirname(stateFile), { recursive: true });
-      writeFileSync(
-        stateFile,
-        JSON.stringify(
-          {
-            pid: session.pid ?? null,
-            state: deriveState(result),
-            result,
-            updatedAt: new Date(result.ts).toISOString(),
-          },
-          null,
-          2,
-        ) + "\n",
-        "utf8",
-      );
+      writeFileSync(tmpPath, payload, "utf8");
+      try {
+        renameSync(tmpPath, stateFile);
+      } catch (renameErr) {
+        // Windows: 대상이 존재할 때 EPERM/EACCES — unlink 후 재시도.
+        if (
+          renameErr?.code === "EEXIST" ||
+          renameErr?.code === "EPERM" ||
+          renameErr?.code === "EACCES"
+        ) {
+          try {
+            unlinkSync(stateFile);
+          } catch {}
+          renameSync(tmpPath, stateFile);
+        } else {
+          throw renameErr;
+        }
+      }
     } catch {
-      // probe state is advisory only.
+      // probe state is advisory only — tmp cleanup
+      try {
+        unlinkSync(tmpPath);
+      } catch {}
     }
   }
 
@@ -264,30 +295,38 @@ export function createHealthProbe(session, opts = {}) {
 
   /**
    * 전체 probe 실행 (L0→L1→L2→L3).
-   * @returns {Promise<object>} probe 결과
+   * @returns {Promise<object|null>} probe 결과. stop() 이후 호출이면 null.
    */
   async function probe() {
-    const result = {
-      l0: probeL0(),
-      l1: probeL1(),
-      l2: await probeL2(),
-      l3: probeL3(),
-      inputWaitPattern: status.inputWaitPattern,
-      ts: Date.now(),
-    };
-    status.lastProbeAt = result.ts;
-    writeState(result);
+    if (stopped) return null;
+    const promise = (async () => {
+      const result = {
+        l0: probeL0(),
+        l1: probeL1(),
+        l2: await probeL2(),
+        l3: probeL3(),
+        inputWaitPattern: status.inputWaitPattern,
+        ts: Date.now(),
+      };
+      status.lastProbeAt = result.ts;
+      writeState(result);
 
-    if (typeof config.onProbe === "function") {
-      config.onProbe(result);
-    }
+      if (typeof config.onProbe === "function") {
+        config.onProbe(result);
+      }
 
-    return result;
+      return result;
+    })();
+    inFlightProbe = promise.finally(() => {
+      if (inFlightProbe === promise) inFlightProbe = null;
+    });
+    return promise;
   }
 
   function start() {
     if (started) return;
     started = true;
+    stopped = false;
     spawnedAt = Date.now();
     lastOutputChangeAt = Date.now();
     lastOutputBytes = 0;
@@ -305,6 +344,9 @@ export function createHealthProbe(session, opts = {}) {
   function stop() {
     if (!started) return;
     started = false;
+    // stopped 를 먼저 set 해야 in-flight probe()의 writeState() 가 skip 된다.
+    // 이후 unlink — in-flight 가 끝나도 writeState 가 no-op 이므로 재생성 없음.
+    stopped = true;
     if (timer) {
       clearInterval(timer);
       timer = null;
@@ -313,6 +355,20 @@ export function createHealthProbe(session, opts = {}) {
       try {
         const stateFile = getStateFilePath();
         if (stateFile) unlinkSync(stateFile);
+      } catch {}
+    }
+  }
+
+  /**
+   * stop() 후 in-flight probe() 가 완료될 때까지 대기.
+   * 결정적 종료가 필요한 테스트/teardown 용. conductor 의 sync stop() 호출자는
+   * 그대로 stop() 만 호출하면 stopped flag 가 race 를 막는다.
+   */
+  async function stopAndDrain() {
+    stop();
+    if (inFlightProbe) {
+      try {
+        await inFlightProbe;
       } catch {}
     }
   }
@@ -333,6 +389,7 @@ export function createHealthProbe(session, opts = {}) {
   return Object.freeze({
     start,
     stop,
+    stopAndDrain,
     probe,
     resetTracking,
     getStatus: () => ({ ...status }),

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -320,6 +320,12 @@ read_probe_state() {
   local pid="$1"
   local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
   [[ -f "$state_file" ]] || return 1
+  # 2-step read (#162): health-probe.mjs 의 atomic write (tmp+rename) 가 도입되었지만
+  # writer 쪽 OS race 또는 race-free 보장을 못 받는 환경 (예: 일부 FS) 에서 빈/부분 파일
+  # 을 sed 가 읽고 stale state 를 반환하는 것을 방지하기 위해 size 가 너무 작으면 무시.
+  local size
+  size=$(wc -c < "$state_file" 2>/dev/null || printf '0')
+  [[ "$size" -ge 20 ]] || return 1
   sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$state_file" 2>/dev/null | head -1
 }
 RUN_ID="${TIMESTAMP}-$$-${RANDOM}"

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -320,6 +320,12 @@ read_probe_state() {
   local pid="$1"
   local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
   [[ -f "$state_file" ]] || return 1
+  # 2-step read (#162): health-probe.mjs 의 atomic write (tmp+rename) 가 도입되었지만
+  # writer 쪽 OS race 또는 race-free 보장을 못 받는 환경 (예: 일부 FS) 에서 빈/부분 파일
+  # 을 sed 가 읽고 stale state 를 반환하는 것을 방지하기 위해 size 가 너무 작으면 무시.
+  local size
+  size=$(wc -c < "$state_file" 2>/dev/null || printf '0')
+  [[ "$size" -ge 20 ]] || return 1
   sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$state_file" 2>/dev/null | head -1
 }
 RUN_ID="${TIMESTAMP}-$$-${RANDOM}"

--- a/tests/unit/health-probe.test.mjs
+++ b/tests/unit/health-probe.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -185,6 +185,132 @@ describe("health-probe: createHealthProbe", () => {
     assert.equal(state.pid, 4242);
     assert.equal(state.state, "mcp_initializing");
     assert.equal(state.result.l2, "fail");
+  });
+});
+
+describe("health-probe: stop() race (#162)", () => {
+  it("stop() 후 probe() 호출은 null 을 반환해야 한다", async () => {
+    const session = {
+      pid: 4243,
+      alive: true,
+      getOutputBytes: () => 0,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session);
+    probe.stop(); // start() 안 했어도 stopped 는 set 안 됨 — start() 후 stop() 필요
+    probe.start();
+    probe.stop();
+    const result = await probe.probe();
+    assert.equal(result, null);
+  });
+
+  it("start() 는 stopped flag 를 리셋해야 한다", async () => {
+    const session = {
+      pid: 4244,
+      alive: true,
+      getOutputBytes: () => 100,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, { intervalMs: 100_000 });
+    probe.start();
+    probe.stop();
+    assert.equal(await probe.probe(), null);
+    probe.start();
+    const result = await probe.probe();
+    assert.ok(result, "start() 후 probe() 는 null 이 아니어야 한다");
+    assert.equal(result.l0, "ok");
+    probe.stop();
+  });
+
+  it("in-flight probe() 가 stop() 후 state file 을 재생성하지 않아야 한다", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-race-"));
+    let releaseMcp;
+    const mcpPromise = new Promise((resolve) => {
+      releaseMcp = resolve;
+    });
+    const session = {
+      pid: 4245,
+      alive: true,
+      getOutputBytes: () => 0,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, {
+      enableL2: true,
+      checkMcp: () => mcpPromise, // 영원히 await — manually release
+      writeStateFile: true,
+      stateDir,
+      intervalMs: 100_000,
+    });
+    probe.start();
+
+    // start() 가 즉시 첫 probe() 를 발사. probeL2 의 await mcpPromise 에서 yield 됨.
+    // 이 시점에 stop() 호출 → stopped=true + unlinkSync (state file 없음)
+    probe.stop();
+
+    // in-flight probe() 를 release. writeState 직전 stopped 체크로 skip 되어야 함.
+    releaseMcp(true);
+
+    // stopAndDrain 대신 stop 이미 호출. in-flight 가 끝날 때까지 micro-task 로 yield.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    const stateFile = join(stateDir, "4245.json");
+    assert.equal(
+      existsSync(stateFile),
+      false,
+      "stop() 후 in-flight probe() 가 state file 을 재생성하면 안 됨",
+    );
+    // tmp 파일도 leak 되면 안 됨 (writeState 가 stopped 를 보고 일찍 return).
+    const leftovers = readdirSync(stateDir).filter((n) => n.startsWith("4245.json.tmp"));
+    assert.deepEqual(leftovers, [], `tmp 파일이 남으면 안 됨: ${leftovers.join(",")}`);
+  });
+
+  it("stopAndDrain() 은 in-flight probe() 완료까지 await 한다", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-drain-"));
+    let releaseMcp;
+    const mcpPromise = new Promise((resolve) => {
+      releaseMcp = resolve;
+    });
+    const session = {
+      pid: 4246,
+      alive: true,
+      getOutputBytes: () => 0,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, {
+      enableL2: true,
+      checkMcp: () => mcpPromise,
+      writeStateFile: true,
+      stateDir,
+      intervalMs: 100_000,
+    });
+    probe.start();
+    // stop+drain 을 먼저 호출하되, drain 은 in-flight release 까지 대기.
+    queueMicrotask(() => releaseMcp(true));
+    await probe.stopAndDrain();
+    const stateFile = join(stateDir, "4246.json");
+    assert.equal(existsSync(stateFile), false);
+  });
+
+  it("atomic write 결과는 항상 valid JSON 이어야 한다", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-atomic-"));
+    const session = {
+      pid: 4247,
+      alive: true,
+      getOutputBytes: () => 256,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, {
+      writeStateFile: true,
+      stateDir,
+    });
+    // 여러 번 연속 write → 매번 JSON.parse 성공해야 함.
+    for (let i = 0; i < 10; i += 1) {
+      await probe.probe();
+      const raw = readFileSync(join(stateDir, "4247.json"), "utf8");
+      assert.doesNotThrow(() => JSON.parse(raw), `iteration ${i} JSON parse fail`);
+    }
+    probe.stop();
   });
 });
 

--- a/tests/unit/health-probe.test.mjs
+++ b/tests/unit/health-probe.test.mjs
@@ -261,8 +261,14 @@ describe("health-probe: stop() race (#162)", () => {
       "stop() 후 in-flight probe() 가 state file 을 재생성하면 안 됨",
     );
     // tmp 파일도 leak 되면 안 됨 (writeState 가 stopped 를 보고 일찍 return).
-    const leftovers = readdirSync(stateDir).filter((n) => n.startsWith("4245.json.tmp"));
-    assert.deepEqual(leftovers, [], `tmp 파일이 남으면 안 됨: ${leftovers.join(",")}`);
+    const leftovers = readdirSync(stateDir).filter((n) =>
+      n.startsWith("4245.json.tmp"),
+    );
+    assert.deepEqual(
+      leftovers,
+      [],
+      `tmp 파일이 남으면 안 됨: ${leftovers.join(",")}`,
+    );
   });
 
   it("stopAndDrain() 은 in-flight probe() 완료까지 await 한다", async () => {
@@ -308,9 +314,194 @@ describe("health-probe: stop() race (#162)", () => {
     for (let i = 0; i < 10; i += 1) {
       await probe.probe();
       const raw = readFileSync(join(stateDir, "4247.json"), "utf8");
-      assert.doesNotThrow(() => JSON.parse(raw), `iteration ${i} JSON parse fail`);
+      assert.doesNotThrow(
+        () => JSON.parse(raw),
+        `iteration ${i} JSON parse fail`,
+      );
     }
     probe.stop();
+  });
+});
+
+// PR #167 review findings — P0 + P1 회귀 가드.
+describe("health-probe: PR #167 review fixes", () => {
+  it("P0 — stop()→start() 재호출 시 old run 의 in-flight probe 가 새 run 의 state 를 덮지 않아야 한다", async () => {
+    // 시나리오: probe1 시작 → await probeL2 진행 중 → stop() → start() (run-2) → probe1 의
+    // writeState 가 epoch 비교로 skip 되어야 한다 (옛 stopped flag 만으로는 start() 가
+    // stopped=false reset 한 후 race 못 막음).
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-epoch-"));
+    let releaseMcp;
+    const mcpPromise = new Promise((resolve) => {
+      releaseMcp = resolve;
+    });
+    let probeCount = 0;
+    const session = {
+      pid: 9170,
+      alive: true,
+      getOutputBytes: () => 100 + probeCount,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, {
+      enableL2: true,
+      checkMcp: () => {
+        probeCount += 1;
+        return mcpPromise; // 영원히 hold 하지 않고 외부에서 release
+      },
+      writeStateFile: true,
+      stateDir,
+      intervalMs: 100_000,
+      onProbe: () => {},
+    });
+    probe.start(); // run-1 (epoch 1) — probe1 시작 (await checkMcp 에 멈춤)
+    // 짧은 yield 로 probe1 이 await checkMcp 까지 도달
+    await new Promise((r) => setImmediate(r));
+
+    probe.stop(); // stopped=true
+    probe.start(); // run-2 (epoch 2) — probe2 시작
+
+    // run-1 의 probe1 은 여전히 await checkMcp 에 멈춰 있다. 해제 → writeState 시도 → epoch 비교로 skip 되어야.
+    releaseMcp(true);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // run-2 의 probe 도 동일 mcpPromise 를 받았으므로 같이 release. 단 epoch 2 라 정상 write.
+    // 이 시점 state file 은 run-2 의 결과여야 (run-1 이 덮으면 회귀).
+    await probe.stopAndDrain();
+    const stateFile = join(stateDir, "9170.json");
+    if (existsSync(stateFile)) {
+      const raw = readFileSync(stateFile, "utf8");
+      assert.doesNotThrow(
+        () => JSON.parse(raw),
+        "state file 은 valid JSON 이어야",
+      );
+    } else {
+      // stop() 후 unlink 됐으면 OK. 핵심: 회귀 가드는 race 로 stale state 가 안 남는 것.
+    }
+  });
+
+  it("P1-1 — 겹친 in-flight probe 들이 모두 drain 되어야 한다 (단일 var 패턴 회귀)", async () => {
+    // 시나리오: 단일 inFlightProbe 변수를 쓰면 N+1 이 N 끝나기 전에 시작 → N 을 덮어써
+    // stopAndDrain() 시 N 이 누락. Set 패턴은 모두 추적.
+    const stateDir = mkdtempSync(join(tmpdir(), "tfx-probe-drain-"));
+    const releases = [];
+    const inFlightCount = { value: 0 };
+    let probeStarted = 0;
+    const session = {
+      pid: 9171,
+      alive: true,
+      getOutputBytes: () => probeStarted * 10,
+      getRecentOutput: () => "",
+    };
+    const probe = createHealthProbe(session, {
+      enableL2: true,
+      checkMcp: () =>
+        new Promise((resolve) => {
+          probeStarted += 1;
+          inFlightCount.value += 1;
+          releases.push(() => {
+            inFlightCount.value -= 1;
+            resolve(true);
+          });
+        }),
+      writeStateFile: true,
+      stateDir,
+      intervalMs: 100_000,
+    });
+    // 수동으로 probe() 3번 연속 호출 — 각각 await checkMcp 에 멈춤 → 3 in-flight 동시
+    const p1 = probe.probe();
+    const p2 = probe.probe();
+    const p3 = probe.probe();
+    await new Promise((r) => setImmediate(r));
+    assert.equal(inFlightCount.value, 3, "3 probe 가 동시 in-flight 여야");
+
+    // stopAndDrain 호출 → release 처리 → 모두 drain 되어야
+    const drainPromise = probe.stopAndDrain();
+    // release 모두 호출
+    for (const release of releases) release();
+    await drainPromise;
+    assert.equal(
+      inFlightCount.value,
+      0,
+      "stopAndDrain 후 in-flight = 0 (모두 drain)",
+    );
+    // promises 도 정상 settle (allSettled 라 reject 도 OK)
+    await Promise.allSettled([p1, p2, p3]);
+  });
+
+  it("P1-2 — atomic write 1차/2차 rename 실패 시뮬레이션 — 기존 파일이 손실되지 않아야 한다 (소스 검증)", () => {
+    // backup-then-swap 패턴이 코드에 들어있는지 source 검증.
+    // 옛 unlinkSync→renameSync 패턴은 1차 unlink 후 2차 rename 실패 시 기존 파일 손실.
+    const source = readFileSync(
+      new URL("../../hub/team/health-probe.mjs", import.meta.url),
+      "utf8",
+    );
+    assert.match(
+      source,
+      /backup-then-swap|backupCreated/,
+      "P1-2 backup-then-swap 패턴 사라짐",
+    );
+    assert.match(
+      source,
+      /renameSync\(stateFile, backupPath\)/,
+      "backup rename 분기 사라짐",
+    );
+    assert.match(
+      source,
+      /renameSync\(backupPath, stateFile\)/,
+      "backup 복구 분기 사라짐",
+    );
+    // 옛 패턴 (unlinkSync → renameSync 직접 시퀀스) 회귀 가드
+    assert.doesNotMatch(
+      source,
+      /unlinkSync\(stateFile\);\s*\}\s*catch\s*\{\}\s*renameSync\(tmpPath, stateFile\);/,
+      "옛 unlinkSync→renameSync 비원자 패턴 회귀",
+    );
+  });
+
+  it("P0 — source 에 runEpoch 가드 분기 포함", () => {
+    const source = readFileSync(
+      new URL("../../hub/team/health-probe.mjs", import.meta.url),
+      "utf8",
+    );
+    assert.match(
+      source,
+      /runEpoch\s*\+=\s*1/,
+      "start() 에서 runEpoch 증가 사라짐",
+    );
+    assert.match(
+      source,
+      /probeEpoch\s*=\s*runEpoch/,
+      "probe() 에서 epoch 캡처 사라짐",
+    );
+    assert.match(
+      source,
+      /probeEpoch\s*!==\s*runEpoch/,
+      "writeState() 의 epoch 비교 사라짐",
+    );
+  });
+
+  it("P1-1 — source 에 inFlightProbes Set 패턴 포함", () => {
+    const source = readFileSync(
+      new URL("../../hub/team/health-probe.mjs", import.meta.url),
+      "utf8",
+    );
+    assert.match(
+      source,
+      /inFlightProbes\s*=\s*new Set\(\)/,
+      "inFlightProbes Set 선언 사라짐",
+    );
+    assert.match(source, /inFlightProbes\.add\(promise\)/, "Set add 사라짐");
+    assert.match(
+      source,
+      /Promise\.allSettled\(Array\.from\(inFlightProbes\)\)/,
+      "stopAndDrain allSettled drain 사라짐",
+    );
+    // 옛 단일 var 패턴 회귀 가드
+    assert.doesNotMatch(
+      source,
+      /let\s+inFlightProbe\s*=\s*null/,
+      "옛 단일 inFlightProbe 변수 회귀",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- `health-probe.mjs` writeState 를 tmp+rename atomic 으로 전환. heartbeat 의 sed 가 부분 파일을 읽는 race 제거.
- `stopped` flag 신설. stop() 직후 in-flight probe() 의 await 점에서 돌아온 writeState 가 state file 을 재생성하지 못하도록 차단.
- `stopAndDrain()` 추가. teardown 결정성이 필요한 호출자용. conductor 의 sync stop() 호출자는 그대로 동작 (stopped flag 가 race 차단).
- `scripts/tfx-route.sh read_probe_state` 에 size>=20 체크 추가. atomic write 가 unsupported 인 환경에서 보수적 fallback.

## Closes

Closes #162.

## 영향 범위

`TFX_PROBE_WRITE_STATE=1` opt-in 환경만. 현재 default off 라 기존 사용자 회귀 리스크 없음. PR #160 의 probe state file 쓰기 경로에서 도출된 MEDIUM race 를 선제 차단.

## 변경 파일

- `hub/team/health-probe.mjs` + `packages/{triflux,remote}/hub/team/health-probe.mjs` (3-way mirror)
- `scripts/tfx-route.sh` + `packages/triflux/scripts/tfx-route.sh`
- `tests/unit/health-probe.test.mjs` — 신규 5 케이스 (stop race, stopAndDrain, atomic JSON 무결성)

## Test plan

- [x] `node --test tests/unit/health-probe.test.mjs` — 23/23 통과 (기존 18 + 신규 5)
- [x] `npm test` 전체 회귀 — 사전 실패 (`scripts/__tests__/mcp-guard-engine.test.mjs` 2 케이스) 은 baseline main `2a8eb2a` 에서도 동일 실패. #166 으로 분리.
- [x] Working tree 3-way mirror 검증 (`diff` 3 파일 동일)

## 후속

- #165 STALL_KILL classify mode + probe state write default on — 이 PR 이 선행 요건.
- #166 mcp-guard-engine port resolve 회귀 (PR #158 follow-up, 본 PR 과 무관).