### PR TITLE
feat(probe): L2 hub /health checker default on (#168)

### DIFF
--- a/hub/team/check-mcp-hub.mjs
+++ b/hub/team/check-mcp-hub.mjs
@@ -1,0 +1,44 @@
+// hub/team/check-mcp-hub.mjs — health-probe L2 용 hub /health ping 체커.
+// health-probe.mjs 의 checkMcp 로 주입되어 `mcp_initializing` state 판정에 사용.
+// hub /health 가 200 이면 OK (MCP transport 인프라 살아있음), 그 외는 fail.
+
+const DEFAULT_HUB_URL = "http://127.0.0.1:27888";
+const DEFAULT_TIMEOUT_MS = 3000;
+
+function resolveHubHealthUrl(hubUrl) {
+  const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
+  return base.replace(/\/+$/, "") + "/health";
+}
+
+/**
+ * Hub /health 기반 L2 checker factory.
+ * @param {object} [opts]
+ * @param {string} [opts.hubUrl] — override. 미지정 시 TFX_HUB_URL env 또는 default.
+ * @param {number} [opts.timeoutMs=3000] — fetch timeout (ms).
+ * @param {typeof fetch} [opts.fetchFn] — fetch 오버라이드 (테스트용).
+ * @returns {() => Promise<boolean>} — true = hub healthy, false = degraded/down/timeout.
+ */
+export function createHubHealthChecker(opts = {}) {
+  const url = resolveHubHealthUrl(opts.hubUrl);
+  const timeoutMs = Number.isFinite(opts.timeoutMs)
+    ? opts.timeoutMs
+    : DEFAULT_TIMEOUT_MS;
+  const fetchFn = opts.fetchFn || globalThis.fetch;
+
+  return async function checkMcpHubHealth() {
+    if (typeof fetchFn !== "function") return false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchFn(url, {
+        method: "GET",
+        signal: controller.signal,
+      });
+      return res.ok === true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/hub/team/check-mcp-hub.mjs
+++ b/hub/team/check-mcp-hub.mjs
@@ -7,7 +7,12 @@ const DEFAULT_TIMEOUT_MS = 3000;
 
 function resolveHubHealthUrl(hubUrl) {
   const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
-  return base.replace(/\/+$/, "") + "/health";
+  // `/mcp` suffix 제거 (triflux convention — bridge.mjs:54, hub-client.mjs,
+  // lead-control.mjs, session-sync.mjs 전부 TFX_HUB_URL 을 MCP transport URL
+  // 로 쓰고 base URL 이 필요할 때 `/mcp$` 를 strip 한다). 제거하지 않으면
+  // `.../mcp/health` 가 되어 hub 가 404 로 응답 → L2 영구 fail → heartbeat
+  // 이 지속적으로 `mcp_initializing` 로 grace — #173 Codex P2 review.
+  return base.replace(/\/mcp\/?$/, "").replace(/\/+$/, "") + "/health";
 }
 
 /**

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -22,6 +22,7 @@ import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
+import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
   ensureConductorRegistry,
@@ -700,6 +701,16 @@ export function createConductor(opts = {}) {
         // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
           probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
+        // #168 P3: L2 (hub /health) checker wiring. probeOpts 가 명시 주입하면
+        // 그걸 우선. 아니면 TFX_PROBE_L2=0 로 opt-out. 나머지 경우 hub URL 기반
+        // default checker 주입 → deriveState 가 `mcp_initializing` 라벨을 생산 →
+        // heartbeat (read_probe_state) 가 probe-grace 분기로 감.
+        enableL2: probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
+        checkMcp:
+          probeOpts.checkMcp ||
+          (process.env.TFX_PROBE_L2 === "0"
+            ? undefined
+            : createHubHealthChecker({ hubUrl: process.env.TFX_HUB_URL })),
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/hub/team/health-probe.mjs
+++ b/hub/team/health-probe.mjs
@@ -28,7 +28,10 @@ export const PROBE_DEFAULTS = Object.freeze({
   l1ThresholdMs: 30_000,
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
-  enableL2: false,
+  // #168 P3: default off → on. checkMcp 미주입 시에도 probeL2 가 skip 반환하므로
+  // safe. conductor wiring 이 checkMcp 를 주입하면 실제 L2 판정이 활성화된다.
+  // opt-out: TFX_PROBE_L2=0 (conductor 에서 false 주입).
+  enableL2: true,
   writeStateFile: false,
   stateDir: join(tmpdir(), "tfx-probe"),
 });

--- a/packages/remote/hub/team/check-mcp-hub.mjs
+++ b/packages/remote/hub/team/check-mcp-hub.mjs
@@ -1,0 +1,44 @@
+// hub/team/check-mcp-hub.mjs — health-probe L2 용 hub /health ping 체커.
+// health-probe.mjs 의 checkMcp 로 주입되어 `mcp_initializing` state 판정에 사용.
+// hub /health 가 200 이면 OK (MCP transport 인프라 살아있음), 그 외는 fail.
+
+const DEFAULT_HUB_URL = "http://127.0.0.1:27888";
+const DEFAULT_TIMEOUT_MS = 3000;
+
+function resolveHubHealthUrl(hubUrl) {
+  const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
+  return base.replace(/\/+$/, "") + "/health";
+}
+
+/**
+ * Hub /health 기반 L2 checker factory.
+ * @param {object} [opts]
+ * @param {string} [opts.hubUrl] — override. 미지정 시 TFX_HUB_URL env 또는 default.
+ * @param {number} [opts.timeoutMs=3000] — fetch timeout (ms).
+ * @param {typeof fetch} [opts.fetchFn] — fetch 오버라이드 (테스트용).
+ * @returns {() => Promise<boolean>} — true = hub healthy, false = degraded/down/timeout.
+ */
+export function createHubHealthChecker(opts = {}) {
+  const url = resolveHubHealthUrl(opts.hubUrl);
+  const timeoutMs = Number.isFinite(opts.timeoutMs)
+    ? opts.timeoutMs
+    : DEFAULT_TIMEOUT_MS;
+  const fetchFn = opts.fetchFn || globalThis.fetch;
+
+  return async function checkMcpHubHealth() {
+    if (typeof fetchFn !== "function") return false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchFn(url, {
+        method: "GET",
+        signal: controller.signal,
+      });
+      return res.ok === true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/packages/remote/hub/team/check-mcp-hub.mjs
+++ b/packages/remote/hub/team/check-mcp-hub.mjs
@@ -7,7 +7,12 @@ const DEFAULT_TIMEOUT_MS = 3000;
 
 function resolveHubHealthUrl(hubUrl) {
   const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
-  return base.replace(/\/+$/, "") + "/health";
+  // `/mcp` suffix 제거 (triflux convention — bridge.mjs:54, hub-client.mjs,
+  // lead-control.mjs, session-sync.mjs 전부 TFX_HUB_URL 을 MCP transport URL
+  // 로 쓰고 base URL 이 필요할 때 `/mcp$` 를 strip 한다). 제거하지 않으면
+  // `.../mcp/health` 가 되어 hub 가 404 로 응답 → L2 영구 fail → heartbeat
+  // 이 지속적으로 `mcp_initializing` 로 grace — #173 Codex P2 review.
+  return base.replace(/\/mcp\/?$/, "").replace(/\/+$/, "") + "/health";
 }
 
 /**

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -22,6 +22,7 @@ import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "@triflux/core/hub/account-broker.mjs";
 import { execFile, spawn } from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { killProcess } from "@triflux/core/hub/platform.mjs";
+import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
   ensureConductorRegistry,
@@ -30,7 +31,6 @@ import {
 import { createEventLog } from "./event-log.mjs";
 import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
-import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
@@ -705,8 +705,7 @@ export function createConductor(opts = {}) {
         // 그걸 우선. 아니면 TFX_PROBE_L2=0 로 opt-out. 나머지 경우 hub URL 기반
         // default checker 주입 → deriveState 가 `mcp_initializing` 라벨을 생산 →
         // heartbeat (read_probe_state) 가 probe-grace 분기로 감.
-        enableL2:
-          probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
+        enableL2: probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
         checkMcp:
           probeOpts.checkMcp ||
           (process.env.TFX_PROBE_L2 === "0"

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -30,6 +30,7 @@ import {
 import { createEventLog } from "./event-log.mjs";
 import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
+import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
@@ -700,6 +701,17 @@ export function createConductor(opts = {}) {
         // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
           probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
+        // #168 P3: L2 (hub /health) checker wiring. probeOpts 가 명시 주입하면
+        // 그걸 우선. 아니면 TFX_PROBE_L2=0 로 opt-out. 나머지 경우 hub URL 기반
+        // default checker 주입 → deriveState 가 `mcp_initializing` 라벨을 생산 →
+        // heartbeat (read_probe_state) 가 probe-grace 분기로 감.
+        enableL2:
+          probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
+        checkMcp:
+          probeOpts.checkMcp ||
+          (process.env.TFX_PROBE_L2 === "0"
+            ? undefined
+            : createHubHealthChecker({ hubUrl: process.env.TFX_HUB_URL })),
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/remote/hub/team/health-probe.mjs
+++ b/packages/remote/hub/team/health-probe.mjs
@@ -28,7 +28,10 @@ export const PROBE_DEFAULTS = Object.freeze({
   l1ThresholdMs: 30_000,
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
-  enableL2: false,
+  // #168 P3: default off → on. checkMcp 미주입 시에도 probeL2 가 skip 반환하므로
+  // safe. conductor wiring 이 checkMcp 를 주입하면 실제 L2 판정이 활성화된다.
+  // opt-out: TFX_PROBE_L2=0 (conductor 에서 false 주입).
+  enableL2: true,
   writeStateFile: false,
   stateDir: join(tmpdir(), "tfx-probe"),
 });

--- a/packages/triflux/hub/team/check-mcp-hub.mjs
+++ b/packages/triflux/hub/team/check-mcp-hub.mjs
@@ -1,0 +1,44 @@
+// hub/team/check-mcp-hub.mjs — health-probe L2 용 hub /health ping 체커.
+// health-probe.mjs 의 checkMcp 로 주입되어 `mcp_initializing` state 판정에 사용.
+// hub /health 가 200 이면 OK (MCP transport 인프라 살아있음), 그 외는 fail.
+
+const DEFAULT_HUB_URL = "http://127.0.0.1:27888";
+const DEFAULT_TIMEOUT_MS = 3000;
+
+function resolveHubHealthUrl(hubUrl) {
+  const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
+  return base.replace(/\/+$/, "") + "/health";
+}
+
+/**
+ * Hub /health 기반 L2 checker factory.
+ * @param {object} [opts]
+ * @param {string} [opts.hubUrl] — override. 미지정 시 TFX_HUB_URL env 또는 default.
+ * @param {number} [opts.timeoutMs=3000] — fetch timeout (ms).
+ * @param {typeof fetch} [opts.fetchFn] — fetch 오버라이드 (테스트용).
+ * @returns {() => Promise<boolean>} — true = hub healthy, false = degraded/down/timeout.
+ */
+export function createHubHealthChecker(opts = {}) {
+  const url = resolveHubHealthUrl(opts.hubUrl);
+  const timeoutMs = Number.isFinite(opts.timeoutMs)
+    ? opts.timeoutMs
+    : DEFAULT_TIMEOUT_MS;
+  const fetchFn = opts.fetchFn || globalThis.fetch;
+
+  return async function checkMcpHubHealth() {
+    if (typeof fetchFn !== "function") return false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchFn(url, {
+        method: "GET",
+        signal: controller.signal,
+      });
+      return res.ok === true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/packages/triflux/hub/team/check-mcp-hub.mjs
+++ b/packages/triflux/hub/team/check-mcp-hub.mjs
@@ -7,7 +7,12 @@ const DEFAULT_TIMEOUT_MS = 3000;
 
 function resolveHubHealthUrl(hubUrl) {
   const base = hubUrl || process.env.TFX_HUB_URL || DEFAULT_HUB_URL;
-  return base.replace(/\/+$/, "") + "/health";
+  // `/mcp` suffix 제거 (triflux convention — bridge.mjs:54, hub-client.mjs,
+  // lead-control.mjs, session-sync.mjs 전부 TFX_HUB_URL 을 MCP transport URL
+  // 로 쓰고 base URL 이 필요할 때 `/mcp$` 를 strip 한다). 제거하지 않으면
+  // `.../mcp/health` 가 되어 hub 가 404 로 응답 → L2 영구 fail → heartbeat
+  // 이 지속적으로 `mcp_initializing` 로 grace — #173 Codex P2 review.
+  return base.replace(/\/mcp\/?$/, "").replace(/\/+$/, "") + "/health";
 }
 
 /**

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -22,6 +22,7 @@ import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
+import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
   ensureConductorRegistry,
@@ -30,7 +31,6 @@ import {
 import { createEventLog } from "./event-log.mjs";
 import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
-import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
@@ -705,8 +705,7 @@ export function createConductor(opts = {}) {
         // 그걸 우선. 아니면 TFX_PROBE_L2=0 로 opt-out. 나머지 경우 hub URL 기반
         // default checker 주입 → deriveState 가 `mcp_initializing` 라벨을 생산 →
         // heartbeat (read_probe_state) 가 probe-grace 분기로 감.
-        enableL2:
-          probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
+        enableL2: probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
         checkMcp:
           probeOpts.checkMcp ||
           (process.env.TFX_PROBE_L2 === "0"

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -30,6 +30,7 @@ import {
 import { createEventLog } from "./event-log.mjs";
 import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
+import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
@@ -700,6 +701,17 @@ export function createConductor(opts = {}) {
         // opt-out: TFX_PROBE_WRITE_STATE=0 명시.
         writeStateFile:
           probeOpts.writeStateFile ?? process.env.TFX_PROBE_WRITE_STATE !== "0",
+        // #168 P3: L2 (hub /health) checker wiring. probeOpts 가 명시 주입하면
+        // 그걸 우선. 아니면 TFX_PROBE_L2=0 로 opt-out. 나머지 경우 hub URL 기반
+        // default checker 주입 → deriveState 가 `mcp_initializing` 라벨을 생산 →
+        // heartbeat (read_probe_state) 가 probe-grace 분기로 감.
+        enableL2:
+          probeOpts.enableL2 ?? process.env.TFX_PROBE_L2 !== "0",
+        checkMcp:
+          probeOpts.checkMcp ||
+          (process.env.TFX_PROBE_L2 === "0"
+            ? undefined
+            : createHubHealthChecker({ hubUrl: process.env.TFX_HUB_URL })),
         onProbe: (result) => handleProbeResult(session, result),
       },
     );

--- a/packages/triflux/hub/team/health-probe.mjs
+++ b/packages/triflux/hub/team/health-probe.mjs
@@ -28,7 +28,10 @@ export const PROBE_DEFAULTS = Object.freeze({
   l1ThresholdMs: 30_000,
   l2ThresholdMs: 30_000,
   l3ThresholdMs: 120_000,
-  enableL2: false,
+  // #168 P3: default off → on. checkMcp 미주입 시에도 probeL2 가 skip 반환하므로
+  // safe. conductor wiring 이 checkMcp 를 주입하면 실제 L2 판정이 활성화된다.
+  // opt-out: TFX_PROBE_L2=0 (conductor 에서 false 주입).
+  enableL2: true,
   writeStateFile: false,
   stateDir: join(tmpdir(), "tfx-probe"),
 });

--- a/tests/unit/check-mcp-hub.test.mjs
+++ b/tests/unit/check-mcp-hub.test.mjs
@@ -90,6 +90,45 @@ describe("#168 createHubHealthChecker", () => {
     assert.equal(calls[0], "http://example:9999/health");
   });
 
+  it("strips /mcp suffix from hubUrl (#173 Codex P2)", async () => {
+    const calls = [];
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999/mcp",
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    await check();
+    assert.equal(calls[0], "http://example:9999/health");
+  });
+
+  it("strips /mcp/ suffix with trailing slash from hubUrl", async () => {
+    const calls = [];
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999/mcp/",
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    await check();
+    assert.equal(calls[0], "http://example:9999/health");
+  });
+
+  it("honors TFX_HUB_URL with /mcp suffix", async () => {
+    process.env.TFX_HUB_URL = "http://env-host:1234/mcp";
+    const calls = [];
+    const check = createHubHealthChecker({
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    await check();
+    assert.equal(calls[0], "http://env-host:1234/health");
+  });
+
   it("returns false when global fetch missing and no fetchFn given", async () => {
     const originalFetch = globalThis.fetch;
     try {

--- a/tests/unit/check-mcp-hub.test.mjs
+++ b/tests/unit/check-mcp-hub.test.mjs
@@ -1,0 +1,103 @@
+// tests/unit/check-mcp-hub.test.mjs
+// #168 P3: hub /health ping checker factory 동작 검증.
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { createHubHealthChecker } from "../../hub/team/check-mcp-hub.mjs";
+
+describe("#168 createHubHealthChecker", () => {
+  const ORIGINAL_ENV = process.env.TFX_HUB_URL;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.TFX_HUB_URL;
+    else process.env.TFX_HUB_URL = ORIGINAL_ENV;
+  });
+
+  it("returns true when hub /health responds 200", async () => {
+    const calls = [];
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999",
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    const ok = await check();
+    assert.equal(ok, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0], "http://example:9999/health");
+  });
+
+  it("returns false when hub /health responds non-ok", async () => {
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999",
+      fetchFn: async () => ({ ok: false }),
+    });
+    assert.equal(await check(), false);
+  });
+
+  it("returns false on fetch reject (network/timeout)", async () => {
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999",
+      fetchFn: async () => {
+        throw new Error("ENOTFOUND");
+      },
+    });
+    assert.equal(await check(), false);
+  });
+
+  it("aborts after timeoutMs", async () => {
+    let aborted = false;
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999",
+      timeoutMs: 10,
+      fetchFn: (_url, opts) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () => {
+            aborted = true;
+            reject(new Error("aborted"));
+          });
+        }),
+    });
+    assert.equal(await check(), false);
+    assert.equal(aborted, true);
+  });
+
+  it("honors TFX_HUB_URL env when hubUrl not passed", async () => {
+    process.env.TFX_HUB_URL = "http://env-host:1234";
+    const calls = [];
+    const check = createHubHealthChecker({
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    await check();
+    assert.equal(calls[0], "http://env-host:1234/health");
+  });
+
+  it("strips trailing slash from hubUrl", async () => {
+    const calls = [];
+    const check = createHubHealthChecker({
+      hubUrl: "http://example:9999/",
+      fetchFn: async (url) => {
+        calls.push(url);
+        return { ok: true };
+      },
+    });
+    await check();
+    assert.equal(calls[0], "http://example:9999/health");
+  });
+
+  it("returns false when global fetch missing and no fetchFn given", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = undefined;
+      const check = createHubHealthChecker({ hubUrl: "http://example:9999" });
+      assert.equal(await check(), false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/tests/unit/conductor-probe-l2-default.test.mjs
+++ b/tests/unit/conductor-probe-l2-default.test.mjs
@@ -1,0 +1,80 @@
+// tests/unit/conductor-probe-l2-default.test.mjs
+// #168 P3: conductor 가 createHealthProbe 호출 시 enableL2 default on +
+// checkMcp 주입 + TFX_PROBE_L2=0 opt-out shape 를 가지는지 소스 레벨 검증.
+// (런타임 shape 검증은 health-probe.test.mjs 쪽이 담당.)
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+describe("#168 conductor probe L2 default (hub health checker wiring)", () => {
+  it("conductor.mjs imports createHubHealthChecker", () => {
+    const src = readFileSync(
+      path.join(REPO_ROOT, "hub/team/conductor.mjs"),
+      "utf8",
+    );
+    assert.match(
+      src,
+      /import\s*\{\s*createHubHealthChecker\s*\}\s*from\s*["']\.\/check-mcp-hub\.mjs["']/,
+      "conductor 가 check-mcp-hub.mjs 의 createHubHealthChecker 를 import 해야 함",
+    );
+  });
+
+  it("enableL2 default = `!== '0'` (TFX_PROBE_L2 opt-out 패턴)", () => {
+    const src = readFileSync(
+      path.join(REPO_ROOT, "hub/team/conductor.mjs"),
+      "utf8",
+    );
+    assert.match(
+      src,
+      /enableL2[^\n]*process\.env\.TFX_PROBE_L2\s*!==\s*"0"/,
+      "conductor 의 enableL2 default 는 `!== '0'` opt-out 패턴이어야 함 (#168)",
+    );
+  });
+
+  it("checkMcp 주입: probeOpts.checkMcp 우선, 미지정 시 createHubHealthChecker 기본", () => {
+    const src = readFileSync(
+      path.join(REPO_ROOT, "hub/team/conductor.mjs"),
+      "utf8",
+    );
+    assert.match(
+      src,
+      /checkMcp:\s*\n?\s*probeOpts\.checkMcp\s*\|\|/,
+      "probeOpts.checkMcp 가 우선 override 가능해야 함",
+    );
+    assert.match(
+      src,
+      /createHubHealthChecker\(\s*\{\s*hubUrl:\s*process\.env\.TFX_HUB_URL\s*\}\s*\)/,
+      "default 는 TFX_HUB_URL 기반 createHubHealthChecker 여야 함",
+    );
+    assert.match(
+      src,
+      /process\.env\.TFX_PROBE_L2\s*===\s*"0"\s*\n?\s*\?\s*undefined/,
+      "TFX_PROBE_L2=0 이면 checkMcp=undefined 로 wiring 건너뛰어야 함",
+    );
+  });
+
+  it("packages 미러 (triflux, remote) 도 동일 패턴", () => {
+    for (const mirror of [
+      "packages/triflux/hub/team/conductor.mjs",
+      "packages/remote/hub/team/conductor.mjs",
+    ]) {
+      const src = readFileSync(path.join(REPO_ROOT, mirror), "utf8");
+      assert.match(
+        src,
+        /enableL2[^\n]*process\.env\.TFX_PROBE_L2\s*!==\s*"0"/,
+        `${mirror} mirror 의 enableL2 default wiring drift`,
+      );
+      assert.match(
+        src,
+        /createHubHealthChecker/,
+        `${mirror} mirror 가 createHubHealthChecker 를 쓰지 않음`,
+      );
+    }
+  });
+});

--- a/tests/unit/health-probe.test.mjs
+++ b/tests/unit/health-probe.test.mjs
@@ -517,4 +517,8 @@ describe("health-probe: PROBE_DEFAULTS", () => {
   it("probe 주기는 5초여야 한다", () => {
     assert.equal(PROBE_DEFAULTS.intervalMs, 5_000);
   });
+
+  it("#168 P3: enableL2 default 는 true (checkMcp 미주입 시 probeL2 가 skip 반환)", () => {
+    assert.equal(PROBE_DEFAULTS.enableL2, true);
+  });
 });


### PR DESCRIPTION
## Summary

- probe state 파일에 `mcp_initializing` 라벨이 실제로 생산되도록 L2 wiring 을 활성화. heartbeat_monitor (tfx-route.sh) 의 `read_probe_state` + `probe-grace` 분기는 이미 land 되어 있지만 writer 부재로 dead code 였음.
- `createHubHealthChecker` 신규 팩토리 — hub `/health` 에 fetch, 200 OK → true, 그 외/timeout/abort/fetch 부재 → false. TFX_HUB_URL env fallback + trailing slash 정규화.
- `PROBE_DEFAULTS.enableL2` false → true (checkMcp 미주입 시 probeL2 는 여전히 `skip` 반환하므로 기존 소비자 호환).
- conductor.mjs 가 probeOpts 우선, 미지정 시 default checker 주입. opt-out: `TFX_PROBE_L2=0`.
- packages/{remote,triflux} 3 사본 pack.mjs 로 동기화.

## 설계 결정

- conductor 가 MCP profile 정보를 알지 못하므로 profile-conditional activation 대신 **default on + env opt-out** 패턴 채택.
- hub 가 정상이면 모든 worker L2=ok (noise 없음), hub degraded/down 이면 L2=fail → `deriveState` 가 `mcp_initializing` 라벨 생산 → heartbeat grace 분기 실전 가동.
- `checkMcp` 시그널은 plan 문서 (`.triflux/plans/phase-probe-heartbeat-wire.md`) 의 "low priority / trust the CLI" 원칙에 맞춰 단순 hub ping 으로 제한. per-worker MCP JSON-RPC ping 은 별도 이슈로 분리.

## Test plan

- [x] `node --test tests/unit/check-mcp-hub.test.mjs` (7 케이스) — 200/non-ok/reject/timeout abort/env/trailing slash/fetch 부재
- [x] `node --test tests/unit/conductor-probe-l2-default.test.mjs` (4 케이스) — import, enableL2 `!== "0"` 패턴, checkMcp 주입 shape, 2 mirror drift 가드
- [x] `node --test tests/unit/health-probe.test.mjs` (기존 + `PROBE_DEFAULTS.enableL2=true` 가드 1)
- [x] broader conductor/probe regression — conductor/conductor-mesh-bridge/conductor-registry/env-probe/mcp-health 107/107 PASS
- [x] `npm run lint` — 0 errors, 6 warnings (모두 baseline)

closes #168