### PR TITLE
feat(hub): conductor cleanup orchestration with process tree helpers (P2)

### DIFF
--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -20,6 +20,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
+import {
+  findProcessTree,
+  killProcessTree,
+  killProcessTreeSnapshot,
+} from "../lib/process-utils.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
@@ -33,11 +38,6 @@ import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
-import {
-  killProcessTree,
-  killProcessTreeSnapshot,
-  findProcessTree,
-} from "../lib/process-utils.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
 import {
   buildSynapseTaskSummary,

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -33,6 +33,11 @@ import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
+import {
+  killProcessTree,
+  killProcessTreeSnapshot,
+  findProcessTree,
+} from "../lib/process-utils.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
 import {
   buildSynapseTaskSummary,
@@ -152,6 +157,12 @@ function swapAuthFile(lease, agent, sessionId, eventLog) {
  */
 export function createConductor(opts = {}) {
   const spawnFn = opts.deps?.spawn || spawn;
+  const processUtils = {
+    killProcessTree: opts.deps?.killProcessTree || killProcessTree,
+    killProcessTreeSnapshot:
+      opts.deps?.killProcessTreeSnapshot || killProcessTreeSnapshot,
+    findProcessTree: opts.deps?.findProcessTree || findProcessTree,
+  };
   const {
     logsDir,
     maxRestarts = DEFAULT_MAX_RESTARTS,
@@ -324,6 +335,16 @@ export function createConductor(opts = {}) {
     const pid = child.pid;
     if (!pid) return;
 
+    try {
+      if (session.descendantSnapshot?.length > 0) {
+        processUtils.killProcessTreeSnapshot(session.descendantSnapshot);
+      }
+    } catch {
+      /* best-effort cleanup */
+    }
+
+    if (!session.alive) return;
+
     // SIGTERM 먼저
     try {
       child.kill("SIGTERM");
@@ -332,16 +353,24 @@ export function createConductor(opts = {}) {
     }
 
     // Grace period 대기
-    await new Promise((resolve) => {
+    const exited = await new Promise((resolve) => {
       const timer = setTimeout(() => {
-        forceKill(pid);
-        resolve();
+        resolve(false);
       }, graceMs);
       child.once("exit", () => {
         clearTimeout(timer);
-        resolve();
+        resolve(true);
       });
     });
+
+    if (!exited) {
+      try {
+        processUtils.killProcessTree(pid);
+      } catch {
+        forceKill(pid);
+      }
+      session.alive = false;
+    }
   }
 
   /**
@@ -430,7 +459,7 @@ export function createConductor(opts = {}) {
   /**
    * 실패 처리 — restart 또는 DEAD.
    */
-  function handleFailure(session, reason) {
+  async function handleFailure(session, reason) {
     if (TERMINAL_STATES.has(session.state)) return;
 
     transition(session, STATES.FAILED, reason);
@@ -452,6 +481,7 @@ export function createConductor(opts = {}) {
         }
       }, backoffMs);
     } else {
+      await cleanupChild(session);
       transition(session, STATES.DEAD, `maxRestarts(${maxRestarts})_exceeded`);
       emitter.emit("dead", { sessionId: session.id, reason });
 
@@ -569,6 +599,7 @@ export function createConductor(opts = {}) {
     session.child = child;
     session.outPath = outPath;
     session.errPath = errPath;
+    session.descendantSnapshot = [];
 
     // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
     // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
@@ -583,6 +614,19 @@ export function createConductor(opts = {}) {
       legacyCommand: launcher.command,
       restart: session.restarts,
     });
+
+    if (session._descendantSnapshotTimer) {
+      clearTimeout(session._descendantSnapshotTimer);
+    }
+    session._descendantSnapshotTimer = setTimeout(() => {
+      session._descendantSnapshotTimer = null;
+      if (session.child !== child) return;
+      try {
+        session.descendantSnapshot = processUtils.findProcessTree(child.pid);
+      } catch {
+        /* best-effort snapshot */
+      }
+    }, 200);
 
     // stdout+stderr 통합 추적 (F3 해결: stderr만 출력되는 경우도 advancing 판정)
     const trackOutput = (buf) => {
@@ -609,6 +653,10 @@ export function createConductor(opts = {}) {
 
     child.on("exit", (code, signal) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       try {
         outWs.end();
       } catch {
@@ -671,6 +719,10 @@ export function createConductor(opts = {}) {
 
     child.on("error", (err) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       eventLog.append("child_error", {
         session: session.id,
         error: err.message,
@@ -999,6 +1051,7 @@ export function createConductor(opts = {}) {
       outPath: null,
       errPath: null,
       createdAt: Date.now(),
+      descendantSnapshot: [],
     };
 
     sessions.set(resolvedConfig.id, session);
@@ -1087,12 +1140,21 @@ export function createConductor(opts = {}) {
 
     eventLog.append("shutdown", { reason, sessions: sessions.size });
 
+    const cleanedSessionIds = new Set();
     const cleanups = [...sessions.values()]
-      .filter((s) => !TERMINAL_STATES.has(s.state))
+      .filter((s) => {
+        if (cleanedSessionIds.has(s.id)) return false;
+        cleanedSessionIds.add(s.id);
+        return true;
+      })
       .map(async (s) => {
         if (s._respawnTimer) {
           clearTimeout(s._respawnTimer);
           s._respawnTimer = null;
+        }
+        if (s._descendantSnapshotTimer) {
+          clearTimeout(s._descendantSnapshotTimer);
+          s._descendantSnapshotTimer = null;
         }
         s.probe?.stop();
         await cleanupChild(s);

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -20,6 +20,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
+import {
+  findProcessTree,
+  killProcessTree,
+  killProcessTreeSnapshot,
+} from "../lib/process-utils.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
@@ -33,11 +38,6 @@ import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
-import {
-  killProcessTree,
-  killProcessTreeSnapshot,
-  findProcessTree,
-} from "../lib/process-utils.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
 import {
   buildSynapseTaskSummary,

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -33,6 +33,11 @@ import { buildSpawnSpecForMode, MODES } from "./execution-mode.mjs";
 import { extractCompletionPayload } from "./extract-completion-payload.mjs";
 import { createHealthProbe } from "./health-probe.mjs";
 import { buildLauncher } from "./launcher-template.mjs";
+import {
+  killProcessTree,
+  killProcessTreeSnapshot,
+  findProcessTree,
+} from "../lib/process-utils.mjs";
 import { createSentinelCapture } from "./sentinel-capture.mjs";
 import {
   buildSynapseTaskSummary,
@@ -152,6 +157,12 @@ function swapAuthFile(lease, agent, sessionId, eventLog) {
  */
 export function createConductor(opts = {}) {
   const spawnFn = opts.deps?.spawn || spawn;
+  const processUtils = {
+    killProcessTree: opts.deps?.killProcessTree || killProcessTree,
+    killProcessTreeSnapshot:
+      opts.deps?.killProcessTreeSnapshot || killProcessTreeSnapshot,
+    findProcessTree: opts.deps?.findProcessTree || findProcessTree,
+  };
   const {
     logsDir,
     maxRestarts = DEFAULT_MAX_RESTARTS,
@@ -324,6 +335,16 @@ export function createConductor(opts = {}) {
     const pid = child.pid;
     if (!pid) return;
 
+    try {
+      if (session.descendantSnapshot?.length > 0) {
+        processUtils.killProcessTreeSnapshot(session.descendantSnapshot);
+      }
+    } catch {
+      /* best-effort cleanup */
+    }
+
+    if (!session.alive) return;
+
     // SIGTERM 먼저
     try {
       child.kill("SIGTERM");
@@ -332,16 +353,24 @@ export function createConductor(opts = {}) {
     }
 
     // Grace period 대기
-    await new Promise((resolve) => {
+    const exited = await new Promise((resolve) => {
       const timer = setTimeout(() => {
-        forceKill(pid);
-        resolve();
+        resolve(false);
       }, graceMs);
       child.once("exit", () => {
         clearTimeout(timer);
-        resolve();
+        resolve(true);
       });
     });
+
+    if (!exited) {
+      try {
+        processUtils.killProcessTree(pid);
+      } catch {
+        forceKill(pid);
+      }
+      session.alive = false;
+    }
   }
 
   /**
@@ -430,7 +459,7 @@ export function createConductor(opts = {}) {
   /**
    * 실패 처리 — restart 또는 DEAD.
    */
-  function handleFailure(session, reason) {
+  async function handleFailure(session, reason) {
     if (TERMINAL_STATES.has(session.state)) return;
 
     transition(session, STATES.FAILED, reason);
@@ -452,6 +481,7 @@ export function createConductor(opts = {}) {
         }
       }, backoffMs);
     } else {
+      await cleanupChild(session);
       transition(session, STATES.DEAD, `maxRestarts(${maxRestarts})_exceeded`);
       emitter.emit("dead", { sessionId: session.id, reason });
 
@@ -569,6 +599,7 @@ export function createConductor(opts = {}) {
     session.child = child;
     session.outPath = outPath;
     session.errPath = errPath;
+    session.descendantSnapshot = [];
 
     // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
     // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
@@ -583,6 +614,19 @@ export function createConductor(opts = {}) {
       legacyCommand: launcher.command,
       restart: session.restarts,
     });
+
+    if (session._descendantSnapshotTimer) {
+      clearTimeout(session._descendantSnapshotTimer);
+    }
+    session._descendantSnapshotTimer = setTimeout(() => {
+      session._descendantSnapshotTimer = null;
+      if (session.child !== child) return;
+      try {
+        session.descendantSnapshot = processUtils.findProcessTree(child.pid);
+      } catch {
+        /* best-effort snapshot */
+      }
+    }, 200);
 
     // stdout+stderr 통합 추적 (F3 해결: stderr만 출력되는 경우도 advancing 판정)
     const trackOutput = (buf) => {
@@ -609,6 +653,10 @@ export function createConductor(opts = {}) {
 
     child.on("exit", (code, signal) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       try {
         outWs.end();
       } catch {
@@ -671,6 +719,10 @@ export function createConductor(opts = {}) {
 
     child.on("error", (err) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       eventLog.append("child_error", {
         session: session.id,
         error: err.message,
@@ -999,6 +1051,7 @@ export function createConductor(opts = {}) {
       outPath: null,
       errPath: null,
       createdAt: Date.now(),
+      descendantSnapshot: [],
     };
 
     sessions.set(resolvedConfig.id, session);
@@ -1087,12 +1140,21 @@ export function createConductor(opts = {}) {
 
     eventLog.append("shutdown", { reason, sessions: sessions.size });
 
+    const cleanedSessionIds = new Set();
     const cleanups = [...sessions.values()]
-      .filter((s) => !TERMINAL_STATES.has(s.state))
+      .filter((s) => {
+        if (cleanedSessionIds.has(s.id)) return false;
+        cleanedSessionIds.add(s.id);
+        return true;
+      })
       .map(async (s) => {
         if (s._respawnTimer) {
           clearTimeout(s._respawnTimer);
           s._respawnTimer = null;
+        }
+        if (s._descendantSnapshotTimer) {
+          clearTimeout(s._descendantSnapshotTimer);
+          s._descendantSnapshotTimer = null;
         }
         s.probe?.stop();
         await cleanupChild(s);

--- a/tests/unit/conductor.test.mjs
+++ b/tests/unit/conductor.test.mjs
@@ -522,9 +522,7 @@ describe("conductor: shutdown", () => {
     conductor.spawnSession(minConfig({ id: "terminal-shutdown-cleanup" }));
 
     await waitFor(() => procUtils.calls.findProcessTree.length === 1);
-    await waitFor(
-      () => conductor.getSnapshot()[0]?.state === STATES.COMPLETED,
-    );
+    await waitFor(() => conductor.getSnapshot()[0]?.state === STATES.COMPLETED);
     await conductor.shutdown("terminal_cleanup_test");
 
     assert.deepEqual(procUtils.calls.killProcessTreeSnapshot, [

--- a/tests/unit/conductor.test.mjs
+++ b/tests/unit/conductor.test.mjs
@@ -34,12 +34,14 @@ function makeMockSpawn({
   exitCode = 0,
   exitSignal = null,
   exitDelayMs = 0,
+  killExits = true,
+  pid = null,
 } = {}) {
   return function mockSpawn() {
     const child = new EventEmitter();
     let exitTimer = null;
     let exited = false;
-    child.pid = Math.floor(Math.random() * 1_000_000) + 1;
+    child.pid = pid || Math.floor(Math.random() * 1_000_000) + 1;
     child.stdout = new PassThrough();
     child.stderr = new PassThrough();
     child.stdin = new PassThrough();
@@ -57,7 +59,7 @@ function makeMockSpawn({
       });
     };
     child.kill = () => {
-      fire(null, "SIGTERM");
+      if (killExits) fire(null, "SIGTERM");
       return true;
     };
     if (exitDelayMs > 0) {
@@ -66,6 +68,36 @@ function makeMockSpawn({
       fire(exitCode, exitSignal);
     }
     return child;
+  };
+}
+
+function makeMockProcessUtils({
+  snapshot = [],
+  findError = null,
+  calls = null,
+} = {}) {
+  const record = calls || {
+    findProcessTree: [],
+    killProcessTreeSnapshot: [],
+    killProcessTree: [],
+  };
+  return {
+    calls: record,
+    deps: {
+      findProcessTree(pid) {
+        record.findProcessTree.push(pid);
+        if (findError) throw findError;
+        return snapshot;
+      },
+      killProcessTreeSnapshot(value) {
+        record.killProcessTreeSnapshot.push(value);
+        return { killed: value.length, missing: 0 };
+      },
+      killProcessTree(pid) {
+        record.killProcessTree.push(pid);
+        return { ok: true, killed: 1, errors: [] };
+      },
+    },
   };
 }
 
@@ -472,6 +504,158 @@ describe("conductor: shutdown", () => {
 
     const [entry] = conductor.getSnapshot();
     assert.equal(entry.state, STATES.DEAD);
+  });
+
+  it("global shutdown cleanups terminal sessions", async () => {
+    await conductor.shutdown("recreate_for_terminal_cleanup");
+    const procUtils = makeMockProcessUtils({
+      snapshot: [{ pid: 9101 }, { pid: 9102 }],
+    });
+    conductor = makeConductor(logsDir, {
+      graceMs: 10,
+      deps: {
+        spawn: makeMockSpawn({ exitDelayMs: 300, pid: 9101 }),
+        ...procUtils.deps,
+      },
+    });
+
+    conductor.spawnSession(minConfig({ id: "terminal-shutdown-cleanup" }));
+
+    await waitFor(() => procUtils.calls.findProcessTree.length === 1);
+    await waitFor(
+      () => conductor.getSnapshot()[0]?.state === STATES.COMPLETED,
+    );
+    await conductor.shutdown("terminal_cleanup_test");
+
+    assert.deepEqual(procUtils.calls.killProcessTreeSnapshot, [
+      [{ pid: 9101 }, { pid: 9102 }],
+    ]);
+  });
+});
+
+// ── 8-1. process tree cleanup ───────────────────────────────────────────────
+
+describe("conductor: process tree cleanup", () => {
+  it("cleanupChild kills child + descendants when snapshot exists", async () => {
+    await conductor.shutdown("recreate_for_snapshot_cleanup");
+    const procUtils = makeMockProcessUtils({
+      snapshot: [{ pid: 4201 }, { pid: 4202 }],
+    });
+    conductor = makeConductor(logsDir, {
+      graceMs: 10,
+      deps: {
+        spawn: makeMockSpawn({
+          exitDelayMs: 10_000,
+          killExits: false,
+          pid: 4201,
+        }),
+        ...procUtils.deps,
+      },
+    });
+
+    const cfg = minConfig({ id: "snapshot-cleanup" });
+    conductor.spawnSession(cfg);
+    await waitFor(() => procUtils.calls.findProcessTree.length === 1);
+
+    await conductor.killSession(cfg.id, "snapshot_cleanup_test");
+
+    assert.deepEqual(procUtils.calls.killProcessTreeSnapshot, [
+      [{ pid: 4201 }, { pid: 4202 }],
+    ]);
+    assert.deepEqual(procUtils.calls.killProcessTree, [4201]);
+  });
+
+  it("cleanupChild handles missing snapshot gracefully", async () => {
+    await conductor.shutdown("recreate_for_missing_snapshot_cleanup");
+    const procUtils = makeMockProcessUtils({
+      findError: new Error("snapshot failed"),
+    });
+    conductor = makeConductor(logsDir, {
+      graceMs: 10,
+      deps: {
+        spawn: makeMockSpawn({ exitDelayMs: 10_000, pid: 4301 }),
+        ...procUtils.deps,
+      },
+    });
+
+    const cfg = minConfig({ id: "missing-snapshot-cleanup" });
+    conductor.spawnSession(cfg);
+    await waitFor(() => procUtils.calls.findProcessTree.length === 1);
+
+    await assert.doesNotReject(() =>
+      conductor.killSession(cfg.id, "missing_snapshot_cleanup_test"),
+    );
+    assert.deepEqual(procUtils.calls.killProcessTreeSnapshot, []);
+  });
+
+  it("handleFailure final branch invokes cleanupChild before DEAD", async () => {
+    await conductor.shutdown("recreate_for_final_failure_cleanup");
+    const order = [];
+    const procUtils = makeMockProcessUtils({
+      snapshot: [{ pid: 4401 }, { pid: 4402 }],
+      calls: {
+        findProcessTree: [],
+        killProcessTreeSnapshot: [],
+        killProcessTree: [],
+      },
+    });
+    const deps = {
+      findProcessTree: procUtils.deps.findProcessTree,
+      killProcessTree(pid) {
+        procUtils.calls.killProcessTree.push(pid);
+        return { ok: true, killed: 1, errors: [] };
+      },
+      killProcessTreeSnapshot(value) {
+        order.push("cleanup");
+        procUtils.calls.killProcessTreeSnapshot.push(value);
+        return { killed: value.length, missing: 0 };
+      },
+      spawn: makeMockSpawn({ exitCode: 1, exitDelayMs: 300, pid: 4401 }),
+    };
+    conductor = createConductor({
+      logsDir,
+      maxRestarts: 0,
+      graceMs: 10,
+      probeOpts: {
+        intervalMs: 999_999,
+        l1ThresholdMs: 999_999,
+        l3ThresholdMs: 999_999,
+      },
+      deps,
+    });
+    conductor.on("stateChange", (event) => {
+      if (event.to === STATES.DEAD) order.push("dead");
+    });
+
+    conductor.spawnSession(minConfig({ id: "final-failure-cleanup" }));
+
+    await waitFor(() => procUtils.calls.findProcessTree.length === 1);
+    await waitFor(() => order.includes("dead"));
+
+    assert.ok(
+      order.indexOf("cleanup") > -1 &&
+        order.indexOf("cleanup") < order.indexOf("dead"),
+      `expected cleanup before DEAD, got ${order.join(",")}`,
+    );
+  });
+
+  it("spawnSession captures descendantSnapshot after spawn", async () => {
+    await conductor.shutdown("recreate_for_spawn_snapshot_capture");
+    const procUtils = makeMockProcessUtils({
+      snapshot: [{ pid: 4501 }, { pid: 4502 }],
+    });
+    conductor = makeConductor(logsDir, {
+      graceMs: 10,
+      deps: {
+        spawn: makeMockSpawn({ exitDelayMs: 10_000, pid: 4501 }),
+        ...procUtils.deps,
+      },
+    });
+
+    conductor.spawnSession(minConfig({ id: "spawn-snapshot-capture" }));
+
+    await waitFor(() => procUtils.calls.findProcessTree.length === 1);
+    assert.deepEqual(procUtils.calls.findProcessTree, [4501]);
   });
 });
 


### PR DESCRIPTION
## Summary
Phase 2 swarm cleanup integration — `hub/team/conductor.mjs` 가 PR #201 의 process tree helpers (`killProcessTree`, `killProcessTreeSnapshot`, `findProcessTree`) 를 활용해 cleanup orchestration 강화. v10.17.4 의 사용자 cleanup 작업 (cli wrapper protection, session-aware runtime) 과 상호보완 관계.

## Why
- conductor 자체의 cleanup orchestration 이 ad-hoc 였고 kill 후 descendant cleanup 누락 가능성
- final failure path (probe timeout, stall, MCP fail) 에서 cleanup 호출 누락
- v10.17.4 의 lower-level cleanup helper (process-utils + hub-client) 와 정합되는 conductor-level orchestration 필요

## Changes
- `hub/team/conductor.mjs` (root):
  - `cleanupChild()` 가 child kill 후 descendant snapshot 까지 cleanup
  - `handleFailure()` async 변경 + final failure path 에서 cleanup 호출
  - `spawn` 후 200ms delay 후 `findProcessTree()` snapshot 저장 (best-effort)
  - global shutdown loop 가 terminal session 도 cleanup (cleanedSessionIds Set 으로 중복 제거)
- `packages/triflux/hub/team/conductor.mjs` (mirror): byte-identical
- `tests/unit/conductor.test.mjs`: 신규 cleanup orchestration 케이스 (52/52 pass)

## Provenance
- Phase 2 PRD: `.triflux/plans/2026-04-26-swarm-process-tree-cleanup-phase2.md` (P2-conductor shard)
- swarm worker: codex executor (run-1777291731589/P2-conductor)
- main 위 cherry-pick (clean apply, conflict 0)
- 디테일 검토: `.omc/artifacts/review-p2-conductor.md`

## Test plan
- [x] `node --test tests/unit/conductor.test.mjs` — 52/52 pass on main(d43023a)
- [x] biome lint clean (organizeImports 자동 fix 별도 commit)
- [x] mirror SHA-256 byte-identical
- [x] v10.17.4 의 process-utils API 와 호환 확인
- [ ] CI green