### PR TITLE
fix(headless-guard): $()/eval 휴리스틱 .* 좁혀 grep 인자 오탐 방지

### DIFF
--- a/packages/triflux/scripts/headless-guard.mjs
+++ b/packages/triflux/scripts/headless-guard.mjs
@@ -277,11 +277,15 @@ async function main() {
           cmdSanitized,
         );
       } else {
+        // $()/${} 와 eval 직후 첫 토큰만 검사한다.
+        // .* 매칭은 `result=$(grep "codex exec" file)` 같은 grep 인자 패턴까지
+        // 차단하는 오탐을 일으킨다. 진짜 위협은 `$(codex exec ...)` 처럼
+        // command substitution / eval 의 첫 명령이 codex/gemini 인 경우뿐이다.
         hasDirectCli =
-          /\beval\b.*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
+          /\beval\s+(?:["']\s*)?(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
             cmdSanitized,
           ) ||
-          /\$[({].*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
+          /\$[({]\s*(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
             cmdSanitized,
           );
       }

--- a/scripts/headless-guard.mjs
+++ b/scripts/headless-guard.mjs
@@ -277,11 +277,15 @@ async function main() {
           cmdSanitized,
         );
       } else {
+        // $()/${} 와 eval 직후 첫 토큰만 검사한다.
+        // .* 매칭은 `result=$(grep "codex exec" file)` 같은 grep 인자 패턴까지
+        // 차단하는 오탐을 일으킨다. 진짜 위협은 `$(codex exec ...)` 처럼
+        // command substitution / eval 의 첫 명령이 codex/gemini 인 경우뿐이다.
         hasDirectCli =
-          /\beval\b.*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
+          /\beval\s+(?:["']\s*)?(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
             cmdSanitized,
           ) ||
-          /\$[({].*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
+          /\$[({]\s*(codex\s+exec|gemini\s+(-p|--prompt))\b/i.test(
             cmdSanitized,
           );
       }

--- a/tests/unit/headless-guard.test.mjs
+++ b/tests/unit/headless-guard.test.mjs
@@ -307,6 +307,31 @@ describe("headless-guard decision matrix (runtime)", () => {
     assert.equal(result.status, 2);
   });
 
+  it("$() 안의 grep 'codex exec' 인자는 통과한다 (오탐 방지)", () => {
+    // result=$(grep "codex exec" file) 같은 grep 인자 패턴은
+    // command substitution 의 첫 명령이 grep 이므로 차단 대상이 아니다.
+    const result = runGuardWithBashCommand(
+      'result=$(grep -rn "codex exec" hooks/)',
+    );
+    assert.equal(result.status, 0);
+  });
+
+  it("$() 안의 파이프된 grep 'codex exec'도 통과한다 (오탐 방지)", () => {
+    const result = runGuardWithBashCommand(
+      'cmd=$(find . -name "*.mjs" | xargs grep "codex exec")',
+    );
+    assert.equal(result.status, 0);
+  });
+
+  it("eval 안의 grep 'codex exec' subshell도 통과한다 (오탐 방지)", () => {
+    // eval "$(grep ...)" 는 eval 의 인자가 subshell 이고 그 안의 첫 명령이 grep.
+    // 진짜 위협 (eval "codex exec ...") 과 구분된다.
+    const result = runGuardWithBashCommand(
+      "eval \"$(grep 'codex exec' file.mjs)\"",
+    );
+    assert.equal(result.status, 0);
+  });
+
   it("psmux send-keys에 codex exec payload가 있으면 deny한다", () => {
     const result = runGuardWithBashCommand(
       "psmux send-keys -t sess \"codex exec 'hello'\" Enter",


### PR DESCRIPTION
## 요약

`scripts/headless-guard.mjs` 의 2차 휴리스틱이 `result=\$(grep \"codex exec\" file)` 같은 grep 인자 패턴까지 codex 직접 호출로 잡아 코드베이스 탐색조차 차단되던 오탐을 fix.

## 원인

```js
// 변경 전
/\$[({].*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i
/\beval\b.*\b(codex\s+exec|gemini\s+(-p|--prompt))\b/i
```

`.*` 가 너무 넓어 `\$(grep \"codex exec\" file)` 의 grep 첫 토큰을 건너뛰고 인자 안 \"codex exec\" 까지 매칭.

## 해결

```js
// 변경 후
/\beval\s+(?:[\"']\s*)?(codex\s+exec|gemini\s+(-p|--prompt))\b/i
/\$[({]\s*(codex\s+exec|gemini\s+(-p|--prompt))\b/i
```

`.*` → `\s*` 로 좁혀 command substitution / eval 의 **첫 명령** 이 codex/gemini 인 경우만 차단. 진짜 위협 (\`\$(codex exec ...)\`, \`eval \"codex exec ...\"\`) 은 그대로 차단.

## 테스트

- 회귀 보존: 기존 차단 케이스 (`\$()` 안 codex exec, `eval` 으로 감싼 codex exec) 모두 그대로 deny.
- 신규 오탐 방지 3 케이스:
  - `result=\$(grep -rn \"codex exec\" hooks/)` 통과
  - `cmd=\$(find . | xargs grep \"codex exec\")` 통과
  - `eval \"\$(grep 'codex exec' file)\"` 통과
- 전체: 68/68 pass, biome lint clean (557 files)

## Mirror

`packages/triflux/scripts/headless-guard.mjs` 동기 수정. 테스트는 main 트리에만 존재 (mirror에는 tests 디렉토리 없음).

## 컨텍스트

체크포인트 \`20260425-173953-pr185-silent-flush-fix-open-review-pending.md\` 의 5단계 (\"headless-guard grep 오탐 fix\"). PR #185 머지 직후 후속.