### PR TITLE
fix(tfx-route): MCP graceful degradation default — all-dead stall 방지 (#170)

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1649,7 +1649,10 @@ _mcp_preflight_filter_dead() {
   local remaining_alive=0
   local rflag
   for rflag in "${CODEX_CONFIG_FLAGS[@]}"; do
-    if [[ "$rflag" =~ ^mcp_servers\.[^.]+\.enabled=true$ ]]; then
+    # #153 + #170 P1: candidate 추출 정규식 (line 1607) 과 일관 — dotted server 이름
+    # (e.g. mcp_servers.foo.bar.enabled=true) 도 alive 로 카운트한다. `[^.]+` 는 첫 dot
+    # 에서 끊겨 dotted alive 만 남은 경우 false all-dead 판정 → 불필요 degraded.
+    if [[ "$rflag" =~ ^mcp_servers\..+\.enabled=true$ ]]; then
       remaining_alive=$((remaining_alive + 1))
     fi
   done
@@ -2111,11 +2114,16 @@ FALLBACK_EOF
     # swap 후 config override 플래그 클리어 — 제거된 서버에 override 보내면 "invalid transport" 에러
     CODEX_CONFIG_FLAGS=()
     CODEX_CONFIG_JSON="{}"
-    # #170 graceful degradation: MCP 전부 dead 면 transport=auto 라도 exec 강제.
+    # #170 graceful degradation: MCP 전부 dead 면 transport 무관 exec 강제.
     # _mcp_preflight_filter_dead 가 _TFX_MCP_DEGRADED=1 를 export 했으면 이미 stall 보장 안 됨.
+    # 사용자가 TFX_CODEX_TRANSPORT=mcp 명시했더라도 dead MCP 와 connect 시도 = stall →
+    # warning + exec 강제 (transport 명시는 사용자 의도지만 stall 회피가 우선).
     # MCP_HINT (e.g. "context7으로 조회하세요") 도 prompt 에서 제거 — degraded 환경에서
     # 모델이 사용 불가 도구를 시도하면 stall/실패 trigger.
-    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" && "$TFX_CODEX_TRANSPORT" == "auto" ]]; then
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      if [[ "$TFX_CODEX_TRANSPORT" == "mcp" ]]; then
+        echo "[tfx-route] WARNING: TFX_CODEX_TRANSPORT=mcp + all-MCP-dead → exec 강제 (stall 회피)" >&2
+      fi
       TFX_CODEX_TRANSPORT="exec"
       FULL_PROMPT="$PROMPT"
     fi

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1640,10 +1640,12 @@ _mcp_preflight_filter_dead() {
   CODEX_CONFIG_FLAGS=("${new_flags[@]}")
   echo "[tfx-route] MCP preflight: ${#dead_names[@]}개 dead MCP 제외 (${dead_list})" >&2
 
-  # #148: profile-allowed 전부 dead 인 all-dead 엣지케이스 조기 실패.
-  # 빈 allowed_pat 은 _codex_config_swap fail-safe (#132) 에 의해 원본 config
-  # 전체를 유지 → 비필요 MCP 까지 전부 spawn → 역효과.
-  # TFX_MCP_ALLOW_ALL_DEAD=1 로 명시적 opt-in 시 MCP 없이 진행 (degraded).
+  # #170 graceful degradation (회귀 fix):
+  # all-dead 시 default 는 exec mode 자동 fallback. TFX_MCP_FAIL_ON_ALL_DEAD=1 로
+  # 명시 opt-in 시만 #148 기존 동작 (early fail). TFX_MCP_ALLOW_ALL_DEAD=1 은 호환성
+  # 유지 (alias for graceful default). 단 transport 가 auto 인 채로 run_codex_mcp 를
+  # 호출하면 dead MCP 와 connect 시도 → stall → 본 fix 의 _TFX_MCP_DEGRADED=1 marker
+  # 가 호출자 에서 transport=exec 강제 + MCP_HINT 자동 주입 skip 을 유발한다.
   local remaining_alive=0
   local rflag
   for rflag in "${CODEX_CONFIG_FLAGS[@]}"; do
@@ -1653,13 +1655,14 @@ _mcp_preflight_filter_dead() {
   done
 
   if [[ "$remaining_alive" -eq 0 ]]; then
-    if [[ "${TFX_MCP_ALLOW_ALL_DEAD:-0}" == "1" ]]; then
-      echo "[tfx-route] TFX_MCP_ALLOW_ALL_DEAD=1 — MCP 없이 계속 진행 (degraded)" >&2
-      return 0
+    if [[ "${TFX_MCP_FAIL_ON_ALL_DEAD:-0}" == "1" ]]; then
+      echo "[tfx-route] 조기 실패: TFX_MCP_FAIL_ON_ALL_DEAD=1 + MCP 전부 dead — Codex 호출 중단" >&2
+      echo "  복구: (1) dead MCP 복구 (2) TFX_MCP_HEALTH_CHECK=0 preflight 비활성 (3) TFX_MCP_FAIL_ON_ALL_DEAD=0 graceful degradation" >&2
+      return 78
     fi
-    echo "[tfx-route] 조기 실패: profile 에서 허용한 MCP 전부 dead — Codex 호출 중단" >&2
-    echo "  복구: (1) dead MCP 복구 (2) TFX_MCP_HEALTH_CHECK=0 preflight 비활성 (3) TFX_MCP_ALLOW_ALL_DEAD=1 MCP 없이 진행" >&2
-    return 78
+    export _TFX_MCP_DEGRADED=1
+    echo "[tfx-route] graceful degradation: MCP 전부 dead → exec mode 자동 전환 (set TFX_MCP_FAIL_ON_ALL_DEAD=1 to revert to early-fail)" >&2
+    return 0
   fi
 }
 
@@ -2108,6 +2111,14 @@ FALLBACK_EOF
     # swap 후 config override 플래그 클리어 — 제거된 서버에 override 보내면 "invalid transport" 에러
     CODEX_CONFIG_FLAGS=()
     CODEX_CONFIG_JSON="{}"
+    # #170 graceful degradation: MCP 전부 dead 면 transport=auto 라도 exec 강제.
+    # _mcp_preflight_filter_dead 가 _TFX_MCP_DEGRADED=1 를 export 했으면 이미 stall 보장 안 됨.
+    # MCP_HINT (e.g. "context7으로 조회하세요") 도 prompt 에서 제거 — degraded 환경에서
+    # 모델이 사용 불가 도구를 시도하면 stall/실패 trigger.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" && "$TFX_CODEX_TRANSPORT" == "auto" ]]; then
+      TFX_CODEX_TRANSPORT="exec"
+      FULL_PROMPT="$PROMPT"
+    fi
     codex_transport_effective="exec"
     if [[ "$TFX_CODEX_TRANSPORT" != "exec" ]]; then
       run_codex_mcp "$FULL_PROMPT" "$use_tee" || exit_code=$?

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1649,7 +1649,10 @@ _mcp_preflight_filter_dead() {
   local remaining_alive=0
   local rflag
   for rflag in "${CODEX_CONFIG_FLAGS[@]}"; do
-    if [[ "$rflag" =~ ^mcp_servers\.[^.]+\.enabled=true$ ]]; then
+    # #153 + #170 P1: candidate 추출 정규식 (line 1607) 과 일관 — dotted server 이름
+    # (e.g. mcp_servers.foo.bar.enabled=true) 도 alive 로 카운트한다. `[^.]+` 는 첫 dot
+    # 에서 끊겨 dotted alive 만 남은 경우 false all-dead 판정 → 불필요 degraded.
+    if [[ "$rflag" =~ ^mcp_servers\..+\.enabled=true$ ]]; then
       remaining_alive=$((remaining_alive + 1))
     fi
   done
@@ -2111,11 +2114,16 @@ FALLBACK_EOF
     # swap 후 config override 플래그 클리어 — 제거된 서버에 override 보내면 "invalid transport" 에러
     CODEX_CONFIG_FLAGS=()
     CODEX_CONFIG_JSON="{}"
-    # #170 graceful degradation: MCP 전부 dead 면 transport=auto 라도 exec 강제.
+    # #170 graceful degradation: MCP 전부 dead 면 transport 무관 exec 강제.
     # _mcp_preflight_filter_dead 가 _TFX_MCP_DEGRADED=1 를 export 했으면 이미 stall 보장 안 됨.
+    # 사용자가 TFX_CODEX_TRANSPORT=mcp 명시했더라도 dead MCP 와 connect 시도 = stall →
+    # warning + exec 강제 (transport 명시는 사용자 의도지만 stall 회피가 우선).
     # MCP_HINT (e.g. "context7으로 조회하세요") 도 prompt 에서 제거 — degraded 환경에서
     # 모델이 사용 불가 도구를 시도하면 stall/실패 trigger.
-    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" && "$TFX_CODEX_TRANSPORT" == "auto" ]]; then
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      if [[ "$TFX_CODEX_TRANSPORT" == "mcp" ]]; then
+        echo "[tfx-route] WARNING: TFX_CODEX_TRANSPORT=mcp + all-MCP-dead → exec 강제 (stall 회피)" >&2
+      fi
       TFX_CODEX_TRANSPORT="exec"
       FULL_PROMPT="$PROMPT"
     fi

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1640,10 +1640,12 @@ _mcp_preflight_filter_dead() {
   CODEX_CONFIG_FLAGS=("${new_flags[@]}")
   echo "[tfx-route] MCP preflight: ${#dead_names[@]}개 dead MCP 제외 (${dead_list})" >&2
 
-  # #148: profile-allowed 전부 dead 인 all-dead 엣지케이스 조기 실패.
-  # 빈 allowed_pat 은 _codex_config_swap fail-safe (#132) 에 의해 원본 config
-  # 전체를 유지 → 비필요 MCP 까지 전부 spawn → 역효과.
-  # TFX_MCP_ALLOW_ALL_DEAD=1 로 명시적 opt-in 시 MCP 없이 진행 (degraded).
+  # #170 graceful degradation (회귀 fix):
+  # all-dead 시 default 는 exec mode 자동 fallback. TFX_MCP_FAIL_ON_ALL_DEAD=1 로
+  # 명시 opt-in 시만 #148 기존 동작 (early fail). TFX_MCP_ALLOW_ALL_DEAD=1 은 호환성
+  # 유지 (alias for graceful default). 단 transport 가 auto 인 채로 run_codex_mcp 를
+  # 호출하면 dead MCP 와 connect 시도 → stall → 본 fix 의 _TFX_MCP_DEGRADED=1 marker
+  # 가 호출자 에서 transport=exec 강제 + MCP_HINT 자동 주입 skip 을 유발한다.
   local remaining_alive=0
   local rflag
   for rflag in "${CODEX_CONFIG_FLAGS[@]}"; do
@@ -1653,13 +1655,14 @@ _mcp_preflight_filter_dead() {
   done
 
   if [[ "$remaining_alive" -eq 0 ]]; then
-    if [[ "${TFX_MCP_ALLOW_ALL_DEAD:-0}" == "1" ]]; then
-      echo "[tfx-route] TFX_MCP_ALLOW_ALL_DEAD=1 — MCP 없이 계속 진행 (degraded)" >&2
-      return 0
+    if [[ "${TFX_MCP_FAIL_ON_ALL_DEAD:-0}" == "1" ]]; then
+      echo "[tfx-route] 조기 실패: TFX_MCP_FAIL_ON_ALL_DEAD=1 + MCP 전부 dead — Codex 호출 중단" >&2
+      echo "  복구: (1) dead MCP 복구 (2) TFX_MCP_HEALTH_CHECK=0 preflight 비활성 (3) TFX_MCP_FAIL_ON_ALL_DEAD=0 graceful degradation" >&2
+      return 78
     fi
-    echo "[tfx-route] 조기 실패: profile 에서 허용한 MCP 전부 dead — Codex 호출 중단" >&2
-    echo "  복구: (1) dead MCP 복구 (2) TFX_MCP_HEALTH_CHECK=0 preflight 비활성 (3) TFX_MCP_ALLOW_ALL_DEAD=1 MCP 없이 진행" >&2
-    return 78
+    export _TFX_MCP_DEGRADED=1
+    echo "[tfx-route] graceful degradation: MCP 전부 dead → exec mode 자동 전환 (set TFX_MCP_FAIL_ON_ALL_DEAD=1 to revert to early-fail)" >&2
+    return 0
   fi
 }
 
@@ -2108,6 +2111,14 @@ FALLBACK_EOF
     # swap 후 config override 플래그 클리어 — 제거된 서버에 override 보내면 "invalid transport" 에러
     CODEX_CONFIG_FLAGS=()
     CODEX_CONFIG_JSON="{}"
+    # #170 graceful degradation: MCP 전부 dead 면 transport=auto 라도 exec 강제.
+    # _mcp_preflight_filter_dead 가 _TFX_MCP_DEGRADED=1 를 export 했으면 이미 stall 보장 안 됨.
+    # MCP_HINT (e.g. "context7으로 조회하세요") 도 prompt 에서 제거 — degraded 환경에서
+    # 모델이 사용 불가 도구를 시도하면 stall/실패 trigger.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" && "$TFX_CODEX_TRANSPORT" == "auto" ]]; then
+      TFX_CODEX_TRANSPORT="exec"
+      FULL_PROMPT="$PROMPT"
+    fi
     codex_transport_effective="exec"
     if [[ "$TFX_CODEX_TRANSPORT" != "exec" ]]; then
       run_codex_mcp "$FULL_PROMPT" "$use_tee" || exit_code=$?

--- a/tests/unit/tfx-route-preflight-all-dead.test.mjs
+++ b/tests/unit/tfx-route-preflight-all-dead.test.mjs
@@ -125,7 +125,9 @@ describe("#148 _mcp_preflight_filter_dead — all-dead early fail", () => {
     assert.match(result.stderr, /1개 dead MCP 제외 \(dead1\)/);
   });
 
-  it("all-dead: profile 전부 dead → rc=78 조기 실패", () => {
+  it("#170 all-dead default: graceful degradation (rc=0)", () => {
+    // PR #170 회귀 fix: default 동작이 early-fail (rc=78) 에서 graceful (rc=0+marker) 로 변경.
+    // 호출자 (run_codex_mcp 분기) 가 _TFX_MCP_DEGRADED 마커 보고 transport=exec 강제.
     const result = runPreflight({
       flags: [
         "-c",
@@ -136,12 +138,33 @@ describe("#148 _mcp_preflight_filter_dead — all-dead early fail", () => {
       deadList: "dead1,dead2",
     });
     cleanupDirs.push(result.dir);
-    assert.equal(result.preflightRc, 78, `stderr: ${result.stderr}`);
-    assert.match(result.stderr, /조기 실패.*MCP 전부 dead/);
-    assert.match(result.stderr, /TFX_MCP_ALLOW_ALL_DEAD=1/);
+    assert.equal(result.preflightRc, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stderr, /graceful degradation/);
+    assert.match(result.stderr, /MCP 전부 dead/);
+    assert.equal(result.remainingCount, 0);
   });
 
-  it("all-dead + TFX_MCP_ALLOW_ALL_DEAD=1 → rc=0 degraded 진행", () => {
+  it("#170 all-dead + TFX_MCP_FAIL_ON_ALL_DEAD=1 → rc=78 (opt-in early fail)", () => {
+    // 옛 #148 동작은 TFX_MCP_FAIL_ON_ALL_DEAD=1 명시 opt-in 으로만 활성.
+    const result = runPreflight({
+      flags: [
+        "-c",
+        "mcp_servers.dead1.enabled=true",
+        "-c",
+        "mcp_servers.dead2.enabled=true",
+      ],
+      deadList: "dead1,dead2",
+      envVars: { TFX_MCP_FAIL_ON_ALL_DEAD: "1" },
+    });
+    cleanupDirs.push(result.dir);
+    assert.equal(result.preflightRc, 78, `stderr: ${result.stderr}`);
+    assert.match(result.stderr, /조기 실패.*MCP 전부 dead/);
+    assert.match(result.stderr, /TFX_MCP_FAIL_ON_ALL_DEAD/);
+  });
+
+  it("all-dead + TFX_MCP_ALLOW_ALL_DEAD=1 (legacy alias) → rc=0 degraded 진행", () => {
+    // TFX_MCP_ALLOW_ALL_DEAD=1 은 호환성 유지 — graceful degradation 의 explicit alias.
+    // FAIL_ON_ALL_DEAD 기본 0 이므로 동작상 차이 없음 (테스트는 명시 opt-in 호환성 회귀 가드).
     const result = runPreflight({
       flags: [
         "-c",
@@ -154,8 +177,7 @@ describe("#148 _mcp_preflight_filter_dead — all-dead early fail", () => {
     });
     cleanupDirs.push(result.dir);
     assert.equal(result.preflightRc, 0, `stderr: ${result.stderr}`);
-    assert.match(result.stderr, /TFX_MCP_ALLOW_ALL_DEAD=1/);
-    assert.match(result.stderr, /degraded/);
+    assert.match(result.stderr, /graceful degradation/);
     assert.equal(result.remainingCount, 0);
   });
 
@@ -299,7 +321,7 @@ describe("#153 dotted server names — preflight regex 는 dot 포함", () => {
     ]);
   });
 
-  it("dotted 서버 + all-dead → rc=78 조기 실패 (#148 과 동일 경로)", () => {
+  it("dotted 서버 + all-dead → rc=0 graceful degradation (#170 default)", () => {
     const result = runPreflight({
       flags: [
         "-c",
@@ -310,17 +332,79 @@ describe("#153 dotted server names — preflight regex 는 dot 포함", () => {
       deadList: "foo.bar,baz.qux",
     });
     cleanupDirs.push(result.dir);
+    assert.equal(result.preflightRc, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stderr, /graceful degradation/);
+  });
+
+  it("dotted 서버 + all-dead + TFX_MCP_FAIL_ON_ALL_DEAD=1 → rc=78 (opt-in)", () => {
+    const result = runPreflight({
+      flags: [
+        "-c",
+        "mcp_servers.foo.bar.enabled=true",
+        "-c",
+        "mcp_servers.baz.qux.enabled=true",
+      ],
+      deadList: "foo.bar,baz.qux",
+      envVars: { TFX_MCP_FAIL_ON_ALL_DEAD: "1" },
+    });
+    cleanupDirs.push(result.dir);
     assert.equal(result.preflightRc, 78, `stderr: ${result.stderr}`);
     assert.match(result.stderr, /조기 실패.*MCP 전부 dead/);
   });
 
-  it("non-dotted 서버도 기존과 동일하게 동작 (회귀 없음)", () => {
+  it("non-dotted 서버 단독 dead → rc=0 graceful (#170 default 동작)", () => {
     const result = runPreflight({
       flags: ["-c", "mcp_servers.simple.enabled=true"],
       deadList: "simple",
     });
     cleanupDirs.push(result.dir);
-    assert.equal(result.preflightRc, 78, `stderr: ${result.stderr}`);
-    assert.match(result.stderr, /전부 dead/);
+    assert.equal(result.preflightRc, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stderr, /graceful degradation/);
+  });
+});
+
+// PR #170 — graceful degradation marker 가 호출자 (run_codex_mcp 분기) 에서
+// transport=exec 강제 + FULL_PROMPT 리셋 (MCP_HINT 제거) 을 trigger 한다.
+// 이 분기가 회귀하면 dead MCP 환경에서 codex-mcp.mjs 가 spawn 되어 stall 재발.
+describe("#170 transport degradation marker — source 분기 회귀 가드", () => {
+  it("source 에 _TFX_MCP_DEGRADED 마커 + transport=exec 강제 분기", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    assert.match(
+      source,
+      /_TFX_MCP_DEGRADED:-0/,
+      "_TFX_MCP_DEGRADED 마커 분기가 사라짐",
+    );
+    assert.match(
+      source,
+      /TFX_CODEX_TRANSPORT="exec"/,
+      "transport=exec 강제 분기가 사라짐",
+    );
+    assert.match(
+      source,
+      /FULL_PROMPT="\$PROMPT"/,
+      "FULL_PROMPT 리셋 (MCP_HINT 제거) 분기가 사라짐",
+    );
+  });
+
+  it("source 에 TFX_MCP_FAIL_ON_ALL_DEAD opt-in 분기 포함", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    assert.match(
+      source,
+      /TFX_MCP_FAIL_ON_ALL_DEAD:-0/,
+      "TFX_MCP_FAIL_ON_ALL_DEAD opt-in 이 사라지면 #148 동작 복원 불가",
+    );
+  });
+
+  it("packages/triflux/scripts/tfx-route.sh mirror 가 main 과 byte-identical", () => {
+    const main = readFileSync(SCRIPT_PATH, "utf8");
+    const mirrorPath = path.join(
+      REPO_ROOT,
+      "packages",
+      "triflux",
+      "scripts",
+      "tfx-route.sh",
+    );
+    const mirror = readFileSync(mirrorPath, "utf8");
+    assert.equal(main, mirror, "mirror drift — patch 가 한쪽에만 적용됨");
   });
 });

--- a/tests/unit/tfx-route-preflight-all-dead.test.mjs
+++ b/tests/unit/tfx-route-preflight-all-dead.test.mjs
@@ -408,3 +408,75 @@ describe("#170 transport degradation marker — source 분기 회귀 가드", ()
     assert.equal(main, mirror, "mirror drift — patch 가 한쪽에만 적용됨");
   });
 });
+
+// PR #171 review P1-1: dotted MCP alive 카운트 회귀 가드.
+// remaining_alive 정규식이 [^.]+ 면 dotted alive 만 남은 경우 false all-dead 판정.
+describe("#170 P1-1 dotted alive survivor — false degraded 방지", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const d of cleanupDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("dead 1개 + dotted alive 1개 → rc=0 정상 통과 (degraded 아님)", () => {
+    // dotted alive 가 카운트 안 되면 remaining_alive=0 → degraded 로 빠짐.
+    // 정상 동작: dotted alive 도 +1 → remaining_alive>=1 → degraded marker 미설정.
+    const result = runPreflight({
+      flags: [
+        "-c",
+        "mcp_servers.dead1.enabled=true",
+        "-c",
+        "mcp_servers.foo.bar.enabled=true",
+      ],
+      deadList: "dead1",
+    });
+    cleanupDirs.push(result.dir);
+    assert.equal(result.preflightRc, 0, `stderr: ${result.stderr}`);
+    assert.doesNotMatch(
+      result.stderr,
+      /graceful degradation/,
+      "dotted alive 1개 있는데도 degraded 로 빠짐 — 정규식 회귀",
+    );
+    // dotted alive flag 보존 + dead flag 제거 검증
+    assert.deepEqual(result.remainingFlags, [
+      "-c",
+      "mcp_servers.foo.bar.enabled=true",
+    ]);
+  });
+
+  it("source 의 remaining_alive 정규식이 dotted 허용 (`.+` 사용)", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    // [^.]+ 패턴이 remaining_alive 분기에 다시 나타나면 회귀
+    const remainingAliveBlock = source.match(
+      /remaining_alive=0[\s\S]{0,400}?for rflag/,
+    );
+    assert.ok(remainingAliveBlock, "remaining_alive 블록을 찾을 수 없음");
+    // 같은 분기 내 정규식 추출
+    const regexMatch = source.match(
+      /remaining_alive=\$\(\(remaining_alive[\s\S]{0,200}?fi\s+done/,
+    );
+    assert.ok(
+      !/\[\^\.\]\+/.test(regexMatch?.[0] || ""),
+      "remaining_alive 정규식이 [^.]+ 로 회귀 (dotted alive 카운트 누락 위험)",
+    );
+  });
+});
+
+// PR #171 review P1-2: degraded 시 user 명시 transport=mcp 도 exec 강제.
+describe("#170 P1-2 degraded transport mcp 강제 회귀 가드", () => {
+  it("source 분기가 transport=auto 외 mcp 도 exec 강제 (warning 포함)", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    // 옛 패턴: && "$TFX_CODEX_TRANSPORT" == "auto" — 회귀 시 P1-2 재발
+    assert.doesNotMatch(
+      source,
+      /_TFX_MCP_DEGRADED:-0.*?== "1"\s*&&\s*"\$TFX_CODEX_TRANSPORT"\s*==\s*"auto"/s,
+      "_TFX_MCP_DEGRADED 분기가 transport=auto 만 대상으로 회귀 — user 명시 mcp 시 stall 재발",
+    );
+    assert.match(
+      source,
+      /TFX_CODEX_TRANSPORT=mcp.*all-MCP-dead.*exec 강제/,
+      "transport=mcp + degraded 경고 메시지가 사라짐",
+    );
+  });
+});


### PR DESCRIPTION
Closes #170

## 회귀 요약

`TFX_MCP_ALLOW_ALL_DEAD=1` 가 preflight check 만 우회 → swap 은 fail-safe 로 스킵 → CODEX_CONFIG_FLAGS 클리어 후에도 transport=auto 분기는 여전히 `run_codex_mcp` 호출 → codex-mcp.mjs worker 가 dead MCP (context7 / brave-search) 와 connect 시도 → quiet stall 250s+ → STALL_KILL.

추가로 prompt 에 자동 주입된 MCP_HINT (`"context7으로 조회하세요…"`) 는 모델이 dead 도구를 호출하게 만들어 또 다른 stall trigger.

## Fix

| 영역 | 변경 |
|------|------|
| `_mcp_preflight_filter_dead` | default 동작을 early-fail (#148, rc=78) → graceful degradation (rc=0 + `_TFX_MCP_DEGRADED=1` export) |
| 옛 동작 보존 | `TFX_MCP_FAIL_ON_ALL_DEAD=1` 명시 opt-in 으로만 활성 |
| 호환성 | `TFX_MCP_ALLOW_ALL_DEAD=1` 은 alias 유지 (graceful default 와 동일 동작) |
| `run_codex_mcp` 분기 (line 2134) | `_TFX_MCP_DEGRADED=1` 보면 `TFX_CODEX_TRANSPORT="exec"` 강제 + `FULL_PROMPT="$PROMPT"` 로 MCP_HINT 제거 |
| 3-mirror sync | `scripts/tfx-route.sh` + `packages/triflux/scripts/tfx-route.sh` 동시 적용 |

## 회귀 가드

- `tests/unit/tfx-route-preflight-all-dead.test.mjs` — 기존 3건 갱신 + 신규 6건
  - graceful default (`#170 all-dead default: graceful degradation`)
  - `TFX_MCP_FAIL_ON_ALL_DEAD=1` opt-in early fail
  - `TFX_MCP_ALLOW_ALL_DEAD=1` legacy alias
  - dotted server graceful + opt-in
  - source 분기 회귀 가드 (`_TFX_MCP_DEGRADED`, transport=exec, FULL_PROMPT 리셋)
  - mirror byte-identical 검증
- 17/17 pass. tfx-route-args / config-swap / stall-kill 32/32 pass — 회귀 없음

## E2E 검증

```
$ scripts/tfx-route.sh --async codex "say 'hello' in one word and stop" auto 60
[tfx-route] graceful degradation: MCP 전부 dead → exec mode 자동 전환
[tfx-route] codex_transport_effective=exec
=== OUTPUT ===
hello
```

env var 없이 default 동작만으로 stall 회피 + 정상 응답.

## 영향

- 사용자 요구 ("MCP 있으면 쓰고 없으면 알아서") 와 정확히 일치하는 default
- v10.14.0 이후 dead MCP 환경에서 PR Codex 교차 리뷰 dispatch 가 전부 stall → 본 PR merge 후 정상 dispatch 가능
- PR #167 / #169 의 codex_transport_effective=exec 우회 (`TFX_CODEX_TRANSPORT=exec`) 도 본 PR merge 후 불필요