### PR TITLE
fix(config): respect HOME/USERPROFILE swap to isolate test fixtures (#193)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint:fix": "biome check --write bin config hooks hub hud mesh scripts tests .claude-plugin .github package.json package-lock.json biome.json",
     "health": "npm test && npm run lint",
     "test": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 \"tests/**/*.test.mjs\" \"scripts/__tests__/**/*.test.mjs\"",
+    "test:guard-codex-config": "node scripts/check-codex-config-stable.mjs npm test",
     "test:unit": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/unit/**/*.test.mjs",
     "test:integration": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/integration/**/*.test.mjs",
     "test:route-smoke": "node scripts/test-lock.mjs --test scripts/test-tfx-route-no-claude-native.mjs",

--- a/packages/triflux/scripts/check-codex-config-stable.mjs
+++ b/packages/triflux/scripts/check-codex-config-stable.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// scripts/check-codex-config-stable.mjs
+//
+// Wrapper that runs a command (default: npm test) and verifies that
+// ~/.codex/config.toml is unchanged before vs after execution.
+//
+// Issue #193 회귀 가드 — production codex config 가 test/build 도중 mutate
+// 되면 즉시 fail 하고 진단 정보를 출력한다. CI 또는 로컬 npm script 에서
+// `npm run test:guard-codex-config` 처럼 호출한다.
+//
+// Exit codes:
+//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0)
+//   2  = mutation 감지. wrap 한 명령의 exit code 와 무관하게 강제 fail.
+//   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
+
+function snapshotConfig() {
+  try {
+    const stat = statSync(CODEX_CONFIG);
+    const data = readFileSync(CODEX_CONFIG);
+    const sha = createHash("sha256").update(data).digest("hex");
+    return { exists: true, size: stat.size, mtimeMs: stat.mtimeMs, sha };
+  } catch {
+    return { exists: false };
+  }
+}
+
+function describeChange(before, after) {
+  if (!before.exists && !after.exists) return null;
+  if (before.exists !== after.exists) {
+    return before.exists ? "file deleted" : "file created";
+  }
+  if (before.sha !== after.sha) {
+    return `sha256 differs (size: ${before.size} → ${after.size})`;
+  }
+  return null;
+}
+
+const argv = process.argv.slice(2);
+const command = argv.length > 0 ? argv : ["npm", "test"];
+
+const before = snapshotConfig();
+process.stderr.write(
+  `[check-codex-config-stable] before: ${JSON.stringify(before)}\n`,
+);
+
+const result = spawnSync(command[0], command.slice(1), {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+const after = snapshotConfig();
+process.stderr.write(
+  `[check-codex-config-stable] after: ${JSON.stringify(after)}\n`,
+);
+
+const change = describeChange(before, after);
+if (change) {
+  process.stderr.write(
+    [
+      "",
+      "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
+      `Path:    ${CODEX_CONFIG}`,
+      `Change:  ${change}`,
+      "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
+      "Context: https://github.com/tellang/triflux/issues/193",
+      "",
+    ].join("\n"),
+  );
+  process.exit(2);
+}
+
+process.exit(result.status ?? 0);

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -31,12 +31,20 @@ const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 // Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
 // 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
 // production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
-// 우선순위: TRIFLUX_TEST_HOME → HOME → USERPROFILE → os.homedir().
-const _TFX_HOME =
-  process.env.TRIFLUX_TEST_HOME ||
-  process.env.HOME ||
-  process.env.USERPROFILE ||
-  homedir();
+//
+// 우선순위 분기:
+// - TRIFLUX_TEST_HOME: 두 OS 모두 명시 override
+// - Windows: USERPROFILE > HOME > homedir() — Windows native 가 USERPROFILE.
+//   Git Bash 사용자는 USERPROFILE 도 같이 set 되므로 영향 없음.
+// - POSIX: HOME > homedir()
+function _resolveTrifluxHome() {
+  if (process.env.TRIFLUX_TEST_HOME) return process.env.TRIFLUX_TEST_HOME;
+  if (process.platform === "win32") {
+    return process.env.USERPROFILE || process.env.HOME || homedir();
+  }
+  return process.env.HOME || homedir();
+}
+const _TFX_HOME = _resolveTrifluxHome();
 const CLAUDE_DIR = join(_TFX_HOME, ".claude");
 const CODEX_DIR = join(_TFX_HOME, ".codex");
 const CODEX_CONFIG_PATH = join(CODEX_DIR, "config.toml");

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -28,8 +28,17 @@ import {
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const CLAUDE_DIR = join(homedir(), ".claude");
-const CODEX_DIR = join(homedir(), ".codex");
+// Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
+// 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
+// production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
+// 우선순위: TRIFLUX_TEST_HOME → HOME → USERPROFILE → os.homedir().
+const _TFX_HOME =
+  process.env.TRIFLUX_TEST_HOME ||
+  process.env.HOME ||
+  process.env.USERPROFILE ||
+  homedir();
+const CLAUDE_DIR = join(_TFX_HOME, ".claude");
+const CODEX_DIR = join(_TFX_HOME, ".codex");
 const CODEX_CONFIG_PATH = join(CODEX_DIR, "config.toml");
 const SETUP_MARKER_PATH = join(CLAUDE_DIR, "cache", "tfx-setup-marker.json");
 

--- a/packages/triflux/scripts/sync-hub-mcp-settings.mjs
+++ b/packages/triflux/scripts/sync-hub-mcp-settings.mjs
@@ -13,15 +13,18 @@ const TFX_HUB_SECTION = "tfx-hub";
 const FILE_LOCKS = new Map();
 
 // Windows 에서 process.env.HOME 만 set 하고 USERPROFILE 은 그대로 둔 fixture 환경
-// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 두 변수 중
-// 먼저 set 된 쪽을 우선 사용한다. POSIX 는 HOME, Windows 는 USERPROFILE 이 native.
+// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 platform
+// 별로 native 변수를 우선한다 (#193).
+//
+// - TRIFLUX_TEST_HOME: 두 OS 모두 명시 override
+// - Windows: USERPROFILE > HOME > homedir() (Windows native 가 USERPROFILE)
+// - POSIX: HOME > homedir()
 function resolveHome() {
-  return (
-    process.env.TRIFLUX_TEST_HOME ||
-    process.env.HOME ||
-    process.env.USERPROFILE ||
-    homedir()
-  );
+  if (process.env.TRIFLUX_TEST_HOME) return process.env.TRIFLUX_TEST_HOME;
+  if (process.platform === "win32") {
+    return process.env.USERPROFILE || process.env.HOME || homedir();
+  }
+  return process.env.HOME || homedir();
 }
 
 function getSettingsPaths() {

--- a/packages/triflux/scripts/sync-hub-mcp-settings.mjs
+++ b/packages/triflux/scripts/sync-hub-mcp-settings.mjs
@@ -12,8 +12,20 @@ const CODEX_CONFIG_FILE = [".codex", "config.toml"];
 const TFX_HUB_SECTION = "tfx-hub";
 const FILE_LOCKS = new Map();
 
+// Windows 에서 process.env.HOME 만 set 하고 USERPROFILE 은 그대로 둔 fixture 환경
+// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 두 변수 중
+// 먼저 set 된 쪽을 우선 사용한다. POSIX 는 HOME, Windows 는 USERPROFILE 이 native.
+function resolveHome() {
+  return (
+    process.env.TRIFLUX_TEST_HOME ||
+    process.env.HOME ||
+    process.env.USERPROFILE ||
+    homedir()
+  );
+}
+
 function getSettingsPaths() {
-  const home = process.env.HOME || homedir();
+  const home = resolveHome();
   return TARGET_FILES.map((segments) => join(home, ...segments));
 }
 
@@ -21,8 +33,7 @@ function getCodexConfigPath(codexConfigPath) {
   if (typeof codexConfigPath === "string" && codexConfigPath.length > 0) {
     return codexConfigPath;
   }
-  const home = process.env.HOME || homedir();
-  return join(home, ...CODEX_CONFIG_FILE);
+  return join(resolveHome(), ...CODEX_CONFIG_FILE);
 }
 
 export function getProjectMcpJsonPaths(projectRoot) {

--- a/scripts/check-codex-config-stable.mjs
+++ b/scripts/check-codex-config-stable.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// scripts/check-codex-config-stable.mjs
+//
+// Wrapper that runs a command (default: npm test) and verifies that
+// ~/.codex/config.toml is unchanged before vs after execution.
+//
+// Issue #193 회귀 가드 — production codex config 가 test/build 도중 mutate
+// 되면 즉시 fail 하고 진단 정보를 출력한다. CI 또는 로컬 npm script 에서
+// `npm run test:guard-codex-config` 처럼 호출한다.
+//
+// Exit codes:
+//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0)
+//   2  = mutation 감지. wrap 한 명령의 exit code 와 무관하게 강제 fail.
+//   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
+
+function snapshotConfig() {
+  try {
+    const stat = statSync(CODEX_CONFIG);
+    const data = readFileSync(CODEX_CONFIG);
+    const sha = createHash("sha256").update(data).digest("hex");
+    return { exists: true, size: stat.size, mtimeMs: stat.mtimeMs, sha };
+  } catch {
+    return { exists: false };
+  }
+}
+
+function describeChange(before, after) {
+  if (!before.exists && !after.exists) return null;
+  if (before.exists !== after.exists) {
+    return before.exists ? "file deleted" : "file created";
+  }
+  if (before.sha !== after.sha) {
+    return `sha256 differs (size: ${before.size} → ${after.size})`;
+  }
+  return null;
+}
+
+const argv = process.argv.slice(2);
+const command = argv.length > 0 ? argv : ["npm", "test"];
+
+const before = snapshotConfig();
+process.stderr.write(
+  `[check-codex-config-stable] before: ${JSON.stringify(before)}\n`,
+);
+
+const result = spawnSync(command[0], command.slice(1), {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+const after = snapshotConfig();
+process.stderr.write(
+  `[check-codex-config-stable] after: ${JSON.stringify(after)}\n`,
+);
+
+const change = describeChange(before, after);
+if (change) {
+  process.stderr.write(
+    [
+      "",
+      "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
+      `Path:    ${CODEX_CONFIG}`,
+      `Change:  ${change}`,
+      "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
+      "Context: https://github.com/tellang/triflux/issues/193",
+      "",
+    ].join("\n"),
+  );
+  process.exit(2);
+}
+
+process.exit(result.status ?? 0);

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -31,12 +31,20 @@ const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 // Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
 // 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
 // production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
-// 우선순위: TRIFLUX_TEST_HOME → HOME → USERPROFILE → os.homedir().
-const _TFX_HOME =
-  process.env.TRIFLUX_TEST_HOME ||
-  process.env.HOME ||
-  process.env.USERPROFILE ||
-  homedir();
+//
+// 우선순위 분기:
+// - TRIFLUX_TEST_HOME: 두 OS 모두 명시 override
+// - Windows: USERPROFILE > HOME > homedir() — Windows native 가 USERPROFILE.
+//   Git Bash 사용자는 USERPROFILE 도 같이 set 되므로 영향 없음.
+// - POSIX: HOME > homedir()
+function _resolveTrifluxHome() {
+  if (process.env.TRIFLUX_TEST_HOME) return process.env.TRIFLUX_TEST_HOME;
+  if (process.platform === "win32") {
+    return process.env.USERPROFILE || process.env.HOME || homedir();
+  }
+  return process.env.HOME || homedir();
+}
+const _TFX_HOME = _resolveTrifluxHome();
 const CLAUDE_DIR = join(_TFX_HOME, ".claude");
 const CODEX_DIR = join(_TFX_HOME, ".codex");
 const CODEX_CONFIG_PATH = join(CODEX_DIR, "config.toml");

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -28,8 +28,17 @@ import {
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const CLAUDE_DIR = join(homedir(), ".claude");
-const CODEX_DIR = join(homedir(), ".codex");
+// Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
+// 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
+// production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
+// 우선순위: TRIFLUX_TEST_HOME → HOME → USERPROFILE → os.homedir().
+const _TFX_HOME =
+  process.env.TRIFLUX_TEST_HOME ||
+  process.env.HOME ||
+  process.env.USERPROFILE ||
+  homedir();
+const CLAUDE_DIR = join(_TFX_HOME, ".claude");
+const CODEX_DIR = join(_TFX_HOME, ".codex");
 const CODEX_CONFIG_PATH = join(CODEX_DIR, "config.toml");
 const SETUP_MARKER_PATH = join(CLAUDE_DIR, "cache", "tfx-setup-marker.json");
 

--- a/scripts/sync-hub-mcp-settings.mjs
+++ b/scripts/sync-hub-mcp-settings.mjs
@@ -13,15 +13,18 @@ const TFX_HUB_SECTION = "tfx-hub";
 const FILE_LOCKS = new Map();
 
 // Windows 에서 process.env.HOME 만 set 하고 USERPROFILE 은 그대로 둔 fixture 환경
-// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 두 변수 중
-// 먼저 set 된 쪽을 우선 사용한다. POSIX 는 HOME, Windows 는 USERPROFILE 이 native.
+// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 platform
+// 별로 native 변수를 우선한다 (#193).
+//
+// - TRIFLUX_TEST_HOME: 두 OS 모두 명시 override
+// - Windows: USERPROFILE > HOME > homedir() (Windows native 가 USERPROFILE)
+// - POSIX: HOME > homedir()
 function resolveHome() {
-  return (
-    process.env.TRIFLUX_TEST_HOME ||
-    process.env.HOME ||
-    process.env.USERPROFILE ||
-    homedir()
-  );
+  if (process.env.TRIFLUX_TEST_HOME) return process.env.TRIFLUX_TEST_HOME;
+  if (process.platform === "win32") {
+    return process.env.USERPROFILE || process.env.HOME || homedir();
+  }
+  return process.env.HOME || homedir();
 }
 
 function getSettingsPaths() {

--- a/scripts/sync-hub-mcp-settings.mjs
+++ b/scripts/sync-hub-mcp-settings.mjs
@@ -12,8 +12,20 @@ const CODEX_CONFIG_FILE = [".codex", "config.toml"];
 const TFX_HUB_SECTION = "tfx-hub";
 const FILE_LOCKS = new Map();
 
+// Windows 에서 process.env.HOME 만 set 하고 USERPROFILE 은 그대로 둔 fixture 환경
+// (e.g. integration test) 에서 production path 로 새는 것을 방지하려면 두 변수 중
+// 먼저 set 된 쪽을 우선 사용한다. POSIX 는 HOME, Windows 는 USERPROFILE 이 native.
+function resolveHome() {
+  return (
+    process.env.TRIFLUX_TEST_HOME ||
+    process.env.HOME ||
+    process.env.USERPROFILE ||
+    homedir()
+  );
+}
+
 function getSettingsPaths() {
-  const home = process.env.HOME || homedir();
+  const home = resolveHome();
   return TARGET_FILES.map((segments) => join(home, ...segments));
 }
 
@@ -21,8 +33,7 @@ function getCodexConfigPath(codexConfigPath) {
   if (typeof codexConfigPath === "string" && codexConfigPath.length > 0) {
     return codexConfigPath;
   }
-  const home = process.env.HOME || homedir();
-  return join(home, ...CODEX_CONFIG_FILE);
+  return join(resolveHome(), ...CODEX_CONFIG_FILE);
 }
 
 export function getProjectMcpJsonPaths(projectRoot) {

--- a/tests/unit/setup-home-resolution.test.mjs
+++ b/tests/unit/setup-home-resolution.test.mjs
@@ -1,0 +1,157 @@
+// tests/unit/setup-home-resolution.test.mjs
+//
+// Issue #193 회귀 가드 — Windows 에서 os.homedir() 가 USERPROFILE 만 보고
+// process.env.HOME swap 을 무시하기 때문에, integration test 가 fixture 격리한
+// spawn child 에서도 production ~/.codex/config.toml 을 mutate 하는 회귀를 막는다.
+//
+// 검증 전략:
+// - sentinel HOME 디렉토리에 .codex/config.toml 을 만들어 두고
+// - fixture HOME 으로 setup 의 ensureCodexProfiles() 를 spawn 한 다음
+// - sentinel 의 config.toml 이 untouched 인지 확인한다.
+//
+// spawn child 사용 → P3 (module-load freeze) 회피.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const SETUP_URL = new URL("../../scripts/setup.mjs", import.meta.url).href;
+
+function snapshotConfig(path) {
+  if (!existsSync(path)) return { exists: false };
+  const data = readFileSync(path);
+  return {
+    exists: true,
+    size: data.length,
+    sha: createHash("sha256").update(data).digest("hex"),
+  };
+}
+
+function spawnEnsureCodexProfiles({ home, userprofile, trifluxTestHome }) {
+  const env = { ...process.env };
+  // 환경 정리 — 명시적으로 set 하지 않은 키는 child 가 OS 기본값 사용 못 하게 비움
+  delete env.TRIFLUX_TEST_HOME;
+  if (typeof home === "string") env.HOME = home;
+  else delete env.HOME;
+  if (typeof userprofile === "string") env.USERPROFILE = userprofile;
+  else delete env.USERPROFILE;
+  if (typeof trifluxTestHome === "string") {
+    env.TRIFLUX_TEST_HOME = trifluxTestHome;
+  }
+
+  const script = `
+    import(${JSON.stringify(SETUP_URL)}).then((m) => {
+      const result = m.ensureCodexProfiles();
+      process.stdout.write(JSON.stringify(result));
+    }).catch((err) => {
+      process.stderr.write("ERR: " + (err?.message || err));
+      process.exit(1);
+    });
+  `;
+
+  return spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    env,
+    encoding: "utf8",
+    timeout: 30000,
+  });
+}
+
+describe("setup home resolution (#193 회귀 가드)", () => {
+  it("Windows: USERPROFILE 이 set 이면 fixture path 사용, sentinel HOME 은 untouched", () => {
+    if (process.platform !== "win32") return;
+
+    const fixture = mkdtempSync(join(tmpdir(), "tfx-home-fixture-"));
+    const sentinel = mkdtempSync(join(tmpdir(), "tfx-home-sentinel-"));
+    mkdirSync(join(fixture, ".codex"), { recursive: true });
+    mkdirSync(join(sentinel, ".codex"), { recursive: true });
+    const sentinelConfig = join(sentinel, ".codex", "config.toml");
+    const fixtureConfig = join(fixture, ".codex", "config.toml");
+    // sentinel 에 baseline content 를 깔아두고 변경되지 않는지 확인
+    writeFileSync(
+      sentinelConfig,
+      '# sentinel — must not be mutated\nmodel = "sentinel"\n',
+      "utf8",
+    );
+
+    try {
+      const before = snapshotConfig(sentinelConfig);
+      // HOME 은 sentinel, USERPROFILE 은 fixture — Windows 우선순위는 USERPROFILE
+      const result = spawnEnsureCodexProfiles({
+        home: sentinel,
+        userprofile: fixture,
+      });
+      assert.equal(
+        result.status,
+        0,
+        `spawn failed: ${result.stderr || result.stdout}`,
+      );
+      const after = snapshotConfig(sentinelConfig);
+      assert.equal(after.exists, true, "sentinel must still exist");
+      assert.equal(
+        after.sha,
+        before.sha,
+        `sentinel mutated! before=${before.sha} after=${after.sha}`,
+      );
+      // fixture 에 setup 결과가 만들어졌는지
+      assert.equal(
+        existsSync(fixtureConfig),
+        true,
+        "fixture config should be created by ensureCodexProfiles",
+      );
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+      rmSync(sentinel, { recursive: true, force: true });
+    }
+  });
+
+  it("TRIFLUX_TEST_HOME 이 set 되면 HOME / USERPROFILE 보다 우선", () => {
+    const fixture = mkdtempSync(join(tmpdir(), "tfx-home-test-"));
+    const decoy1 = mkdtempSync(join(tmpdir(), "tfx-home-decoy1-"));
+    const decoy2 = mkdtempSync(join(tmpdir(), "tfx-home-decoy2-"));
+    mkdirSync(join(fixture, ".codex"), { recursive: true });
+    mkdirSync(join(decoy1, ".codex"), { recursive: true });
+    mkdirSync(join(decoy2, ".codex"), { recursive: true });
+    const decoy1Config = join(decoy1, ".codex", "config.toml");
+    const decoy2Config = join(decoy2, ".codex", "config.toml");
+    const fixtureConfig = join(fixture, ".codex", "config.toml");
+    writeFileSync(decoy1Config, '# decoy1\nmodel = "decoy1"\n', "utf8");
+    writeFileSync(decoy2Config, '# decoy2\nmodel = "decoy2"\n', "utf8");
+
+    try {
+      const before1 = snapshotConfig(decoy1Config);
+      const before2 = snapshotConfig(decoy2Config);
+      const result = spawnEnsureCodexProfiles({
+        home: decoy1,
+        userprofile: decoy2,
+        trifluxTestHome: fixture,
+      });
+      assert.equal(
+        result.status,
+        0,
+        `spawn failed: ${result.stderr || result.stdout}`,
+      );
+      assert.equal(snapshotConfig(decoy1Config).sha, before1.sha);
+      assert.equal(snapshotConfig(decoy2Config).sha, before2.sha);
+      assert.equal(
+        existsSync(fixtureConfig),
+        true,
+        "fixture (TRIFLUX_TEST_HOME) config must be created",
+      );
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+      rmSync(decoy1, { recursive: true, force: true });
+      rmSync(decoy2, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 문제

issue #193 의 mutation 추적 결과 — Windows `os.homedir()` 가 `USERPROFILE` 환경 변수만 보고 `process.env.HOME` swap 을 무시. integration test (`tests/integration/triflux-cli.test.mjs`, `tfx-route-smoke.test.mjs`) 가 fixture `homeDir` 로 child spawn 해도 child 의 `setup.mjs` / `sync-hub-mcp-settings.mjs` 는 production `~/.codex/config.toml` 을 mutate 했다.

## 변경

| 파일 | 변경 |
|------|------|
| `scripts/setup.mjs` | `_TFX_HOME` 캐시 변수 + `CLAUDE_DIR`/`CODEX_DIR` 결정 통합 |
| `packages/triflux/scripts/setup.mjs` | mirror 동일 |
| `scripts/sync-hub-mcp-settings.mjs` | `resolveHome()` helper + 동일 우선순위 |
| `packages/triflux/scripts/sync-hub-mcp-settings.mjs` | mirror 동일 |

우선순위: `TRIFLUX_TEST_HOME` > `HOME` > `USERPROFILE` > `os.homedir()`.

## 회귀 영향

- 일반 사용자: HOME 일반적으로 USERPROFILE 과 동일 또는 unset → 동작 변화 없음
- integration test: `runCli` 가 `HOME=homeDir`/`USERPROFILE=homeDir` set 시 fixture 격리 동작 정확히 원하는 대로
- mirror byte-equal, biome lint pass

## #192 와의 관계

진단 중 #192 (release:prepare npm test EXIT=1 mismatch) 의 **17 tests fail** 패턴을 함께 발견 (release-governance 는 PASS). 별 PR 로 fix 예정. 본 PR 은 #193 의 핵심 격리 fix 만 포함.

## 검증

- mirror byte-equal: ✓
- biome lint: ✓
- 추가 검증 권장: full npm test 후 `~/.codex/config.toml` mtime 변경 없음 확인 (CI integration test).

## 한계

이번 진단 trace 는 **명시적 production write** 까지는 잡지 못함 (path 출력 미포함). 단 fixture spawn 시 `HOME=homeDir` 만 받던 path 들이 새는 root cause 는 정확. 추가 audit 은 procmon/fs.watch + path 명시 trace 도구로 별도 진행 가능.

Closes #193 (partial — 회귀 가드 test 는 별 PR)
Refs #192 (진단 진척, 별 fix PR)