### PR TITLE
fix(#192): fixture sync + hosts-compat normalization (swarm 2 shards)

### DIFF
--- a/hooks/safety-guard.mjs
+++ b/hooks/safety-guard.mjs
@@ -123,9 +123,12 @@ function getWindowsHostIds() {
       ids.add(name);
       if (cfg.tailscale?.ip) ids.add(cfg.tailscale.ip);
       if (cfg.tailscale?.dns) ids.add(cfg.tailscale.dns);
+      if (cfg.ssh?.host) ids.add(cfg.ssh.host);
       if (cfg.ssh?.user) {
         ids.add(`${cfg.ssh.user}@${name}`);
         if (cfg.tailscale?.ip) ids.add(`${cfg.ssh.user}@${cfg.tailscale.ip}`);
+        if (cfg.tailscale?.dns) ids.add(`${cfg.ssh.user}@${cfg.tailscale.dns}`);
+        if (cfg.ssh?.host) ids.add(`${cfg.ssh.user}@${cfg.ssh.host}`);
       }
     }
   } catch {

--- a/hub/lib/hosts-compat.mjs
+++ b/hub/lib/hosts-compat.mjs
@@ -133,8 +133,20 @@ function normalizeLastProbe(rawProbe) {
   return Object.keys(probe).length > 0 ? probe : null;
 }
 
+function normalizeResources(rawHost) {
+  const rawResources =
+    rawHost.resources && typeof rawHost.resources === "object"
+      ? rawHost.resources
+      : {};
+  const rawSpecs =
+    rawHost.specs && typeof rawHost.specs === "object" ? rawHost.specs : {};
+  return { ...rawResources, ...rawSpecs };
+}
+
 export function normalizeHost(rawHost = {}, name = "") {
   const sshUser = rawHost.ssh_user || rawHost.ssh?.user || rawHost.user || null;
+  const sshHost = rawHost.ssh?.host || rawHost.host || null;
+  const resources = normalizeResources(rawHost);
   const tailscale = {
     ip: rawHost.tailscale?.ip || null,
     dns: rawHost.tailscale?.dns || null,
@@ -167,15 +179,14 @@ export function normalizeHost(rawHost = {}, name = "") {
     ssh: {
       ...(rawHost.ssh && typeof rawHost.ssh === "object" ? rawHost.ssh : {}),
       user: sshUser,
+      host: sshHost,
     },
     tailscale,
     capabilities,
     capabilities_v2,
     last_probe: normalizeLastProbe(rawHost.last_probe),
-    specs:
-      rawHost.specs && typeof rawHost.specs === "object"
-        ? { ...rawHost.specs }
-        : {},
+    resources,
+    specs: { ...resources },
     raw: { ...rawHost },
   };
 }
@@ -234,12 +245,16 @@ export function resolveHost(nameOrAlias, repoRoot) {
       ...host.aliases,
       host.tailscale.ip,
       host.tailscale.dns,
+      host.ssh.host,
       host.ssh_user ? `${host.ssh_user}@${name}` : null,
       host.ssh_user && host.tailscale.ip
         ? `${host.ssh_user}@${host.tailscale.ip}`
         : null,
       host.ssh_user && host.tailscale.dns
         ? `${host.ssh_user}@${host.tailscale.dns}`
+        : null,
+      host.ssh_user && host.ssh.host
+        ? `${host.ssh_user}@${host.ssh.host}`
         : null,
     ]);
     for (const alias of aliases) {

--- a/hub/lib/ssh-command.mjs
+++ b/hub/lib/ssh-command.mjs
@@ -2,7 +2,7 @@
 // PowerShell 호스트에 bash 문법(2>/dev/null, &&, $())을 보내는 사고를 방지한다.
 // 모든 SSH 명령 생성 코드에서 이 유틸리티를 사용할 것.
 
-import { readHosts } from "./hosts-compat.mjs";
+import { readHost, readHosts, resolveHost } from "./hosts-compat.mjs";
 
 /** hosts.json 캐시 (프로세스 수명 동안 유지) */
 let hostsCache = null;
@@ -28,7 +28,7 @@ function loadHostsCache(repoRoot) {
 export function detectHostOs(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  const hostCfg = hostsCache.hosts?.[hostAlias];
+  const hostCfg = resolveHost(hostAlias, repoRoot)?.host;
   if (hostCfg?.os === "windows") return "windows";
   if (hostCfg?.os) return "posix";
 
@@ -163,7 +163,7 @@ export function validateCommandForOs(command, os) {
  */
 export function getHostConfig(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
-  return hostsCache.hosts?.[hostAlias] ?? null;
+  return readHost(hostAlias, repoRoot);
 }
 
 /**
@@ -175,13 +175,7 @@ export function getHostConfig(hostAlias, repoRoot) {
 export function resolveHostAlias(alias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  if (hostsCache.hosts?.[alias]) return alias;
-
-  for (const [name, cfg] of Object.entries(hostsCache.hosts || {})) {
-    if (cfg.aliases.includes(alias)) return name;
-  }
-
-  return null;
+  return resolveHost(alias, repoRoot)?.name ?? null;
 }
 
 /**

--- a/hub/team/agent-map.json
+++ b/hub/team/agent-map.json
@@ -1,6 +1,8 @@
 {
   "executor": "codex",
   "build-fixer": "codex",
+  "cleanup": "codex",
+  "deslop": "codex",
   "debugger": "codex",
   "deep-executor": "codex",
   "architect": "codex",

--- a/packages/core/hooks/safety-guard.mjs
+++ b/packages/core/hooks/safety-guard.mjs
@@ -123,9 +123,12 @@ function getWindowsHostIds() {
       ids.add(name);
       if (cfg.tailscale?.ip) ids.add(cfg.tailscale.ip);
       if (cfg.tailscale?.dns) ids.add(cfg.tailscale.dns);
+      if (cfg.ssh?.host) ids.add(cfg.ssh.host);
       if (cfg.ssh?.user) {
         ids.add(`${cfg.ssh.user}@${name}`);
         if (cfg.tailscale?.ip) ids.add(`${cfg.ssh.user}@${cfg.tailscale.ip}`);
+        if (cfg.tailscale?.dns) ids.add(`${cfg.ssh.user}@${cfg.tailscale.dns}`);
+        if (cfg.ssh?.host) ids.add(`${cfg.ssh.user}@${cfg.ssh.host}`);
       }
     }
   } catch {

--- a/packages/core/hub/lib/hosts-compat.mjs
+++ b/packages/core/hub/lib/hosts-compat.mjs
@@ -133,8 +133,20 @@ function normalizeLastProbe(rawProbe) {
   return Object.keys(probe).length > 0 ? probe : null;
 }
 
+function normalizeResources(rawHost) {
+  const rawResources =
+    rawHost.resources && typeof rawHost.resources === "object"
+      ? rawHost.resources
+      : {};
+  const rawSpecs =
+    rawHost.specs && typeof rawHost.specs === "object" ? rawHost.specs : {};
+  return { ...rawResources, ...rawSpecs };
+}
+
 export function normalizeHost(rawHost = {}, name = "") {
   const sshUser = rawHost.ssh_user || rawHost.ssh?.user || rawHost.user || null;
+  const sshHost = rawHost.ssh?.host || rawHost.host || null;
+  const resources = normalizeResources(rawHost);
   const tailscale = {
     ip: rawHost.tailscale?.ip || null,
     dns: rawHost.tailscale?.dns || null,
@@ -167,15 +179,14 @@ export function normalizeHost(rawHost = {}, name = "") {
     ssh: {
       ...(rawHost.ssh && typeof rawHost.ssh === "object" ? rawHost.ssh : {}),
       user: sshUser,
+      host: sshHost,
     },
     tailscale,
     capabilities,
     capabilities_v2,
     last_probe: normalizeLastProbe(rawHost.last_probe),
-    specs:
-      rawHost.specs && typeof rawHost.specs === "object"
-        ? { ...rawHost.specs }
-        : {},
+    resources,
+    specs: { ...resources },
     raw: { ...rawHost },
   };
 }
@@ -234,12 +245,16 @@ export function resolveHost(nameOrAlias, repoRoot) {
       ...host.aliases,
       host.tailscale.ip,
       host.tailscale.dns,
+      host.ssh.host,
       host.ssh_user ? `${host.ssh_user}@${name}` : null,
       host.ssh_user && host.tailscale.ip
         ? `${host.ssh_user}@${host.tailscale.ip}`
         : null,
       host.ssh_user && host.tailscale.dns
         ? `${host.ssh_user}@${host.tailscale.dns}`
+        : null,
+      host.ssh_user && host.ssh.host
+        ? `${host.ssh_user}@${host.ssh.host}`
         : null,
     ]);
     for (const alias of aliases) {

--- a/packages/core/hub/lib/ssh-command.mjs
+++ b/packages/core/hub/lib/ssh-command.mjs
@@ -2,7 +2,7 @@
 // PowerShell 호스트에 bash 문법(2>/dev/null, &&, $())을 보내는 사고를 방지한다.
 // 모든 SSH 명령 생성 코드에서 이 유틸리티를 사용할 것.
 
-import { readHosts } from "./hosts-compat.mjs";
+import { readHost, readHosts, resolveHost } from "./hosts-compat.mjs";
 
 /** hosts.json 캐시 (프로세스 수명 동안 유지) */
 let hostsCache = null;
@@ -28,7 +28,7 @@ function loadHostsCache(repoRoot) {
 export function detectHostOs(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  const hostCfg = hostsCache.hosts?.[hostAlias];
+  const hostCfg = resolveHost(hostAlias, repoRoot)?.host;
   if (hostCfg?.os === "windows") return "windows";
   if (hostCfg?.os) return "posix";
 
@@ -163,7 +163,7 @@ export function validateCommandForOs(command, os) {
  */
 export function getHostConfig(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
-  return hostsCache.hosts?.[hostAlias] ?? null;
+  return readHost(hostAlias, repoRoot);
 }
 
 /**
@@ -175,13 +175,7 @@ export function getHostConfig(hostAlias, repoRoot) {
 export function resolveHostAlias(alias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  if (hostsCache.hosts?.[alias]) return alias;
-
-  for (const [name, cfg] of Object.entries(hostsCache.hosts || {})) {
-    if (cfg.aliases.includes(alias)) return name;
-  }
-
-  return null;
+  return resolveHost(alias, repoRoot)?.name ?? null;
 }
 
 /**

--- a/packages/remote/hub/team/agent-map.json
+++ b/packages/remote/hub/team/agent-map.json
@@ -1,6 +1,8 @@
 {
   "executor": "codex",
   "build-fixer": "codex",
+  "cleanup": "codex",
+  "deslop": "codex",
   "debugger": "codex",
   "deep-executor": "codex",
   "architect": "codex",

--- a/packages/triflux/hooks/safety-guard.mjs
+++ b/packages/triflux/hooks/safety-guard.mjs
@@ -123,9 +123,12 @@ function getWindowsHostIds() {
       ids.add(name);
       if (cfg.tailscale?.ip) ids.add(cfg.tailscale.ip);
       if (cfg.tailscale?.dns) ids.add(cfg.tailscale.dns);
+      if (cfg.ssh?.host) ids.add(cfg.ssh.host);
       if (cfg.ssh?.user) {
         ids.add(`${cfg.ssh.user}@${name}`);
         if (cfg.tailscale?.ip) ids.add(`${cfg.ssh.user}@${cfg.tailscale.ip}`);
+        if (cfg.tailscale?.dns) ids.add(`${cfg.ssh.user}@${cfg.tailscale.dns}`);
+        if (cfg.ssh?.host) ids.add(`${cfg.ssh.user}@${cfg.ssh.host}`);
       }
     }
   } catch {

--- a/packages/triflux/hub/lib/hosts-compat.mjs
+++ b/packages/triflux/hub/lib/hosts-compat.mjs
@@ -133,8 +133,20 @@ function normalizeLastProbe(rawProbe) {
   return Object.keys(probe).length > 0 ? probe : null;
 }
 
+function normalizeResources(rawHost) {
+  const rawResources =
+    rawHost.resources && typeof rawHost.resources === "object"
+      ? rawHost.resources
+      : {};
+  const rawSpecs =
+    rawHost.specs && typeof rawHost.specs === "object" ? rawHost.specs : {};
+  return { ...rawResources, ...rawSpecs };
+}
+
 export function normalizeHost(rawHost = {}, name = "") {
   const sshUser = rawHost.ssh_user || rawHost.ssh?.user || rawHost.user || null;
+  const sshHost = rawHost.ssh?.host || rawHost.host || null;
+  const resources = normalizeResources(rawHost);
   const tailscale = {
     ip: rawHost.tailscale?.ip || null,
     dns: rawHost.tailscale?.dns || null,
@@ -167,15 +179,14 @@ export function normalizeHost(rawHost = {}, name = "") {
     ssh: {
       ...(rawHost.ssh && typeof rawHost.ssh === "object" ? rawHost.ssh : {}),
       user: sshUser,
+      host: sshHost,
     },
     tailscale,
     capabilities,
     capabilities_v2,
     last_probe: normalizeLastProbe(rawHost.last_probe),
-    specs:
-      rawHost.specs && typeof rawHost.specs === "object"
-        ? { ...rawHost.specs }
-        : {},
+    resources,
+    specs: { ...resources },
     raw: { ...rawHost },
   };
 }
@@ -234,12 +245,16 @@ export function resolveHost(nameOrAlias, repoRoot) {
       ...host.aliases,
       host.tailscale.ip,
       host.tailscale.dns,
+      host.ssh.host,
       host.ssh_user ? `${host.ssh_user}@${name}` : null,
       host.ssh_user && host.tailscale.ip
         ? `${host.ssh_user}@${host.tailscale.ip}`
         : null,
       host.ssh_user && host.tailscale.dns
         ? `${host.ssh_user}@${host.tailscale.dns}`
+        : null,
+      host.ssh_user && host.ssh.host
+        ? `${host.ssh_user}@${host.ssh.host}`
         : null,
     ]);
     for (const alias of aliases) {

--- a/packages/triflux/hub/lib/ssh-command.mjs
+++ b/packages/triflux/hub/lib/ssh-command.mjs
@@ -2,7 +2,7 @@
 // PowerShell 호스트에 bash 문법(2>/dev/null, &&, $())을 보내는 사고를 방지한다.
 // 모든 SSH 명령 생성 코드에서 이 유틸리티를 사용할 것.
 
-import { readHosts } from "./hosts-compat.mjs";
+import { readHost, readHosts, resolveHost } from "./hosts-compat.mjs";
 
 /** hosts.json 캐시 (프로세스 수명 동안 유지) */
 let hostsCache = null;
@@ -28,7 +28,7 @@ function loadHostsCache(repoRoot) {
 export function detectHostOs(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  const hostCfg = hostsCache.hosts?.[hostAlias];
+  const hostCfg = resolveHost(hostAlias, repoRoot)?.host;
   if (hostCfg?.os === "windows") return "windows";
   if (hostCfg?.os) return "posix";
 
@@ -163,7 +163,7 @@ export function validateCommandForOs(command, os) {
  */
 export function getHostConfig(hostAlias, repoRoot) {
   loadHostsCache(repoRoot);
-  return hostsCache.hosts?.[hostAlias] ?? null;
+  return readHost(hostAlias, repoRoot);
 }
 
 /**
@@ -175,13 +175,7 @@ export function getHostConfig(hostAlias, repoRoot) {
 export function resolveHostAlias(alias, repoRoot) {
   loadHostsCache(repoRoot);
 
-  if (hostsCache.hosts?.[alias]) return alias;
-
-  for (const [name, cfg] of Object.entries(hostsCache.hosts || {})) {
-    if (cfg.aliases.includes(alias)) return name;
-  }
-
-  return null;
+  return resolveHost(alias, repoRoot)?.name ?? null;
 }
 
 /**

--- a/packages/triflux/hub/team/agent-map.json
+++ b/packages/triflux/hub/team/agent-map.json
@@ -1,6 +1,8 @@
 {
   "executor": "codex",
   "build-fixer": "codex",
+  "cleanup": "codex",
+  "deslop": "codex",
   "debugger": "codex",
   "deep-executor": "codex",
   "architect": "codex",

--- a/tests/unit/intent.test.mjs
+++ b/tests/unit/intent.test.mjs
@@ -60,13 +60,13 @@ describe("intent", () => {
     assert.ok(r.reasoning, "Should have reasoning");
   });
 
-  // 7. classifyIntent: implement → executor/implement/codex53_high
-  it("classifyIntent: implement routes to executor/implement/codex53_high", () => {
+  // 7. classifyIntent: implement → executor/implement/gpt55_high
+  it("classifyIntent: implement routes to executor/implement/gpt55_high", () => {
     const r = classifyIntent("새로운 API 엔드포인트 구현해줘");
     assert.equal(r.category, "implement");
     assert.equal(r.routing.agent, "executor");
     assert.equal(r.routing.mcp, "implement");
-    assert.equal(r.routing.effort, "codex53_high");
+    assert.equal(r.routing.effort, "gpt55_high");
   });
 
   // 8. classifyIntent: document → writer/docs/pro

--- a/tests/unit/routing-qa.test.mjs
+++ b/tests/unit/routing-qa.test.mjs
@@ -215,28 +215,28 @@ describe("route_agent: 에이전트→CLI 매핑", () => {
 // 5. route_agent(): effort/timeout 매핑
 // ========================================================================
 describe("route_agent: effort 레벨 검증", () => {
-  it("executor → codex53_high effort", () => {
-    assert.equal(ROUTE_TABLE.executor?.CLI_EFFORT, "codex53_high");
+  it("executor → gpt55_high effort", () => {
+    assert.equal(ROUTE_TABLE.executor?.CLI_EFFORT, "gpt55_high");
   });
 
-  it("build-fixer → codex53_low effort", () => {
-    assert.equal(ROUTE_TABLE["build-fixer"]?.CLI_EFFORT, "codex53_low");
+  it("build-fixer → gpt55_low effort", () => {
+    assert.equal(ROUTE_TABLE["build-fixer"]?.CLI_EFFORT, "gpt55_low");
   });
 
-  it("deep-executor → gpt54_xhigh effort", () => {
-    assert.equal(ROUTE_TABLE["deep-executor"]?.CLI_EFFORT, "gpt54_xhigh");
+  it("deep-executor → gpt55_xhigh effort", () => {
+    assert.equal(ROUTE_TABLE["deep-executor"]?.CLI_EFFORT, "gpt55_xhigh");
   });
 
   it("spark → spark53_low effort", () => {
     assert.equal(ROUTE_TABLE.spark?.CLI_EFFORT, "spark53_low");
   });
 
-  it("code-reviewer → codex53_high effort", () => {
-    assert.equal(ROUTE_TABLE["code-reviewer"]?.CLI_EFFORT, "codex53_high");
+  it("code-reviewer → gpt55_high effort", () => {
+    assert.equal(ROUTE_TABLE["code-reviewer"]?.CLI_EFFORT, "gpt55_high");
   });
 
-  it("codex alias → codex53_high effort (executor와 동일)", () => {
-    assert.equal(ROUTE_TABLE.codex?.CLI_EFFORT, "codex53_high");
+  it("codex alias → gpt55_high effort (executor와 동일)", () => {
+    assert.equal(ROUTE_TABLE.codex?.CLI_EFFORT, "gpt55_high");
   });
 
   it("gemini alias → pro31 effort", () => {

--- a/tests/unit/safety-guard-psmux.test.mjs
+++ b/tests/unit/safety-guard-psmux.test.mjs
@@ -31,13 +31,17 @@ function createTempRepo(hosts) {
 function runGuard(command, cwd = tmpdir()) {
   const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
   const { TFX_CLEANUP_BYPASS: _unused, ...envClean } = process.env;
+  const env =
+    cwd === tmpdir()
+      ? envClean
+      : { ...envClean, TFX_HOSTS_USER_STATE_DISABLE: "1" };
   try {
     execFileSync("node", [GUARD_PATH], {
       input,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       cwd,
-      env: envClean,
+      env,
     });
     return 0;
   } catch (e) {
@@ -108,8 +112,7 @@ describe("safety-guard psmux rules", () => {
     const repoDir = createTempRepo({
       winbox: {
         os: "windows",
-        ssh: { user: "nested-user" },
-        tailscale: { ip: "100.64.0.9" },
+        ssh: { user: "nested-user", host: "100.64.0.9" },
       },
     });
 

--- a/tests/unit/ssh-command.test.mjs
+++ b/tests/unit/ssh-command.test.mjs
@@ -30,6 +30,48 @@ function createTempRepo(hosts) {
   return repoDir;
 }
 
+const FLAT_HOSTS = {
+  ultra4: {
+    description: "legacy windows host",
+    aliases: ["desktop", "ultra", "울트라"],
+    default_dir: "~/Desktop/Projects",
+    os: "win32",
+    ssh_user: "SSAFY",
+    tailscale: {
+      ip: "100.64.0.1",
+      dns: "desk.ts.net",
+    },
+    capabilities: ["codex", "claude"],
+    resources: { cores: 22, ram_gb: 64 },
+  },
+};
+
+function withSourceHosts(hosts, callback) {
+  const savedDisable = process.env.TFX_HOSTS_USER_STATE_DISABLE;
+  const savedUserState = process.env.TFX_HOSTS_USER_STATE;
+  process.env.TFX_HOSTS_USER_STATE_DISABLE = "1";
+  delete process.env.TFX_HOSTS_USER_STATE;
+  resetHostsCache();
+
+  const repoDir = createTempRepo(hosts);
+  try {
+    return callback(repoDir);
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+    resetHostsCache();
+    if (savedDisable === undefined) {
+      delete process.env.TFX_HOSTS_USER_STATE_DISABLE;
+    } else {
+      process.env.TFX_HOSTS_USER_STATE_DISABLE = savedDisable;
+    }
+    if (savedUserState === undefined) {
+      delete process.env.TFX_HOSTS_USER_STATE;
+    } else {
+      process.env.TFX_HOSTS_USER_STATE = savedUserState;
+    }
+  }
+}
+
 describe("ssh-command", () => {
   beforeEach(() => resetHostsCache());
 
@@ -172,95 +214,116 @@ describe("ssh-command", () => {
 
   describe("getHostConfig", () => {
     it("존재하는 호스트 설정 반환", () => {
-      const cfg = getHostConfig("ultra4");
-      assert.ok(cfg, "ultra4 설정 존재");
-      assert.equal(cfg.os, "windows");
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const cfg = getHostConfig("ultra4", repoDir);
+        assert.ok(cfg, "ultra4 설정 존재");
+        assert.equal(cfg.os, "windows");
+      });
     });
 
     it("없는 호스트는 null 반환", () => {
-      assert.equal(getHostConfig("nonexistent"), null);
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        assert.equal(getHostConfig("nonexistent", repoDir), null);
+      });
     });
 
     it("nested ssh.user shape도 normalized config로 반환", () => {
-      const repoDir = createTempRepo({
-        winbox: {
-          os: "windows",
-          ssh: { user: "nested-user" },
-          tailscale: { ip: "100.64.0.9" },
-          capabilities_v2: { codex: true, high_memory: true },
-          specs: { cores: 12, ram_gb: 48 },
+      withSourceHosts(
+        {
+          winbox: {
+            os: "windows",
+            ssh: { user: "nested-user", host: "100.64.0.9" },
+            tailscale: { ip: "100.64.0.9" },
+            capabilities_v2: { codex: true, high_memory: true },
+            specs: { cores: 12, ram_gb: 48 },
+          },
         },
-      });
-
-      try {
-        const cfg = getHostConfig("winbox", repoDir);
-        assert.equal(cfg?.ssh.user, "nested-user");
-        assert.equal(cfg?.ssh_user, "nested-user");
-        assert.deepEqual(cfg?.capabilities, ["codex", "high-memory"]);
-      } finally {
-        rmSync(repoDir, { recursive: true, force: true });
-      }
+        (repoDir) => {
+          const cfg = getHostConfig("winbox", repoDir);
+          assert.equal(cfg?.ssh.user, "nested-user");
+          assert.equal(cfg?.ssh.host, "100.64.0.9");
+          assert.equal(cfg?.ssh_user, "nested-user");
+          assert.deepEqual(cfg?.capabilities, ["codex", "high-memory"]);
+        },
+      );
     });
   });
 
   describe("detectHostOs", () => {
     it("normalized host registry를 통해 nested windows shape를 감지", () => {
-      const repoDir = createTempRepo({
-        winbox: {
-          os: "windows",
-          ssh: { user: "nested-user" },
+      withSourceHosts(
+        {
+          winbox: {
+            os: "windows",
+            ssh: { user: "nested-user", host: "100.64.0.9" },
+          },
         },
-      });
-
-      try {
-        assert.equal(detectHostOs("winbox", repoDir), "windows");
-      } finally {
-        rmSync(repoDir, { recursive: true, force: true });
-      }
+        (repoDir) => {
+          assert.equal(detectHostOs("winbox", repoDir), "windows");
+          assert.equal(
+            detectHostOs("nested-user@100.64.0.9", repoDir),
+            "windows",
+          );
+        },
+      );
     });
   });
 
   describe("resolveHostAlias", () => {
     it("정확한 키로 해결", () => {
-      assert.equal(resolveHostAlias("ultra4"), "ultra4");
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        assert.equal(resolveHostAlias("ultra4", repoDir), "ultra4");
+      });
     });
 
     it("aliases 배열 내 값으로 해결", () => {
-      const key = resolveHostAlias("울트라");
-      assert.equal(key, "ultra4");
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const key = resolveHostAlias("울트라", repoDir);
+        assert.equal(key, "ultra4");
+      });
     });
 
     it("없는 별칭은 null", () => {
-      assert.equal(resolveHostAlias("unknown-alias"), null);
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        assert.equal(resolveHostAlias("unknown-alias", repoDir), null);
+      });
     });
   });
 
   describe("selectHostForCapability", () => {
     it("codex capability 매칭", () => {
-      const hosts = selectHostForCapability("codex");
-      assert.ok(hosts.length > 0, "codex capable 호스트 존재");
-      assert.equal(hosts[0].name, "ultra4");
-      assert.deepEqual(hosts[0].specs, { cores: 22, ram_gb: 64 });
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const hosts = selectHostForCapability("codex", repoDir);
+        assert.ok(hosts.length > 0, "codex capable 호스트 존재");
+        assert.equal(hosts[0].name, "ultra4");
+        assert.deepEqual(hosts[0].specs, { cores: 22, ram_gb: 64 });
+      });
     });
 
     it("없는 capability는 빈 배열", () => {
-      const hosts = selectHostForCapability("quantum-computing");
-      assert.equal(hosts.length, 0);
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const hosts = selectHostForCapability("quantum-computing", repoDir);
+        assert.equal(hosts.length, 0);
+      });
     });
   });
 
   describe("selectHostByResources", () => {
     it("cores 기준 정렬된 명시적 선택 목록 반환", () => {
-      const hosts = selectHostByResources("codex", "cores");
-      assert.ok(hosts.length > 0, "codex capable 호스트 존재");
-      assert.equal(hosts[0].name, "ultra4");
-      assert.deepEqual(hosts[0].specs, { cores: 22, ram_gb: 64 });
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const hosts = selectHostByResources("codex", "cores", repoDir);
+        assert.ok(hosts.length > 0, "codex capable 호스트 존재");
+        assert.equal(hosts[0].name, "ultra4");
+        assert.deepEqual(hosts[0].specs, { cores: 22, ram_gb: 64 });
+      });
     });
 
     it("ram_gb 기준 정렬된 명시적 선택 목록 반환", () => {
-      const hosts = selectHostByResources("codex", "ram_gb");
-      assert.ok(hosts.length > 0, "codex capable 호스트 존재");
-      assert.equal(hosts[0].specs.ram_gb, 64);
+      withSourceHosts(FLAT_HOSTS, (repoDir) => {
+        const hosts = selectHostByResources("codex", "ram_gb", repoDir);
+        assert.ok(hosts.length > 0, "codex capable 호스트 존재");
+        assert.equal(hosts[0].specs.ram_gb, 64);
+      });
     });
 
     it("지원하지 않는 sortBy는 예외", () => {


### PR DESCRIPTION
## Summary

session32 (PR #196 + #197 머지) 이후 잔존한 #192 deferred 14 fail 해소. tfx-swarm 2 shards (A=fixture, B=host-config) 자동 통합.

**npm test 결과**:
- 이전: 17 fail (3194 tests, 3173 pass)
- 현재: **2 fail** (3196 tests, 3190 pass)
- 잔여 2건: tests/integration/tfx-route-smoke.test.mjs MCP transport (환경 의존, 별 카테고리, 본 PR scope 외)

## Shards

### A-fixture-sync (c698869)
PR #184 모델-직무 매핑 개편 follow-up. route_agent() / classifyIntent() 의 effort tier 갱신을 fixture (test expected 값) 가 따라가게 동기화.
- `tests/unit/intent.test.mjs` (1 fail → 0)
- `tests/unit/routing-qa.test.mjs` (6 fail → 0)
- `hub/team/agent-map.json` + 2 mirror

### B-host-config-normalization (460f5c6)
hosts.json 의 nested ssh.user shape 를 hosts-compat.mjs normalization layer 가 인식하도록 보강.
- `tests/unit/ssh-command.test.mjs` (6 fail → 0)
- `tests/unit/safety-guard-psmux.test.mjs` (1 fail → 0)
- `hub/lib/hosts-compat.mjs` + `hub/lib/ssh-command.mjs` + `hooks/safety-guard.mjs` + 2 mirror

## Test plan

- [x] `npm test` integration branch checkout 후 PASS 율 검증 (3190/3196 = 99.94%)
- [x] `npm run lint` clean (569 files, no fixes)
- [x] `node --test tests/unit/packages-mirror.test.mjs` PASS (mirror byte-equal)
- [x] AI trailer scan CLEAN (Co-Authored-By, Generated with Claude, AI-assisted, 🤖 없음)
- [ ] CI green (push 후 GitHub Actions 자동 검증)
- [ ] 사용자 머지 승인

## Reference

- PRD: `.triflux/plans/2026-04-26-issue192-fixture-host-config.md`
- swarm run: `swarm-1777170589716` (swarm-events.jsonl: completed 2/2, integrated 2/2, integration_failures 0)
- session32 backlog 항목 #2 (fixture), #3 (host config)