### PR TITLE
chore: references/hosts.json* 을 .gitignore 에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ docs/research/*competitor*
 .codex-swarm/
 # swarm preservation artifacts (covered by .codex-swarm/ above, listed explicitly)
 .codex-swarm/recovery/
+
+# user-state hosts.json source-tree fallback (PR #183)
+# 사용자 환경 데이터 (Tailscale IP / SSH user) 노출 방지.
+# 정식 경로: ~/.config/triflux/hosts.json (POSIX) / %APPDATA%\triflux\hosts.json (Windows)
+**/references/hosts.json
+**/references/hosts.json.bak.*


### PR DESCRIPTION
## 요약

PR #183 머지 후 `hosts.json` 정식 경로는 user-state (`~/.config/triflux/hosts.json` POSIX, `%APPDATA%\triflux\hosts.json` Windows). source-tree 의 `references/hosts.json` 은 lazy migration fallback 부산물.

source-tree 에 commit 되면 사용자 Tailscale IP / SSH user 가 public repo 에 노출 → 명시적으로 ignore.

## 추가 패턴

```
**/references/hosts.json
**/references/hosts.json.bak.*
```

대상:
- `references/hosts.json` (root)
- `packages/triflux/references/hosts.json` (mirror)
- `skills/tfx-remote-spawn/references/hosts.json` + `.bak.20260425_040814`
- `packages/triflux/skills/tfx-remote-spawn/references/hosts.json` + `.bak.*`

## 기존 룰로 cover 안 된 이유

기존 `*.bak` 룰은 `.bak` 으로 끝나는 파일만 매칭. `hosts.json.bak.20260425_040814` 같은 timestamp suffix 는 cover 안 됨.

## 영향

- `.md` 분석 문서 (cli-parameter-reference / codex-plugin-cc-*) 는 이미 tracked → 그대로 유지.
- 새 패턴은 untracked `hosts.json*` 만 영향, 기존 tracked 파일에는 무관.

## 컨텍스트

체크포인트 `20260425-173953-pr185-silent-flush-fix-open-review-pending.md` 의 5번 "untracked references/* 처리" 결정 (옵션 A: hosts.json+.bak 만 ignore, .md 는 보존).