### PR TITLE
feat(hub): swarm-hypervisor cleanup integration (P2)

### DIFF
--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { cleanupShardProcesses } from "../lib/process-utils.mjs";
 import { getHostConfig } from "../lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
@@ -193,6 +194,8 @@ export function createSwarmHypervisor(opts) {
     _deps.rebaseShardOntoIntegration || rebaseShardOntoIntegration;
   const cleanupWorktreeImpl =
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
+  const cleanupShardProcessesImpl =
+    _deps.cleanupShardProcesses || cleanupShardProcesses;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
   const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
@@ -219,6 +222,10 @@ export function createSwarmHypervisor(opts) {
   /** @type {Set<string>} shards that have fully completed (not just launched) */
   const completedShards = new Set();
   const cleanedWorktreePaths = new Set();
+  const processCleanupTotals = {
+    totalKilled: 0,
+    byCategory: {},
+  };
 
   const results = new Map(); // shardName → validated result
   const failures = new Map(); // shardName → failure info
@@ -234,6 +241,10 @@ export function createSwarmHypervisor(opts) {
     integrationFailures: [],
     skipped: [],
     integrationBranch: null,
+    processCleanup: {
+      totalKilled: 0,
+      byCategory: {},
+    },
     error: null,
   };
   const integrationPromise = new Promise((resolve) => {
@@ -298,6 +309,8 @@ export function createSwarmHypervisor(opts) {
       return integrationResult;
     }
 
+    const processCleanup = payload.processCleanup || getProcessCleanupSummary();
+
     integrationResult = Object.freeze({
       integrated: Object.freeze([...(payload.integrated || [])]),
       failed: Object.freeze([...(payload.failed || [])]),
@@ -307,6 +320,10 @@ export function createSwarmHypervisor(opts) {
       skipped: Object.freeze([...(payload.skipped || [])]),
       integrationBranch: payload.integrationBranch || null,
       results: Object.freeze([...(payload.results || [])]),
+      processCleanup: Object.freeze({
+        totalKilled: processCleanup.totalKilled || 0,
+        byCategory: Object.freeze({ ...(processCleanup.byCategory || {}) }),
+      }),
       partial:
         payload.partial ??
         (Array.isArray(payload.failed) && payload.failed.length > 0),
@@ -323,11 +340,37 @@ export function createSwarmHypervisor(opts) {
       integrationFailures: [...integrationResult.integrationFailures],
       skipped: [...integrationResult.skipped],
       integrationBranch: integrationResult.integrationBranch,
+      processCleanup: integrationResult.processCleanup,
       error: integrationResult.error,
     };
 
     resolveIntegrationPromise?.(integrationResult);
     return integrationResult;
+  }
+
+  function getProcessCleanupSummary() {
+    return {
+      totalKilled: processCleanupTotals.totalKilled,
+      byCategory: { ...processCleanupTotals.byCategory },
+    };
+  }
+
+  function recordProcessCleanup(result) {
+    if (!result) return getProcessCleanupSummary();
+
+    const killed = Number(result.killed ?? result.totalKilled ?? 0);
+    if (Number.isFinite(killed) && killed > 0) {
+      processCleanupTotals.totalKilled += killed;
+    }
+
+    for (const [category, count] of Object.entries(result.byCategory || {})) {
+      const numeric = Number(count);
+      if (!Number.isFinite(numeric) || numeric <= 0) continue;
+      processCleanupTotals.byCategory[category] =
+        (processCleanupTotals.byCategory[category] || 0) + numeric;
+    }
+
+    return getProcessCleanupSummary();
   }
 
   function git(args, cwd = workdir) {
@@ -1183,6 +1226,33 @@ export function createSwarmHypervisor(opts) {
     }
 
     try {
+      const snapshot = worker.conductor?.getSnapshot?.();
+      const processCleanup = await cleanupShardProcessesImpl({
+        worktreePath: worker.worktreePath,
+        sessionIds: [worker.sessionId || worker.sessionConfig?.id].filter(
+          Boolean,
+        ),
+        topPids: snapshot?.topPids ?? [],
+        runId: plan?.runId || runId,
+        shardName,
+      });
+      worker.processCleanup = processCleanup;
+      recordProcessCleanup(processCleanup);
+      eventLog.append("process_cleanup", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        killed: processCleanup?.killed ?? 0,
+        byCategory: processCleanup?.byCategory || {},
+      });
+    } catch (err) {
+      eventLog.append("process_cleanup_failed", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        error: err.message,
+      });
+    }
+
+    try {
       await cleanupWorktreeImpl({
         worktreePath: worker.worktreePath,
         branchName,
@@ -1317,6 +1387,12 @@ export function createSwarmHypervisor(opts) {
         integrationFailures: [...integrationPromiseState.integrationFailures],
         skipped: [...integrationPromiseState.skipped],
         integrationBranch: integrationPromiseState.integrationBranch,
+        processCleanup: Object.freeze({
+          totalKilled: integrationPromiseState.processCleanup.totalKilled,
+          byCategory: Object.freeze({
+            ...integrationPromiseState.processCleanup.byCategory,
+          }),
+        }),
         error: integrationPromiseState.error,
       }),
     });
@@ -1485,11 +1561,21 @@ export function createSwarmHypervisor(opts) {
     await Promise.allSettled(shutdowns);
 
     if (!keepFailedWorktrees) {
-      for (const [shardName, failureInfo] of failures) {
-        const worker = workers.get(shardName);
+      const cleanupCandidates = new Map();
+      for (const [shardName, worker] of workers) {
+        cleanupCandidates.set(shardName, worker);
+      }
+      for (const [shardName, worker] of redundantWorkers) {
+        cleanupCandidates.set(`${shardName}:redundant`, worker);
+      }
+
+      for (const [candidateName, worker] of cleanupCandidates) {
+        const shardName = worker?.shardConfig?.name || candidateName;
+        const failureInfo = failures.get(shardName);
         const shard =
           worker?.shardConfig ||
           plan?.shards.find((item) => item.name === shardName);
+        if (!worker?.worktreePath) continue;
         await maybeCleanupWorktree(shardName, worker, shard, {
           force: true,
           failureReason: failureInfo?.mode || failureInfo?.reason || reason,

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { cleanupShardProcesses } from "../lib/process-utils.mjs";
 import { getHostConfig } from "../lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
@@ -193,6 +194,8 @@ export function createSwarmHypervisor(opts) {
     _deps.rebaseShardOntoIntegration || rebaseShardOntoIntegration;
   const cleanupWorktreeImpl =
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
+  const cleanupShardProcessesImpl =
+    _deps.cleanupShardProcesses || cleanupShardProcesses;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
   const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
@@ -219,6 +222,10 @@ export function createSwarmHypervisor(opts) {
   /** @type {Set<string>} shards that have fully completed (not just launched) */
   const completedShards = new Set();
   const cleanedWorktreePaths = new Set();
+  const processCleanupTotals = {
+    totalKilled: 0,
+    byCategory: {},
+  };
 
   const results = new Map(); // shardName → validated result
   const failures = new Map(); // shardName → failure info
@@ -234,6 +241,10 @@ export function createSwarmHypervisor(opts) {
     integrationFailures: [],
     skipped: [],
     integrationBranch: null,
+    processCleanup: {
+      totalKilled: 0,
+      byCategory: {},
+    },
     error: null,
   };
   const integrationPromise = new Promise((resolve) => {
@@ -298,6 +309,8 @@ export function createSwarmHypervisor(opts) {
       return integrationResult;
     }
 
+    const processCleanup = payload.processCleanup || getProcessCleanupSummary();
+
     integrationResult = Object.freeze({
       integrated: Object.freeze([...(payload.integrated || [])]),
       failed: Object.freeze([...(payload.failed || [])]),
@@ -307,6 +320,10 @@ export function createSwarmHypervisor(opts) {
       skipped: Object.freeze([...(payload.skipped || [])]),
       integrationBranch: payload.integrationBranch || null,
       results: Object.freeze([...(payload.results || [])]),
+      processCleanup: Object.freeze({
+        totalKilled: processCleanup.totalKilled || 0,
+        byCategory: Object.freeze({ ...(processCleanup.byCategory || {}) }),
+      }),
       partial:
         payload.partial ??
         (Array.isArray(payload.failed) && payload.failed.length > 0),
@@ -323,11 +340,37 @@ export function createSwarmHypervisor(opts) {
       integrationFailures: [...integrationResult.integrationFailures],
       skipped: [...integrationResult.skipped],
       integrationBranch: integrationResult.integrationBranch,
+      processCleanup: integrationResult.processCleanup,
       error: integrationResult.error,
     };
 
     resolveIntegrationPromise?.(integrationResult);
     return integrationResult;
+  }
+
+  function getProcessCleanupSummary() {
+    return {
+      totalKilled: processCleanupTotals.totalKilled,
+      byCategory: { ...processCleanupTotals.byCategory },
+    };
+  }
+
+  function recordProcessCleanup(result) {
+    if (!result) return getProcessCleanupSummary();
+
+    const killed = Number(result.killed ?? result.totalKilled ?? 0);
+    if (Number.isFinite(killed) && killed > 0) {
+      processCleanupTotals.totalKilled += killed;
+    }
+
+    for (const [category, count] of Object.entries(result.byCategory || {})) {
+      const numeric = Number(count);
+      if (!Number.isFinite(numeric) || numeric <= 0) continue;
+      processCleanupTotals.byCategory[category] =
+        (processCleanupTotals.byCategory[category] || 0) + numeric;
+    }
+
+    return getProcessCleanupSummary();
   }
 
   function git(args, cwd = workdir) {
@@ -1183,6 +1226,33 @@ export function createSwarmHypervisor(opts) {
     }
 
     try {
+      const snapshot = worker.conductor?.getSnapshot?.();
+      const processCleanup = await cleanupShardProcessesImpl({
+        worktreePath: worker.worktreePath,
+        sessionIds: [worker.sessionId || worker.sessionConfig?.id].filter(
+          Boolean,
+        ),
+        topPids: snapshot?.topPids ?? [],
+        runId: plan?.runId || runId,
+        shardName,
+      });
+      worker.processCleanup = processCleanup;
+      recordProcessCleanup(processCleanup);
+      eventLog.append("process_cleanup", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        killed: processCleanup?.killed ?? 0,
+        byCategory: processCleanup?.byCategory || {},
+      });
+    } catch (err) {
+      eventLog.append("process_cleanup_failed", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        error: err.message,
+      });
+    }
+
+    try {
       await cleanupWorktreeImpl({
         worktreePath: worker.worktreePath,
         branchName,
@@ -1317,6 +1387,12 @@ export function createSwarmHypervisor(opts) {
         integrationFailures: [...integrationPromiseState.integrationFailures],
         skipped: [...integrationPromiseState.skipped],
         integrationBranch: integrationPromiseState.integrationBranch,
+        processCleanup: Object.freeze({
+          totalKilled: integrationPromiseState.processCleanup.totalKilled,
+          byCategory: Object.freeze({
+            ...integrationPromiseState.processCleanup.byCategory,
+          }),
+        }),
         error: integrationPromiseState.error,
       }),
     });
@@ -1485,11 +1561,21 @@ export function createSwarmHypervisor(opts) {
     await Promise.allSettled(shutdowns);
 
     if (!keepFailedWorktrees) {
-      for (const [shardName, failureInfo] of failures) {
-        const worker = workers.get(shardName);
+      const cleanupCandidates = new Map();
+      for (const [shardName, worker] of workers) {
+        cleanupCandidates.set(shardName, worker);
+      }
+      for (const [shardName, worker] of redundantWorkers) {
+        cleanupCandidates.set(`${shardName}:redundant`, worker);
+      }
+
+      for (const [candidateName, worker] of cleanupCandidates) {
+        const shardName = worker?.shardConfig?.name || candidateName;
+        const failureInfo = failures.get(shardName);
         const shard =
           worker?.shardConfig ||
           plan?.shards.find((item) => item.name === shardName);
+        if (!worker?.worktreePath) continue;
         await maybeCleanupWorktree(shardName, worker, shard, {
           force: true,
           failureReason: failureInfo?.mode || failureInfo?.reason || reason,

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -114,6 +114,7 @@ function createMockConductorFactory() {
     let completed = false;
     let deadHandler = null;
     let sessionConfig = null;
+    let topPids = [];
     const conductor = {
       spawnSession(config) {
         sessionConfig = config;
@@ -122,13 +123,18 @@ function createMockConductorFactory() {
         if (event === "dead") deadHandler = handler;
       },
       getSnapshot() {
-        return completed
+        const snapshot = completed
           ? [{ state: "completed", outPath: sessionConfig?.outPath || null }]
           : [{ state: "healthy", outPath: sessionConfig?.outPath || null }];
+        snapshot.topPids = topPids;
+        return snapshot;
       },
       shutdown() {
         completed = true;
         return Promise.resolve();
+      },
+      setTopPids(pids) {
+        topPids = pids;
       },
       complete(sessionId = sessionConfig?.id || "session", completionPayload) {
         completed = true;
@@ -594,6 +600,192 @@ describe("swarm-hypervisor", () => {
       ]);
     });
 
+    it("maybeCleanupWorktree calls cleanupShardProcesses before worktree remove", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+      const calls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "process-cleanup-order",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          prepareIntegrationBranch: async () => ({
+            integrationBranch: "swarm/process-cleanup-order/merge",
+            baseCommit: "abc123",
+          }),
+          rebaseShardOntoIntegration: async () => ({
+            ok: true,
+            headCommit: "def456",
+          }),
+          cleanupShardProcesses: async (opts) => {
+            calls.push({ type: "process", opts });
+            return { killed: 1, byCategory: { node: 1 } };
+          },
+          cleanupWorktree: async (opts) => {
+            calls.push({ type: "worktree", opts });
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].setTopPids([12345]);
+      conductors[0].complete();
+      await hv.integrationComplete();
+
+      assert.deepEqual(
+        calls.map((call) => call.type),
+        ["process", "worktree"],
+      );
+      assert.deepEqual(calls[0].opts, {
+        worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
+        sessionIds: [conductors[0].sessionConfig.id],
+        topPids: [12345],
+        runId: "process-cleanup-order",
+        shardName: "worker-a",
+      });
+    });
+
+    it("maybeCleanupWorktree skips remote shards", async () => {
+      const basePlan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const plan = {
+        ...basePlan,
+        shards: [
+          {
+            ...basePlan.shards[0],
+            host: "remote-host",
+            _remoteEnv: { claudePath: "claude" },
+          },
+        ],
+      };
+      const { createConductor, conductors } = createMockConductorFactory();
+      const cleanupCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "remote-cleanup-skip",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          prepareIntegrationBranch: async () => ({
+            integrationBranch: "swarm/remote-cleanup-skip/merge",
+            baseCommit: "abc123",
+          }),
+          rebaseShardOntoIntegration: async () => ({
+            ok: true,
+            headCommit: "def456",
+          }),
+          cleanupShardProcesses: async (opts) => {
+            cleanupCalls.push({ type: "process", opts });
+          },
+          cleanupWorktree: async (opts) => {
+            cleanupCalls.push({ type: "worktree", opts });
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].complete();
+      await hv.integrationComplete();
+
+      assert.deepEqual(cleanupCalls, []);
+    });
+
+    it("maybeCleanupWorktree continues on cleanupShardProcesses failure", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+      const cleanupCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "process-cleanup-failure",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          prepareIntegrationBranch: async () => ({
+            integrationBranch: "swarm/process-cleanup-failure/merge",
+            baseCommit: "abc123",
+          }),
+          rebaseShardOntoIntegration: async () => ({
+            ok: true,
+            headCommit: "def456",
+          }),
+          cleanupShardProcesses: async () => {
+            throw new Error("simulated process cleanup failure");
+          },
+          cleanupWorktree: async (opts) => {
+            cleanupCalls.push(opts);
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].complete();
+      await hv.integrationComplete();
+
+      assert.equal(cleanupCalls.length, 1);
+      await hv.shutdown("flush_process_cleanup_failure");
+      assert.equal(
+        readEventLog(hv.eventLogPath).some(
+          (entry) => entry.event === "process_cleanup_failed",
+        ),
+        true,
+      );
+    });
+
+    it("summary includes processCleanup metadata", async () => {
+      const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "process-cleanup-summary",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          prepareIntegrationBranch: async () => ({
+            integrationBranch: "swarm/process-cleanup-summary/merge",
+            baseCommit: "abc123",
+          }),
+          rebaseShardOntoIntegration: async () => ({
+            ok: true,
+            headCommit: "def456",
+          }),
+          cleanupShardProcesses: async () => ({
+            killed: 3,
+            byCategory: { node: 2, bash: 1 },
+          }),
+          cleanupWorktree: async () => {},
+        },
+      });
+
+      await hv.launch(plan);
+      conductors[0].complete();
+      const result = await hv.integrationComplete();
+
+      assert.deepEqual(result.processCleanup, {
+        totalKilled: 3,
+        byCategory: { node: 2, bash: 1 },
+      });
+    });
+
     it("exposes an awaitable integrationComplete promise", async () => {
       const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
       const { createConductor, conductors } = createMockConductorFactory();
@@ -928,6 +1120,64 @@ describe("swarm-hypervisor", () => {
           worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
           reason: "F1_crash",
         },
+      );
+
+      hv = null;
+    });
+
+    it("shutdown cleanups all launched local workers", async () => {
+      const plan = planSwarm(null, { content: PARALLEL_NO_FILES_PRD });
+      const { createConductor } = createMockConductorFactory();
+      const processCleanupCalls = [];
+      const worktreeCleanupCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "shutdown-all-local",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          cleanupShardProcesses: async (opts) => {
+            processCleanupCalls.push(opts);
+            return { killed: 0, byCategory: {} };
+          },
+          cleanupWorktree: async (opts) => {
+            worktreeCleanupCalls.push(opts);
+          },
+        },
+      });
+
+      await hv.launch(plan);
+      await hv.shutdown("test_shutdown_cleanup_all");
+
+      assert.deepEqual(
+        processCleanupCalls.map((call) => call.shardName).sort(),
+        ["worker-a", "worker-b"],
+      );
+      assert.deepEqual(
+        worktreeCleanupCalls
+          .map((call) => ({
+            worktreePath: call.worktreePath,
+            branchName: call.branchName,
+            force: call.force,
+          }))
+          .sort((a, b) => a.worktreePath.localeCompare(b.worktreePath)),
+        [
+          {
+            worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
+            branchName: "swarm/shutdown-all-local/worker-a",
+            force: true,
+          },
+          {
+            worktreePath: `${workdir}/.codex-swarm/wt-worker-b`,
+            branchName: "swarm/shutdown-all-local/worker-b",
+            force: true,
+          },
+        ],
       );
 
       hv = null;


### PR DESCRIPTION
## Summary
- Applies the P2-hypervisor swarm output from `.codex-swarm/wt-P2-hypervisor` on top of `origin/main` (`d43023a`, v10.17.4 context).
- Integrates shard process cleanup before worktree removal in `swarm-hypervisor.mjs`.
- Extends shutdown cleanup to all launched local workers and adds process cleanup summary metadata.
- Mirrors `hub/team/swarm-hypervisor.mjs` to `packages/triflux/hub/team/swarm-hypervisor.mjs` byte-identically.

## Context
- PRD: `.triflux/plans/2026-04-26-swarm-process-tree-cleanup-phase2.md` (`P2-hypervisor`).
- Source patch: `.codex-swarm/wt-P2-hypervisor`.
- Reconciled manually because the original swarm patch was based on outdated `8890d07` and did not apply cleanly to current main after the v10.17.4 hub MCP/process cleanup work.

## Verification
- `node --test tests/unit/swarm-hypervisor.test.mjs` — 36 pass, 0 fail.
- `npx biome check hub/team/swarm-hypervisor.mjs packages/triflux/hub/team/swarm-hypervisor.mjs tests/unit/swarm-hypervisor.test.mjs` — pass.
- `npx biome check --vcs-enabled=false hub/team/swarm-hypervisor.mjs packages/triflux/hub/team/swarm-hypervisor.mjs tests/unit/swarm-hypervisor.test.mjs` — pass.
- root and `packages/triflux` hypervisor files have matching SHA-256.