### PR TITLE
fix(hub): keepalive uses PID-file URL resolution

### DIFF
--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -35,10 +35,10 @@ import {
 } from "./worktree-lifecycle.mjs";
 
 let ensureHubAliveFn = null;
+let getHubInfoFn = null;
 try {
-  ({ ensureHubAlive: ensureHubAliveFn } = await import(
-    "./cli/services/hub-client.mjs"
-  ));
+  ({ ensureHubAlive: ensureHubAliveFn, getHubInfo: getHubInfoFn } =
+    await import("./cli/services/hub-client.mjs"));
 } catch {
   // hub-client 미설치 환경 — Hub 수동 관리 필요
 }
@@ -120,6 +120,35 @@ function createSharedRegistry(factory) {
   }
 }
 
+function hasOwnDep(deps, key) {
+  return Object.hasOwn(deps, key);
+}
+
+function formatHubHostForUrl(host) {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+function resolveHubStatusUrl(hub) {
+  if (!hub) return null;
+
+  if (typeof hub.url === "string" && hub.url.trim()) {
+    try {
+      const url = new URL(hub.url);
+      url.pathname = "/status";
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  const host = typeof hub.host === "string" ? hub.host.trim() : "";
+  const port = Number(hub.port);
+  if (!host || !Number.isFinite(port) || port <= 0) return null;
+  return `http://${formatHubHostForUrl(host)}:${port}/status`;
+}
+
 /**
  * Create a swarm hypervisor.
  * @param {object} opts
@@ -166,6 +195,12 @@ export function createSwarmHypervisor(opts) {
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
+  const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
+    ? _deps.ensureHubAlive
+    : ensureHubAliveFn;
+  const getHubInfoImpl = hasOwnDep(_deps, "getHubInfo")
+    ? _deps.getHubInfo
+    : getHubInfoFn;
   const emitter = new EventEmitter();
   const eventLog = createEventLog(join(logsDir, "swarm-events.jsonl"));
   const { registry: sharedRegistry, fallbackReason: meshRegistryFallback } =
@@ -1301,19 +1336,33 @@ export function createSwarmHypervisor(opts) {
     hubKeepaliveTimer = setInterval(
       async () => {
         try {
-          const resp = await fetch("http://127.0.0.1:27888/status");
-          if (!resp.ok && ensureHubAliveFn) {
+          const hub = getHubInfoImpl ? await getHubInfoImpl() : null;
+          const statusUrl = resolveHubStatusUrl(hub);
+          if (!statusUrl) {
+            if (ensureHubAliveImpl) {
+              eventLog.append("hub_keepalive_restart", {
+                reason: "hub_url_unresolved",
+              });
+              await ensureHubAliveImpl();
+            }
+            return;
+          }
+
+          const resp = await fetch(statusUrl, {
+            signal: AbortSignal.timeout(5000),
+          });
+          if (!resp.ok && ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {});
-            await ensureHubAliveFn();
+            await ensureHubAliveImpl();
           }
         } catch {
           // Hub 다운 — 재시작 시도
-          if (ensureHubAliveFn) {
+          if (ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {
               reason: "fetch_failed",
             });
             try {
-              await ensureHubAliveFn();
+              await ensureHubAliveImpl();
             } catch {
               eventLog.append("hub_restart_failed", {});
             }
@@ -1340,8 +1389,8 @@ export function createSwarmHypervisor(opts) {
     markIntegrationPromisePending();
 
     // Hub alive 확인 — 죽어있으면 재시작
-    if (ensureHubAliveFn) {
-      ensureHubAliveFn()
+    if (ensureHubAliveImpl) {
+      ensureHubAliveImpl()
         .then((hub) => {
           eventLog.append("hub_ensured", { port: hub?.port });
         })

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -35,10 +35,10 @@ import {
 } from "./worktree-lifecycle.mjs";
 
 let ensureHubAliveFn = null;
+let getHubInfoFn = null;
 try {
-  ({ ensureHubAlive: ensureHubAliveFn } = await import(
-    "./cli/services/hub-client.mjs"
-  ));
+  ({ ensureHubAlive: ensureHubAliveFn, getHubInfo: getHubInfoFn } =
+    await import("./cli/services/hub-client.mjs"));
 } catch {
   // hub-client 미설치 환경 — Hub 수동 관리 필요
 }
@@ -120,6 +120,35 @@ function createSharedRegistry(factory) {
   }
 }
 
+function hasOwnDep(deps, key) {
+  return Object.hasOwn(deps, key);
+}
+
+function formatHubHostForUrl(host) {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+function resolveHubStatusUrl(hub) {
+  if (!hub) return null;
+
+  if (typeof hub.url === "string" && hub.url.trim()) {
+    try {
+      const url = new URL(hub.url);
+      url.pathname = "/status";
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  const host = typeof hub.host === "string" ? hub.host.trim() : "";
+  const port = Number(hub.port);
+  if (!host || !Number.isFinite(port) || port <= 0) return null;
+  return `http://${formatHubHostForUrl(host)}:${port}/status`;
+}
+
 /**
  * Create a swarm hypervisor.
  * @param {object} opts
@@ -166,6 +195,12 @@ export function createSwarmHypervisor(opts) {
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
+  const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
+    ? _deps.ensureHubAlive
+    : ensureHubAliveFn;
+  const getHubInfoImpl = hasOwnDep(_deps, "getHubInfo")
+    ? _deps.getHubInfo
+    : getHubInfoFn;
   const emitter = new EventEmitter();
   const eventLog = createEventLog(join(logsDir, "swarm-events.jsonl"));
   const { registry: sharedRegistry, fallbackReason: meshRegistryFallback } =
@@ -1301,19 +1336,33 @@ export function createSwarmHypervisor(opts) {
     hubKeepaliveTimer = setInterval(
       async () => {
         try {
-          const resp = await fetch("http://127.0.0.1:27888/status");
-          if (!resp.ok && ensureHubAliveFn) {
+          const hub = getHubInfoImpl ? await getHubInfoImpl() : null;
+          const statusUrl = resolveHubStatusUrl(hub);
+          if (!statusUrl) {
+            if (ensureHubAliveImpl) {
+              eventLog.append("hub_keepalive_restart", {
+                reason: "hub_url_unresolved",
+              });
+              await ensureHubAliveImpl();
+            }
+            return;
+          }
+
+          const resp = await fetch(statusUrl, {
+            signal: AbortSignal.timeout(5000),
+          });
+          if (!resp.ok && ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {});
-            await ensureHubAliveFn();
+            await ensureHubAliveImpl();
           }
         } catch {
           // Hub 다운 — 재시작 시도
-          if (ensureHubAliveFn) {
+          if (ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {
               reason: "fetch_failed",
             });
             try {
-              await ensureHubAliveFn();
+              await ensureHubAliveImpl();
             } catch {
               eventLog.append("hub_restart_failed", {});
             }
@@ -1340,8 +1389,8 @@ export function createSwarmHypervisor(opts) {
     markIntegrationPromisePending();
 
     // Hub alive 확인 — 죽어있으면 재시작
-    if (ensureHubAliveFn) {
-      ensureHubAliveFn()
+    if (ensureHubAliveImpl) {
+      ensureHubAliveImpl()
         .then((hub) => {
           eventLog.append("hub_ensured", { port: hub?.port });
         })

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -424,6 +424,69 @@ describe("swarm-hypervisor", () => {
       await assert.rejects(() => hv.launch(plan), /Cannot launch/);
     });
 
+    it("uses PID-file Hub URL resolution for keepalive status probes", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const originalSetInterval = globalThis.setInterval;
+      const originalClearInterval = globalThis.clearInterval;
+      const originalFetch = globalThis.fetch;
+      const timer = {};
+      let keepaliveTick = null;
+      let keepaliveDelay = null;
+      const fetchCalls = [];
+      const { createConductor } = createMockConductorFactory();
+
+      globalThis.setInterval = (fn, delay) => {
+        keepaliveTick = fn;
+        keepaliveDelay = delay;
+        return timer;
+      };
+      globalThis.clearInterval = (id) => {
+        assert.equal(id, timer);
+      };
+      globalThis.fetch = async (url, opts = {}) => {
+        fetchCalls.push({ url: String(url), signal: opts.signal });
+        return { ok: true };
+      };
+
+      try {
+        hv = createSwarmHypervisor({
+          workdir,
+          logsDir,
+          _deps: {
+            createConductor,
+            ensureHubAlive: null,
+            getHubInfo: async () => ({
+              host: "127.0.0.1",
+              port: 28777,
+              url: "http://127.0.0.1:28777/mcp",
+            }),
+            ensureWorktree: async ({ slug, runId }) => ({
+              worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+              branchName: `swarm/${runId}/${slug}`,
+            }),
+          },
+        });
+
+        await hv.launch(plan);
+        assert.equal(keepaliveDelay, 5 * 60 * 1000);
+        assert.equal(typeof keepaliveTick, "function");
+
+        await keepaliveTick();
+
+        assert.equal(fetchCalls.length, 1);
+        assert.equal(fetchCalls[0].url, "http://127.0.0.1:28777/status");
+        assert.ok(fetchCalls[0].signal instanceof AbortSignal);
+      } finally {
+        if (hv) {
+          await hv.shutdown("test_keepalive_cleanup");
+          hv = null;
+        }
+        globalThis.setInterval = originalSetInterval;
+        globalThis.clearInterval = originalClearInterval;
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it("launches redundant workers for critical shards", async () => {
       const plan = planSwarm(null, { content: CRITICAL_PRD });
       ({ hv } = createTestHypervisor(workdir, logsDir));


### PR DESCRIPTION
## Summary
swarm-hypervisor keepalive no longer fetches `http://127.0.0.1:27888/status` directly. It now resolves the active Hub via `getHubInfo()` (PID-file-first), derives `/status` from that resolved URL, and applies `AbortSignal.timeout(5000)` to avoid stalls.

## RCA
- Link: `.omc/artifacts/hub-keepalive-rca.md`
- §가설 1순위: keepalive hardcoded `http://127.0.0.1:27888/status` can produce false-positive `fetch_failed` when Hub is running on a different PID-file-selected port.
- Matches memory `feedback_hub_status_query` BUG-D/BUG-E: Hub status queries must resolve the active target instead of assuming port 27888.

## Changes
- `hub/team/swarm-hypervisor.mjs`: keepalive resolves Hub status URL through `getHubInfo()` and uses a 5s abort timeout.
- `packages/triflux/hub/team/swarm-hypervisor.mjs`: mirror synced byte-identical with root.
- `tests/unit/swarm-hypervisor.test.mjs`: regression test for a Hub running on dynamic port `28777`.

## Verification
- `node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=1 tests/unit/swarm-hypervisor.test.mjs` — 31 pass, 0 fail.
- `npm test` script via `npm.cmd test` with output redirected — tests 3205, pass 3201, fail 0, skipped 4.
- `npm run lint` — clean, 570 files checked.
- `node scripts/release/check-packages-mirror.mjs` — mirror OK.
- SHA-256 root/mirror `swarm-hypervisor.mjs` — both `1DF4A9269E2BFCC3DA44BB02392762CF08F088183A60C1256A717D700BC249E0`.