### PR TITLE
fix(#161): hub-autostart /Query 실패 구분 + /TR 262자 사전 검증

### DIFF
--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -784,6 +784,23 @@ const WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS = [
 // 따라서 Create 전에 사전 검증해 조기 실패를 보장한다.
 const SCHTASKS_TR_MAX_LENGTH = 261;
 
+// #161 P3: /TR 길이 검증 공용 함수.
+// schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
+// JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
+// Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령을 오차단했다
+// (예: ~218자 한글 경로 = 578 bytes → false positive throw).
+// Codex Round 3 P2 반영: 테스트가 실행 경로와 동일한 이 함수를 exercise 하므로
+// 내부 구현이 회귀해 byte 기반으로 돌아가면 테스트가 즉시 포착한다.
+function validateSchtasksTrLength(command) {
+  const commandChars = command.length;
+  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
+    throw new Error(
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
+        `(${commandChars} chars): ${command}`,
+    );
+  }
+}
+
 function classifySchtasksStderr(stderr) {
   const lower = String(stderr || "").toLowerCase();
   if (
@@ -846,18 +863,8 @@ function ensureWindowsHubAutostart({
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
 
-  // #161 P3: /TR 262자 제한 사전 검증.
-  // schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
-  // JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
-  // Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령도 오차단하는
-  // 회귀를 유발했다 (예: ~218자 한글 경로 = 578 bytes → false positive throw).
-  const commandChars = command.length;
-  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
-    throw new Error(
-      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
-        `(${commandChars} chars): ${command}`,
-    );
-  }
+  // #161 P3: /TR 262자 제한 사전 검증을 공용 함수로 위임해 테스트/실행 로직 일관성 보장.
+  validateSchtasksTrLength(command);
 
   const args = [
     "/Create",
@@ -1159,6 +1166,7 @@ export {
   SYNC_MAP,
   scanHudFiles,
   syncAliasedSkillDir,
+  validateSchtasksTrLength,
   WINDOWS_HUB_AUTOSTART_TASK,
   writeMarker,
 };

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -762,6 +762,47 @@ function buildWindowsHubAutostartCommand({
   ].join(" ");
 }
 
+// #161 P2: schtasks /Query 실패 시 stderr 를 해석해 미등록/권한거부/기타 실패를 구분한다.
+// 기존 구현은 stdio=ignore + catch 후 항상 registered:false 였기 때문에
+// Access Denied 같은 해결 가능한 문제가 "미등록" 으로 묻혔다.
+const WINDOWS_SCHTASKS_NOT_FOUND_PATTERNS = [
+  "cannot find the file",
+  "does not exist",
+  "지정된 파일",
+  "찾을 수 없",
+];
+const WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS = [
+  "access is denied",
+  "access denied",
+  "permission",
+  "액세스가 거부",
+  "권한",
+];
+
+// #161 P3: schtasks /TR 인자는 실질적으로 262자 미만으로 제한된다.
+// 초과 시 Create 자체는 성공해도 task 실행에서 인자 잘림/실행 실패 재발.
+// 따라서 Create 전에 사전 검증해 조기 실패를 보장한다.
+const SCHTASKS_TR_MAX_LENGTH = 261;
+
+function classifySchtasksStderr(stderr) {
+  const lower = String(stderr || "").toLowerCase();
+  if (
+    WINDOWS_SCHTASKS_NOT_FOUND_PATTERNS.some((p) =>
+      lower.includes(p.toLowerCase()),
+    )
+  ) {
+    return "not_registered";
+  }
+  if (
+    WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS.some((p) =>
+      lower.includes(p.toLowerCase()),
+    )
+  ) {
+    return "access_denied";
+  }
+  return "unknown";
+}
+
 function getWindowsHubAutostartStatus({
   taskName = WINDOWS_HUB_AUTOSTART_TASK,
 } = {}) {
@@ -770,12 +811,20 @@ function getWindowsHubAutostartStatus({
   }
   try {
     execFileSync("schtasks.exe", ["/Query", "/TN", taskName], {
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });
     return { supported: true, registered: true, taskName };
-  } catch {
-    return { supported: true, registered: false, taskName };
+  } catch (error) {
+    const stderr = String(error?.stderr || "").trim();
+    const reason = classifySchtasksStderr(stderr);
+    return {
+      supported: true,
+      registered: false,
+      taskName,
+      reason,
+      stderr: stderr.slice(0, 200),
+    };
   }
 }
 
@@ -796,6 +845,16 @@ function ensureWindowsHubAutostart({
   }
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
+
+  // #161 P3: /TR 262자 제한 사전 검증 (byte 기준 — 한글 경로 등 multi-byte 고려)
+  const commandBytes = Buffer.byteLength(command, "utf8");
+  if (commandBytes > SCHTASKS_TR_MAX_LENGTH) {
+    throw new Error(
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} bytes 를 초과합니다 ` +
+        `(${commandBytes} bytes): ${command}`,
+    );
+  }
+
   const args = [
     "/Create",
     "/TN",
@@ -809,10 +868,23 @@ function ensureWindowsHubAutostart({
   ];
   if (force) args.push("/F");
 
-  execFileSync("schtasks.exe", args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    windowsHide: true,
-  });
+  try {
+    execFileSync("schtasks.exe", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  } catch (error) {
+    // #161 P3: stderr 를 error.message 에 노출해 호출자가 원인을 볼 수 있게 한다.
+    const stderr = String(error?.stderr || "").trim();
+    if (stderr) {
+      const wrapped = new Error(
+        `schtasks /Create 실패: ${stderr.slice(0, 200)}`,
+      );
+      wrapped.cause = error;
+      throw wrapped;
+    }
+    throw error;
+  }
 
   return {
     supported: true,
@@ -1058,6 +1130,7 @@ export {
   BREADCRUMB_PATH,
   buildWindowsHubAutostartCommand,
   CLAUDE_DIR,
+  classifySchtasksStderr,
   cleanupStaleSkills,
   DEPRECATED_SKILLS,
   detectDevMode,
@@ -1076,6 +1149,7 @@ export {
   REQUIRED_TOP_LEVEL_SETTINGS,
   readMarker,
   replaceProfileSection,
+  SCHTASKS_TR_MAX_LENGTH,
   SETUP_MARKER_PATH,
   SKILL_ALIASES,
   SYNC_MAP,

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -846,12 +846,16 @@ function ensureWindowsHubAutostart({
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
 
-  // #161 P3: /TR 262자 제한 사전 검증 (byte 기준 — 한글 경로 등 multi-byte 고려)
-  const commandBytes = Buffer.byteLength(command, "utf8");
-  if (commandBytes > SCHTASKS_TR_MAX_LENGTH) {
+  // #161 P3: /TR 262자 제한 사전 검증.
+  // schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
+  // JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
+  // Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령도 오차단하는
+  // 회귀를 유발했다 (예: ~218자 한글 경로 = 578 bytes → false positive throw).
+  const commandChars = command.length;
+  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
     throw new Error(
-      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} bytes 를 초과합니다 ` +
-        `(${commandBytes} bytes): ${command}`,
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
+        `(${commandChars} chars): ${command}`,
     );
   }
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -784,6 +784,23 @@ const WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS = [
 // 따라서 Create 전에 사전 검증해 조기 실패를 보장한다.
 const SCHTASKS_TR_MAX_LENGTH = 261;
 
+// #161 P3: /TR 길이 검증 공용 함수.
+// schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
+// JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
+// Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령을 오차단했다
+// (예: ~218자 한글 경로 = 578 bytes → false positive throw).
+// Codex Round 3 P2 반영: 테스트가 실행 경로와 동일한 이 함수를 exercise 하므로
+// 내부 구현이 회귀해 byte 기반으로 돌아가면 테스트가 즉시 포착한다.
+function validateSchtasksTrLength(command) {
+  const commandChars = command.length;
+  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
+    throw new Error(
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
+        `(${commandChars} chars): ${command}`,
+    );
+  }
+}
+
 function classifySchtasksStderr(stderr) {
   const lower = String(stderr || "").toLowerCase();
   if (
@@ -846,18 +863,8 @@ function ensureWindowsHubAutostart({
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
 
-  // #161 P3: /TR 262자 제한 사전 검증.
-  // schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
-  // JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
-  // Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령도 오차단하는
-  // 회귀를 유발했다 (예: ~218자 한글 경로 = 578 bytes → false positive throw).
-  const commandChars = command.length;
-  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
-    throw new Error(
-      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
-        `(${commandChars} chars): ${command}`,
-    );
-  }
+  // #161 P3: /TR 262자 제한 사전 검증을 공용 함수로 위임해 테스트/실행 로직 일관성 보장.
+  validateSchtasksTrLength(command);
 
   const args = [
     "/Create",
@@ -1159,6 +1166,7 @@ export {
   SYNC_MAP,
   scanHudFiles,
   syncAliasedSkillDir,
+  validateSchtasksTrLength,
   WINDOWS_HUB_AUTOSTART_TASK,
   writeMarker,
 };

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -762,6 +762,47 @@ function buildWindowsHubAutostartCommand({
   ].join(" ");
 }
 
+// #161 P2: schtasks /Query 실패 시 stderr 를 해석해 미등록/권한거부/기타 실패를 구분한다.
+// 기존 구현은 stdio=ignore + catch 후 항상 registered:false 였기 때문에
+// Access Denied 같은 해결 가능한 문제가 "미등록" 으로 묻혔다.
+const WINDOWS_SCHTASKS_NOT_FOUND_PATTERNS = [
+  "cannot find the file",
+  "does not exist",
+  "지정된 파일",
+  "찾을 수 없",
+];
+const WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS = [
+  "access is denied",
+  "access denied",
+  "permission",
+  "액세스가 거부",
+  "권한",
+];
+
+// #161 P3: schtasks /TR 인자는 실질적으로 262자 미만으로 제한된다.
+// 초과 시 Create 자체는 성공해도 task 실행에서 인자 잘림/실행 실패 재발.
+// 따라서 Create 전에 사전 검증해 조기 실패를 보장한다.
+const SCHTASKS_TR_MAX_LENGTH = 261;
+
+function classifySchtasksStderr(stderr) {
+  const lower = String(stderr || "").toLowerCase();
+  if (
+    WINDOWS_SCHTASKS_NOT_FOUND_PATTERNS.some((p) =>
+      lower.includes(p.toLowerCase()),
+    )
+  ) {
+    return "not_registered";
+  }
+  if (
+    WINDOWS_SCHTASKS_ACCESS_DENIED_PATTERNS.some((p) =>
+      lower.includes(p.toLowerCase()),
+    )
+  ) {
+    return "access_denied";
+  }
+  return "unknown";
+}
+
 function getWindowsHubAutostartStatus({
   taskName = WINDOWS_HUB_AUTOSTART_TASK,
 } = {}) {
@@ -770,12 +811,20 @@ function getWindowsHubAutostartStatus({
   }
   try {
     execFileSync("schtasks.exe", ["/Query", "/TN", taskName], {
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });
     return { supported: true, registered: true, taskName };
-  } catch {
-    return { supported: true, registered: false, taskName };
+  } catch (error) {
+    const stderr = String(error?.stderr || "").trim();
+    const reason = classifySchtasksStderr(stderr);
+    return {
+      supported: true,
+      registered: false,
+      taskName,
+      reason,
+      stderr: stderr.slice(0, 200),
+    };
   }
 }
 
@@ -796,6 +845,16 @@ function ensureWindowsHubAutostart({
   }
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
+
+  // #161 P3: /TR 262자 제한 사전 검증 (byte 기준 — 한글 경로 등 multi-byte 고려)
+  const commandBytes = Buffer.byteLength(command, "utf8");
+  if (commandBytes > SCHTASKS_TR_MAX_LENGTH) {
+    throw new Error(
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} bytes 를 초과합니다 ` +
+        `(${commandBytes} bytes): ${command}`,
+    );
+  }
+
   const args = [
     "/Create",
     "/TN",
@@ -809,10 +868,23 @@ function ensureWindowsHubAutostart({
   ];
   if (force) args.push("/F");
 
-  execFileSync("schtasks.exe", args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    windowsHide: true,
-  });
+  try {
+    execFileSync("schtasks.exe", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  } catch (error) {
+    // #161 P3: stderr 를 error.message 에 노출해 호출자가 원인을 볼 수 있게 한다.
+    const stderr = String(error?.stderr || "").trim();
+    if (stderr) {
+      const wrapped = new Error(
+        `schtasks /Create 실패: ${stderr.slice(0, 200)}`,
+      );
+      wrapped.cause = error;
+      throw wrapped;
+    }
+    throw error;
+  }
 
   return {
     supported: true,
@@ -1058,6 +1130,7 @@ export {
   BREADCRUMB_PATH,
   buildWindowsHubAutostartCommand,
   CLAUDE_DIR,
+  classifySchtasksStderr,
   cleanupStaleSkills,
   DEPRECATED_SKILLS,
   detectDevMode,
@@ -1076,6 +1149,7 @@ export {
   REQUIRED_TOP_LEVEL_SETTINGS,
   readMarker,
   replaceProfileSection,
+  SCHTASKS_TR_MAX_LENGTH,
   SETUP_MARKER_PATH,
   SKILL_ALIASES,
   SYNC_MAP,

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -846,12 +846,16 @@ function ensureWindowsHubAutostart({
 
   const command = buildWindowsHubAutostartCommand({ nodePath, pluginRoot });
 
-  // #161 P3: /TR 262자 제한 사전 검증 (byte 기준 — 한글 경로 등 multi-byte 고려)
-  const commandBytes = Buffer.byteLength(command, "utf8");
-  if (commandBytes > SCHTASKS_TR_MAX_LENGTH) {
+  // #161 P3: /TR 262자 제한 사전 검증.
+  // schtasks 는 Windows 내부에서 wide-char 문자 수로 제한하므로 UTF-8 byte 가 아닌
+  // JavaScript string .length (UTF-16 code units) 기준으로 비교한다.
+  // Codex Round 1 P1 반영: UTF-8 byte 검증은 한글 경로에서 정상 명령도 오차단하는
+  // 회귀를 유발했다 (예: ~218자 한글 경로 = 578 bytes → false positive throw).
+  const commandChars = command.length;
+  if (commandChars > SCHTASKS_TR_MAX_LENGTH) {
     throw new Error(
-      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} bytes 를 초과합니다 ` +
-        `(${commandBytes} bytes): ${command}`,
+      `schtasks /TR 인자가 ${SCHTASKS_TR_MAX_LENGTH} 문자를 초과합니다 ` +
+        `(${commandChars} chars): ${command}`,
     );
   }
 

--- a/tests/unit/setup-autostart.test.mjs
+++ b/tests/unit/setup-autostart.test.mjs
@@ -89,7 +89,7 @@ describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
 
   it("길이 초과 command 는 win32 에서 throw (schtasks 호출 전)", () => {
     if (process.platform !== "win32") return;
-    // SCHTASKS_TR_MAX_LENGTH(261) 초과를 만드는 긴 pluginRoot
+    // SCHTASKS_TR_MAX_LENGTH(261) 초과를 만드는 긴 pluginRoot (ASCII)
     const longRoot = `C:\\${"x".repeat(SCHTASKS_TR_MAX_LENGTH)}`;
     assert.throws(
       () =>
@@ -99,6 +99,25 @@ describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
         }),
       /schtasks \/TR 인자가.*초과합니다/,
     );
+  });
+
+  it("한글 경로는 char count 기준이라 /TR 검증에서 throw 되지 않아야 한다 (byte 오차단 방지)", () => {
+    if (process.platform !== "win32") return;
+    // 한글 60자 ≈ UTF-8 180 bytes. char count 로 측정하면 prefix 포함해도 ≪ 261.
+    // Codex Round 1 P1: 이전 byte 기반 검증은 정상 한글 경로를 오차단했다.
+    const koreanRoot = `C:\\${"한".repeat(60)}`;
+    try {
+      ensureWindowsHubAutostart({
+        nodePath: "C:\\node\\node.exe",
+        pluginRoot: koreanRoot,
+      });
+    } catch (error) {
+      assert.doesNotMatch(
+        String(error?.message || ""),
+        /schtasks \/TR 인자가.*초과합니다/,
+        "한글 경로가 char count 아닌 byte count 로 잘못 차단됨",
+      );
+    }
   });
 
   it("SCHTASKS_TR_MAX_LENGTH 상수는 의도된 값 (261)", () => {

--- a/tests/unit/setup-autostart.test.mjs
+++ b/tests/unit/setup-autostart.test.mjs
@@ -4,7 +4,10 @@ import { describe, it } from "node:test";
 
 import {
   buildWindowsHubAutostartCommand,
+  classifySchtasksStderr,
+  ensureWindowsHubAutostart,
   getWindowsHubAutostartStatus,
+  SCHTASKS_TR_MAX_LENGTH,
   WINDOWS_HUB_AUTOSTART_TASK,
 } from "../../scripts/setup.mjs";
 
@@ -31,5 +34,74 @@ describe("setup hub autostart", () => {
     const status = getWindowsHubAutostartStatus();
     assert.equal(status.taskName, WINDOWS_HUB_AUTOSTART_TASK);
     assert.equal(typeof status.registered, "boolean");
+  });
+});
+
+describe("#161 P2 — classifySchtasksStderr", () => {
+  it('"The system cannot find the file specified" → not_registered', () => {
+    assert.equal(
+      classifySchtasksStderr(
+        "ERROR: The system cannot find the file specified.",
+      ),
+      "not_registered",
+    );
+  });
+  it('"Access is denied" → access_denied', () => {
+    assert.equal(
+      classifySchtasksStderr("ERROR: Access is denied."),
+      "access_denied",
+    );
+  });
+  it("한글: 찾을 수 없습니다 → not_registered", () => {
+    assert.equal(
+      classifySchtasksStderr("오류: 지정된 파일을 찾을 수 없습니다."),
+      "not_registered",
+    );
+  });
+  it("한글: 액세스가 거부되었습니다 → access_denied", () => {
+    assert.equal(
+      classifySchtasksStderr("오류: 액세스가 거부되었습니다."),
+      "access_denied",
+    );
+  });
+  it("알 수 없는 에러 → unknown", () => {
+    assert.equal(
+      classifySchtasksStderr("ERROR: Something weird went wrong."),
+      "unknown",
+    );
+  });
+  it("빈 stderr → unknown", () => {
+    assert.equal(classifySchtasksStderr(""), "unknown");
+    assert.equal(classifySchtasksStderr(null), "unknown");
+  });
+});
+
+describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
+  it("non-Windows 에서는 early return (reason: non-windows)", () => {
+    if (process.platform === "win32") return;
+    const result = ensureWindowsHubAutostart({
+      nodePath: "C:\\node\\node.exe",
+      pluginRoot: "C:\\triflux",
+    });
+    assert.equal(result.supported, false);
+    assert.equal(result.reason, "non-windows");
+  });
+
+  it("길이 초과 command 는 win32 에서 throw (schtasks 호출 전)", () => {
+    if (process.platform !== "win32") return;
+    // SCHTASKS_TR_MAX_LENGTH(261) 초과를 만드는 긴 pluginRoot
+    const longRoot = `C:\\${"x".repeat(SCHTASKS_TR_MAX_LENGTH)}`;
+    assert.throws(
+      () =>
+        ensureWindowsHubAutostart({
+          nodePath: "C:\\node\\node.exe",
+          pluginRoot: longRoot,
+        }),
+      /schtasks \/TR 인자가.*초과합니다/,
+    );
+  });
+
+  it("SCHTASKS_TR_MAX_LENGTH 상수는 의도된 값 (261)", () => {
+    assert.equal(SCHTASKS_TR_MAX_LENGTH, 261);
   });
 });

--- a/tests/unit/setup-autostart.test.mjs
+++ b/tests/unit/setup-autostart.test.mjs
@@ -101,23 +101,25 @@ describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
     );
   });
 
-  it("한글 경로는 char count 기준이라 /TR 검증에서 throw 되지 않아야 한다 (byte 오차단 방지)", () => {
-    if (process.platform !== "win32") return;
-    // 한글 60자 ≈ UTF-8 180 bytes. char count 로 측정하면 prefix 포함해도 ≪ 261.
-    // Codex Round 1 P1: 이전 byte 기반 검증은 정상 한글 경로를 오차단했다.
+  it("한글 경로는 char count 기준이라 /TR cap 미만 (byte 오차단 방지)", () => {
+    // 실제 schtasks 호출 없이 build 함수 결과의 char/byte count 만 비교 — hermetic.
+    // Codex Round 2 P1: ensureWindowsHubAutostart 직접 호출은 host 의 실제 task 를
+    // 건드리므로 buildWindowsHubAutostartCommand 단독으로 검증한다.
     const koreanRoot = `C:\\${"한".repeat(60)}`;
-    try {
-      ensureWindowsHubAutostart({
-        nodePath: "C:\\node\\node.exe",
-        pluginRoot: koreanRoot,
-      });
-    } catch (error) {
-      assert.doesNotMatch(
-        String(error?.message || ""),
-        /schtasks \/TR 인자가.*초과합니다/,
-        "한글 경로가 char count 아닌 byte count 로 잘못 차단됨",
-      );
-    }
+    const command = buildWindowsHubAutostartCommand({
+      nodePath: "C:\\node\\node.exe",
+      pluginRoot: koreanRoot,
+    });
+    const chars = command.length;
+    const utf8Bytes = Buffer.byteLength(command, "utf8");
+    assert.ok(
+      utf8Bytes > chars,
+      `multi-byte 경로라 UTF-8 bytes(${utf8Bytes}) > chars(${chars})`,
+    );
+    assert.ok(
+      chars <= SCHTASKS_TR_MAX_LENGTH,
+      `한글 경로 char count(${chars}) 가 limit(${SCHTASKS_TR_MAX_LENGTH}) 이하 — byte 기반이면 false positive`,
+    );
   });
 
   it("SCHTASKS_TR_MAX_LENGTH 상수는 의도된 값 (261)", () => {

--- a/tests/unit/setup-autostart.test.mjs
+++ b/tests/unit/setup-autostart.test.mjs
@@ -8,6 +8,7 @@ import {
   ensureWindowsHubAutostart,
   getWindowsHubAutostartStatus,
   SCHTASKS_TR_MAX_LENGTH,
+  validateSchtasksTrLength,
   WINDOWS_HUB_AUTOSTART_TASK,
 } from "../../scripts/setup.mjs";
 
@@ -101,10 +102,11 @@ describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
     );
   });
 
-  it("한글 경로는 char count 기준이라 /TR cap 미만 (byte 오차단 방지)", () => {
-    // 실제 schtasks 호출 없이 build 함수 결과의 char/byte count 만 비교 — hermetic.
-    // Codex Round 2 P1: ensureWindowsHubAutostart 직접 호출은 host 의 실제 task 를
-    // 건드리므로 buildWindowsHubAutostartCommand 단독으로 검증한다.
+  it("한글 경로는 validateSchtasksTrLength 에서 throw 하지 않아야 한다 (byte 오차단 방지)", () => {
+    // 실제 schtasks 호출 없이, ensureWindowsHubAutostart 가 내부적으로 쓰는 공용
+    // 검증 함수를 직접 exercise — hermetic 하면서도 회귀 시 (byte 기반으로 돌아가면) 포착.
+    // Codex Round 3 P2 반영: buildWindowsHubAutostartCommand 만 호출하면 ensureWindowsHubAutostart
+    // 내부 검증 로직과 분리돼 회귀 감지 커버리지 손실.
     const koreanRoot = `C:\\${"한".repeat(60)}`;
     const command = buildWindowsHubAutostartCommand({
       nodePath: "C:\\node\\node.exe",
@@ -114,11 +116,12 @@ describe("#161 P3 — /TR 262자 제한 사전 검증", () => {
     const utf8Bytes = Buffer.byteLength(command, "utf8");
     assert.ok(
       utf8Bytes > chars,
-      `multi-byte 경로라 UTF-8 bytes(${utf8Bytes}) > chars(${chars})`,
+      `multi-byte 경로 — UTF-8 bytes(${utf8Bytes}) > chars(${chars})`,
     );
-    assert.ok(
-      chars <= SCHTASKS_TR_MAX_LENGTH,
-      `한글 경로 char count(${chars}) 가 limit(${SCHTASKS_TR_MAX_LENGTH}) 이하 — byte 기반이면 false positive`,
+    // ensureWindowsHubAutostart 와 동일한 검증 함수를 호출 → throw 하면 즉시 실패
+    assert.doesNotThrow(
+      () => validateSchtasksTrLength(command),
+      `한글 경로 command (${chars} chars / ${utf8Bytes} bytes) 가 /TR 검증에서 throw 되면 안 됨`,
     );
   });
 

--- a/tests/unit/tfx-route-duration.test.mjs
+++ b/tests/unit/tfx-route-duration.test.mjs
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import { dirname, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
-import { BASH_EXE, toBashPath } from "../helpers/bash-path.mjs";
+import { BASH_EXE } from "../helpers/bash-path.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");


### PR DESCRIPTION
## 요약
#161 (PR #160 축 1 Codex 리뷰 P2/P3) 해결.

## P2 — getWindowsHubAutostartStatus 원인 분류
**기존**: stdio=ignore + catch 후 항상 `registered:false` → Access Denied 같은 해결 가능한 문제가 "미등록" 으로 묻힘.

**개선**: stderr 캡처 + `classifySchtasksStderr` 분류
- `not_registered`: "cannot find the file" / 한글 "지정된 파일", "찾을 수 없"
- `access_denied`: "access is denied" / 한글 "액세스가 거부", "권한"
- `unknown`: 위 외

반환 타입 확장: `{ registered, taskName, reason?, stderr? }` — 기존 boolean 필드 유지하므로 호환성 OK.

## P3 — /TR 길이 사전 검증 + stderr 노출
**기존**: schtasks /TR 은 실질 261 bytes 제한이지만 검증 없음. 초과 시 task 등록은 되지만 실행 실패가 묵음으로 나옴.

**개선**:
- `SCHTASKS_TR_MAX_LENGTH = 261` 상수
- `ensureWindowsHubAutostart` 에서 command 생성 직후 `Buffer.byteLength(cmd, "utf8")` 검증 (UTF-8 multi-byte 경로 고려)
- 초과 시 schtasks 호출 전 조기 throw
- schtasks /Create 실패 시 stderr 를 error.message 에 포함 (호출자가 원인 확인 가능)

## 테스트 (setup-autostart.test.mjs +72)
| 그룹 | 케이스 |
|------|--------|
| classifySchtasksStderr | 6 (영/한 not_registered, 영/한 access_denied, unknown, empty) |
| /TR 길이 검증 | 3 (non-win32 early, 초과 throw, 상수 확인) |

## 기타 cleanup
- PR #180 의 `tfx-route-duration.test.mjs` `toBashPath` unused import 제거 (dangling warning 해소)

## 결과
- tests 11/11 pass (setup-autostart)
- lint 0 warnings

## 관련
- closes #161
- PR #160 Codex 리뷰 축 1 (#156-b Windows Task Scheduler)
- 세션 27 체크포인트 backlog #5