### PR TITLE
feat(process-utils): add cleanup helpers for swarm worker process tree (P1)

### DIFF
--- a/hub/lib/process-utils.mjs
+++ b/hub/lib/process-utils.mjs
@@ -455,12 +455,6 @@ function hasExactGbrainServe(commandLine) {
   );
 }
 
-function hasExactFsmonitorDaemon(commandLine) {
-  return /^("?[^"\s]*git(?:\.exe)?"?\s+)?fsmonitor--daemon\s+run\s+--detach$/i.test(
-    commandLine.trim(),
-  );
-}
-
 function hasGbrainServeCommand(commandLine) {
   return /(^|\s)gbrain\s+serve(\s|$)/i.test(commandLine.trim());
 }

--- a/hub/lib/process-utils.mjs
+++ b/hub/lib/process-utils.mjs
@@ -1,7 +1,7 @@
 // hub/lib/process-utils.mjs
 // 프로세스 관련 공유 유틸리티
 
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -18,7 +18,7 @@ const SCAN_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "scan-processes.ps1");
 const TREE_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "get-ancestor-tree.ps1");
 
 // 스크립트 버전 — 내용 변경 시 증가하여 캐시된 스크립트를 갱신
-const SCRIPT_VERSION = 3;
+const SCRIPT_VERSION = 4;
 const VERSION_FILE = join(CLEANUP_SCRIPT_DIR, ".version");
 const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
 const FSMONITOR_DAEMON_PATTERN =
@@ -223,126 +223,13 @@ function hasLiveAncestorChain(pid, procMap, protectedPids) {
   return false;
 }
 
-// kill 대상 프로세스 이름 (Windows)
-// codex/claude도 포함: protectedPids + hasLiveAncestorChain이 활성 인스턴스를 보호하므로
-// 고아(부모 dead + 자식 dead)만 kill됨. pwsh.exe는 사용자 인터랙티브 쉘이므로 제외.
-const KILLABLE_NAMES = new Set([
-  "node.exe",
-  "bash.exe",
-  "cmd.exe",
-  "uvx.exe",
-  "codex.exe",
-  "claude.exe",
-]);
-
 /**
- * 고아 프로세스 트리를 정리한다 (node.exe + bash.exe + cmd.exe + uvx.exe).
- * Windows 전용 — Agent 서브프로세스가 MCP 서버, bash 래퍼, cmd 래퍼를 남기는 문제 대응.
- *
- * 전략: 부모 체인을 루트까지 추적하여, 체인 중간에 죽은 프로세스가 있으면
- * 해당 프로세스 아래의 전체 트리를 고아로 판정하고 정리.
- * 스캔 범위에는 codex/claude/pwsh도 포함하여 체인 추적 정확도를 높인다.
- *
- * 보호 대상: 현재 프로세스 조상 트리, Hub PID
+ * Legacy wrapper for scoped orphan node runtime cleanup.
+ * @param {Parameters<typeof cleanupOrphanRuntimeProcesses>[0]} opts
  * @returns {{ killed: number, remaining: number }}
  */
-export function cleanupOrphanNodeProcesses() {
-  if (!IS_WINDOWS) return cleanupOrphansUnix();
-
-  ensureHelperScripts();
-
-  const myPid = process.pid;
-
-  // Hub PID 보호
-  let hubPid = null;
-  try {
-    const hubPidPath = join(
-      homedir(),
-      ".claude",
-      "cache",
-      "tfx-hub",
-      "hub.pid",
-    );
-    if (existsSync(hubPidPath)) {
-      const hubInfo = JSON.parse(readFileSync(hubPidPath, "utf8"));
-      hubPid = Number(hubInfo?.pid);
-    }
-  } catch {}
-
-  // 보호 PID 세트: 현재 프로세스 + Hub + 현재 프로세스의 조상 트리
-  const protectedPids = new Set();
-  protectedPids.add(myPid);
-  if (Number.isFinite(hubPid) && hubPid > 0) protectedPids.add(hubPid);
-
-  try {
-    const treeOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${TREE_SCRIPT_PATH}" -StartPid ${myPid}`,
-      {
-        encoding: "utf8",
-        timeout: 8000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-    for (const line of treeOutput.split(/\r?\n/)) {
-      const pid = Number.parseInt(line.trim(), 10);
-      if (Number.isFinite(pid) && pid > 0) protectedPids.add(pid);
-    }
-  } catch {}
-
-  // 전체 프로세스 맵 구축 (node + bash + cmd + codex + claude + pwsh + uvx)
-  const procMap = new Map();
-  try {
-    const output = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${SCAN_SCRIPT_PATH}"`,
-      {
-        encoding: "utf8",
-        timeout: 15000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-
-    for (const line of output.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      const [pidStr, ppidStr, name] = trimmed.split(",");
-      const pid = Number.parseInt(pidStr, 10);
-      const ppid = Number.parseInt(ppidStr, 10);
-      if (Number.isFinite(pid) && pid > 0) {
-        procMap.set(pid, { ppid, name: name || "unknown" });
-      }
-    }
-  } catch {}
-
-  // 고아 판정 + 정리 (SIGTERM → 3s → SIGKILL 에스컬레이션)
-  // CLI 도구(codex/claude/pwsh)는 체인 추적용으로만 스캔 — kill 대상에서 제외
-  const orphanPids = [];
-  for (const [pid, info] of procMap) {
-    if (protectedPids.has(pid)) continue;
-    if (!KILLABLE_NAMES.has(info.name?.toLowerCase())) continue;
-    if (hasLiveAncestorChain(pid, procMap, protectedPids)) continue;
-    orphanPids.push(pid);
-  }
-
-  const killed = killWithEscalation(orphanPids, procMap);
-
-  // 남은 프로세스 수 확인
-  let remaining = 0;
-  try {
-    const countOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -Command "(Get-Process node -ErrorAction SilentlyContinue).Count"`,
-      {
-        encoding: "utf8",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-    remaining = Number.parseInt(countOutput.trim(), 10) || 0;
-  } catch {}
-
-  return { killed, remaining };
+export function cleanupOrphanNodeProcesses(opts = {}) {
+  return cleanupOrphanRuntimeProcesses({ ...opts, legacy: true });
 }
 
 function normalizePowerShellJson(output) {
@@ -362,6 +249,560 @@ function parseCreationDateMs(value) {
 
   const ms = Date.parse(text);
   return Number.isFinite(ms) ? ms : NaN;
+}
+
+function normalizePid(value) {
+  const pid = Number(value);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function normalizeName(name) {
+  return String(name || "").toLowerCase();
+}
+
+function normalizeCommandLine(commandLine) {
+  return String(commandLine || "").replace(/\//g, "\\");
+}
+
+function processRecordFromCim(record) {
+  const pid = normalizePid(record?.ProcessId ?? record?.pid);
+  if (!pid) return null;
+  const ppid = Number(record?.ParentProcessId ?? record?.ppid ?? 0);
+  return {
+    pid,
+    ppid: Number.isFinite(ppid) ? ppid : 0,
+    name: String(record?.Name ?? record?.name ?? ""),
+    commandLine: String(record?.CommandLine ?? record?.commandLine ?? ""),
+    creationDate: record?.CreationDate,
+  };
+}
+
+function runSpawn(spawnSyncFn, command, args, options = {}) {
+  return spawnSyncFn(command, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+function runPowerShellJson(spawnSyncFn, command) {
+  const result = runSpawn(spawnSyncFn, "powershell", [
+    "-NoProfile",
+    "-WindowStyle",
+    "Hidden",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    command,
+  ]);
+  if (result.status !== 0) {
+    throw new Error(
+      String(result.stderr || result.error || "PowerShell failed"),
+    );
+  }
+  return normalizePowerShellJson(result.stdout);
+}
+
+function getWindowsProcessSnapshot(spawnSyncFn = spawnSync) {
+  const records = runPowerShellJson(
+    spawnSyncFn,
+    [
+      "$ErrorActionPreference='SilentlyContinue'",
+      "Get-CimInstance Win32_Process |",
+      "Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate |",
+      "ConvertTo-Json -Compress",
+    ].join("; "),
+  );
+  return records.map(processRecordFromCim).filter(Boolean);
+}
+
+function parsePosixProcessSnapshot(output) {
+  const processes = [];
+  for (const line of String(output || "")
+    .split(/\r?\n/)
+    .slice(1)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = /^(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/.exec(trimmed);
+    if (!match) continue;
+    processes.push({
+      pid: Number.parseInt(match[1], 10),
+      ppid: Number.parseInt(match[2], 10),
+      name: match[3],
+      commandLine: match[4] || match[3],
+    });
+  }
+  return processes;
+}
+
+function getPosixProcessSnapshot(spawnSyncFn = spawnSync) {
+  const result = runSpawn(spawnSyncFn, "ps", ["-eo", "pid,ppid,comm,args"]);
+  if (result.status !== 0) return [];
+  return parsePosixProcessSnapshot(result.stdout);
+}
+
+function getProcessSnapshot({
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+} = {}) {
+  try {
+    return isWindows
+      ? getWindowsProcessSnapshot(spawnSyncFn)
+      : getPosixProcessSnapshot(spawnSyncFn);
+  } catch {
+    return [];
+  }
+}
+
+function addHubPid(protectedPids) {
+  try {
+    const hubPidPath = join(
+      homedir(),
+      ".claude",
+      "cache",
+      "tfx-hub",
+      "hub.pid",
+    );
+    if (existsSync(hubPidPath)) {
+      const hubInfo = JSON.parse(readFileSync(hubPidPath, "utf8"));
+      const hubPid = normalizePid(hubInfo?.pid);
+      if (hubPid) protectedPids.add(hubPid);
+    }
+  } catch {}
+}
+
+function getProtectedPids({
+  protectedPids,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  includeAncestorScan = false,
+} = {}) {
+  const result = new Set(protectedPids || []);
+  result.add(process.pid);
+  if (Number.isInteger(process.ppid) && process.ppid > 0) {
+    result.add(process.ppid);
+  }
+  addHubPid(result);
+  if (!includeAncestorScan) return result;
+
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  const byPid = new Map(snapshot.map((proc) => [proc.pid, proc]));
+  let current = process.pid;
+  const seen = new Set();
+  while (current > 0 && !seen.has(current)) {
+    seen.add(current);
+    result.add(current);
+    const parent = byPid.get(current)?.ppid;
+    if (!Number.isInteger(parent) || parent <= 0) break;
+    current = parent;
+  }
+
+  return result;
+}
+
+function collectDescendants(rootPid, processes) {
+  const childrenByParent = new Map();
+  for (const proc of processes) {
+    if (!childrenByParent.has(proc.ppid)) childrenByParent.set(proc.ppid, []);
+    childrenByParent.get(proc.ppid).push(proc);
+  }
+
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const root = byPid.get(rootPid) || {
+    pid: rootPid,
+    ppid: 0,
+    name: "",
+    commandLine: "",
+  };
+  const result = [];
+  const queue = [root];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const proc = queue.shift();
+    if (!proc || seen.has(proc.pid)) continue;
+    seen.add(proc.pid);
+    result.push(proc);
+    for (const child of childrenByParent.get(proc.pid) || []) {
+      queue.push(child);
+    }
+  }
+
+  return result;
+}
+
+function snapshotPids(snapshot) {
+  const values = Array.isArray(snapshot) ? snapshot : [snapshot];
+  return values
+    .map((item) => normalizePid(typeof item === "object" ? item?.pid : item))
+    .filter(Boolean);
+}
+
+function matchesPattern(commandLine, pattern, { exact = false } = {}) {
+  if (pattern instanceof RegExp) return pattern.test(commandLine);
+  const text = String(pattern || "");
+  if (!text) return false;
+  return exact ? commandLine === text : commandLine.includes(text);
+}
+
+function hasExactGbrainServe(commandLine) {
+  return /^("?[^"\s]*bun(?:\.exe)?"?\s+)?gbrain\s+serve$/i.test(
+    commandLine.trim(),
+  );
+}
+
+function hasExactFsmonitorDaemon(commandLine) {
+  return /^("?[^"\s]*git(?:\.exe)?"?\s+)?fsmonitor--daemon\s+run\s+--detach$/i.test(
+    commandLine.trim(),
+  );
+}
+
+function categoryForShardProcess(proc, context) {
+  const name = normalizeName(proc.name);
+  const commandLine = normalizeCommandLine(proc.commandLine);
+  const worktreePath = normalizeCommandLine(context.worktreePath || "");
+  const shardMarker = context.shardName
+    ? `.codex-swarm\\wt-${context.shardName}`
+    : "";
+  const hasWorktree = worktreePath && commandLine.includes(worktreePath);
+  const hasShardMarker = shardMarker && commandLine.includes(shardMarker);
+
+  if (name === "node.exe" || name === "node") {
+    if (hasWorktree || hasShardMarker) return "node";
+  }
+
+  if (name === "bash.exe" || name === "bash" || name === "sh") {
+    if (hasWorktree) return "bash";
+  }
+
+  if (name === "conhost.exe" || name === "conhost") {
+    if (
+      context.sessionIds?.length > 0 &&
+      context.sessionIds.some((id) => id && commandLine.includes(id))
+    ) {
+      return "conhost";
+    }
+  }
+
+  if (name === "bun.exe" || name === "bun") {
+    if (hasExactGbrainServe(proc.commandLine)) return "bun";
+  }
+
+  if (name === "git.exe" || name === "git") {
+    if (hasExactFsmonitorDaemon(proc.commandLine)) return "git";
+  }
+
+  return null;
+}
+
+function killPid(
+  pid,
+  { killFn = process.kill, protectedPids = new Set() } = {},
+) {
+  if (protectedPids.has(pid)) return false;
+  killFn(pid, "SIGKILL");
+  return true;
+}
+
+/**
+ * Return a process tree rooted at `rootPid`.
+ *
+ * Windows queries `Get-CimInstance Win32_Process` once and builds a
+ * ParentProcessId map. POSIX uses `ps` as a best-effort fallback.
+ *
+ * @param {number} rootPid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync}} opts
+ * @returns {Array<{pid: number, ppid: number, name: string, commandLine: string}>}
+ */
+export function findProcessTree(
+  rootPid,
+  { isWindows = IS_WINDOWS, spawnSyncFn = spawnSync } = {},
+) {
+  const pid = normalizePid(rootPid);
+  if (!pid) return [];
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  return collectDescendants(pid, snapshot).map((proc) => ({
+    pid: proc.pid,
+    ppid: proc.ppid,
+    name: proc.name,
+    commandLine: proc.commandLine,
+  }));
+}
+
+/**
+ * Kill a process tree.
+ *
+ * Windows tries `taskkill /T /F /PID <pid>` first. If that fails, it falls
+ * back to a CIM process snapshot and kills descendants recursively. POSIX
+ * first targets the process group, then the PID itself.
+ *
+ * @param {number} pid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{ok: boolean, killed: number, errors: Array}}
+ */
+export function killProcessTree(
+  pid,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids,
+  } = {},
+) {
+  const rootPid = normalizePid(pid);
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+  });
+  const errors = [];
+  if (!rootPid) return { ok: false, killed: 0, errors: ["invalid pid"] };
+  if (protectedSet.has(rootPid)) {
+    return { ok: false, killed: 0, errors: ["protected pid"] };
+  }
+
+  if (isWindows) {
+    const result = runSpawn(spawnSyncFn, "taskkill", [
+      "/T",
+      "/F",
+      "/PID",
+      String(rootPid),
+    ]);
+    if (result.status === 0) return { ok: true, killed: 1, errors };
+    errors.push(String(result.stderr || result.error || "taskkill failed"));
+
+    const tree = findProcessTree(rootPid, { isWindows, spawnSyncFn })
+      .filter((proc) => proc.pid !== rootPid)
+      .reverse();
+    let killed = 0;
+    for (const proc of tree) {
+      if (protectedSet.has(proc.pid) || !isPidAliveFn(proc.pid)) continue;
+      try {
+        killFn(proc.pid, "SIGKILL");
+        killed++;
+      } catch (error) {
+        errors.push({ pid: proc.pid, error: String(error?.message || error) });
+      }
+    }
+    return { ok: killed > 0, killed, errors };
+  }
+
+  let killed = 0;
+  try {
+    killFn(-rootPid, "SIGKILL");
+    killed++;
+  } catch (error) {
+    errors.push({ pid: -rootPid, error: String(error?.message || error) });
+    try {
+      killFn(rootPid, "SIGKILL");
+      killed++;
+    } catch (fallbackError) {
+      errors.push({
+        pid: rootPid,
+        error: String(fallbackError?.message || fallbackError),
+      });
+    }
+  }
+
+  return { ok: killed > 0, killed, errors };
+}
+
+/**
+ * Kill a previously captured PID snapshot with SIGKILL.
+ *
+ * This is used when a parent process has already died and tree lookup can no
+ * longer reconstruct the original descendants.
+ *
+ * @param {Array<number | {pid: number}>} snapshot
+ * @param {{killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, missing: number}}
+ */
+export function killProcessTreeSnapshot(
+  snapshot,
+  {
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids = new Set(),
+  } = {},
+) {
+  let killed = 0;
+  let missing = 0;
+  for (const pid of snapshotPids(snapshot)) {
+    if (protectedPids.has(pid)) continue;
+    if (!isPidAliveFn(pid)) {
+      missing++;
+      continue;
+    }
+    try {
+      killFn(pid, "SIGKILL");
+      killed++;
+    } catch {
+      missing++;
+    }
+  }
+  return { killed, missing };
+}
+
+/**
+ * Find processes whose command line matches any string or RegExp pattern.
+ *
+ * String patterns use substring matching by default; pass `exact: true` for
+ * exact command-line equality.
+ *
+ * @param {Array<RegExp | string>} patterns
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, exact?: boolean, nowMs?: number}} opts
+ * @returns {Array<{pid: number, name: string, commandLine: string, ageMs?: number}>}
+ */
+export function findProcessesByCommandLine(
+  patterns,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    exact = false,
+    nowMs = Date.now(),
+  } = {},
+) {
+  const list = Array.isArray(patterns) ? patterns : [patterns];
+  if (list.length === 0) return [];
+
+  return getProcessSnapshot({ isWindows, spawnSyncFn })
+    .filter((proc) =>
+      list.some((pattern) =>
+        matchesPattern(proc.commandLine, pattern, { exact }),
+      ),
+    )
+    .map((proc) => {
+      const creationMs = parseCreationDateMs(proc.creationDate);
+      const result = {
+        pid: proc.pid,
+        name: proc.name,
+        commandLine: proc.commandLine,
+      };
+      if (Number.isFinite(creationMs)) result.ageMs = nowMs - creationMs;
+      return result;
+    });
+}
+
+/**
+ * Cleanup processes associated with a swarm shard.
+ *
+ * Sequence: kill known top PID snapshots, scan scoped command lines, skip
+ * protected PIDs, and kill only narrowly gated runtime categories.
+ *
+ * @param {{worktreePath?: string, sessionIds?: string[], topPids?: Array<number | {pid: number}>, runId?: string, shardName?: string, dryRun?: boolean, isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, scanned: number, skipped: number, byCategory: {node: number, bash: number, conhost: number, bun: number, git: number}}}
+ */
+export function cleanupShardProcesses({
+  worktreePath,
+  sessionIds = [],
+  topPids = [],
+  runId,
+  shardName,
+  dryRun = false,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+    includeAncestorScan: true,
+  });
+  const byCategory = { node: 0, bash: 0, conhost: 0, bun: 0, git: 0 };
+  let killed = 0;
+  let skipped = 0;
+
+  if (!dryRun && topPids.length > 0) {
+    killed += killProcessTreeSnapshot(topPids, {
+      killFn,
+      protectedPids: protectedSet,
+    }).killed;
+  }
+
+  const scanned = getProcessSnapshot({ isWindows, spawnSyncFn });
+
+  for (const proc of scanned) {
+    const category = categoryForShardProcess(proc, {
+      worktreePath,
+      sessionIds,
+      shardName,
+    });
+    if (!category) continue;
+    byCategory[category]++;
+    if (protectedSet.has(proc.pid)) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) continue;
+    try {
+      if (killPid(proc.pid, { killFn, protectedPids: protectedSet })) killed++;
+    } catch {}
+  }
+
+  return { killed, scanned: scanned.length, skipped, byCategory };
+}
+
+/**
+ * Cleanup narrowly gated orphan runtime processes.
+ *
+ * Windows scans node/bash/bun and optional conhost command lines. POSIX is a
+ * best-effort fallback. `legacy: true` preserves `cleanupOrphanNodeProcesses`
+ * behavior by targeting scoped orphan node runtimes only.
+ *
+ * @param {{legacy?: boolean, includeConhost?: boolean, sessionIds?: string[], isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, remaining: number}}
+ */
+export function cleanupOrphanRuntimeProcesses({
+  legacy = false,
+  includeConhost = false,
+  sessionIds = [],
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  if (!isWindows) return cleanupOrphansUnix();
+
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+  });
+  const processes = getProcessSnapshot({ isWindows, spawnSyncFn });
+  let killed = 0;
+
+  for (const proc of processes) {
+    if (protectedSet.has(proc.pid)) continue;
+    const name = normalizeName(proc.name);
+    const commandLine = normalizeCommandLine(proc.commandLine);
+    let shouldKill = false;
+
+    if (legacy) {
+      shouldKill =
+        name === "node.exe" &&
+        commandLine.includes(".codex-swarm\\wt-") &&
+        /hub\\server\.mjs/i.test(commandLine);
+    } else if (name === "bun.exe") {
+      shouldKill = hasExactGbrainServe(proc.commandLine);
+    } else if (includeConhost && name === "conhost.exe") {
+      shouldKill =
+        sessionIds.length > 0 &&
+        sessionIds.some((id) => id && commandLine.includes(id));
+    }
+
+    if (!shouldKill) continue;
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+    } catch {}
+  }
+
+  const remaining = processes.length - killed;
+  return { killed, remaining };
 }
 
 /**

--- a/hub/lib/process-utils.mjs
+++ b/hub/lib/process-utils.mjs
@@ -24,6 +24,14 @@ const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
 const FSMONITOR_DAEMON_PATTERN =
   /(^|\s)fsmonitor--daemon\s+run\s+--detach(\s|$)/;
 const DEFAULT_FSMONITOR_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const LEGACY_ORPHAN_KILLABLE_NAMES = new Set([
+  "node.exe",
+  "bash.exe",
+  "cmd.exe",
+  "uvx.exe",
+  "codex.exe",
+  "claude.exe",
+]);
 
 /**
  * 주어진 PID의 프로세스가 살아있는지 확인한다.
@@ -307,12 +315,7 @@ function runPowerShellJson(spawnSyncFn, command) {
 function getWindowsProcessSnapshot(spawnSyncFn = spawnSync) {
   const records = runPowerShellJson(
     spawnSyncFn,
-    [
-      "$ErrorActionPreference='SilentlyContinue'",
-      "Get-CimInstance Win32_Process |",
-      "Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate |",
-      "ConvertTo-Json -Compress",
-    ].join("; "),
+    "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate | ConvertTo-Json -Depth 3 -Compress",
   );
   return records.map(processRecordFromCim).filter(Boolean);
 }
@@ -458,6 +461,14 @@ function hasExactFsmonitorDaemon(commandLine) {
   );
 }
 
+function hasGbrainServeCommand(commandLine) {
+  return /(^|\s)gbrain\s+serve(\s|$)/i.test(commandLine.trim());
+}
+
+function hasFsmonitorDaemonCommand(commandLine) {
+  return FSMONITOR_DAEMON_PATTERN.test(commandLine);
+}
+
 function categoryForShardProcess(proc, context) {
   const name = normalizeName(proc.name);
   const commandLine = normalizeCommandLine(proc.commandLine);
@@ -486,11 +497,18 @@ function categoryForShardProcess(proc, context) {
   }
 
   if (name === "bun.exe" || name === "bun") {
-    if (hasExactGbrainServe(proc.commandLine)) return "bun";
+    if ((hasWorktree || hasShardMarker) && hasGbrainServeCommand(commandLine)) {
+      return "bun";
+    }
   }
 
   if (name === "git.exe" || name === "git") {
-    if (hasExactFsmonitorDaemon(proc.commandLine)) return "git";
+    if (
+      (hasWorktree || hasShardMarker) &&
+      hasFsmonitorDaemonCommand(commandLine)
+    ) {
+      return "git";
+    }
   }
 
   return null;
@@ -771,9 +789,13 @@ export function cleanupOrphanRuntimeProcesses({
     protectedPids,
     isWindows,
     spawnSyncFn,
+    includeAncestorScan: legacy,
   });
   const processes = getProcessSnapshot({ isWindows, spawnSyncFn });
   let killed = 0;
+  const procMap = legacy
+    ? new Map(processes.map((proc) => [proc.pid, proc]))
+    : null;
 
   for (const proc of processes) {
     if (protectedSet.has(proc.pid)) continue;
@@ -783,9 +805,8 @@ export function cleanupOrphanRuntimeProcesses({
 
     if (legacy) {
       shouldKill =
-        name === "node.exe" &&
-        commandLine.includes(".codex-swarm\\wt-") &&
-        /hub\\server\.mjs/i.test(commandLine);
+        LEGACY_ORPHAN_KILLABLE_NAMES.has(name) &&
+        !hasLiveAncestorChain(proc.pid, procMap, protectedSet);
     } else if (name === "bun.exe") {
       shouldKill = hasExactGbrainServe(proc.commandLine);
     } else if (includeConhost && name === "conhost.exe") {

--- a/packages/triflux/hub/lib/process-utils.mjs
+++ b/packages/triflux/hub/lib/process-utils.mjs
@@ -455,12 +455,6 @@ function hasExactGbrainServe(commandLine) {
   );
 }
 
-function hasExactFsmonitorDaemon(commandLine) {
-  return /^("?[^"\s]*git(?:\.exe)?"?\s+)?fsmonitor--daemon\s+run\s+--detach$/i.test(
-    commandLine.trim(),
-  );
-}
-
 function hasGbrainServeCommand(commandLine) {
   return /(^|\s)gbrain\s+serve(\s|$)/i.test(commandLine.trim());
 }

--- a/packages/triflux/hub/lib/process-utils.mjs
+++ b/packages/triflux/hub/lib/process-utils.mjs
@@ -1,7 +1,7 @@
 // hub/lib/process-utils.mjs
 // 프로세스 관련 공유 유틸리티
 
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -18,7 +18,7 @@ const SCAN_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "scan-processes.ps1");
 const TREE_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "get-ancestor-tree.ps1");
 
 // 스크립트 버전 — 내용 변경 시 증가하여 캐시된 스크립트를 갱신
-const SCRIPT_VERSION = 3;
+const SCRIPT_VERSION = 4;
 const VERSION_FILE = join(CLEANUP_SCRIPT_DIR, ".version");
 const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
 const FSMONITOR_DAEMON_PATTERN =
@@ -223,126 +223,13 @@ function hasLiveAncestorChain(pid, procMap, protectedPids) {
   return false;
 }
 
-// kill 대상 프로세스 이름 (Windows)
-// codex/claude도 포함: protectedPids + hasLiveAncestorChain이 활성 인스턴스를 보호하므로
-// 고아(부모 dead + 자식 dead)만 kill됨. pwsh.exe는 사용자 인터랙티브 쉘이므로 제외.
-const KILLABLE_NAMES = new Set([
-  "node.exe",
-  "bash.exe",
-  "cmd.exe",
-  "uvx.exe",
-  "codex.exe",
-  "claude.exe",
-]);
-
 /**
- * 고아 프로세스 트리를 정리한다 (node.exe + bash.exe + cmd.exe + uvx.exe).
- * Windows 전용 — Agent 서브프로세스가 MCP 서버, bash 래퍼, cmd 래퍼를 남기는 문제 대응.
- *
- * 전략: 부모 체인을 루트까지 추적하여, 체인 중간에 죽은 프로세스가 있으면
- * 해당 프로세스 아래의 전체 트리를 고아로 판정하고 정리.
- * 스캔 범위에는 codex/claude/pwsh도 포함하여 체인 추적 정확도를 높인다.
- *
- * 보호 대상: 현재 프로세스 조상 트리, Hub PID
+ * Legacy wrapper for scoped orphan node runtime cleanup.
+ * @param {Parameters<typeof cleanupOrphanRuntimeProcesses>[0]} opts
  * @returns {{ killed: number, remaining: number }}
  */
-export function cleanupOrphanNodeProcesses() {
-  if (!IS_WINDOWS) return cleanupOrphansUnix();
-
-  ensureHelperScripts();
-
-  const myPid = process.pid;
-
-  // Hub PID 보호
-  let hubPid = null;
-  try {
-    const hubPidPath = join(
-      homedir(),
-      ".claude",
-      "cache",
-      "tfx-hub",
-      "hub.pid",
-    );
-    if (existsSync(hubPidPath)) {
-      const hubInfo = JSON.parse(readFileSync(hubPidPath, "utf8"));
-      hubPid = Number(hubInfo?.pid);
-    }
-  } catch {}
-
-  // 보호 PID 세트: 현재 프로세스 + Hub + 현재 프로세스의 조상 트리
-  const protectedPids = new Set();
-  protectedPids.add(myPid);
-  if (Number.isFinite(hubPid) && hubPid > 0) protectedPids.add(hubPid);
-
-  try {
-    const treeOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${TREE_SCRIPT_PATH}" -StartPid ${myPid}`,
-      {
-        encoding: "utf8",
-        timeout: 8000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-    for (const line of treeOutput.split(/\r?\n/)) {
-      const pid = Number.parseInt(line.trim(), 10);
-      if (Number.isFinite(pid) && pid > 0) protectedPids.add(pid);
-    }
-  } catch {}
-
-  // 전체 프로세스 맵 구축 (node + bash + cmd + codex + claude + pwsh + uvx)
-  const procMap = new Map();
-  try {
-    const output = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${SCAN_SCRIPT_PATH}"`,
-      {
-        encoding: "utf8",
-        timeout: 15000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-
-    for (const line of output.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      const [pidStr, ppidStr, name] = trimmed.split(",");
-      const pid = Number.parseInt(pidStr, 10);
-      const ppid = Number.parseInt(ppidStr, 10);
-      if (Number.isFinite(pid) && pid > 0) {
-        procMap.set(pid, { ppid, name: name || "unknown" });
-      }
-    }
-  } catch {}
-
-  // 고아 판정 + 정리 (SIGTERM → 3s → SIGKILL 에스컬레이션)
-  // CLI 도구(codex/claude/pwsh)는 체인 추적용으로만 스캔 — kill 대상에서 제외
-  const orphanPids = [];
-  for (const [pid, info] of procMap) {
-    if (protectedPids.has(pid)) continue;
-    if (!KILLABLE_NAMES.has(info.name?.toLowerCase())) continue;
-    if (hasLiveAncestorChain(pid, procMap, protectedPids)) continue;
-    orphanPids.push(pid);
-  }
-
-  const killed = killWithEscalation(orphanPids, procMap);
-
-  // 남은 프로세스 수 확인
-  let remaining = 0;
-  try {
-    const countOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -Command "(Get-Process node -ErrorAction SilentlyContinue).Count"`,
-      {
-        encoding: "utf8",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-    remaining = Number.parseInt(countOutput.trim(), 10) || 0;
-  } catch {}
-
-  return { killed, remaining };
+export function cleanupOrphanNodeProcesses(opts = {}) {
+  return cleanupOrphanRuntimeProcesses({ ...opts, legacy: true });
 }
 
 function normalizePowerShellJson(output) {
@@ -362,6 +249,560 @@ function parseCreationDateMs(value) {
 
   const ms = Date.parse(text);
   return Number.isFinite(ms) ? ms : NaN;
+}
+
+function normalizePid(value) {
+  const pid = Number(value);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function normalizeName(name) {
+  return String(name || "").toLowerCase();
+}
+
+function normalizeCommandLine(commandLine) {
+  return String(commandLine || "").replace(/\//g, "\\");
+}
+
+function processRecordFromCim(record) {
+  const pid = normalizePid(record?.ProcessId ?? record?.pid);
+  if (!pid) return null;
+  const ppid = Number(record?.ParentProcessId ?? record?.ppid ?? 0);
+  return {
+    pid,
+    ppid: Number.isFinite(ppid) ? ppid : 0,
+    name: String(record?.Name ?? record?.name ?? ""),
+    commandLine: String(record?.CommandLine ?? record?.commandLine ?? ""),
+    creationDate: record?.CreationDate,
+  };
+}
+
+function runSpawn(spawnSyncFn, command, args, options = {}) {
+  return spawnSyncFn(command, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+function runPowerShellJson(spawnSyncFn, command) {
+  const result = runSpawn(spawnSyncFn, "powershell", [
+    "-NoProfile",
+    "-WindowStyle",
+    "Hidden",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    command,
+  ]);
+  if (result.status !== 0) {
+    throw new Error(
+      String(result.stderr || result.error || "PowerShell failed"),
+    );
+  }
+  return normalizePowerShellJson(result.stdout);
+}
+
+function getWindowsProcessSnapshot(spawnSyncFn = spawnSync) {
+  const records = runPowerShellJson(
+    spawnSyncFn,
+    [
+      "$ErrorActionPreference='SilentlyContinue'",
+      "Get-CimInstance Win32_Process |",
+      "Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate |",
+      "ConvertTo-Json -Compress",
+    ].join("; "),
+  );
+  return records.map(processRecordFromCim).filter(Boolean);
+}
+
+function parsePosixProcessSnapshot(output) {
+  const processes = [];
+  for (const line of String(output || "")
+    .split(/\r?\n/)
+    .slice(1)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = /^(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/.exec(trimmed);
+    if (!match) continue;
+    processes.push({
+      pid: Number.parseInt(match[1], 10),
+      ppid: Number.parseInt(match[2], 10),
+      name: match[3],
+      commandLine: match[4] || match[3],
+    });
+  }
+  return processes;
+}
+
+function getPosixProcessSnapshot(spawnSyncFn = spawnSync) {
+  const result = runSpawn(spawnSyncFn, "ps", ["-eo", "pid,ppid,comm,args"]);
+  if (result.status !== 0) return [];
+  return parsePosixProcessSnapshot(result.stdout);
+}
+
+function getProcessSnapshot({
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+} = {}) {
+  try {
+    return isWindows
+      ? getWindowsProcessSnapshot(spawnSyncFn)
+      : getPosixProcessSnapshot(spawnSyncFn);
+  } catch {
+    return [];
+  }
+}
+
+function addHubPid(protectedPids) {
+  try {
+    const hubPidPath = join(
+      homedir(),
+      ".claude",
+      "cache",
+      "tfx-hub",
+      "hub.pid",
+    );
+    if (existsSync(hubPidPath)) {
+      const hubInfo = JSON.parse(readFileSync(hubPidPath, "utf8"));
+      const hubPid = normalizePid(hubInfo?.pid);
+      if (hubPid) protectedPids.add(hubPid);
+    }
+  } catch {}
+}
+
+function getProtectedPids({
+  protectedPids,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  includeAncestorScan = false,
+} = {}) {
+  const result = new Set(protectedPids || []);
+  result.add(process.pid);
+  if (Number.isInteger(process.ppid) && process.ppid > 0) {
+    result.add(process.ppid);
+  }
+  addHubPid(result);
+  if (!includeAncestorScan) return result;
+
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  const byPid = new Map(snapshot.map((proc) => [proc.pid, proc]));
+  let current = process.pid;
+  const seen = new Set();
+  while (current > 0 && !seen.has(current)) {
+    seen.add(current);
+    result.add(current);
+    const parent = byPid.get(current)?.ppid;
+    if (!Number.isInteger(parent) || parent <= 0) break;
+    current = parent;
+  }
+
+  return result;
+}
+
+function collectDescendants(rootPid, processes) {
+  const childrenByParent = new Map();
+  for (const proc of processes) {
+    if (!childrenByParent.has(proc.ppid)) childrenByParent.set(proc.ppid, []);
+    childrenByParent.get(proc.ppid).push(proc);
+  }
+
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const root = byPid.get(rootPid) || {
+    pid: rootPid,
+    ppid: 0,
+    name: "",
+    commandLine: "",
+  };
+  const result = [];
+  const queue = [root];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const proc = queue.shift();
+    if (!proc || seen.has(proc.pid)) continue;
+    seen.add(proc.pid);
+    result.push(proc);
+    for (const child of childrenByParent.get(proc.pid) || []) {
+      queue.push(child);
+    }
+  }
+
+  return result;
+}
+
+function snapshotPids(snapshot) {
+  const values = Array.isArray(snapshot) ? snapshot : [snapshot];
+  return values
+    .map((item) => normalizePid(typeof item === "object" ? item?.pid : item))
+    .filter(Boolean);
+}
+
+function matchesPattern(commandLine, pattern, { exact = false } = {}) {
+  if (pattern instanceof RegExp) return pattern.test(commandLine);
+  const text = String(pattern || "");
+  if (!text) return false;
+  return exact ? commandLine === text : commandLine.includes(text);
+}
+
+function hasExactGbrainServe(commandLine) {
+  return /^("?[^"\s]*bun(?:\.exe)?"?\s+)?gbrain\s+serve$/i.test(
+    commandLine.trim(),
+  );
+}
+
+function hasExactFsmonitorDaemon(commandLine) {
+  return /^("?[^"\s]*git(?:\.exe)?"?\s+)?fsmonitor--daemon\s+run\s+--detach$/i.test(
+    commandLine.trim(),
+  );
+}
+
+function categoryForShardProcess(proc, context) {
+  const name = normalizeName(proc.name);
+  const commandLine = normalizeCommandLine(proc.commandLine);
+  const worktreePath = normalizeCommandLine(context.worktreePath || "");
+  const shardMarker = context.shardName
+    ? `.codex-swarm\\wt-${context.shardName}`
+    : "";
+  const hasWorktree = worktreePath && commandLine.includes(worktreePath);
+  const hasShardMarker = shardMarker && commandLine.includes(shardMarker);
+
+  if (name === "node.exe" || name === "node") {
+    if (hasWorktree || hasShardMarker) return "node";
+  }
+
+  if (name === "bash.exe" || name === "bash" || name === "sh") {
+    if (hasWorktree) return "bash";
+  }
+
+  if (name === "conhost.exe" || name === "conhost") {
+    if (
+      context.sessionIds?.length > 0 &&
+      context.sessionIds.some((id) => id && commandLine.includes(id))
+    ) {
+      return "conhost";
+    }
+  }
+
+  if (name === "bun.exe" || name === "bun") {
+    if (hasExactGbrainServe(proc.commandLine)) return "bun";
+  }
+
+  if (name === "git.exe" || name === "git") {
+    if (hasExactFsmonitorDaemon(proc.commandLine)) return "git";
+  }
+
+  return null;
+}
+
+function killPid(
+  pid,
+  { killFn = process.kill, protectedPids = new Set() } = {},
+) {
+  if (protectedPids.has(pid)) return false;
+  killFn(pid, "SIGKILL");
+  return true;
+}
+
+/**
+ * Return a process tree rooted at `rootPid`.
+ *
+ * Windows queries `Get-CimInstance Win32_Process` once and builds a
+ * ParentProcessId map. POSIX uses `ps` as a best-effort fallback.
+ *
+ * @param {number} rootPid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync}} opts
+ * @returns {Array<{pid: number, ppid: number, name: string, commandLine: string}>}
+ */
+export function findProcessTree(
+  rootPid,
+  { isWindows = IS_WINDOWS, spawnSyncFn = spawnSync } = {},
+) {
+  const pid = normalizePid(rootPid);
+  if (!pid) return [];
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  return collectDescendants(pid, snapshot).map((proc) => ({
+    pid: proc.pid,
+    ppid: proc.ppid,
+    name: proc.name,
+    commandLine: proc.commandLine,
+  }));
+}
+
+/**
+ * Kill a process tree.
+ *
+ * Windows tries `taskkill /T /F /PID <pid>` first. If that fails, it falls
+ * back to a CIM process snapshot and kills descendants recursively. POSIX
+ * first targets the process group, then the PID itself.
+ *
+ * @param {number} pid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{ok: boolean, killed: number, errors: Array}}
+ */
+export function killProcessTree(
+  pid,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids,
+  } = {},
+) {
+  const rootPid = normalizePid(pid);
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+  });
+  const errors = [];
+  if (!rootPid) return { ok: false, killed: 0, errors: ["invalid pid"] };
+  if (protectedSet.has(rootPid)) {
+    return { ok: false, killed: 0, errors: ["protected pid"] };
+  }
+
+  if (isWindows) {
+    const result = runSpawn(spawnSyncFn, "taskkill", [
+      "/T",
+      "/F",
+      "/PID",
+      String(rootPid),
+    ]);
+    if (result.status === 0) return { ok: true, killed: 1, errors };
+    errors.push(String(result.stderr || result.error || "taskkill failed"));
+
+    const tree = findProcessTree(rootPid, { isWindows, spawnSyncFn })
+      .filter((proc) => proc.pid !== rootPid)
+      .reverse();
+    let killed = 0;
+    for (const proc of tree) {
+      if (protectedSet.has(proc.pid) || !isPidAliveFn(proc.pid)) continue;
+      try {
+        killFn(proc.pid, "SIGKILL");
+        killed++;
+      } catch (error) {
+        errors.push({ pid: proc.pid, error: String(error?.message || error) });
+      }
+    }
+    return { ok: killed > 0, killed, errors };
+  }
+
+  let killed = 0;
+  try {
+    killFn(-rootPid, "SIGKILL");
+    killed++;
+  } catch (error) {
+    errors.push({ pid: -rootPid, error: String(error?.message || error) });
+    try {
+      killFn(rootPid, "SIGKILL");
+      killed++;
+    } catch (fallbackError) {
+      errors.push({
+        pid: rootPid,
+        error: String(fallbackError?.message || fallbackError),
+      });
+    }
+  }
+
+  return { ok: killed > 0, killed, errors };
+}
+
+/**
+ * Kill a previously captured PID snapshot with SIGKILL.
+ *
+ * This is used when a parent process has already died and tree lookup can no
+ * longer reconstruct the original descendants.
+ *
+ * @param {Array<number | {pid: number}>} snapshot
+ * @param {{killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, missing: number}}
+ */
+export function killProcessTreeSnapshot(
+  snapshot,
+  {
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids = new Set(),
+  } = {},
+) {
+  let killed = 0;
+  let missing = 0;
+  for (const pid of snapshotPids(snapshot)) {
+    if (protectedPids.has(pid)) continue;
+    if (!isPidAliveFn(pid)) {
+      missing++;
+      continue;
+    }
+    try {
+      killFn(pid, "SIGKILL");
+      killed++;
+    } catch {
+      missing++;
+    }
+  }
+  return { killed, missing };
+}
+
+/**
+ * Find processes whose command line matches any string or RegExp pattern.
+ *
+ * String patterns use substring matching by default; pass `exact: true` for
+ * exact command-line equality.
+ *
+ * @param {Array<RegExp | string>} patterns
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, exact?: boolean, nowMs?: number}} opts
+ * @returns {Array<{pid: number, name: string, commandLine: string, ageMs?: number}>}
+ */
+export function findProcessesByCommandLine(
+  patterns,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    exact = false,
+    nowMs = Date.now(),
+  } = {},
+) {
+  const list = Array.isArray(patterns) ? patterns : [patterns];
+  if (list.length === 0) return [];
+
+  return getProcessSnapshot({ isWindows, spawnSyncFn })
+    .filter((proc) =>
+      list.some((pattern) =>
+        matchesPattern(proc.commandLine, pattern, { exact }),
+      ),
+    )
+    .map((proc) => {
+      const creationMs = parseCreationDateMs(proc.creationDate);
+      const result = {
+        pid: proc.pid,
+        name: proc.name,
+        commandLine: proc.commandLine,
+      };
+      if (Number.isFinite(creationMs)) result.ageMs = nowMs - creationMs;
+      return result;
+    });
+}
+
+/**
+ * Cleanup processes associated with a swarm shard.
+ *
+ * Sequence: kill known top PID snapshots, scan scoped command lines, skip
+ * protected PIDs, and kill only narrowly gated runtime categories.
+ *
+ * @param {{worktreePath?: string, sessionIds?: string[], topPids?: Array<number | {pid: number}>, runId?: string, shardName?: string, dryRun?: boolean, isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, scanned: number, skipped: number, byCategory: {node: number, bash: number, conhost: number, bun: number, git: number}}}
+ */
+export function cleanupShardProcesses({
+  worktreePath,
+  sessionIds = [],
+  topPids = [],
+  runId,
+  shardName,
+  dryRun = false,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+    includeAncestorScan: true,
+  });
+  const byCategory = { node: 0, bash: 0, conhost: 0, bun: 0, git: 0 };
+  let killed = 0;
+  let skipped = 0;
+
+  if (!dryRun && topPids.length > 0) {
+    killed += killProcessTreeSnapshot(topPids, {
+      killFn,
+      protectedPids: protectedSet,
+    }).killed;
+  }
+
+  const scanned = getProcessSnapshot({ isWindows, spawnSyncFn });
+
+  for (const proc of scanned) {
+    const category = categoryForShardProcess(proc, {
+      worktreePath,
+      sessionIds,
+      shardName,
+    });
+    if (!category) continue;
+    byCategory[category]++;
+    if (protectedSet.has(proc.pid)) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) continue;
+    try {
+      if (killPid(proc.pid, { killFn, protectedPids: protectedSet })) killed++;
+    } catch {}
+  }
+
+  return { killed, scanned: scanned.length, skipped, byCategory };
+}
+
+/**
+ * Cleanup narrowly gated orphan runtime processes.
+ *
+ * Windows scans node/bash/bun and optional conhost command lines. POSIX is a
+ * best-effort fallback. `legacy: true` preserves `cleanupOrphanNodeProcesses`
+ * behavior by targeting scoped orphan node runtimes only.
+ *
+ * @param {{legacy?: boolean, includeConhost?: boolean, sessionIds?: string[], isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, remaining: number}}
+ */
+export function cleanupOrphanRuntimeProcesses({
+  legacy = false,
+  includeConhost = false,
+  sessionIds = [],
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  if (!isWindows) return cleanupOrphansUnix();
+
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+  });
+  const processes = getProcessSnapshot({ isWindows, spawnSyncFn });
+  let killed = 0;
+
+  for (const proc of processes) {
+    if (protectedSet.has(proc.pid)) continue;
+    const name = normalizeName(proc.name);
+    const commandLine = normalizeCommandLine(proc.commandLine);
+    let shouldKill = false;
+
+    if (legacy) {
+      shouldKill =
+        name === "node.exe" &&
+        commandLine.includes(".codex-swarm\\wt-") &&
+        /hub\\server\.mjs/i.test(commandLine);
+    } else if (name === "bun.exe") {
+      shouldKill = hasExactGbrainServe(proc.commandLine);
+    } else if (includeConhost && name === "conhost.exe") {
+      shouldKill =
+        sessionIds.length > 0 &&
+        sessionIds.some((id) => id && commandLine.includes(id));
+    }
+
+    if (!shouldKill) continue;
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+    } catch {}
+  }
+
+  const remaining = processes.length - killed;
+  return { killed, remaining };
 }
 
 /**

--- a/packages/triflux/hub/lib/process-utils.mjs
+++ b/packages/triflux/hub/lib/process-utils.mjs
@@ -24,6 +24,14 @@ const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
 const FSMONITOR_DAEMON_PATTERN =
   /(^|\s)fsmonitor--daemon\s+run\s+--detach(\s|$)/;
 const DEFAULT_FSMONITOR_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const LEGACY_ORPHAN_KILLABLE_NAMES = new Set([
+  "node.exe",
+  "bash.exe",
+  "cmd.exe",
+  "uvx.exe",
+  "codex.exe",
+  "claude.exe",
+]);
 
 /**
  * 주어진 PID의 프로세스가 살아있는지 확인한다.
@@ -307,12 +315,7 @@ function runPowerShellJson(spawnSyncFn, command) {
 function getWindowsProcessSnapshot(spawnSyncFn = spawnSync) {
   const records = runPowerShellJson(
     spawnSyncFn,
-    [
-      "$ErrorActionPreference='SilentlyContinue'",
-      "Get-CimInstance Win32_Process |",
-      "Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate |",
-      "ConvertTo-Json -Compress",
-    ].join("; "),
+    "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate | ConvertTo-Json -Depth 3 -Compress",
   );
   return records.map(processRecordFromCim).filter(Boolean);
 }
@@ -458,6 +461,14 @@ function hasExactFsmonitorDaemon(commandLine) {
   );
 }
 
+function hasGbrainServeCommand(commandLine) {
+  return /(^|\s)gbrain\s+serve(\s|$)/i.test(commandLine.trim());
+}
+
+function hasFsmonitorDaemonCommand(commandLine) {
+  return FSMONITOR_DAEMON_PATTERN.test(commandLine);
+}
+
 function categoryForShardProcess(proc, context) {
   const name = normalizeName(proc.name);
   const commandLine = normalizeCommandLine(proc.commandLine);
@@ -486,11 +497,18 @@ function categoryForShardProcess(proc, context) {
   }
 
   if (name === "bun.exe" || name === "bun") {
-    if (hasExactGbrainServe(proc.commandLine)) return "bun";
+    if ((hasWorktree || hasShardMarker) && hasGbrainServeCommand(commandLine)) {
+      return "bun";
+    }
   }
 
   if (name === "git.exe" || name === "git") {
-    if (hasExactFsmonitorDaemon(proc.commandLine)) return "git";
+    if (
+      (hasWorktree || hasShardMarker) &&
+      hasFsmonitorDaemonCommand(commandLine)
+    ) {
+      return "git";
+    }
   }
 
   return null;
@@ -771,9 +789,13 @@ export function cleanupOrphanRuntimeProcesses({
     protectedPids,
     isWindows,
     spawnSyncFn,
+    includeAncestorScan: legacy,
   });
   const processes = getProcessSnapshot({ isWindows, spawnSyncFn });
   let killed = 0;
+  const procMap = legacy
+    ? new Map(processes.map((proc) => [proc.pid, proc]))
+    : null;
 
   for (const proc of processes) {
     if (protectedSet.has(proc.pid)) continue;
@@ -783,9 +805,8 @@ export function cleanupOrphanRuntimeProcesses({
 
     if (legacy) {
       shouldKill =
-        name === "node.exe" &&
-        commandLine.includes(".codex-swarm\\wt-") &&
-        /hub\\server\.mjs/i.test(commandLine);
+        LEGACY_ORPHAN_KILLABLE_NAMES.has(name) &&
+        !hasLiveAncestorChain(proc.pid, procMap, protectedSet);
     } else if (name === "bun.exe") {
       shouldKill = hasExactGbrainServe(proc.commandLine);
     } else if (includeConhost && name === "conhost.exe") {

--- a/tests/unit/process-utils.test.mjs
+++ b/tests/unit/process-utils.test.mjs
@@ -32,6 +32,14 @@ function mockSpawnSync({ processRecords = [], failTaskkill = false } = {}) {
       };
     }
     if (command === "powershell") {
+      const psCommand = args.at(-1) || "";
+      if (psCommand.includes("|;")) {
+        return {
+          status: 1,
+          stdout: "",
+          stderr: "An empty pipe element is not allowed.",
+        };
+      }
       return {
         status: 0,
         stdout: psJson(processRecords),
@@ -80,6 +88,19 @@ const SWARM_PROCS = [
     ParentProcessId: 1,
     Name: "git.exe",
     CommandLine: "git fsmonitor--daemon run --detach",
+  },
+  {
+    ProcessId: 316,
+    ParentProcessId: 1,
+    Name: "bun.exe",
+    CommandLine: "bun gbrain serve C:\\repo\\.codex-swarm\\wt-alpha",
+  },
+  {
+    ProcessId: 317,
+    ParentProcessId: 1,
+    Name: "git.exe",
+    CommandLine:
+      "git -C C:\\repo\\.codex-swarm\\wt-alpha fsmonitor--daemon run --detach",
   },
 ];
 
@@ -304,7 +325,7 @@ describe("process tree cleanup helpers", () => {
 
     assert.deepEqual(
       result.map((p) => p.pid),
-      [310, 311, 314],
+      [310, 311, 314, 316, 317],
     );
   });
 
@@ -330,6 +351,8 @@ describe("process tree cleanup helpers", () => {
     assert.equal(result.byCategory.bun, 1);
     assert.equal(result.byCategory.git, 1);
     assert.ok(killed.every(([pid]) => pid !== 312));
+    assert.ok(killed.every(([pid]) => pid !== 314));
+    assert.ok(killed.every(([pid]) => pid !== 315));
   });
 
   it("cleanupShardProcesses skips protected PIDs", () => {
@@ -370,6 +393,74 @@ describe("process tree cleanup helpers", () => {
     assert.deepEqual(killed, []);
   });
 
+  it("legacy cleanupOrphanNodeProcesses uses ancestor-chain orphan scope", () => {
+    const killed = [];
+    const result = cleanupOrphanNodeProcesses({
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({
+        processRecords: [
+          {
+            ProcessId: 410,
+            ParentProcessId: 999991,
+            Name: "node.exe",
+            CommandLine: "node C:\\tmp\\mcp-server.js",
+          },
+          {
+            ProcessId: 411,
+            ParentProcessId: 999992,
+            Name: "bash.exe",
+            CommandLine: "bash -lc worker",
+          },
+          {
+            ProcessId: 412,
+            ParentProcessId: 999993,
+            Name: "cmd.exe",
+            CommandLine: "cmd.exe /c worker",
+          },
+          {
+            ProcessId: 413,
+            ParentProcessId: 999994,
+            Name: "uvx.exe",
+            CommandLine: "uvx mcp-server",
+          },
+          {
+            ProcessId: 414,
+            ParentProcessId: 999995,
+            Name: "codex.exe",
+            CommandLine: "codex exec",
+          },
+          {
+            ProcessId: 415,
+            ParentProcessId: 999996,
+            Name: "claude.exe",
+            CommandLine: "claude --mcp",
+          },
+          {
+            ProcessId: 416,
+            ParentProcessId: 417,
+            Name: "node.exe",
+            CommandLine: "node live-child.js",
+          },
+          {
+            ProcessId: 417,
+            ParentProcessId: process.pid,
+            Name: "pwsh.exe",
+            CommandLine: "pwsh",
+          },
+        ],
+      }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.killed, 6);
+    assert.deepEqual(
+      killed.map(([pid]) => pid),
+      [410, 411, 412, 413, 414, 415],
+    );
+    assert.ok(killed.every(([, signal]) => signal === "SIGKILL"));
+  });
+
   it("cleanupOrphanRuntimeProcesses includes bun.exe", () => {
     const killed = [];
     const result = cleanupOrphanRuntimeProcesses({
@@ -392,7 +483,11 @@ describe("process tree cleanup helpers", () => {
       protectedPids: new Set(),
     });
 
-    assert.equal(result.killed, 1);
-    assert.deepEqual(killed, [[310, "SIGKILL"]]);
+    assert.equal(result.killed, 3);
+    assert.deepEqual(killed, [
+      [310, "SIGKILL"],
+      [311, "SIGKILL"],
+      [312, "SIGKILL"],
+    ]);
   });
 });

--- a/tests/unit/process-utils.test.mjs
+++ b/tests/unit/process-utils.test.mjs
@@ -2,8 +2,15 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  cleanupOrphanNodeProcesses,
+  cleanupOrphanRuntimeProcesses,
+  cleanupShardProcesses,
   cleanupStaleFsmonitorDaemons,
   findFsmonitorDaemons,
+  findProcessesByCommandLine,
+  findProcessTree,
+  killProcessTree,
+  killProcessTreeSnapshot,
 } from "../../hub/lib/process-utils.mjs";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -12,6 +19,69 @@ const NOW_MS = Date.parse("2026-04-26T00:00:00.000Z");
 function psJson(records) {
   return JSON.stringify(records);
 }
+
+function mockSpawnSync({ processRecords = [], failTaskkill = false } = {}) {
+  const calls = [];
+  const fn = (command, args = []) => {
+    calls.push({ command, args });
+    if (command === "taskkill") {
+      return {
+        status: failTaskkill ? 1 : 0,
+        stdout: "",
+        stderr: failTaskkill ? "not found" : "",
+      };
+    }
+    if (command === "powershell") {
+      return {
+        status: 0,
+        stdout: psJson(processRecords),
+        stderr: "",
+      };
+    }
+    return { status: 0, stdout: "", stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const SWARM_PROCS = [
+  {
+    ProcessId: 310,
+    ParentProcessId: 1,
+    Name: "node.exe",
+    CommandLine: "node C:\\repo\\.codex-swarm\\wt-alpha\\hub\\server.mjs",
+  },
+  {
+    ProcessId: 311,
+    ParentProcessId: 310,
+    Name: "bash.exe",
+    CommandLine: "bash -lc cd C:\\repo\\.codex-swarm\\wt-alpha",
+  },
+  {
+    ProcessId: 312,
+    ParentProcessId: 1,
+    Name: "node.exe",
+    CommandLine: "node C:\\other\\hub\\server.mjs",
+  },
+  {
+    ProcessId: 313,
+    ParentProcessId: 1,
+    Name: "conhost.exe",
+    CommandLine: "conhost.exe psmux session-1",
+  },
+  {
+    ProcessId: 314,
+    ParentProcessId: 1,
+    Name: "bun.exe",
+    CommandLine: "bun gbrain serve",
+  },
+  {
+    ProcessId: 315,
+    ParentProcessId: 1,
+    Name: "git.exe",
+    CommandLine: "git fsmonitor--daemon run --detach",
+  },
+];
 
 describe("findFsmonitorDaemons", () => {
   it("returns [] on non-Windows platforms", () => {
@@ -107,5 +177,222 @@ describe("cleanupStaleFsmonitorDaemons", () => {
     assert.equal(result.killed, 1);
     assert.equal(result.stale.length, 1);
     assert.deepEqual(kills, [[201, "SIGKILL"]]);
+  });
+});
+
+describe("process tree cleanup helpers", () => {
+  it("killProcessTree returns ok=true on success", () => {
+    const spawnSyncFn = mockSpawnSync();
+    const result = killProcessTree(1234, {
+      isWindows: true,
+      spawnSyncFn,
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.killed, 1);
+    assert.deepEqual(result.errors, []);
+    assert.equal(spawnSyncFn.calls[0].command, "taskkill");
+    assert.deepEqual(spawnSyncFn.calls[0].args, ["/T", "/F", "/PID", "1234"]);
+  });
+
+  it("killProcessTree falls back to Get-CimInstance when parent dead", () => {
+    const spawnSyncFn = mockSpawnSync({
+      failTaskkill: true,
+      processRecords: [
+        {
+          ProcessId: 200,
+          ParentProcessId: 1,
+          Name: "node.exe",
+          CommandLine: "node parent.js",
+        },
+        {
+          ProcessId: 201,
+          ParentProcessId: 200,
+          Name: "node.exe",
+          CommandLine: "node child.js",
+        },
+        {
+          ProcessId: 202,
+          ParentProcessId: 201,
+          Name: "bash.exe",
+          CommandLine: "bash worker.sh",
+        },
+      ],
+    });
+    const killed = [];
+
+    const result = killProcessTree(200, {
+      isWindows: true,
+      spawnSyncFn,
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      isPidAliveFn: (pid) => pid !== 200,
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.killed, 2);
+    assert.deepEqual(killed, [
+      [202, "SIGKILL"],
+      [201, "SIGKILL"],
+    ]);
+    assert.equal(spawnSyncFn.calls[1].command, "powershell");
+  });
+
+  it("findProcessTree builds descendant map", () => {
+    const result = findProcessTree(10, {
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({
+        processRecords: [
+          {
+            ProcessId: 10,
+            ParentProcessId: 1,
+            Name: "node.exe",
+            CommandLine: "node root.js",
+          },
+          {
+            ProcessId: 11,
+            ParentProcessId: 10,
+            Name: "bash.exe",
+            CommandLine: "bash child.sh",
+          },
+          {
+            ProcessId: 12,
+            ParentProcessId: 11,
+            Name: "node.exe",
+            CommandLine: "node grandchild.js",
+          },
+          {
+            ProcessId: 99,
+            ParentProcessId: 1,
+            Name: "node.exe",
+            CommandLine: "node unrelated.js",
+          },
+        ],
+      }),
+    });
+
+    assert.deepEqual(
+      result.map((p) => p.pid),
+      [10, 11, 12],
+    );
+    assert.equal(result[2].ppid, 11);
+    assert.equal(result[2].name, "node.exe");
+  });
+
+  it("killProcessTreeSnapshot tolerates missing PIDs", () => {
+    const killed = [];
+    const result = killProcessTreeSnapshot([301, { pid: 302 }, 303], {
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      isPidAliveFn: (pid) => pid !== 302,
+      protectedPids: new Set(),
+    });
+
+    assert.deepEqual(killed, [
+      [301, "SIGKILL"],
+      [303, "SIGKILL"],
+    ]);
+    assert.equal(result.killed, 2);
+    assert.equal(result.missing, 1);
+  });
+
+  it("findProcessesByCommandLine matches substring patterns", () => {
+    const result = findProcessesByCommandLine(["wt-alpha", /gbrain serve/], {
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+    });
+
+    assert.deepEqual(
+      result.map((p) => p.pid),
+      [310, 311, 314],
+    );
+  });
+
+  it("cleanupShardProcesses scopes by worktreePath", () => {
+    const killed = [];
+    const result = cleanupShardProcesses({
+      worktreePath: "C:\\repo\\.codex-swarm\\wt-alpha",
+      sessionIds: ["session-1"],
+      topPids: [],
+      runId: "run-1",
+      shardName: "alpha",
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.scanned, SWARM_PROCS.length);
+    assert.equal(result.killed, 5);
+    assert.equal(result.byCategory.node, 1);
+    assert.equal(result.byCategory.bash, 1);
+    assert.equal(result.byCategory.conhost, 1);
+    assert.equal(result.byCategory.bun, 1);
+    assert.equal(result.byCategory.git, 1);
+    assert.ok(killed.every(([pid]) => pid !== 312));
+  });
+
+  it("cleanupShardProcesses skips protected PIDs", () => {
+    const killed = [];
+    const result = cleanupShardProcesses({
+      worktreePath: "C:\\repo\\.codex-swarm\\wt-alpha",
+      sessionIds: ["session-1"],
+      topPids: [],
+      runId: "run-1",
+      shardName: "alpha",
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set([310]),
+    });
+
+    assert.equal(result.skipped, 1);
+    assert.ok(killed.every(([pid]) => pid !== 310));
+  });
+
+  it("cleanupShardProcesses dryRun=true kills nothing", () => {
+    const killed = [];
+    const result = cleanupShardProcesses({
+      worktreePath: "C:\\repo\\.codex-swarm\\wt-alpha",
+      sessionIds: ["session-1"],
+      topPids: [],
+      runId: "run-1",
+      shardName: "alpha",
+      dryRun: true,
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.killed, 0);
+    assert.equal(result.byCategory.bun, 1);
+    assert.deepEqual(killed, []);
+  });
+
+  it("cleanupOrphanRuntimeProcesses includes bun.exe", () => {
+    const killed = [];
+    const result = cleanupOrphanRuntimeProcesses({
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.killed, 1);
+    assert.deepEqual(killed, [[314, "SIGKILL"]]);
+  });
+
+  it("legacy cleanupOrphanNodeProcesses wrapper still works", () => {
+    const killed = [];
+    const result = cleanupOrphanNodeProcesses({
+      isWindows: true,
+      spawnSyncFn: mockSpawnSync({ processRecords: SWARM_PROCS }),
+      killFn: (pid, signal) => killed.push([pid, signal]),
+      protectedPids: new Set(),
+    });
+
+    assert.equal(result.killed, 1);
+    assert.deepEqual(killed, [[310, "SIGKILL"]]);
   });
 });


### PR DESCRIPTION
## Summary
- swarm worker process tree cleanup의 Phase 1 — helper 함수 6개 추가
- `killProcessTree`, `findProcessTree`, `killProcessTreeSnapshot`, `findProcessesByCommandLine`, `cleanupShardProcesses`, `cleanupOrphanRuntimeProcesses` 신규 export
- 기존 `cleanupOrphanNodeProcesses`는 wrapper로 유지 (회귀 없음)
- Mirror sync 자동 적용 (root + `packages/triflux/`)

## Background
- Codex 분석: `.omc/artifacts/codex-swarm-worker-cleanup-analysis.md` 권고 D 조합
- fsmonitor PR #200 follow-up. swarm 1회당 ~50 node + ~40 bash + ~25 conhost spawn 누수 family
- 전체 PRD: `.triflux/plans/2026-04-26-swarm-process-tree-cleanup.md`
- Phase 1 PRD: `.triflux/plans/2026-04-26-swarm-process-tree-cleanup-phase1.md`
- Phase 2 (conductor / hypervisor / psmux 변경)는 P1 머지 후 별도 PR

## Test plan
- [x] tests/unit/process-utils.test.mjs 신규 케이스 10개 PASS
- [x] 전체 테스트 회귀 0 (3210 pass / 0 fail / 4 skipped)
- [x] biome lint clean (570 files, no fixes)

## Notes
- Phase 1은 helper 정의만, 호출 사용 없음 → 단독 머지 안전
- Windows 우선, POSIX best-effort fallback
- protected PIDs (current process + ancestors, hub.pid, live main hub PID) skip 보장