### PR TITLE
fix(test): quota doesNotMatch 범위 좁혀 graceful degradation 경고와 분리

### DIFF
--- a/tests/integration/tfx-route-quota.test.mjs
+++ b/tests/integration/tfx-route-quota.test.mjs
@@ -244,7 +244,8 @@ auto_reroute codex
 
       assert.notEqual(result.status, 0); // 에러로 인해 종료되어야 함
       // TFX_QUOTA_REROUTE=0 조건에 의해 auto_reroute로 넘어가지 않아야 함
-      assert.doesNotMatch(out(result), /자동 전환/);
+      // `[tfx-quota]` prefix 로 auto_reroute 메시지만 매칭 — `[tfx-route]` graceful degradation 은 제외
+      assert.doesNotMatch(out(result), /\[tfx-quota\].*자동 전환/);
     });
 
     it("3. TFX_REROUTED_FROM 설정 시 중복 재귀 전환 방지", () => {
@@ -273,7 +274,7 @@ auto_reroute codex
       fs.unlinkSync(fakeCodex);
 
       assert.notEqual(result.status, 0);
-      assert.doesNotMatch(out(result), /자동 전환/);
+      assert.doesNotMatch(out(result), /\[tfx-quota\].*자동 전환/);
     });
   });
 });


### PR DESCRIPTION
## 요약
PR #171 에서 추가된 graceful degradation 메시지 (`[tfx-route] graceful degradation: MCP 전부 dead → exec mode 자동 전환`) 가 quota reroute 검증 테스트의 `doesNotMatch /자동 전환/` 과 충돌 → main baseline 에서 2개 테스트 fail 상태였음.

## 원인
- PR #171 이전 `자동 전환` 문구는 오직 `auto_reroute` 함수 (tfx-route.sh:710-722) 에서만 출력
- PR #171 이 `[tfx-route] graceful degradation: ... → exec mode 자동 전환` 메시지를 preflight 경로에 추가
- quota 테스트의 `TFX_QUOTA_REROUTE=0` / `TFX_REROUTED_FROM` 검증은 `auto_reroute` 호출 여부를 확인하는 목적이지만 정규식이 새 메시지까지 포함해서 오탐

## 수정
테스트 정규식을 `/자동 전환/` → `/\[tfx-quota\].*자동 전환/` 로 좁힘. `auto_reroute` 는 반드시 `[tfx-quota]` prefix 로만 출력하므로 의도와 일치.

## 테스트 결과
```
tests/integration/tfx-route-quota.test.mjs
# tests 10 # pass 10 # fail 0  (이전: fail 2)
```

## 범위
- `tests/integration/tfx-route-quota.test.mjs` 1파일 수정 (+3 -2)
- 실제 동작 변경 없음 (assertion 정규식 범위만 조정)

## 관련
- PR #171 (graceful degradation 도입)
- 세션 27 체크포인트 backlog #1
- smoke test 3 fail 은 graceful degradation 과 무관 (config.toml 손상 감지, MCP 서버 환경 누락) → 별도 이슈 예정