### PR TITLE
feat(probe): STALL_KILL classify mode + probe state default on (#165)

### DIFF
--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -696,8 +696,10 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        // #165: default off → on. atomic write (#162) 로 race 제거됨.
+        // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
-          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
+          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -19,9 +19,9 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
-import { broker } from "@triflux/core/hub/account-broker.mjs";
-import { execFile, spawn } from "@triflux/core/hub/lib/spawn-trace.mjs";
-import { killProcess } from "@triflux/core/hub/platform.mjs";
+import { broker } from "../account-broker.mjs";
+import { execFile, spawn } from "../lib/spawn-trace.mjs";
+import { killProcess } from "../platform.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
   ensureConductorRegistry,
@@ -696,8 +696,10 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        // #165: default off → on. atomic write (#162) 로 race 제거됨.
+        // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
-          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
+          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -696,8 +696,10 @@ export function createConductor(opts = {}) {
       },
       {
         ...probeOpts,
+        // #165: default off → on. atomic write (#162) 로 race 제거됨.
+        // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
-          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE === "1",
+          probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1428,12 +1428,25 @@ heartbeat_monitor() {
         stall_count=0
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=${probe_state}(probe-grace)" >&2
       elif [[ "$stall_count" -ge "$stall_threshold" ]]; then
-        # STALL kill (#144/#66 regression guard): stall=threshold+grace 이상 지속 시 SIGTERM→SIGKILL.
-        # 땜빵(PLANNING P4 구현 전): default 1 → 0. false kill >> true stuck 비용이 압도적이라
-        # opt-in 으로 전환. debug 필요 시 TFX_STALL_KILL=1 로 명시 활성화. classify mode는 차기.
-        local kill_on_stall="${TFX_STALL_KILL:-0}"
+        # STALL 판정 modes (#165 PLANNING P4):
+        #   off  (alias: 0, disabled)  — silent. kill 안 함, STALL_CLASSIFY 로그도 없음
+        #   classify (default)          — kill 안 함. STALL_CLASSIFY 로그로 evidence 노출
+        #   kill (alias: 1, on)         — threshold+grace 초과 시 SIGTERM→SIGKILL
+        # PR #160 에서 default 1 → 0 으로 임시 후퇴 (false kill 방지). 본 PR(#165) 에서
+        # classify 로 승격 — evidence 는 남기되 false kill 리스크 없음.
+        local kill_on_stall="${TFX_STALL_KILL:-classify}"
+        [[ -z "$kill_on_stall" ]] && kill_on_stall="classify"
         local kill_grace="${TFX_STALL_KILL_GRACE:-30}"
-        if [[ "$kill_on_stall" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
+        local _should_kill=0
+        case "$kill_on_stall" in
+          1|on|kill) _should_kill=1 ;;
+          classify|0|off|disabled) ;;
+          *)
+            echo "[tfx-heartbeat] pid=$pid warning TFX_STALL_KILL=$kill_on_stall unknown, fallback classify" >&2
+            kill_on_stall="classify"
+            ;;
+        esac
+        if [[ "$_should_kill" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
           echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
           # Snapshot child PIDs before SIGTERM — wrapper 가 SIGTERM 을 수용해 죽으면
           # 부모 소멸 후 taskkill /T 가 자식 트리를 탐색하지 못해 codex 자식이 orphan 으로 남는다.
@@ -1481,6 +1494,9 @@ heartbeat_monitor() {
             fi
           fi
           break
+        fi
+        if [[ "$kill_on_stall" == "classify" && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_CLASSIFY stall=${stall_count}s (no-kill — TFX_STALL_KILL=classify)" >&2
         fi
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL stall=${stall_count}s" >&2
       else

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1428,12 +1428,25 @@ heartbeat_monitor() {
         stall_count=0
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=${probe_state}(probe-grace)" >&2
       elif [[ "$stall_count" -ge "$stall_threshold" ]]; then
-        # STALL kill (#144/#66 regression guard): stall=threshold+grace 이상 지속 시 SIGTERM→SIGKILL.
-        # 땜빵(PLANNING P4 구현 전): default 1 → 0. false kill >> true stuck 비용이 압도적이라
-        # opt-in 으로 전환. debug 필요 시 TFX_STALL_KILL=1 로 명시 활성화. classify mode는 차기.
-        local kill_on_stall="${TFX_STALL_KILL:-0}"
+        # STALL 판정 modes (#165 PLANNING P4):
+        #   off  (alias: 0, disabled)  — silent. kill 안 함, STALL_CLASSIFY 로그도 없음
+        #   classify (default)          — kill 안 함. STALL_CLASSIFY 로그로 evidence 노출
+        #   kill (alias: 1, on)         — threshold+grace 초과 시 SIGTERM→SIGKILL
+        # PR #160 에서 default 1 → 0 으로 임시 후퇴 (false kill 방지). 본 PR(#165) 에서
+        # classify 로 승격 — evidence 는 남기되 false kill 리스크 없음.
+        local kill_on_stall="${TFX_STALL_KILL:-classify}"
+        [[ -z "$kill_on_stall" ]] && kill_on_stall="classify"
         local kill_grace="${TFX_STALL_KILL_GRACE:-30}"
-        if [[ "$kill_on_stall" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
+        local _should_kill=0
+        case "$kill_on_stall" in
+          1|on|kill) _should_kill=1 ;;
+          classify|0|off|disabled) ;;
+          *)
+            echo "[tfx-heartbeat] pid=$pid warning TFX_STALL_KILL=$kill_on_stall unknown, fallback classify" >&2
+            kill_on_stall="classify"
+            ;;
+        esac
+        if [[ "$_should_kill" -eq 1 && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
           echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_KILL stall=${stall_count}s — SIGTERM" >&2
           # Snapshot child PIDs before SIGTERM — wrapper 가 SIGTERM 을 수용해 죽으면
           # 부모 소멸 후 taskkill /T 가 자식 트리를 탐색하지 못해 codex 자식이 orphan 으로 남는다.
@@ -1481,6 +1494,9 @@ heartbeat_monitor() {
             fi
           fi
           break
+        fi
+        if [[ "$kill_on_stall" == "classify" && "$stall_count" -ge $((stall_threshold + kill_grace)) ]]; then
+          echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL_CLASSIFY stall=${stall_count}s (no-kill — TFX_STALL_KILL=classify)" >&2
         fi
         echo "[tfx-heartbeat] pid=$pid elapsed=${elapsed}s output=${current_size}B${expected_suffix} status=STALL stall=${stall_count}s" >&2
       else

--- a/tests/unit/conductor-probe-default.test.mjs
+++ b/tests/unit/conductor-probe-default.test.mjs
@@ -1,0 +1,54 @@
+// tests/unit/conductor-probe-default.test.mjs
+// #165: TFX_PROBE_WRITE_STATE default off → on 전환 shape 검증.
+// conductor.mjs 의 health-probe 생성 라인이 "default on, opt-out = 0" 형태인지 확인.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+describe("#165 conductor probe writeStateFile default", () => {
+  it("conductor.mjs 는 TFX_PROBE_WRITE_STATE 가 '0' 이 아닐 때 writeStateFile=true 여야 한다", () => {
+    const src = readFileSync(
+      path.join(REPO_ROOT, "hub/team/conductor.mjs"),
+      "utf8",
+    );
+    // default on: 조건은 `!== "0"` (명시적 off 만 opt-out)
+    assert.match(
+      src,
+      /writeStateFile[^\n]*process\.env\.TFX_PROBE_WRITE_STATE\s*!==\s*"0"/,
+      "conductor 의 probe writeStateFile default 는 `!== '0'` 패턴이어야 함 (PR #165)",
+    );
+    // 금지: 이전 `=== "1"` 패턴 (default off) 은 더 이상 존재하면 안 됨.
+    assert.doesNotMatch(
+      src,
+      /writeStateFile[^\n]*process\.env\.TFX_PROBE_WRITE_STATE\s*===\s*"1"/,
+      "PR #160 의 default off 패턴이 남아있으면 안 됨",
+    );
+  });
+
+  it("packages 미러 (triflux, remote) 도 동일 패턴을 따라야 한다", () => {
+    const triflux = readFileSync(
+      path.join(REPO_ROOT, "packages/triflux/hub/team/conductor.mjs"),
+      "utf8",
+    );
+    const remote = readFileSync(
+      path.join(REPO_ROOT, "packages/remote/hub/team/conductor.mjs"),
+      "utf8",
+    );
+    for (const [name, src] of [
+      ["triflux", triflux],
+      ["remote", remote],
+    ]) {
+      assert.match(
+        src,
+        /writeStateFile[^\n]*process\.env\.TFX_PROBE_WRITE_STATE\s*!==\s*"0"/,
+        `${name} mirror 의 writeStateFile default 가 drift 됨`,
+      );
+    }
+  });
+});

--- a/tests/unit/tfx-route-stall-kill.test.mjs
+++ b/tests/unit/tfx-route-stall-kill.test.mjs
@@ -50,10 +50,33 @@ describe("#144/#66 heartbeat stall kill — shape", () => {
     assert.match(hb, /kill -KILL "\$pid"/, "SIGKILL 강제 경로 필수");
   });
 
-  it("kill_on_stall 기본값은 활성화(1)이고, grace 기본값은 30초", () => {
+  it("kill_on_stall 기본값은 classify 이고, grace 기본값은 30초 (#165)", () => {
+    // PR #160: default 1 → 0 으로 임시 후퇴 (false kill 방지)
+    // PR #165: 0 → classify 승격. evidence 는 남기되 kill 은 명시적 opt-in.
     const hb = extractFunction("heartbeat_monitor");
-    assert.match(hb, /kill_on_stall="\$\{TFX_STALL_KILL:-1\}"/);
+    assert.match(hb, /kill_on_stall="\$\{TFX_STALL_KILL:-classify\}"/);
     assert.match(hb, /kill_grace="\$\{TFX_STALL_KILL_GRACE:-30\}"/);
+  });
+
+  it("TFX_STALL_KILL 은 kill / classify / off 세 모드를 지원한다 (#165)", () => {
+    const hb = extractFunction("heartbeat_monitor");
+    // case 문에 세 모드 모두 존재해야 함
+    assert.match(hb, /1\|on\|kill/, "kill alias (1|on|kill) case arm 필요");
+    assert.match(
+      hb,
+      /classify\|0\|off\|disabled/,
+      "no-kill alias (classify|0|off|disabled) case arm 필요",
+    );
+    assert.match(
+      hb,
+      /STALL_CLASSIFY/,
+      "classify mode 의 evidence 로그 STALL_CLASSIFY 필요",
+    );
+    assert.match(
+      hb,
+      /no-kill — TFX_STALL_KILL=classify/,
+      "STALL_CLASSIFY 로그에 사용자 개입 힌트 필요",
+    );
   });
 
   it("Windows(MINGW/MSYS) 에서는 taskkill /T /F 로 프로세스 트리를 종료한다", () => {
@@ -94,64 +117,69 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
     }
   });
 
-  it("stall 이 지속되면 worker 에게 SIGTERM 을 보내고 loop 을 break 한다", (t) => {
-    const dir = mkdtempSync(path.join(tmpdir(), "tfx-stall-"));
+  function buildStallScript({ killMode, stdoutLog, stderrLog }) {
+    const hb = extractFunction("heartbeat_monitor");
+    const findForks = extractFunction("_find_fork_pids");
+    // bash file 로 실행. spawnSync("bash", ["-c", script]) 는 Windows Git Bash 에서
+    // 긴 script 의 line ending / argv 한도 문제로 EOF 오류를 내는 경우가 있어
+    // 파일 경유가 안전하다.
+    return [
+      "#!/usr/bin/env bash",
+      "set -u",
+      "export TFX_HEARTBEAT=1",
+      "export TFX_HEARTBEAT_INTERVAL=1",
+      "export TFX_STALL_THRESHOLD=2",
+      `export TFX_STALL_KILL=${killMode}`,
+      "export TFX_STALL_KILL_GRACE=1",
+      `STDOUT_LOG='${stdoutLog}'`,
+      `STDERR_LOG='${stderrLog}'`,
+      "TIMESTAMP=$(date +%s)",
+      "",
+      findForks,
+      hb,
+      "",
+      "sleep 30 &",
+      "CHILD_PID=$!",
+      "echo \"CHILD_PID=$CHILD_PID\" >&2",
+      "",
+      "heartbeat_monitor \"$CHILD_PID\" 1 2 &",
+      "HB_PID=$!",
+      "",
+      "for i in 1 2 3 4 5 6 7 8 9 10; do",
+      "  sleep 1",
+      "  if ! kill -0 \"$CHILD_PID\" 2>/dev/null; then",
+      "    echo \"CHILD_KILLED_AFTER=${i}s\" >&2",
+      "    break",
+      "  fi",
+      "done",
+      "",
+      "kill \"$HB_PID\" 2>/dev/null || true",
+      "wait \"$HB_PID\" 2>/dev/null || true",
+      "kill \"$CHILD_PID\" 2>/dev/null || true",
+      "",
+      "if kill -0 \"$CHILD_PID\" 2>/dev/null; then",
+      "  echo \"RESULT=child_still_alive\" >&2",
+      "  exit 1",
+      "else",
+      "  echo \"RESULT=child_terminated\" >&2",
+      "fi",
+      "",
+    ].join("\n");
+  }
+
+  it("TFX_STALL_KILL=kill 이면 stall 지속 시 worker 에게 SIGTERM 을 보내고 loop 을 break 한다", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-stall-kill-"));
     cleanupDirs.push(dir);
     const stdoutLog = path.join(dir, "stdout.log");
     const stderrLog = path.join(dir, "stderr.log");
+    const scriptFile = path.join(dir, "run.sh");
     writeFileSync(stdoutLog, "");
     writeFileSync(stderrLog, "");
-
-    // heartbeat_monitor + _find_fork_pids 함수를 subshell 에 주입하고,
-    // 실제 child (sleep 60) 에 대해 짧은 interval 로 감시 → STALL_KILL 유도.
-    const hb = extractFunction("heartbeat_monitor");
-    const findForks = extractFunction("_find_fork_pids");
-
-    const script = `
-set -u
-export TFX_HEARTBEAT=1
-export TFX_HEARTBEAT_INTERVAL=1
-export TFX_STALL_THRESHOLD=2
-export TFX_STALL_KILL=1
-export TFX_STALL_KILL_GRACE=1
-STDOUT_LOG='${stdoutLog}'
-STDERR_LOG='${stderrLog}'
-TIMESTAMP=$(date +%s)
-
-${findForks}
-${hb}
-
-# Fork a dummy child that would otherwise run for 30s (simulating a stalled codex worker)
-sleep 30 &
-CHILD_PID=$!
-echo "CHILD_PID=$CHILD_PID" >&2
-
-# Launch heartbeat monitor on the child in background — it should SIGTERM after ~4s
-heartbeat_monitor "$CHILD_PID" 1 2 &
-HB_PID=$!
-
-# Wait up to 10s for heartbeat to do its work
-for i in 1 2 3 4 5 6 7 8 9 10; do
-  sleep 1
-  if ! kill -0 "$CHILD_PID" 2>/dev/null; then
-    echo "CHILD_KILLED_AFTER=\${i}s" >&2
-    break
-  fi
-done
-
-# Cleanup heartbeat + any stragglers
-kill "$HB_PID" 2>/dev/null || true
-wait "$HB_PID" 2>/dev/null || true
-kill "$CHILD_PID" 2>/dev/null || true
-
-if kill -0 "$CHILD_PID" 2>/dev/null; then
-  echo "RESULT=child_still_alive" >&2
-  exit 1
-else
-  echo "RESULT=child_terminated" >&2
-fi
-`;
-    const result = spawnSync("bash", ["-c", script], {
+    writeFileSync(
+      scriptFile,
+      buildStallScript({ killMode: "kill", stdoutLog, stderrLog }),
+    );
+    const result = spawnSync("bash", [scriptFile], {
       encoding: "utf8",
       cwd: REPO_ROOT,
       timeout: 20_000,
@@ -164,5 +192,37 @@ fi
     assert.match(result.stderr, /status=STALL_KILL/, "STALL_KILL 상태 로그");
     assert.match(result.stderr, /SIGTERM/, "SIGTERM 발사 로그");
     assert.match(result.stderr, /RESULT=child_terminated/);
+  });
+
+  it("TFX_STALL_KILL=classify (default) 이면 stall 은 STALL_CLASSIFY 로그만 내고 kill 안 한다 (#165)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-stall-classify-"));
+    cleanupDirs.push(dir);
+    const stdoutLog = path.join(dir, "stdout.log");
+    const stderrLog = path.join(dir, "stderr.log");
+    const scriptFile = path.join(dir, "run.sh");
+    writeFileSync(stdoutLog, "");
+    writeFileSync(stderrLog, "");
+    writeFileSync(
+      scriptFile,
+      buildStallScript({ killMode: "classify", stdoutLog, stderrLog }),
+    );
+    const result = spawnSync("bash", [scriptFile], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      timeout: 20_000,
+    });
+    // classify 는 kill 안 함 → child 는 우리가 수동 kill 하므로 terminated.
+    // 중요한 건 STALL_KILL 은 안 뜨고 STALL_CLASSIFY 가 떴어야 한다.
+    assert.match(result.stderr, /STALL_CLASSIFY/, "classify evidence 로그 필요");
+    assert.doesNotMatch(
+      result.stderr,
+      /status=STALL_KILL/,
+      "classify mode 에서는 STALL_KILL 로그가 없어야 함",
+    );
+    assert.doesNotMatch(
+      result.stderr,
+      /SIGTERM/,
+      "classify mode 에서는 SIGTERM 이 발사되면 안 됨",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `scripts/tfx-route.sh` heartbeat_monitor: `TFX_STALL_KILL` 에 세 모드 수용 (`kill` / `classify` / `off`). default `0` → `classify`. false kill 리스크 없이 진단 가치 유지.
- `hub/team/conductor.mjs`: `writeStateFile` default `off` → `on`. atomic write (#162) 로 race 제거된 상태에서 safe. opt-out = `TFX_PROBE_WRITE_STATE=0`.
- 3-way mirror (hub/, packages/triflux/, packages/remote/) 적용. remote 는 `@triflux/core` import 경로 유지 — 단순 cp 불가.

## Closes

Closes #165 (P1 + P2 부분). P3 (conductor L2 wiring + checkMcp) 는 #168 로 분리.

## 선행 의존

PR #167 (#162 atomic write) — merge 선행 필요. 이 PR 은 PR #167 을 base 로 올린 branch 위에 쌓였으므로 #167 merge 후 본 PR 도 main 대상으로 자동 rebase 가능.

## TFX_STALL_KILL modes

| mode | alias | 동작 |
|------|-------|------|
| `kill` | `1`, `on` | threshold+grace 초과 시 SIGTERM→SIGKILL + orphan sweep |
| `classify` (default) | — | kill 안 함. `STALL_CLASSIFY` 로그로 evidence 노출 |
| `off` | `0`, `disabled` | silent. kill 도 classify 로그도 없음 |
| unknown | — | warning + `classify` 로 fallback |

## Test plan

- [x] `node --test tests/unit/tfx-route-stall-kill.test.mjs` — 7/7 (기존 4 + 신규 3)
- [x] `node --test tests/unit/conductor-probe-default.test.mjs` — 2/2 신규
- [x] `npm test` 전체 — 163 pass / 2 fail. 실패 2 는 #166 (PR #158 follow-up, baseline `2a8eb2a` 에서도 동일 실패, 본 PR 과 무관)
- [x] bash file 경유로 Windows Git Bash EOF race 우회 (기존 `bash -c script` 는 긴 heredoc 에서 line ending 이슈)

## 후속

- #168 (P3): conductor enableL2 기본 활성화 + checkMcp 구현. probe state → heartbeat wiring 자동화.
- #166 (pre-existing, 별개): mcp-guard-engine port resolve 회귀.