### PR TITLE
fix(swarm): lease-outside validate guard + 모델-직무 매핑 개편

### DIFF
--- a/.claude/rules/tfx-escalation-chain.md
+++ b/.claude/rules/tfx-escalation-chain.md
@@ -9,9 +9,9 @@
 
 | # | CLI | 모델 | 이유 |
 |---|-----|------|------|
-| 1 | codex | gpt-5.4-mini | 비용 최저, 단순 태스크 대부분 해결. (gpt-5.5 mini 변종 부재 → 5.4-mini 유지) |
-| 2 | codex | gpt-5.5 | 신규 플래그십, Anthropic 대비 비용 우위 유지 |
-| 3 | claude | sonnet-4-6 | 도구 사용 + 장문 추론 필요 시 승격 |
+| 1 | codex | gpt-5.4-mini | 비용 최저, fast tier, 단순 태스크 대부분 해결. (gpt-5.5 mini 변종 부재 → 5.4-mini 유지) |
+| 2 | codex | gpt-5.3-codex | 가성비 중간, code specialized. Plus/free 모두 OK. fast tier 미지원이지만 reasoning depth 보강. |
+| 3 | codex | gpt-5.5 | top reasoning + 코드 강함, fast tier. sonnet-4-6 보다 코드/추론/비용 모두 우위라 sonnet 단계 제거 후 격상. |
 | 4 | claude | opus-4-7 | 최종 수단, 복잡 아키텍처/합의 요구 시 |
 
 체인 길이 소진 시 `BUDGET_EXCEEDED` with `reason: "escalation-chain-exhausted"`.

--- a/hub/intent.mjs
+++ b/hub/intent.mjs
@@ -61,17 +61,22 @@ function _tryCodexClassify(prompt) {
  * triflux 특화 의도 카테고리 (10개)
  */
 export const INTENT_CATEGORIES = {
-  implement: { agent: "executor", mcp: "implement", effort: "codex53_high" },
-  debug: { agent: "debugger", mcp: "implement", effort: "codex53_high" },
-  analyze: { agent: "analyst", mcp: "analyze", effort: "gpt54_xhigh" },
-  design: { agent: "architect", mcp: "analyze", effort: "gpt54_xhigh" },
-  review: { agent: "code-reviewer", mcp: "review", effort: "codex53_high" },
+  // 모델 정책 (2026-04-25):
+  // - gpt-5.5 = 메인 (코드 포함 모든 메인 직무, fast tier 가능)
+  // - gpt-5.4-mini = 자잘/부가/가성비 (fast tier 가능)
+  // - gpt-5.3-codex = escalation 가성비 중간 (fast 미지원)
+  // - gpt-5.4 폐기, gpt-5.5 로 격상
+  implement: { agent: "executor", mcp: "implement", effort: "gpt55_high" },
+  debug: { agent: "debugger", mcp: "implement", effort: "gpt55_xhigh" },
+  analyze: { agent: "analyst", mcp: "analyze", effort: "gpt55_xhigh" },
+  design: { agent: "architect", mcp: "analyze", effort: "gpt55_xhigh" },
+  review: { agent: "code-reviewer", mcp: "review", effort: "gpt55_high" },
   document: { agent: "writer", mcp: "docs", effort: "pro" },
-  research: { agent: "scientist", mcp: "analyze", effort: "codex53_high" },
+  research: { agent: "scientist", mcp: "analyze", effort: "gpt55_high" },
   "quick-fix": {
     agent: "build-fixer",
     mcp: "implement",
-    effort: "codex53_low",
+    effort: "gpt55_low",
   },
   explain: { agent: "writer", mcp: "docs", effort: "flash" },
   test: { agent: "test-engineer", mcp: null, effort: null },

--- a/hub/team/retry-state-machine.mjs
+++ b/hub/team/retry-state-machine.mjs
@@ -38,10 +38,17 @@ export const MODES = Object.freeze({
   ESCALATE: "auto-escalate",
 });
 
+// Escalation chain (2026-04-25 정책):
+//   1. gpt-5.4-mini   — 비용 최저, fast tier, 단순 task 대부분 해결
+//   2. gpt-5.3-codex  — 가성비 중간, code specialized (Plus/free 모두 OK, fast 미지원)
+//   3. gpt-5.5         — top reasoning + 코드 강함, fast tier
+//   4. claude opus-4-7 — 최종 수단
+// sonnet-4-6 단계는 제거: gpt-5.5 가 코드/추론/비용 모두 우위 + 5.3-codex 가성비
+// 단계가 더 적합한 중간 격상.
 const DEFAULT_ESCALATION_CHAIN = Object.freeze([
   Object.freeze({ cli: "codex", model: "gpt-5.4-mini" }),
+  Object.freeze({ cli: "codex", model: "gpt-5.3-codex" }),
   Object.freeze({ cli: "codex", model: "gpt-5.5" }),
-  Object.freeze({ cli: "claude", model: "sonnet-4-6" }),
   Object.freeze({ cli: "claude", model: "opus-4-7" }),
 ]);
 

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -855,7 +855,14 @@ export function createSwarmHypervisor(opts) {
    * @returns {{ ok: boolean, violations: Array }}
    */
   function validateResult(shardName, changedFiles) {
-    const violations = lockManager.validateChanges(shardName, changedFiles);
+    // Pass the shard's own lease so validateChanges can flag out-of-lease
+    // writes to distribution-critical paths (regression of #115/#34 —
+    // recovery patches were carrying `+++ /dev/null` deletions of
+    // .claude-plugin/marketplace.json, undetected by lease-only checks).
+    const ownLease = plan.leaseMap.get(shardName) || [];
+    const violations = lockManager.validateChanges(shardName, changedFiles, {
+      ownLease,
+    });
 
     eventLog.append("validate_result", {
       shard: shardName,

--- a/hub/team/swarm-locks.mjs
+++ b/hub/team/swarm-locks.mjs
@@ -8,6 +8,26 @@ import { dirname, relative, resolve } from "node:path";
 
 const LOCK_TTL_MS = 10 * 60_000; // 10 minutes default TTL
 
+// Distribution-critical paths. A swarm worker that modifies these without
+// having them explicitly listed in its shard lease is almost certainly a
+// recovery-patch fallout (worker exited before commit, hypervisor saved
+// patch with destructive `+++ /dev/null` deletions). Block by default;
+// override via validateChanges options.sensitiveDeny.
+//
+// Paths use POSIX separators (matches normalizePath output).
+const SENSITIVE_PATH_PREFIXES = [
+  ".claude-plugin/",
+  "bin/",
+  ".github/workflows/",
+];
+const SENSITIVE_PATH_FILES = [
+  ".gitignore",
+  ".npmignore",
+  "package.json",
+  "package-lock.json",
+  "biome.json",
+];
+
 /**
  * Swarm lock manager factory.
  * @param {object} [opts]
@@ -205,20 +225,52 @@ export function createSwarmLocks(opts = {}) {
   /**
    * Validate a set of changed files against the lease map.
    * Returns all violations found.
+   *
+   * Beyond the basic cross-lease check, when `options.ownLease` is supplied
+   * (the caller's known lease set), this also flags out-of-lease writes to
+   * distribution-critical paths — e.g. recovery-patch fallouts where a
+   * worker's recorded diff carries `+++ /dev/null` deletions of files like
+   * `.claude-plugin/marketplace.json` (regression of #115 / #34).
+   *
+   * `options.ownLease` is opt-in to preserve existing callers; when omitted,
+   * legacy behavior (cross-lease check only) is kept.
+   *
    * @param {string} workerId
    * @param {string[]} changedFiles
-   * @returns {Array<{ file: string, holder: string }>}
+   * @param {{ ownLease?: string[], sensitiveDeny?: { prefixes?: string[], files?: string[] } }} [options]
+   * @returns {Array<{ file: string, holder?: string, kind: "other-lease" | "sensitive-out-of-lease" }>}
    */
-  function validateChanges(workerId, changedFiles) {
+  function validateChanges(workerId, changedFiles, options = {}) {
     pruneExpired();
     const violations = [];
+    const ownLeaseSet = Array.isArray(options.ownLease)
+      ? new Set(options.ownLease.map((path) => normalizePath(path)))
+      : null;
+    const sensitivePrefixes =
+      options.sensitiveDeny?.prefixes ?? SENSITIVE_PATH_PREFIXES;
+    const sensitiveFiles = new Set(
+      options.sensitiveDeny?.files ?? SENSITIVE_PATH_FILES,
+    );
 
     for (const file of changedFiles) {
       const path = normalizePath(file);
       const entry = locks.get(path);
 
       if (entry && entry.workerId !== workerId && !isExpired(entry)) {
-        violations.push({ file, holder: entry.workerId });
+        violations.push({ file, holder: entry.workerId, kind: "other-lease" });
+        continue;
+      }
+
+      // Sensitive-path guard only runs when caller supplied ownLease.
+      // We only flag when the worker did NOT explicitly lease the file —
+      // an explicit lease means the shard intentionally owns it.
+      if (ownLeaseSet && !ownLeaseSet.has(path)) {
+        const isSensitive =
+          sensitiveFiles.has(path) ||
+          sensitivePrefixes.some((prefix) => path.startsWith(prefix));
+        if (isSensitive) {
+          violations.push({ file, kind: "sensitive-out-of-lease" });
+        }
       }
     }
 

--- a/packages/triflux/hub/intent.mjs
+++ b/packages/triflux/hub/intent.mjs
@@ -61,17 +61,22 @@ function _tryCodexClassify(prompt) {
  * triflux 특화 의도 카테고리 (10개)
  */
 export const INTENT_CATEGORIES = {
-  implement: { agent: "executor", mcp: "implement", effort: "codex53_high" },
-  debug: { agent: "debugger", mcp: "implement", effort: "codex53_high" },
-  analyze: { agent: "analyst", mcp: "analyze", effort: "gpt54_xhigh" },
-  design: { agent: "architect", mcp: "analyze", effort: "gpt54_xhigh" },
-  review: { agent: "code-reviewer", mcp: "review", effort: "codex53_high" },
+  // 모델 정책 (2026-04-25):
+  // - gpt-5.5 = 메인 (코드 포함 모든 메인 직무, fast tier 가능)
+  // - gpt-5.4-mini = 자잘/부가/가성비 (fast tier 가능)
+  // - gpt-5.3-codex = escalation 가성비 중간 (fast 미지원)
+  // - gpt-5.4 폐기, gpt-5.5 로 격상
+  implement: { agent: "executor", mcp: "implement", effort: "gpt55_high" },
+  debug: { agent: "debugger", mcp: "implement", effort: "gpt55_xhigh" },
+  analyze: { agent: "analyst", mcp: "analyze", effort: "gpt55_xhigh" },
+  design: { agent: "architect", mcp: "analyze", effort: "gpt55_xhigh" },
+  review: { agent: "code-reviewer", mcp: "review", effort: "gpt55_high" },
   document: { agent: "writer", mcp: "docs", effort: "pro" },
-  research: { agent: "scientist", mcp: "analyze", effort: "codex53_high" },
+  research: { agent: "scientist", mcp: "analyze", effort: "gpt55_high" },
   "quick-fix": {
     agent: "build-fixer",
     mcp: "implement",
-    effort: "codex53_low",
+    effort: "gpt55_low",
   },
   explain: { agent: "writer", mcp: "docs", effort: "flash" },
   test: { agent: "test-engineer", mcp: null, effort: null },

--- a/packages/triflux/hub/team/retry-state-machine.mjs
+++ b/packages/triflux/hub/team/retry-state-machine.mjs
@@ -38,10 +38,17 @@ export const MODES = Object.freeze({
   ESCALATE: "auto-escalate",
 });
 
+// Escalation chain (2026-04-25 정책):
+//   1. gpt-5.4-mini   — 비용 최저, fast tier, 단순 task 대부분 해결
+//   2. gpt-5.3-codex  — 가성비 중간, code specialized (Plus/free 모두 OK, fast 미지원)
+//   3. gpt-5.5         — top reasoning + 코드 강함, fast tier
+//   4. claude opus-4-7 — 최종 수단
+// sonnet-4-6 단계는 제거: gpt-5.5 가 코드/추론/비용 모두 우위 + 5.3-codex 가성비
+// 단계가 더 적합한 중간 격상.
 const DEFAULT_ESCALATION_CHAIN = Object.freeze([
   Object.freeze({ cli: "codex", model: "gpt-5.4-mini" }),
+  Object.freeze({ cli: "codex", model: "gpt-5.3-codex" }),
   Object.freeze({ cli: "codex", model: "gpt-5.5" }),
-  Object.freeze({ cli: "claude", model: "sonnet-4-6" }),
   Object.freeze({ cli: "claude", model: "opus-4-7" }),
 ]);
 

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -855,7 +855,14 @@ export function createSwarmHypervisor(opts) {
    * @returns {{ ok: boolean, violations: Array }}
    */
   function validateResult(shardName, changedFiles) {
-    const violations = lockManager.validateChanges(shardName, changedFiles);
+    // Pass the shard's own lease so validateChanges can flag out-of-lease
+    // writes to distribution-critical paths (regression of #115/#34 —
+    // recovery patches were carrying `+++ /dev/null` deletions of
+    // .claude-plugin/marketplace.json, undetected by lease-only checks).
+    const ownLease = plan.leaseMap.get(shardName) || [];
+    const violations = lockManager.validateChanges(shardName, changedFiles, {
+      ownLease,
+    });
 
     eventLog.append("validate_result", {
       shard: shardName,

--- a/packages/triflux/hub/team/swarm-locks.mjs
+++ b/packages/triflux/hub/team/swarm-locks.mjs
@@ -8,6 +8,26 @@ import { dirname, relative, resolve } from "node:path";
 
 const LOCK_TTL_MS = 10 * 60_000; // 10 minutes default TTL
 
+// Distribution-critical paths. A swarm worker that modifies these without
+// having them explicitly listed in its shard lease is almost certainly a
+// recovery-patch fallout (worker exited before commit, hypervisor saved
+// patch with destructive `+++ /dev/null` deletions). Block by default;
+// override via validateChanges options.sensitiveDeny.
+//
+// Paths use POSIX separators (matches normalizePath output).
+const SENSITIVE_PATH_PREFIXES = [
+  ".claude-plugin/",
+  "bin/",
+  ".github/workflows/",
+];
+const SENSITIVE_PATH_FILES = [
+  ".gitignore",
+  ".npmignore",
+  "package.json",
+  "package-lock.json",
+  "biome.json",
+];
+
 /**
  * Swarm lock manager factory.
  * @param {object} [opts]
@@ -205,20 +225,49 @@ export function createSwarmLocks(opts = {}) {
   /**
    * Validate a set of changed files against the lease map.
    * Returns all violations found.
+   *
+   * Beyond the basic cross-lease check, when `options.ownLease` is supplied
+   * (the caller's known lease set), this also flags out-of-lease writes to
+   * distribution-critical paths — e.g. recovery-patch fallouts where a
+   * worker's recorded diff carries `+++ /dev/null` deletions of files like
+   * `.claude-plugin/marketplace.json` (regression of #115 / #34).
+   *
+   * `options.ownLease` is opt-in to preserve existing callers; when omitted,
+   * legacy behavior (cross-lease check only) is kept.
+   *
    * @param {string} workerId
    * @param {string[]} changedFiles
-   * @returns {Array<{ file: string, holder: string }>}
+   * @param {{ ownLease?: string[], sensitiveDeny?: { prefixes?: string[], files?: string[] } }} [options]
+   * @returns {Array<{ file: string, holder?: string, kind: "other-lease" | "sensitive-out-of-lease" }>}
    */
-  function validateChanges(workerId, changedFiles) {
+  function validateChanges(workerId, changedFiles, options = {}) {
     pruneExpired();
     const violations = [];
+    const ownLeaseSet = Array.isArray(options.ownLease)
+      ? new Set(options.ownLease.map((path) => normalizePath(path)))
+      : null;
+    const sensitivePrefixes =
+      options.sensitiveDeny?.prefixes ?? SENSITIVE_PATH_PREFIXES;
+    const sensitiveFiles = new Set(
+      options.sensitiveDeny?.files ?? SENSITIVE_PATH_FILES,
+    );
 
     for (const file of changedFiles) {
       const path = normalizePath(file);
       const entry = locks.get(path);
 
       if (entry && entry.workerId !== workerId && !isExpired(entry)) {
-        violations.push({ file, holder: entry.workerId });
+        violations.push({ file, holder: entry.workerId, kind: "other-lease" });
+        continue;
+      }
+
+      if (ownLeaseSet && !ownLeaseSet.has(path)) {
+        const isSensitive =
+          sensitiveFiles.has(path) ||
+          sensitivePrefixes.some((prefix) => path.startsWith(prefix));
+        if (isSensitive) {
+          violations.push({ file, kind: "sensitive-out-of-lease" });
+        }
       }
     }
 

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -911,38 +911,45 @@ route_agent() {
   case "$agent" in
     # ─── 구현 레인 ───
     executor|codex)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     build-fixer)
-      CLI_ARGS="exec --profile codex53_low ${codex_base}"
-      CLI_EFFORT="codex53_low"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      # 빌드 수정 — npm/biome/test-lock 등 도메인 지식 필요. base capability 우위로 gpt55_low (fast tier).
+      CLI_ARGS="exec --profile gpt55_low ${codex_base}"
+      CLI_EFFORT="gpt55_low"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+    cleanup|deslop)
+      # 슬롭/정리 — 패턴 매칭 위주. 가성비 mini (gpt-5.4-mini, fast tier).
+      CLI_ARGS="exec --profile mini54_med ${codex_base}"
+      CLI_EFFORT="mini54_med"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     debugger)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      # 디버깅 — 깊은 코드 추적 필요, gpt-5.5 xhigh
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
-    # ─── 설계/분석 레인 (5.4: 1M 컨텍스트, 에이전틱) ───
+    # ─── 설계/분석 레인 (gpt-5.5 xhigh — 5.4 폐기, 5.5 격상) ───
     deep-executor|architect|critic)
-      CLI_ARGS="exec --profile gpt54_xhigh ${codex_base}"
-      CLI_EFFORT="gpt54_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
     planner|analyst)
-      CLI_ARGS="exec --profile gpt54_xhigh ${codex_base}"
-      CLI_EFFORT="gpt54_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="fg"; OPUS_OVERSIGHT="true" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="fg"; OPUS_OVERSIGHT="true" ;;
 
-    # ─── 리뷰 레인 (5.3-codex: SWE-Bench 72%) ───
+    # ─── 리뷰 레인 (gpt-5.5 — 코드 리뷰도 5.5가 강함) ───
     code-reviewer|quality-reviewer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     security-reviewer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
+      # 보안 = 깊은 사고 → xhigh
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base} review"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
 
     # ─── 리서치 레인 ───
     scientist|document-specialist)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1440; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1440; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     scientist-deep)
-      CLI_ARGS="exec --profile gpt54_high ${codex_base}"
-      CLI_EFFORT="gpt54_high"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── UI/문서 레인 ───
     designer|gemini)
@@ -958,14 +965,14 @@ route_agent() {
 
     # ─── 검증/테스트 ───
     verifier)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     test-engineer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     qa-tester)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── 경량 ───
     spark)
@@ -975,8 +982,8 @@ route_agent() {
     *)
       case "$CLI_TYPE" in
         codex)
-          CLI_ARGS="exec --profile codex53_high ${codex_base}"
-          CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+          CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+          CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
         gemini)
           CLI_ARGS="-m $(resolve_gemini_profile pro31) -y --prompt"
           CLI_EFFORT="pro31"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
@@ -1143,9 +1150,9 @@ apply_plan_guard() {
   if [[ "$CLI_EFFORT" == spark53_* ]]; then
     local codex_base
     codex_base="$(build_codex_base)"
-    CLI_ARGS="exec --profile codex53_high ${codex_base}"
-    CLI_EFFORT="codex53_high"
-    echo "[tfx-route] TFX_CODEX_PLAN=$TFX_CODEX_PLAN: spark → codex53_high로 다운그레이드 (Pro 전용)" >&2
+    CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+    CLI_EFFORT="gpt55_high"
+    echo "[tfx-route] TFX_CODEX_PLAN=$TFX_CODEX_PLAN: spark → gpt55_high로 다운그레이드 (Pro 전용)" >&2
   fi
 }
 
@@ -1168,29 +1175,29 @@ apply_no_claude_native_mode() {
 
   case "$AGENT_TYPE" in
     explore)
-      CLI_ARGS="exec --profile codex53_low ${codex_base}"
-      CLI_EFFORT="codex53_low"
+      CLI_ARGS="exec --profile gpt55_low ${codex_base}"
+      CLI_EFFORT="gpt55_low"
       DEFAULT_TIMEOUT=600
       RUN_MODE="fg"
       OPUS_OVERSIGHT="false"
       ;;
     verifier)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="fg"
       OPUS_OVERSIGHT="false"
       ;;
     test-engineer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="bg"
       OPUS_OVERSIGHT="false"
       ;;
     qa-tester)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="bg"
       OPUS_OVERSIGHT="false"

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -911,38 +911,45 @@ route_agent() {
   case "$agent" in
     # ─── 구현 레인 ───
     executor|codex)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     build-fixer)
-      CLI_ARGS="exec --profile codex53_low ${codex_base}"
-      CLI_EFFORT="codex53_low"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      # 빌드 수정 — npm/biome/test-lock 등 도메인 지식 필요. base capability 우위로 gpt55_low (fast tier).
+      CLI_ARGS="exec --profile gpt55_low ${codex_base}"
+      CLI_EFFORT="gpt55_low"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+    cleanup|deslop)
+      # 슬롭/정리 — 패턴 매칭 위주. 가성비 mini (gpt-5.4-mini, fast tier).
+      CLI_ARGS="exec --profile mini54_med ${codex_base}"
+      CLI_EFFORT="mini54_med"; DEFAULT_TIMEOUT=540; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     debugger)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      # 디버깅 — 깊은 코드 추적 필요, gpt-5.5 xhigh
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
-    # ─── 설계/분석 레인 (5.4: 1M 컨텍스트, 에이전틱) ───
+    # ─── 설계/분석 레인 (gpt-5.5 xhigh — 5.4 폐기, 5.5 격상) ───
     deep-executor|architect|critic)
-      CLI_ARGS="exec --profile gpt54_xhigh ${codex_base}"
-      CLI_EFFORT="gpt54_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
     planner|analyst)
-      CLI_ARGS="exec --profile gpt54_xhigh ${codex_base}"
-      CLI_EFFORT="gpt54_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="fg"; OPUS_OVERSIGHT="true" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="fg"; OPUS_OVERSIGHT="true" ;;
 
-    # ─── 리뷰 레인 (5.3-codex: SWE-Bench 72%) ───
+    # ─── 리뷰 레인 (gpt-5.5 — 코드 리뷰도 5.5가 강함) ───
     code-reviewer|quality-reviewer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     security-reviewer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
+      # 보안 = 깊은 사고 → xhigh
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base} review"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=1800; RUN_MODE="bg"; OPUS_OVERSIGHT="true" ;;
 
     # ─── 리서치 레인 ───
     scientist|document-specialist)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1440; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1440; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     scientist-deep)
-      CLI_ARGS="exec --profile gpt54_high ${codex_base}"
-      CLI_EFFORT="gpt54_high"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_xhigh ${codex_base}"
+      CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── UI/문서 레인 ───
     designer|gemini)
@@ -958,14 +965,14 @@ route_agent() {
 
     # ─── 검증/테스트 ───
     verifier)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
     test-engineer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
     qa-tester)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1200; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── 경량 ───
     spark)
@@ -975,8 +982,8 @@ route_agent() {
     *)
       case "$CLI_TYPE" in
         codex)
-          CLI_ARGS="exec --profile codex53_high ${codex_base}"
-          CLI_EFFORT="codex53_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
+          CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+          CLI_EFFORT="gpt55_high"; DEFAULT_TIMEOUT=1080; RUN_MODE="fg"; OPUS_OVERSIGHT="false" ;;
         gemini)
           CLI_ARGS="-m $(resolve_gemini_profile pro31) -y --prompt"
           CLI_EFFORT="pro31"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
@@ -1143,9 +1150,9 @@ apply_plan_guard() {
   if [[ "$CLI_EFFORT" == spark53_* ]]; then
     local codex_base
     codex_base="$(build_codex_base)"
-    CLI_ARGS="exec --profile codex53_high ${codex_base}"
-    CLI_EFFORT="codex53_high"
-    echo "[tfx-route] TFX_CODEX_PLAN=$TFX_CODEX_PLAN: spark → codex53_high로 다운그레이드 (Pro 전용)" >&2
+    CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+    CLI_EFFORT="gpt55_high"
+    echo "[tfx-route] TFX_CODEX_PLAN=$TFX_CODEX_PLAN: spark → gpt55_high로 다운그레이드 (Pro 전용)" >&2
   fi
 }
 
@@ -1168,29 +1175,29 @@ apply_no_claude_native_mode() {
 
   case "$AGENT_TYPE" in
     explore)
-      CLI_ARGS="exec --profile codex53_low ${codex_base}"
-      CLI_EFFORT="codex53_low"
+      CLI_ARGS="exec --profile gpt55_low ${codex_base}"
+      CLI_EFFORT="gpt55_low"
       DEFAULT_TIMEOUT=600
       RUN_MODE="fg"
       OPUS_OVERSIGHT="false"
       ;;
     verifier)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="fg"
       OPUS_OVERSIGHT="false"
       ;;
     test-engineer)
-      CLI_ARGS="exec --profile codex53_high ${codex_base}"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base}"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="bg"
       OPUS_OVERSIGHT="false"
       ;;
     qa-tester)
-      CLI_ARGS="exec --profile codex53_high ${codex_base} review"
-      CLI_EFFORT="codex53_high"
+      CLI_ARGS="exec --profile gpt55_high ${codex_base} review"
+      CLI_EFFORT="gpt55_high"
       DEFAULT_TIMEOUT=1200
       RUN_MODE="bg"
       OPUS_OVERSIGHT="false"

--- a/tests/unit/retry-state-machine.test.mjs
+++ b/tests/unit/retry-state-machine.test.mjs
@@ -148,14 +148,22 @@ describe("retry-state-machine — bounded / ralph / auto-escalate", () => {
       assert.equal(last.reason, "escalation-chain-exhausted");
     });
 
-    it("DEFAULT_ESCALATION_CHAIN 은 Codex:gpt-5.4-mini → Codex:gpt-5.5 순", () => {
-      assert.equal(DEFAULT_ESCALATION_CHAIN.length >= 2, true);
-      const first = DEFAULT_ESCALATION_CHAIN[0];
-      assert.equal(first.cli, "codex");
-      assert.equal(first.model, "gpt-5.4-mini");
-      const second = DEFAULT_ESCALATION_CHAIN[1];
-      assert.equal(second.cli, "codex");
-      assert.equal(second.model, "gpt-5.5");
+    it("DEFAULT_ESCALATION_CHAIN 은 mini-5.4 → codex-5.3 → gpt-5.5 → opus-4-7 순", () => {
+      // 2026-04-25 정책 갱신: sonnet-4-6 단계 제거, 5.3-codex 가성비 중간 단계 추가.
+      assert.equal(DEFAULT_ESCALATION_CHAIN.length, 4);
+      const [s1, s2, s3, s4] = DEFAULT_ESCALATION_CHAIN;
+
+      assert.equal(s1.cli, "codex");
+      assert.equal(s1.model, "gpt-5.4-mini");
+
+      assert.equal(s2.cli, "codex");
+      assert.equal(s2.model, "gpt-5.3-codex");
+
+      assert.equal(s3.cli, "codex");
+      assert.equal(s3.model, "gpt-5.5");
+
+      assert.equal(s4.cli, "claude");
+      assert.equal(s4.model, "opus-4-7");
     });
   });
 

--- a/tests/unit/swarm-locks.test.mjs
+++ b/tests/unit/swarm-locks.test.mjs
@@ -130,6 +130,75 @@ describe("swarm-locks", () => {
       assert.equal(violations.length, 1);
       assert.equal(violations[0].holder, "worker-2");
     });
+
+    // Regression for #115/#34 — recovery patch from a worker that exits
+    // without committing was carrying `+++ /dev/null` deletions of
+    // distribution-critical files (.claude-plugin/marketplace.json,
+    // plugin.json) outside of any shard's lease. The previous validator
+    // only checked for cross-lease writes, so these went undetected.
+    describe("sensitive path guard (out-of-lease destructive)", () => {
+      it("flags .claude-plugin/* changes when not in worker's lease", () => {
+        const locks = createSwarmLocks({ repoRoot: tmpDir });
+        locks.acquire("worker-1", ["src/a.mjs"]);
+
+        const violations = locks.validateChanges(
+          "worker-1",
+          [".claude-plugin/marketplace.json"],
+          { ownLease: ["src/a.mjs"] },
+        );
+        assert.equal(violations.length, 1);
+        assert.equal(violations[0].kind, "sensitive-out-of-lease");
+        assert.equal(violations[0].file, ".claude-plugin/marketplace.json");
+      });
+
+      it("allows sensitive path changes when explicitly leased", () => {
+        const locks = createSwarmLocks({ repoRoot: tmpDir });
+        locks.acquire("worker-1", ["package.json"]);
+
+        const violations = locks.validateChanges("worker-1", ["package.json"], {
+          ownLease: ["package.json"],
+        });
+        assert.equal(violations.length, 0);
+      });
+
+      it("flags package.json / .gitignore / bin/ / .github/workflows/", () => {
+        const locks = createSwarmLocks({ repoRoot: tmpDir });
+        locks.acquire("worker-1", ["docs/x.md"]);
+
+        const violations = locks.validateChanges(
+          "worker-1",
+          ["package.json", ".gitignore", "bin/tfx", ".github/workflows/ci.yml"],
+          { ownLease: ["docs/x.md"] },
+        );
+        assert.equal(violations.length, 4);
+        for (const v of violations) {
+          assert.equal(v.kind, "sensitive-out-of-lease");
+        }
+      });
+
+      it("non-sensitive out-of-lease changes still pass (backward compat)", () => {
+        const locks = createSwarmLocks({ repoRoot: tmpDir });
+        locks.acquire("worker-1", ["src/a.mjs"]);
+
+        const violations = locks.validateChanges(
+          "worker-1",
+          ["src/somewhere-else.mjs", "docs/random.md"],
+          { ownLease: ["src/a.mjs"] },
+        );
+        assert.equal(violations.length, 0);
+      });
+
+      it("backward compat: omitting ownLease keeps legacy behavior", () => {
+        const locks = createSwarmLocks({ repoRoot: tmpDir });
+        locks.acquire("worker-1", ["src/a.mjs"]);
+
+        // No ownLease passed → only cross-lease check, sensitive guard inactive
+        const violations = locks.validateChanges("worker-1", [
+          ".claude-plugin/marketplace.json",
+        ]);
+        assert.equal(violations.length, 0);
+      });
+    });
   });
 
   describe("TTL expiry", () => {


### PR DESCRIPTION
## Summary

두 개의 결합도 낮은 commit:

### 1. `b6c642a` — swarm meta C: lease-outside destructive validate (회귀 #115, #34 후속)

`swarm-locks.validateChanges` 가 cross-lease 침범만 보고 lease 외 file 변경은 무검증 통과시키던 회귀.
2026-04-25 #178 작업 중 core-compat recovery patch 안에 `.claude-plugin/{marketplace,plugin}.json` `+++ /dev/null` (삭제 시도) 가 그대로 들어왔다 — worker 가 commit 했다면 distribution 깨짐.

- `validateChanges(workerId, changedFiles, options?)` 에 `ownLease` + `sensitiveDeny` 옵션 추가 (backward compat)
- distribution-critical paths (`.claude-plugin/`, `bin/`, `.github/workflows/`, `package.json`, `.gitignore` 등) 차단
- `swarm-hypervisor.validateResult` 가 `plan.leaseMap[shardName]` 을 ownLease 로 전달
- packages/triflux mirror 동기화

#34 BUG-I 가 worktree-level intentional deletion 처리, #115 가 sentinel-framed payload 도입했지만 patch-level lease-outside destructive deletion 은 미커버였다 — 4개월 만의 회귀.

### 2. `60faa71` — 모델-직무 매핑 개편 (gpt-5.4 폐기, mini/codex53 가성비 분리)

| 모델 | 역할 |
|------|------|
| gpt-5.5 | 메인 (코드 작성/리뷰/추론, fast tier) |
| gpt-5.4-mini | 자잘/부가 (cleanup, fast tier) |
| gpt-5.3-codex | escalation 가성비 중간 (Plus/free OK, fast 미지원) |
| gpt-5.4 (mini 외) | 폐기 → gpt-5.5 격상 |

직무별 매핑 (전체 표는 commit 본문):
- executor / build-fixer (빌드는 도메인 지식 필요): gpt55_high / gpt55_low
- debugger / planner / architect / critic / security-reviewer: gpt55_xhigh
- code-reviewer / verifier / scientist: gpt55_high
- cleanup / deslop (신규 case): mini54_med (가성비)

**Escalation chain** (`retry-state-machine.mjs` + `tfx-escalation-chain.md`):
1. codex:gpt-5.4-mini (cheap, fast)
2. **codex:gpt-5.3-codex** (가성비 중간, code specialized) ← 신규
3. codex:gpt-5.5 (top reasoning, fast)
4. claude:opus-4-7 (last resort)

sonnet-4-6 단계 제거: gpt-5.5 가 코드/추론/비용 모두 우위 + 5.3-codex 가성비 단계가 더 적합한 중간 격상.

## Test plan

- [x] swarm + retry-state-machine tests **66/66 pass** (5 신규 sensitive guard case + chain expectation 갱신)
- [x] backward compat — `validateChanges(workerId, changedFiles)` (옵션 미제공) 기존 동작 유지
- [x] lint clean

## Cross-review status

`gpt-5.5 xhigh` 로 cross-review 시도했으나 **codex 0.124.0 의 silent-until-flush + tfx-route.sh wrapper 미캡처 회귀** 로 결과 missing. 이는 issue #176 + 본 세션의 swarm meta 분석에서 식별한 worker signaling family 와 동일 — 별도 통합 PR 후속 처리 예정.

매핑 결정은 사용자 직감 + 객관 분석 일치로 확정.