### PR TITLE
fix(worktree): stop fsmonitor daemon cleanup (B+C)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -462,14 +462,14 @@ function printJson(payload) {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
-function withConsoleSilenced(enabled, fn) {
+async function withConsoleSilenced(enabled, fn) {
   if (!enabled) return fn();
   const originalLog = console.log;
   const originalError = console.error;
   console.log = () => {};
   console.error = () => {};
   try {
-    return fn();
+    return await fn();
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -1846,6 +1846,7 @@ async function cmdDoctor(options = {}) {
     checks: [],
     actions: [],
     hook_coverage: { total: 0, registered: 0, missing: [] },
+    fsmonitorDaemons: { stale: 0, killed: 0 },
     issue_count: 0,
   };
 
@@ -3126,9 +3127,11 @@ async function cmdDoctor(options = {}) {
     section("Orphan Processes");
     if (process.platform === "win32") {
       try {
-        const { cleanupOrphanNodeProcesses } = await import(
-          "../hub/lib/process-utils.mjs"
-        );
+        const {
+          cleanupOrphanNodeProcesses,
+          cleanupStaleFsmonitorDaemons,
+          findFsmonitorDaemons,
+        } = await import("../hub/lib/process-utils.mjs");
         if (fix) {
           const { killed, remaining } = cleanupOrphanNodeProcesses();
           if (killed > 0) {
@@ -3156,6 +3159,55 @@ async function cmdDoctor(options = {}) {
           } else {
             ok(`node.exe ${count}개 (정상 범위)`);
           }
+        }
+
+        const fsmonitorStale = findFsmonitorDaemons({
+          minAgeMs: 24 * 60 * 60 * 1000,
+        });
+        let fsmonitorKilled = 0;
+        if (fix && fsmonitorStale.length > 0) {
+          const cleanupResult = cleanupStaleFsmonitorDaemons({
+            minAgeMs: 24 * 60 * 60 * 1000,
+          });
+          fsmonitorKilled = cleanupResult.killed;
+          report.actions.push({
+            type: "git-fsmonitor-cleanup",
+            status:
+              fsmonitorKilled === fsmonitorStale.length ? "ok" : "partial",
+            stale: fsmonitorStale.length,
+            killed: fsmonitorKilled,
+          });
+          warn(
+            `stale git fsmonitor daemon ${fsmonitorKilled}/${fsmonitorStale.length}개 정리`,
+          );
+        } else if (fsmonitorStale.length > 0) {
+          warn(
+            `stale git fsmonitor daemon ${fsmonitorStale.length}개 발견 (24h+). 정리: tfx doctor --fix`,
+          );
+        } else {
+          ok("stale git fsmonitor daemon 없음");
+        }
+
+        report.fsmonitorDaemons = {
+          stale: fsmonitorStale.length,
+          killed: fsmonitorKilled,
+        };
+        addDoctorCheck(report, {
+          name: "fsmonitor-daemons",
+          status: fsmonitorStale.length > 0 ? "warning" : "ok",
+          stale: fsmonitorStale.length,
+          killed: fsmonitorKilled,
+          detail: fsmonitorStale.map((p) => ({
+            pid: p.pid,
+            parentPid: p.parentPid,
+            ageHours: Number((p.ageMs / (60 * 60 * 1000)).toFixed(1)),
+          })),
+        });
+        if (
+          fsmonitorStale.length > 0 &&
+          (!fix || fsmonitorKilled < fsmonitorStale.length)
+        ) {
+          issues++;
         }
       } catch (e) {
         info(`고아 프로세스 검사 실패: ${e.message}`);

--- a/hub/lib/process-utils.mjs
+++ b/hub/lib/process-utils.mjs
@@ -20,6 +20,10 @@ const TREE_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "get-ancestor-tree.ps1");
 // 스크립트 버전 — 내용 변경 시 증가하여 캐시된 스크립트를 갱신
 const SCRIPT_VERSION = 3;
 const VERSION_FILE = join(CLEANUP_SCRIPT_DIR, ".version");
+const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
+const FSMONITOR_DAEMON_PATTERN =
+  /(^|\s)fsmonitor--daemon\s+run\s+--detach(\s|$)/;
+const DEFAULT_FSMONITOR_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
  * 주어진 PID의 프로세스가 살아있는지 확인한다.
@@ -339,6 +343,107 @@ export function cleanupOrphanNodeProcesses() {
   } catch {}
 
   return { killed, remaining };
+}
+
+function normalizePowerShellJson(output) {
+  const trimmed = String(output || "").trim();
+  if (!trimmed || trimmed === "null") return [];
+  const parsed = JSON.parse(trimmed);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function parseCreationDateMs(value) {
+  if (!value) return NaN;
+  if (value instanceof Date) return value.getTime();
+
+  const text = String(value);
+  const dotNetMatch = /\/Date\((-?\d+)\)\//.exec(text);
+  if (dotNetMatch) return Number.parseInt(dotNetMatch[1], 10);
+
+  const ms = Date.parse(text);
+  return Number.isFinite(ms) ? ms : NaN;
+}
+
+/**
+ * Find stale git fsmonitor--daemon processes.
+ *
+ * Windows only. The CIM query is scoped to git.exe and the command line marker
+ * is intentionally narrow so foreground git commands are never targeted.
+ *
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean}} opts
+ * @returns {Array<{pid: number, parentPid: number, creationDate: string, ageMs: number, commandLine: string}>}
+ */
+export function findFsmonitorDaemons({
+  minAgeMs = DEFAULT_FSMONITOR_MIN_AGE_MS,
+  execSyncFn = execSync,
+  nowMs = Date.now(),
+  isWindows = IS_WINDOWS,
+} = {}) {
+  if (!isWindows) return [];
+
+  ensureHelperScripts();
+
+  let records;
+  try {
+    const output = execSyncFn(
+      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process -Filter \\"Name='git.exe'\\" | Where-Object { $_.CommandLine -match '(^|\\s)fsmonitor--daemon run --detach(\\s|$)' } | Select-Object ProcessId,ParentProcessId,CreationDate,CommandLine | ConvertTo-Json -Compress"`,
+      {
+        encoding: "utf8",
+        timeout: 10000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    records = normalizePowerShellJson(output);
+  } catch {
+    return [];
+  }
+
+  const stale = [];
+  for (const record of records) {
+    const pid = Number(record?.ProcessId);
+    const parentPid = Number(record?.ParentProcessId);
+    const commandLine = String(record?.CommandLine || "");
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (!commandLine.includes(FSMONITOR_DAEMON_MARKER)) continue;
+    if (!FSMONITOR_DAEMON_PATTERN.test(commandLine)) continue;
+
+    const creationMs = parseCreationDateMs(record?.CreationDate);
+    const ageMs = Number.isFinite(creationMs) ? nowMs - creationMs : NaN;
+    if (!Number.isFinite(ageMs) || ageMs < minAgeMs) continue;
+
+    stale.push({
+      pid,
+      parentPid: Number.isFinite(parentPid) ? parentPid : 0,
+      creationDate: String(record?.CreationDate || ""),
+      ageMs,
+      commandLine,
+    });
+  }
+
+  return stale;
+}
+
+/**
+ * Cleanup stale git fsmonitor--daemon processes.
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean, killFn?: typeof process.kill}} opts
+ * @returns {{killed: number, stale: Array}}
+ */
+export function cleanupStaleFsmonitorDaemons({
+  killFn = process.kill,
+  ...findOpts
+} = {}) {
+  const stale = findFsmonitorDaemons(findOpts);
+  let killed = 0;
+
+  for (const proc of stale) {
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+    } catch {}
+  }
+
+  return { killed, stale };
 }
 
 /**

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -27,7 +27,10 @@ import { createAdaptiveEngine } from "./adaptive.mjs";
 import { createAssignCallbackServer } from "./assign-callbacks.mjs";
 import { DelegatorService } from "./delegator/index.mjs";
 import { createHitlManager } from "./hitl.mjs";
-import { cleanupOrphanNodeProcesses } from "./lib/process-utils.mjs";
+import {
+  cleanupOrphanNodeProcesses,
+  cleanupStaleFsmonitorDaemons,
+} from "./lib/process-utils.mjs";
 import * as spawnTrace from "./lib/spawn-trace.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
@@ -1823,6 +1826,18 @@ export async function startHub({
         if (killed > 0) {
           hubLog.info({ killed }, "hub.orphan_cleanup");
         }
+
+        const { killed: fsmonitorKilled, stale } = cleanupStaleFsmonitorDaemons(
+          {
+            minAgeMs: 24 * 60 * 60 * 1000,
+          },
+        );
+        if (fsmonitorKilled > 0) {
+          hubLog.info(
+            { killed: fsmonitorKilled, stale: stale.length },
+            "hub.fsmonitor_cleanup",
+          );
+        }
       } catch {}
 
       // stale tfx-spawn-* psmux 세션 정리 (30분 이상 idle)
@@ -2486,6 +2501,15 @@ if (selfRun) {
         hubLog.info({ signal }, "hub.stopping");
         try {
           cleanupOrphanNodeProcesses();
+          const { killed, stale } = cleanupStaleFsmonitorDaemons({
+            minAgeMs: 24 * 60 * 60 * 1000,
+          });
+          if (killed > 0) {
+            hubLog.info(
+              { killed, stale: stale.length },
+              "hub.fsmonitor_cleanup",
+            );
+          }
         } catch {}
         try {
           cleanupStaleSpawnSessions(hubLog);

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -84,6 +84,30 @@ function git(args, cwd) {
   });
 }
 
+/**
+ * Best-effort shutdown for the Git fsmonitor daemon attached to a worktree.
+ * Missing or already-stopped daemons are treated as successful no-ops because
+ * cleanup should not be blocked by watcher state.
+ *
+ * @param {string} worktreePath
+ * @param {(args: string[], cwd: string) => Promise<string>} [gitImpl=git]
+ * @returns {Promise<{ ok: boolean, stopped: boolean, reason?: 'not_running', error?: string }>}
+ */
+async function stopFsmonitorDaemon(worktreePath, gitImpl = git) {
+  try {
+    await gitImpl(["fsmonitor--daemon", "stop"], worktreePath);
+    return { ok: true, stopped: true };
+  } catch (err) {
+    const msg = String(err?.message || err || "");
+    if (
+      /not running|not watching|fsmonitor--daemon is not running/iu.test(msg)
+    ) {
+      return { ok: true, stopped: false, reason: "not_running" };
+    }
+    return { ok: false, stopped: false, error: msg };
+  }
+}
+
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -129,10 +153,10 @@ function resolveCleanupTarget(worktreePath, rootDir) {
   };
 }
 
-async function branchExists(branchName, rootDir) {
+async function branchExists(branchName, rootDir, gitImpl = git) {
   if (!branchName) return false;
   try {
-    const listed = await git(["branch", "--list", branchName], rootDir);
+    const listed = await gitImpl(["branch", "--list", branchName], rootDir);
     return listed.trim().length > 0;
   } catch {
     return false;
@@ -419,13 +443,15 @@ export async function cleanupWorktree({
   branchName,
   rootDir = process.cwd(),
   force = false,
+  _git = git,
 }) {
   const { resolvedWorktree } = resolveCleanupTarget(worktreePath, rootDir);
+  const fsmonitorStop = await stopFsmonitorDaemon(resolvedWorktree, _git);
   const forceArgs = force ? ["--force"] : [];
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      await git(
+      await _git(
         ["worktree", "remove", ...forceArgs, resolvedWorktree],
         rootDir,
       );
@@ -444,18 +470,20 @@ export async function cleanupWorktree({
 
   await sleep(SLEEP_MS);
   try {
-    await git(["worktree", "prune"], rootDir);
+    await _git(["worktree", "prune"], rootDir);
   } catch {
     /* best-effort */
   }
 
-  if (branchName && (await branchExists(branchName, rootDir))) {
+  if (branchName && (await branchExists(branchName, rootDir, _git))) {
     try {
-      await git(["branch", "-D", branchName], rootDir);
+      await _git(["branch", "-D", branchName], rootDir);
     } catch {
       /* branch may already be gone */
     }
   }
+
+  return { ok: true, fsmonitorStop };
 }
 
 /**
@@ -496,14 +524,14 @@ export async function pruneWorktree({
     }
   }
 
-  await cleanupWorktree({
+  const cleanupResult = await cleanupWorktree({
     worktreePath,
     branchName,
     rootDir,
     force,
   });
 
-  return { ok: true };
+  return { ok: true, fsmonitorStop: cleanupResult.fsmonitorStop };
 }
 
 /**
@@ -548,6 +576,7 @@ export async function pruneOrphanWorktrees({ rootDir = process.cwd() } = {}) {
     const normalized = normPath(fullPath);
     if (!registeredPaths.has(normalized)) {
       try {
+        await stopFsmonitorDaemon(fullPath).catch(() => null);
         await rm(fullPath, { recursive: true, force: true });
         removed.push(dir);
       } catch {

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -462,14 +462,14 @@ function printJson(payload) {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
-function withConsoleSilenced(enabled, fn) {
+async function withConsoleSilenced(enabled, fn) {
   if (!enabled) return fn();
   const originalLog = console.log;
   const originalError = console.error;
   console.log = () => {};
   console.error = () => {};
   try {
-    return fn();
+    return await fn();
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -1846,6 +1846,7 @@ async function cmdDoctor(options = {}) {
     checks: [],
     actions: [],
     hook_coverage: { total: 0, registered: 0, missing: [] },
+    fsmonitorDaemons: { stale: 0, killed: 0 },
     issue_count: 0,
   };
 
@@ -3126,9 +3127,11 @@ async function cmdDoctor(options = {}) {
     section("Orphan Processes");
     if (process.platform === "win32") {
       try {
-        const { cleanupOrphanNodeProcesses } = await import(
-          "../hub/lib/process-utils.mjs"
-        );
+        const {
+          cleanupOrphanNodeProcesses,
+          cleanupStaleFsmonitorDaemons,
+          findFsmonitorDaemons,
+        } = await import("../hub/lib/process-utils.mjs");
         if (fix) {
           const { killed, remaining } = cleanupOrphanNodeProcesses();
           if (killed > 0) {
@@ -3156,6 +3159,55 @@ async function cmdDoctor(options = {}) {
           } else {
             ok(`node.exe ${count}개 (정상 범위)`);
           }
+        }
+
+        const fsmonitorStale = findFsmonitorDaemons({
+          minAgeMs: 24 * 60 * 60 * 1000,
+        });
+        let fsmonitorKilled = 0;
+        if (fix && fsmonitorStale.length > 0) {
+          const cleanupResult = cleanupStaleFsmonitorDaemons({
+            minAgeMs: 24 * 60 * 60 * 1000,
+          });
+          fsmonitorKilled = cleanupResult.killed;
+          report.actions.push({
+            type: "git-fsmonitor-cleanup",
+            status:
+              fsmonitorKilled === fsmonitorStale.length ? "ok" : "partial",
+            stale: fsmonitorStale.length,
+            killed: fsmonitorKilled,
+          });
+          warn(
+            `stale git fsmonitor daemon ${fsmonitorKilled}/${fsmonitorStale.length}개 정리`,
+          );
+        } else if (fsmonitorStale.length > 0) {
+          warn(
+            `stale git fsmonitor daemon ${fsmonitorStale.length}개 발견 (24h+). 정리: tfx doctor --fix`,
+          );
+        } else {
+          ok("stale git fsmonitor daemon 없음");
+        }
+
+        report.fsmonitorDaemons = {
+          stale: fsmonitorStale.length,
+          killed: fsmonitorKilled,
+        };
+        addDoctorCheck(report, {
+          name: "fsmonitor-daemons",
+          status: fsmonitorStale.length > 0 ? "warning" : "ok",
+          stale: fsmonitorStale.length,
+          killed: fsmonitorKilled,
+          detail: fsmonitorStale.map((p) => ({
+            pid: p.pid,
+            parentPid: p.parentPid,
+            ageHours: Number((p.ageMs / (60 * 60 * 1000)).toFixed(1)),
+          })),
+        });
+        if (
+          fsmonitorStale.length > 0 &&
+          (!fix || fsmonitorKilled < fsmonitorStale.length)
+        ) {
+          issues++;
         }
       } catch (e) {
         info(`고아 프로세스 검사 실패: ${e.message}`);

--- a/packages/triflux/hub/lib/process-utils.mjs
+++ b/packages/triflux/hub/lib/process-utils.mjs
@@ -20,6 +20,10 @@ const TREE_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "get-ancestor-tree.ps1");
 // 스크립트 버전 — 내용 변경 시 증가하여 캐시된 스크립트를 갱신
 const SCRIPT_VERSION = 3;
 const VERSION_FILE = join(CLEANUP_SCRIPT_DIR, ".version");
+const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
+const FSMONITOR_DAEMON_PATTERN =
+  /(^|\s)fsmonitor--daemon\s+run\s+--detach(\s|$)/;
+const DEFAULT_FSMONITOR_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
  * 주어진 PID의 프로세스가 살아있는지 확인한다.
@@ -339,6 +343,107 @@ export function cleanupOrphanNodeProcesses() {
   } catch {}
 
   return { killed, remaining };
+}
+
+function normalizePowerShellJson(output) {
+  const trimmed = String(output || "").trim();
+  if (!trimmed || trimmed === "null") return [];
+  const parsed = JSON.parse(trimmed);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function parseCreationDateMs(value) {
+  if (!value) return NaN;
+  if (value instanceof Date) return value.getTime();
+
+  const text = String(value);
+  const dotNetMatch = /\/Date\((-?\d+)\)\//.exec(text);
+  if (dotNetMatch) return Number.parseInt(dotNetMatch[1], 10);
+
+  const ms = Date.parse(text);
+  return Number.isFinite(ms) ? ms : NaN;
+}
+
+/**
+ * Find stale git fsmonitor--daemon processes.
+ *
+ * Windows only. The CIM query is scoped to git.exe and the command line marker
+ * is intentionally narrow so foreground git commands are never targeted.
+ *
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean}} opts
+ * @returns {Array<{pid: number, parentPid: number, creationDate: string, ageMs: number, commandLine: string}>}
+ */
+export function findFsmonitorDaemons({
+  minAgeMs = DEFAULT_FSMONITOR_MIN_AGE_MS,
+  execSyncFn = execSync,
+  nowMs = Date.now(),
+  isWindows = IS_WINDOWS,
+} = {}) {
+  if (!isWindows) return [];
+
+  ensureHelperScripts();
+
+  let records;
+  try {
+    const output = execSyncFn(
+      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process -Filter \\"Name='git.exe'\\" | Where-Object { $_.CommandLine -match '(^|\\s)fsmonitor--daemon run --detach(\\s|$)' } | Select-Object ProcessId,ParentProcessId,CreationDate,CommandLine | ConvertTo-Json -Compress"`,
+      {
+        encoding: "utf8",
+        timeout: 10000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    records = normalizePowerShellJson(output);
+  } catch {
+    return [];
+  }
+
+  const stale = [];
+  for (const record of records) {
+    const pid = Number(record?.ProcessId);
+    const parentPid = Number(record?.ParentProcessId);
+    const commandLine = String(record?.CommandLine || "");
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (!commandLine.includes(FSMONITOR_DAEMON_MARKER)) continue;
+    if (!FSMONITOR_DAEMON_PATTERN.test(commandLine)) continue;
+
+    const creationMs = parseCreationDateMs(record?.CreationDate);
+    const ageMs = Number.isFinite(creationMs) ? nowMs - creationMs : NaN;
+    if (!Number.isFinite(ageMs) || ageMs < minAgeMs) continue;
+
+    stale.push({
+      pid,
+      parentPid: Number.isFinite(parentPid) ? parentPid : 0,
+      creationDate: String(record?.CreationDate || ""),
+      ageMs,
+      commandLine,
+    });
+  }
+
+  return stale;
+}
+
+/**
+ * Cleanup stale git fsmonitor--daemon processes.
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean, killFn?: typeof process.kill}} opts
+ * @returns {{killed: number, stale: Array}}
+ */
+export function cleanupStaleFsmonitorDaemons({
+  killFn = process.kill,
+  ...findOpts
+} = {}) {
+  const stale = findFsmonitorDaemons(findOpts);
+  let killed = 0;
+
+  for (const proc of stale) {
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+    } catch {}
+  }
+
+  return { killed, stale };
 }
 
 /**

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -27,7 +27,10 @@ import { createAdaptiveEngine } from "./adaptive.mjs";
 import { createAssignCallbackServer } from "./assign-callbacks.mjs";
 import { DelegatorService } from "./delegator/index.mjs";
 import { createHitlManager } from "./hitl.mjs";
-import { cleanupOrphanNodeProcesses } from "./lib/process-utils.mjs";
+import {
+  cleanupOrphanNodeProcesses,
+  cleanupStaleFsmonitorDaemons,
+} from "./lib/process-utils.mjs";
 import * as spawnTrace from "./lib/spawn-trace.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
@@ -1823,6 +1826,18 @@ export async function startHub({
         if (killed > 0) {
           hubLog.info({ killed }, "hub.orphan_cleanup");
         }
+
+        const { killed: fsmonitorKilled, stale } = cleanupStaleFsmonitorDaemons(
+          {
+            minAgeMs: 24 * 60 * 60 * 1000,
+          },
+        );
+        if (fsmonitorKilled > 0) {
+          hubLog.info(
+            { killed: fsmonitorKilled, stale: stale.length },
+            "hub.fsmonitor_cleanup",
+          );
+        }
       } catch {}
 
       // stale tfx-spawn-* psmux 세션 정리 (30분 이상 idle)
@@ -2486,6 +2501,15 @@ if (selfRun) {
         hubLog.info({ signal }, "hub.stopping");
         try {
           cleanupOrphanNodeProcesses();
+          const { killed, stale } = cleanupStaleFsmonitorDaemons({
+            minAgeMs: 24 * 60 * 60 * 1000,
+          });
+          if (killed > 0) {
+            hubLog.info(
+              { killed, stale: stale.length },
+              "hub.fsmonitor_cleanup",
+            );
+          }
         } catch {}
         try {
           cleanupStaleSpawnSessions(hubLog);

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -84,6 +84,30 @@ function git(args, cwd) {
   });
 }
 
+/**
+ * Best-effort shutdown for the Git fsmonitor daemon attached to a worktree.
+ * Missing or already-stopped daemons are treated as successful no-ops because
+ * cleanup should not be blocked by watcher state.
+ *
+ * @param {string} worktreePath
+ * @param {(args: string[], cwd: string) => Promise<string>} [gitImpl=git]
+ * @returns {Promise<{ ok: boolean, stopped: boolean, reason?: 'not_running', error?: string }>}
+ */
+async function stopFsmonitorDaemon(worktreePath, gitImpl = git) {
+  try {
+    await gitImpl(["fsmonitor--daemon", "stop"], worktreePath);
+    return { ok: true, stopped: true };
+  } catch (err) {
+    const msg = String(err?.message || err || "");
+    if (
+      /not running|not watching|fsmonitor--daemon is not running/iu.test(msg)
+    ) {
+      return { ok: true, stopped: false, reason: "not_running" };
+    }
+    return { ok: false, stopped: false, error: msg };
+  }
+}
+
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -129,10 +153,10 @@ function resolveCleanupTarget(worktreePath, rootDir) {
   };
 }
 
-async function branchExists(branchName, rootDir) {
+async function branchExists(branchName, rootDir, gitImpl = git) {
   if (!branchName) return false;
   try {
-    const listed = await git(["branch", "--list", branchName], rootDir);
+    const listed = await gitImpl(["branch", "--list", branchName], rootDir);
     return listed.trim().length > 0;
   } catch {
     return false;
@@ -419,13 +443,15 @@ export async function cleanupWorktree({
   branchName,
   rootDir = process.cwd(),
   force = false,
+  _git = git,
 }) {
   const { resolvedWorktree } = resolveCleanupTarget(worktreePath, rootDir);
+  const fsmonitorStop = await stopFsmonitorDaemon(resolvedWorktree, _git);
   const forceArgs = force ? ["--force"] : [];
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      await git(
+      await _git(
         ["worktree", "remove", ...forceArgs, resolvedWorktree],
         rootDir,
       );
@@ -444,18 +470,20 @@ export async function cleanupWorktree({
 
   await sleep(SLEEP_MS);
   try {
-    await git(["worktree", "prune"], rootDir);
+    await _git(["worktree", "prune"], rootDir);
   } catch {
     /* best-effort */
   }
 
-  if (branchName && (await branchExists(branchName, rootDir))) {
+  if (branchName && (await branchExists(branchName, rootDir, _git))) {
     try {
-      await git(["branch", "-D", branchName], rootDir);
+      await _git(["branch", "-D", branchName], rootDir);
     } catch {
       /* branch may already be gone */
     }
   }
+
+  return { ok: true, fsmonitorStop };
 }
 
 /**
@@ -496,14 +524,14 @@ export async function pruneWorktree({
     }
   }
 
-  await cleanupWorktree({
+  const cleanupResult = await cleanupWorktree({
     worktreePath,
     branchName,
     rootDir,
     force,
   });
 
-  return { ok: true };
+  return { ok: true, fsmonitorStop: cleanupResult.fsmonitorStop };
 }
 
 /**
@@ -548,6 +576,7 @@ export async function pruneOrphanWorktrees({ rootDir = process.cwd() } = {}) {
     const normalized = normPath(fullPath);
     if (!registeredPaths.has(normalized)) {
       try {
+        await stopFsmonitorDaemon(fullPath).catch(() => null);
         await rm(fullPath, { recursive: true, force: true });
         removed.push(dir);
       } catch {

--- a/tests/unit/process-utils.test.mjs
+++ b/tests/unit/process-utils.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  cleanupStaleFsmonitorDaemons,
+  findFsmonitorDaemons,
+} from "../../hub/lib/process-utils.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = Date.parse("2026-04-26T00:00:00.000Z");
+
+function psJson(records) {
+  return JSON.stringify(records);
+}
+
+describe("findFsmonitorDaemons", () => {
+  it("returns [] on non-Windows platforms", () => {
+    const seen = [];
+    const result = findFsmonitorDaemons({
+      isWindows: false,
+      execSyncFn: () => {
+        seen.push("exec");
+        return "";
+      },
+    });
+
+    assert.deepEqual(result, []);
+    assert.deepEqual(seen, []);
+  });
+
+  it("finds only stale git fsmonitor daemons with exact command marker", () => {
+    const result = findFsmonitorDaemons({
+      isWindows: true,
+      minAgeMs: DAY_MS,
+      nowMs: NOW_MS,
+      execSyncFn: (command) => {
+        assert.match(command, /Get-CimInstance Win32_Process/);
+        assert.match(command, /Name='git\.exe'/);
+        assert.match(command, /fsmonitor--daemon run --detach/);
+        return psJson([
+          {
+            ProcessId: 101,
+            ParentProcessId: 10,
+            CreationDate: "2026-04-24T23:59:59.000Z",
+            CommandLine: "git fsmonitor--daemon run --detach --ipc-threads=8",
+          },
+          {
+            ProcessId: 102,
+            ParentProcessId: 10,
+            CreationDate: "2026-04-25T23:59:59.000Z",
+            CommandLine: "git fsmonitor--daemon run --detach --ipc-threads=8",
+          },
+          {
+            ProcessId: 103,
+            ParentProcessId: 10,
+            CreationDate: "2026-04-24T23:59:59.000Z",
+            CommandLine: "git status",
+          },
+          {
+            ProcessId: 104,
+            ParentProcessId: 10,
+            CreationDate: "2026-04-24T23:59:59.000Z",
+            CommandLine: "git fsmonitor--daemon run --detached",
+          },
+        ]);
+      },
+    });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].pid, 101);
+    assert.equal(result[0].parentPid, 10);
+    assert.equal(
+      result[0].commandLine,
+      "git fsmonitor--daemon run --detach --ipc-threads=8",
+    );
+    assert.ok(result[0].ageMs >= DAY_MS);
+  });
+});
+
+describe("cleanupStaleFsmonitorDaemons", () => {
+  it("kills only stale fsmonitor daemon pids with SIGKILL", () => {
+    const kills = [];
+    const result = cleanupStaleFsmonitorDaemons({
+      isWindows: true,
+      minAgeMs: DAY_MS,
+      nowMs: NOW_MS,
+      execSyncFn: () =>
+        psJson([
+          {
+            ProcessId: 201,
+            ParentProcessId: 20,
+            CreationDate: "2026-04-24T23:59:59.000Z",
+            CommandLine: "git fsmonitor--daemon run --detach --ipc-threads=8",
+          },
+          {
+            ProcessId: 202,
+            ParentProcessId: 20,
+            CreationDate: "2026-04-24T23:59:59.000Z",
+            CommandLine: "git worktree remove C:/repo/wt",
+          },
+        ]),
+      killFn: (pid, signal) => {
+        kills.push([pid, signal]);
+      },
+    });
+
+    assert.equal(result.killed, 1);
+    assert.equal(result.stale.length, 1);
+    assert.deepEqual(kills, [[201, "SIGKILL"]]);
+  });
+});

--- a/tests/unit/worktree-lifecycle.test.mjs
+++ b/tests/unit/worktree-lifecycle.test.mjs
@@ -33,6 +33,31 @@ function makeTmpRepo() {
   return dir;
 }
 
+function makeGitSpy(behavior, calls = []) {
+  return async (args, cwd) => {
+    if (args[0] === "fsmonitor--daemon" && args[1] === "stop") {
+      calls.push("fsmonitor-stop");
+      if (behavior === "not_running") {
+        throw new Error(
+          "git fsmonitor--daemon failed: fatal: fsmonitor--daemon is not running",
+        );
+      }
+      if (behavior === "error") {
+        throw new Error("git fsmonitor--daemon failed: fatal: ipc failure");
+      }
+      return "";
+    }
+
+    if (args[0] === "worktree" && args[1] === "remove") {
+      calls.push("worktree-remove");
+    }
+
+    return execFileSync("git", args, { cwd, windowsHide: true })
+      .toString()
+      .trim();
+  };
+}
+
 describe("worktree-lifecycle", () => {
   let repoDir;
 
@@ -215,6 +240,76 @@ describe("worktree-lifecycle", () => {
         }),
       /main working tree/,
     );
+  });
+
+  it("calls fsmonitor stop before worktree remove", async () => {
+    const wt = await ensureWorktree({
+      slug: "fsmonitor-order",
+      runId: "test-run",
+      rootDir: repoDir,
+      baseBranch: "main",
+    });
+
+    const calls = [];
+    const cleanupResult = await cleanupWorktree({
+      worktreePath: wt.worktreePath,
+      branchName: wt.branchName,
+      rootDir: repoDir,
+      force: true,
+      _git: makeGitSpy("success", calls),
+    });
+
+    assert.deepEqual(cleanupResult.fsmonitorStop, {
+      ok: true,
+      stopped: true,
+    });
+    assert.deepEqual(calls.slice(0, 2), ["fsmonitor-stop", "worktree-remove"]);
+  });
+
+  it("tolerates 'fsmonitor--daemon is not running' error", async () => {
+    const wt = await ensureWorktree({
+      slug: "fsmonitor-not-running",
+      runId: "test-run",
+      rootDir: repoDir,
+      baseBranch: "main",
+    });
+
+    const result = await cleanupWorktree({
+      worktreePath: wt.worktreePath,
+      branchName: wt.branchName,
+      rootDir: repoDir,
+      force: true,
+      _git: makeGitSpy("not_running"),
+    });
+
+    assert.equal(existsSync(wt.worktreePath), false);
+    assert.deepEqual(result.fsmonitorStop, {
+      ok: true,
+      stopped: false,
+      reason: "not_running",
+    });
+  });
+
+  it("tolerates unexpected stop error", async () => {
+    const wt = await ensureWorktree({
+      slug: "fsmonitor-stop-error",
+      runId: "test-run",
+      rootDir: repoDir,
+      baseBranch: "main",
+    });
+
+    const result = await cleanupWorktree({
+      worktreePath: wt.worktreePath,
+      branchName: wt.branchName,
+      rootDir: repoDir,
+      force: true,
+      _git: makeGitSpy("error"),
+    });
+
+    assert.equal(existsSync(wt.worktreePath), false);
+    assert.equal(result.fsmonitorStop.ok, false);
+    assert.equal(result.fsmonitorStop.stopped, false);
+    assert.match(result.fsmonitorStop.error, /fatal: ipc failure/);
   });
 
   it("W-08 (#127): rebaseShardOntoIntegration — cherry-pick applies shard commits to integration", async () => {


### PR DESCRIPTION
## Summary

124개 git fsmonitor daemon orphan 사고 (회귀 X, Codex 문제 X)의 영구 방지. Codex 분석 권고 B+C 구현.

- **Root cause** (Codex P1): `cleanupWorktree()`가 `git worktree remove`만 수행하고 `git fsmonitor--daemon stop` 선행 호출 누락. Worktree 삭제 후에는 per-worktree IPC pipe lookup 실패 → daemon이 19시간+ 고아 상태로 잔존.
- **Fix B (primary)**: `cleanupWorktree()` + `pruneOrphanWorktrees()`에 `stopFsmonitorDaemon()` best-effort 호출 추가
- **Fix C (safety net)**: `tfx doctor --json/--fix` + hub 5분 timer에 stale fsmonitor cleanup (24h+ age, exact CommandLine match `fsmonitor--daemon run --detach`)

## 변경

| Shard | 파일 | Lines |
|-------|------|-------|
| A | `hub/team/worktree-lifecycle.mjs` + mirror + tests | +169 -16 |
| B | `bin/triflux.mjs` + `hub/lib/process-utils.mjs` + `hub/server.mjs` + mirrors + tests | +485 -12 |

총 9 files, +654 -28. Mirror sync는 Codex가 자동 처리 (별도 shard 불필요).

## 검증

### Unit tests
\`\`\`
npm test
ℹ tests 3200
ℹ pass 3200
ℹ fail 0
ℹ skipped 4
\`\`\`

신규 케이스 모두 통과:
- worktree-lifecycle: 'calls fsmonitor stop before worktree remove', 'tolerates not-running', 'tolerates unexpected error'
- process-utils: findFsmonitorDaemons / cleanupStaleFsmonitorDaemons unit cases

### Live verification

`cleanupWorktree('.codex-swarm/wt-A-...')` 호출 결과:
\`\`\`json
{
  \"ok\": true,
  \"fsmonitorStop\": { \"ok\": true, \"stopped\": true }
}
\`\`\`

`cleanupStaleFsmonitorDaemons({ minAgeMs: 5*60*1000 })` 호출 결과:
\`\`\`json
{ \"killed\": 21, \"stale\": [...] }
\`\`\`

`tfx doctor --json` 출력에 새 섹션 추가:
\`\`\`json
{
  \"name\": \"fsmonitor-daemons\",
  \"status\": \"ok\",
  \"stale\": 0
},
\"fsmonitorDaemons\": { \"stale\": 0, \"killed\": 0 }
\`\`\`

이번 sprint에서 fsmonitor 124 → 0 (인공 cleanup) → swarm 1회로 28 누적 → 새 코드로 0 회복까지 end-to-end 검증.

## 분석 보고서

Codex `analyst` (gpt-5.5 xhigh) 분석 489줄: `.omc/artifacts/codex-fsmonitor-analysis.md`
- P1: triflux cleanup 누락 (직접 증거 강함, High 신뢰)
- P2: Git for Windows fsmonitor lifecycle gap (Medium-High)
- P3: Windows ConPTY race (Medium-Low, fsmonitor 대비 약함)
- 외부 근거: [Git fsmonitor docs](https://git-scm.com/docs/git-fsmonitor--daemon), [VS Code #161088](https://github.com/microsoft/vscode/issues/161088), [Microsoft ClosePseudoConsole](https://learn.microsoft.com/en-us/windows/console/closepseudoconsole)

PRD: `.triflux/plans/2026-04-26-fsmonitor-cleanup-b-plus-c.md` (design doc), `.triflux/plans/2026-04-26-fsmonitor-cleanup-swarm.md` (swarm dispatch)

## Out-of-scope (별도 follow-up)

- swarm worker process tree cleanup (node/bash/conhost orphan, 같은 family 추가 사고)
- `psmux.killSessionByTitle` → `killPsmuxSession` 수렴 (P3 ConPTY race 보강)

## Test plan

- [x] npm test 통과 (3200/3200)
- [x] 신규 unit cases 추가 + 통과
- [x] cleanupWorktree 새 코드 live 호출 시 fsmonitorStop=stopped:true 검증
- [x] cleanupStaleFsmonitorDaemons live 호출 시 21개 daemon kill 검증
- [x] tfx doctor --json에 fsmonitorDaemons 섹션 노출 확인
- [x] 기존 worktree-lifecycle 테스트 회귀 0