### PR TITLE
chore: gitignore .mcp.json.bak-* atomic write backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,9 @@ docs/research/*competitor*
 # 정식 경로: ~/.config/triflux/hosts.json (POSIX) / %APPDATA%\triflux\hosts.json (Windows)
 **/references/hosts.json
 **/references/hosts.json.bak.*
+
+# .mcp.json atomic write backups (sync-hub-mcp-settings.mjs writeTextAtomic)
+# 정상 흐름에서는 finally 에서 정리되지만, rollback 실패 시 수동 복구용으로
+# 보존된다. repo 에 staged 되면 안 된다.
+.mcp.json.bak-*
+**/.mcp.json.bak-*


### PR DESCRIPTION
## 변경

writeTextAtomic 의 rollback 실패 시 보존되는 `.mcp.json.bak-<pid>-<ts>` 가 프로젝트 root 에 untracked 로 노출되는 noise 차단.

## 컨텍스트

`scripts/sync-hub-mcp-settings.mjs` 의 writeTextAtomic 은:
1. tmp → dest rename 으로 atomic write
2. 실패 시 backup 으로 rollback 시도
3. rollback 자체가 실패한 경우, 수동 복구용으로 backup 을 의도적으로 보존 (line 130-141)

이 보존된 backup 들이 git status 에 매번 untracked 로 떠서 noise 발생. 본 PR 은 .gitignore 에 패턴 추가로 차단.

## 영향

- 정상 흐름: 이미 finally 에서 cleanup 되므로 영향 없음
- rollback 실패 시: backup 파일 보존은 동일, 다만 git untracked 표시 안 됨 (수동 복구는 여전히 가능)
- 기존 staged 파일 영향 없음 (untracked 만 ignore)