### PR TITLE
chore(lint): baseline 6 warnings cleanup

### DIFF
--- a/tests/unit/check-mcp-hub.test.mjs
+++ b/tests/unit/check-mcp-hub.test.mjs
@@ -2,7 +2,7 @@
 // #168 P3: hub /health ping checker factory 동작 검증.
 
 import assert from "node:assert/strict";
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 
 import { createHubHealthChecker } from "../../hub/team/check-mcp-hub.mjs";
 

--- a/tests/unit/setup-codex-profiles.test.mjs
+++ b/tests/unit/setup-codex-profiles.test.mjs
@@ -8,7 +8,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..", "..");
 
 const {
-  ensureCodexProfiles,
   hasProfileSection,
   REQUIRED_CODEX_PROFILES,
   REQUIRED_TOP_LEVEL_SETTINGS,

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -13,8 +13,6 @@ const {
   detectDevMode,
   SYNC_MAP,
   BREADCRUMB_PATH,
-  PLUGIN_ROOT,
-  CLAUDE_DIR,
   ensureHooksInSettings,
   ensureCodexHubServerConfig,
 } = await import("../../scripts/setup.mjs");

--- a/tests/unit/shared.test.mjs
+++ b/tests/unit/shared.test.mjs
@@ -17,8 +17,10 @@ describe("shared.mjs", () => {
     ];
 
     for (const key of keys) {
-      assert.equal(typeof shared[key], "string");
-      assert.ok(shared[key].startsWith("\x1b["));
+      // biome-ignore lint/performance/noDynamicNamespaceImportAccess: 테스트는 상수 키를 반복 순회하며 타입/값을 검증해야 하므로 dynamic access 가 의도된 동작
+      const value = shared[key];
+      assert.equal(typeof value, "string");
+      assert.ok(value.startsWith("\x1b["));
     }
   });
 });


### PR DESCRIPTION
## 요약
biome lint baseline 에 남아있던 6 warnings 일괄 정리. 모두 test 파일이며 실제 동작 변경 없음.

## 변경
| 파일 | 변경 | 사유 |
|------|------|------|
| `tests/unit/check-mcp-hub.test.mjs` | `beforeEach` import 제거 | unused (afterEach 만 사용) |
| `tests/unit/setup-codex-profiles.test.mjs` | `ensureCodexProfiles` destructure 제거 | unused (주석에만 언급) |
| `tests/unit/setup-sync.test.mjs` | `PLUGIN_ROOT`, `CLAUDE_DIR` destructure 제거 | unused |
| `tests/unit/shared.test.mjs` | biome-ignore 주석 + 로컬 변수 바인딩 | 테스트 의도상 dynamic namespace access 가 정당함 |

## lint 결과
- Before: 6 warnings (3 × noUnusedVariables, 1 × noUnusedImports FIXABLE, 2 × noDynamicNamespaceImportAccess)
- After: 0 warnings

## 테스트
```
tests/unit/check-mcp-hub.test.mjs
tests/unit/setup-codex-profiles.test.mjs
tests/unit/setup-sync.test.mjs
tests/unit/shared.test.mjs
# tests 52 # pass 52 # fail 0
```

## 관련
- 세션 27 체크포인트 backlog #6