### PR TITLE
fix(mcp-guard-engine): resolveHubUrl pid port cascade 제거 (#166)

### DIFF
--- a/packages/core/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/core/scripts/lib/mcp-guard-engine.mjs
@@ -851,14 +851,13 @@ export function resolveHubUrl() {
         : DEFAULT_HUB_PATH,
   };
 
+  // PR #158 정책: port = TFX_HUB_PORT env (없으면 registry/default 27888) single source.
+  // hub.pid 는 loopback host 힌트 전용. 과거 pid port cascade 는 오염된 port 영속화의
+  // 원인이었고 hub-ensure.resolveHubTarget 에서 이미 제거됨. 여기도 일관 적용.
   const hubPidPath = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
   if (existsSync(hubPidPath)) {
     try {
       const info = readJsonFile(hubPidPath);
-      if (!envPort) {
-        const pidPort = Number(info?.port);
-        if (Number.isFinite(pidPort) && pidPort > 0) target.port = pidPort;
-      }
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;

--- a/packages/remote/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/remote/scripts/lib/mcp-guard-engine.mjs
@@ -851,14 +851,13 @@ export function resolveHubUrl() {
         : DEFAULT_HUB_PATH,
   };
 
+  // PR #158 정책: port = TFX_HUB_PORT env (없으면 registry/default 27888) single source.
+  // hub.pid 는 loopback host 힌트 전용. 과거 pid port cascade 는 오염된 port 영속화의
+  // 원인이었고 hub-ensure.resolveHubTarget 에서 이미 제거됨. 여기도 일관 적용.
   const hubPidPath = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
   if (existsSync(hubPidPath)) {
     try {
       const info = readJsonFile(hubPidPath);
-      if (!envPort) {
-        const pidPort = Number(info?.port);
-        if (Number.isFinite(pidPort) && pidPort > 0) target.port = pidPort;
-      }
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -101,14 +101,16 @@ describe("mcp guard engine", () => {
     );
   });
 
-  it("replaces stdio MCP entries with tfx-hub and writes a backup", () => {
+  it("replaces stdio MCP entries with tfx-hub and writes a backup (TFX_HUB_PORT env overrides)", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
+    process.env.TFX_HUB_PORT = "30123";
 
+    // hub.pid port 는 무시되어야 한다 (PR #158: pid = host hint only).
     const pidPath = join(homeDir, ".claude", "cache", "tfx-hub", "hub.pid");
     writeFileSync(
       pidPath,
-      JSON.stringify({ host: "127.0.0.1", port: 30123 }),
+      JSON.stringify({ host: "127.0.0.1", port: 40404 }),
       "utf8",
     );
 
@@ -141,9 +143,18 @@ describe("mcp guard engine", () => {
     assert.equal(Object.hasOwn(updated.mcpServers, "unsafe-stdio"), false);
   });
 
-  it("uses hub.pid port before registry fallback when resolving Hub URL", () => {
+  it("uses TFX_HUB_PORT env as single source when resolving Hub URL", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
+    process.env.TFX_HUB_PORT = "29991";
+
+    assert.equal(resolveHubUrl(), "http://127.0.0.1:29991/mcp");
+  });
+
+  it("ignores hub.pid port (pid is host hint only, PR #158 policy)", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+    delete process.env.TFX_HUB_PORT;
 
     writeFileSync(
       join(homeDir, ".claude", "cache", "tfx-hub", "hub.pid"),
@@ -151,6 +162,8 @@ describe("mcp guard engine", () => {
       "utf8",
     );
 
-    assert.equal(resolveHubUrl(), "http://127.0.0.1:29991/mcp");
+    // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
+    // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
+    assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
   });
 });

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -851,14 +851,13 @@ export function resolveHubUrl() {
         : DEFAULT_HUB_PATH,
   };
 
+  // PR #158 정책: port = TFX_HUB_PORT env (없으면 registry/default 27888) single source.
+  // hub.pid 는 loopback host 힌트 전용. 과거 pid port cascade 는 오염된 port 영속화의
+  // 원인이었고 hub-ensure.resolveHubTarget 에서 이미 제거됨. 여기도 일관 적용.
   const hubPidPath = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
   if (existsSync(hubPidPath)) {
     try {
       const info = readJsonFile(hubPidPath);
-      if (!envPort) {
-        const pidPort = Number(info?.port);
-        if (Number.isFinite(pidPort) && pidPort > 0) target.port = pidPort;
-      }
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;

--- a/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -101,14 +101,16 @@ describe("mcp guard engine", () => {
     );
   });
 
-  it("replaces stdio MCP entries with tfx-hub and writes a backup", () => {
+  it("replaces stdio MCP entries with tfx-hub and writes a backup (TFX_HUB_PORT env overrides)", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
+    process.env.TFX_HUB_PORT = "30123";
 
+    // hub.pid port 는 무시되어야 한다 (PR #158: pid = host hint only).
     const pidPath = join(homeDir, ".claude", "cache", "tfx-hub", "hub.pid");
     writeFileSync(
       pidPath,
-      JSON.stringify({ host: "127.0.0.1", port: 30123 }),
+      JSON.stringify({ host: "127.0.0.1", port: 40404 }),
       "utf8",
     );
 
@@ -141,9 +143,18 @@ describe("mcp guard engine", () => {
     assert.equal(Object.hasOwn(updated.mcpServers, "unsafe-stdio"), false);
   });
 
-  it("uses hub.pid port before registry fallback when resolving Hub URL", () => {
+  it("uses TFX_HUB_PORT env as single source when resolving Hub URL", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
+    process.env.TFX_HUB_PORT = "29991";
+
+    assert.equal(resolveHubUrl(), "http://127.0.0.1:29991/mcp");
+  });
+
+  it("ignores hub.pid port (pid is host hint only, PR #158 policy)", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+    delete process.env.TFX_HUB_PORT;
 
     writeFileSync(
       join(homeDir, ".claude", "cache", "tfx-hub", "hub.pid"),
@@ -151,6 +162,8 @@ describe("mcp guard engine", () => {
       "utf8",
     );
 
-    assert.equal(resolveHubUrl(), "http://127.0.0.1:29991/mcp");
+    // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
+    // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
+    assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
   });
 });

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -851,14 +851,13 @@ export function resolveHubUrl() {
         : DEFAULT_HUB_PATH,
   };
 
+  // PR #158 정책: port = TFX_HUB_PORT env (없으면 registry/default 27888) single source.
+  // hub.pid 는 loopback host 힌트 전용. 과거 pid port cascade 는 오염된 port 영속화의
+  // 원인이었고 hub-ensure.resolveHubTarget 에서 이미 제거됨. 여기도 일관 적용.
   const hubPidPath = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
   if (existsSync(hubPidPath)) {
     try {
       const info = readJsonFile(hubPidPath);
-      if (!envPort) {
-        const pidPort = Number(info?.port);
-        if (Number.isFinite(pidPort) && pidPort > 0) target.port = pidPort;
-      }
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;


### PR DESCRIPTION
## Summary

- PR #158 (env = single source of truth 정책) 을 `mcp-guard-engine.resolveHubUrl()` 에도 일관 적용. 기존에는 `hub-ensure.resolveHubTarget()` 만 policy 반영 → 두 함수가 다른 정책으로 drift.
- pid port cascade 분기 제거. pid 는 loopback host hint 전용. port 는 `TFX_HUB_PORT` env 또는 registry/default 27888 이 유일한 source.
- 테스트 2개 갱신 + 회귀 가드 1개 추가 (env 우선, pid port 무시).

## 회귀 재현

baseline (main) 에서 `TFX_HUB_PORT=27888` 이 shell 에 설정된 환경이면:
\`\`\`
✖ replaces stdio MCP entries with tfx-hub and writes a backup
  expected: http://127.0.0.1:30123/mcp
  actual:   http://127.0.0.1:27888/mcp

✖ uses hub.pid port before registry fallback when resolving Hub URL
  expected: http://127.0.0.1:29991/mcp
  actual:   http://127.0.0.1:27888/mcp
\`\`\`

envPort 가 set 되면 pidPort 를 무시하므로 hub.pid 의 port 가 쓰이지 못함. 정책상 이 테스트 expect 자체가 outdated.

## 변경 파일

- \`scripts/lib/mcp-guard-engine.mjs\` + 사본 3개 (\`packages/{core,remote,triflux}/scripts/lib/\`): \`resolveHubUrl()\` 의 `!envPort` 분기 제거. PR #158 정책 근거 주석 추가.
- \`scripts/__tests__/mcp-guard-engine.test.mjs\` + \`packages/triflux/\` 사본: 테스트 2개 의도 갱신 + \`ignores hub.pid port (pid is host hint only, PR #158 policy)\` 회귀 가드 신설.

## 검증

\`\`\`
$ node --test scripts/__tests__/mcp-guard-engine.test.mjs
ℹ tests 6
ℹ pass 6
ℹ fail 0
\`\`\`

전체 npm test: 3089 PASS, 5 FAIL (tfx-route-quota.test.mjs — PR #171 graceful degradation 출력이 quota reroute expect 와 충돌하는 baseline 부채, main 에서도 동일 실패. 본 PR scope 밖).

## Test plan

- [ ] Codex 교차 리뷰 (본 PR 은 Claude 작성 → Codex 검토, CLAUDE.md 룰)
- [ ] squash merge
- [ ] 후속: quota test 부채는 별도 issue 로 분리

Fixes #166