### PR TITLE
fix(codex-mcp): 0.124.0 silent-success 회귀 detect + exec fallback 트리거

### DIFF
--- a/hub/workers/codex-mcp.mjs
+++ b/hub/workers/codex-mcp.mjs
@@ -533,13 +533,28 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
 
   try {
     const result = await worker.execute(options.prompt, options);
-    if (result.output) {
+    const hasOutput =
+      typeof result.output === "string" && result.output.trim().length > 0;
+    if (hasOutput) {
       process.stdout.write(result.output);
       if (!result.output.endsWith("\n")) {
         process.stdout.write("\n");
       }
     }
-    process.exitCode = result.exitCode;
+    // Silent-success regression guard (codex 0.124.0+):
+    // codex MCP can return exitCode=0 with empty/whitespace `output` when the
+    // result-extraction path fails to read the assistant content from the MCP
+    // response. Without this guard, tfx-route.sh sees STDOUT_LOG=0 bytes and
+    // treats it as success — caller gets nothing back.
+    // Promote to a transport failure so the wrapper falls back to `codex exec`.
+    if (!hasOutput && result.exitCode === 0) {
+      console.error(
+        "[codex-mcp] WARNING: empty output with exit 0 — treating as transport failure (codex 0.124.0 silent-flush regression). Wrapper will fall back to exec path.",
+      );
+      process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
+    } else {
+      process.exitCode = result.exitCode;
+    }
   } catch (error) {
     const lines = [error instanceof Error ? error.message : String(error)];
     if (error instanceof CodexMcpTransportError && error.stderr) {

--- a/packages/triflux/hub/workers/codex-mcp.mjs
+++ b/packages/triflux/hub/workers/codex-mcp.mjs
@@ -533,13 +533,28 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
 
   try {
     const result = await worker.execute(options.prompt, options);
-    if (result.output) {
+    const hasOutput =
+      typeof result.output === "string" && result.output.trim().length > 0;
+    if (hasOutput) {
       process.stdout.write(result.output);
       if (!result.output.endsWith("\n")) {
         process.stdout.write("\n");
       }
     }
-    process.exitCode = result.exitCode;
+    // Silent-success regression guard (codex 0.124.0+):
+    // codex MCP can return exitCode=0 with empty/whitespace `output` when the
+    // result-extraction path fails to read the assistant content from the MCP
+    // response. Without this guard, tfx-route.sh sees STDOUT_LOG=0 bytes and
+    // treats it as success — caller gets nothing back.
+    // Promote to a transport failure so the wrapper falls back to `codex exec`.
+    if (!hasOutput && result.exitCode === 0) {
+      console.error(
+        "[codex-mcp] WARNING: empty output with exit 0 — treating as transport failure (codex 0.124.0 silent-flush regression). Wrapper will fall back to exec path.",
+      );
+      process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
+    } else {
+      process.exitCode = result.exitCode;
+    }
   } catch (error) {
     const lines = [error instanceof Error ? error.message : String(error)];
     if (error instanceof CodexMcpTransportError && error.stderr) {

--- a/tests/fixtures/fake-codex.mjs
+++ b/tests/fixtures/fake-codex.mjs
@@ -107,6 +107,20 @@ async function runMcpServer() {
       return errorResult("fake tool failure");
     }
 
+    if (mode === "mcp-empty") {
+      if (name === "codex") {
+        const threadId = nextThreadId();
+        return textResult(threadId, "");
+      }
+      if (name === "codex-reply") {
+        const threadId =
+          typeof args.threadId === "string" && args.threadId
+            ? args.threadId
+            : nextThreadId();
+        return textResult(threadId, "");
+      }
+    }
+
     if (name === "codex") {
       const threadId = nextThreadId();
       const memory = rememberFromPrompt(prompt);

--- a/tests/unit/codex-mcp-worker.test.mjs
+++ b/tests/unit/codex-mcp-worker.test.mjs
@@ -129,4 +129,19 @@ describe("CodexMcpWorker", () => {
       await worker.stop();
     }
   });
+
+  it("MCP가 빈 content + exit 0 을 반환하면 worker.execute가 빈 output + exit 0 을 그대로 반환한다 (codex 0.124.0 silent-flush regression reproduction)", async () => {
+    // runCodexMcpCli 의 silent-success guard 가 detect 해야 할 입력 케이스.
+    // worker 자체는 응답을 그대로 전달하고, guard 는 CLI 진입점에서 process.exitCode 를
+    // CODEX_MCP_TRANSPORT_EXIT_CODE 로 승격하여 wrapper 에 fallback 신호를 보낸다.
+    const worker = createWorker({ FAKE_CODEX_MODE: "mcp-empty" });
+
+    try {
+      const result = await worker.execute("anything");
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.output.trim(), "");
+    } finally {
+      await worker.stop();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

codex 0.124.0 부터 codex MCP 가 exitCode=0 + 빈 output 으로 응답하는 silent-success 회귀가 발생한다. tfx-route.sh 가 `STDOUT_LOG=0 byte` 를 success 로 오판하면서 caller 가 결과를 받지 못하는 silent-flush 경로가 열린다. background task `bkzdlw1nu` 에서 72s × 0B output (status=quiet) 으로 재현 확인.

wrapper 레이어에서 빈 output + exit 0 케이스를 detect 해 `CODEX_MCP_TRANSPORT_EXIT_CODE` 로 승격, tfx-route.sh 의 `codex exec` fallback 을 트리거한다.

## Changes

- `hub/workers/codex-mcp.mjs` + mirror (`packages/triflux/hub/workers/codex-mcp.mjs`)
  - `runCodexMcpCli` 에 `hasOutput` 검사 (string + `trim().length > 0`)
  - 빈 output + exit 0 → `CODEX_MCP_TRANSPORT_EXIT_CODE` + stderr WARNING
- `tests/fixtures/fake-codex.mjs`: `mcp-empty` 모드 (codex/codex-reply 응답을 빈 content 로 반환)
- `tests/unit/codex-mcp-worker.test.mjs`: silent-flush regression reproduction case (5 → 6 tests)

## Test plan

- [x] `node --test tests/unit/codex-mcp-worker.test.mjs` — 6/6 pass (신규 케이스 포함)
- [x] `npm run lint` — 557 files, no fixes applied
- [ ] cross-review sanity: 머지 후 자연 검증 (silent-flush detect → exec fallback 동작)

## Context

- background task evidence: `bkzdlw1nu.output` (72s × 0B, codex 0.124.0 silent-flush 재현)
- 후속 통합: worker signaling 통합 PR (issue #176 + 메타 B/E + 이번 silent-flush) 별도 진행
- headless-guard grep 오탐 fix 도 별도 후속 PR