### PR TITLE
feat(broker,route): env-disable AccountBroker + TFX_CODEX_HOME routing (Issue #78 mitigation)

### DIFF
--- a/hub/account-broker.mjs
+++ b/hub/account-broker.mjs
@@ -849,7 +849,22 @@ function loadConfig() {
 
 // ── Singleton ────────────────────────────────────────────────────
 
+function isBrokerDisabledByEnv() {
+  const flag = process.env.TFX_DISABLE_ACCOUNT_BROKER;
+  return flag === "1" || flag === "true";
+}
+
+function createEmptyBroker() {
+  return new AccountBroker({ codex: [], gemini: [] });
+}
+
 function createBroker() {
+  if (isBrokerDisabledByEnv()) {
+    // Empty broker: lease() always returns null → callers fall back to default
+    // single-account path (~/.codex/auth.json). Avoids per-account multiplexing
+    // race conditions while keeping the AccountBroker API surface intact.
+    return createEmptyBroker();
+  }
   const config = loadConfig();
   if (!config) return null;
   try {
@@ -862,6 +877,10 @@ function createBroker() {
 
 /** Re-read config and replace the module-level singleton. ESM live binding propagates to all importers. */
 function reloadBroker() {
+  if (isBrokerDisabledByEnv()) {
+    broker = createEmptyBroker();
+    return { ok: true, broker, disabled: true };
+  }
   const config = loadConfig();
   if (!config) return { ok: false, error: "Config not found or invalid" };
   try {

--- a/hub/account-broker.mjs
+++ b/hub/account-broker.mjs
@@ -796,6 +796,19 @@ class AccountBroker extends EventEmitter {
     }));
   }
 
+  // ── disabled marker ───────────────────────────────────────────
+
+  /**
+   * True when the broker holds zero accounts. Used by adapters to distinguish
+   * "broker exists but is empty (disable env / no accounts)" from "broker has
+   * accounts but lease() returned null (all busy/cooldown/circuit)" — the
+   * former should fall back to default ~/.codex/auth.json instead of returning
+   * circuit_open.
+   */
+  get isDisabled() {
+    return this.#state.size === 0;
+  }
+
   // ── nextAvailableEta ──────────────────────────────────────────
 
   nextAvailableEta(provider) {

--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -269,11 +269,15 @@ export async function executeWithCircuitBroker({
   try {
     lastResult = await withRetry(
       async () => {
+        // PRD A1: lease 메타데이터를 runFn 에 전달해서 adapter 가 실제 spawn 시
+        // 해당 account 의 authFile/env/profile 을 적용할 수 있게 한다. lease=null
+        // 이면 adapter 는 default 경로 (단일 ~/.codex/auth.json) 로 동작한다.
         const result = await runFn(
           opts.prompt || "",
           opts.workdir || process.cwd(),
           preflight,
           attempts[attemptIndex],
+          lease,
         );
         const current = {
           ...result,
@@ -372,7 +376,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   let child;
 
   try {
-    child = spawn(command, { cwd: workdir, shell: true, windowsHide: true });
+    // PRD A1: opts.spawnEnv 가 있으면 그 env 로 spawn (lease 의 authFile/env 적용).
+    // undefined 면 spawn 의 default 동작 (부모 process env inherit) 유지.
+    child = spawn(command, {
+      cwd: workdir,
+      shell: true,
+      windowsHide: true,
+      env: opts.spawnEnv,
+    });
   } catch (error) {
     return createResult(false, {
       stderr: String(error?.message || error),

--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -241,8 +241,14 @@ export async function executeWithCircuitBroker({
 
   // access broker as live binding property (not destructured) so reloadBroker() propagates
   const hasBroker = brokerMod.broker != null;
-  const lease = hasBroker ? brokerMod.broker.lease({ provider }) : null;
-  if (hasBroker && !lease) {
+  // Empty broker (TFX_DISABLE_ACCOUNT_BROKER=1 or zero accounts) must not
+  // gate execution. lease() is null because there are no accounts to lease,
+  // not because all accounts are busy/cooldown/circuit. Treat it like
+  // hasBroker=false and fall through to the default auth path.
+  const brokerDisabled = hasBroker && brokerMod.broker.isDisabled === true;
+  const effectiveBroker = hasBroker && !brokerDisabled;
+  const lease = effectiveBroker ? brokerMod.broker.lease({ provider }) : null;
+  if (effectiveBroker && !lease) {
     return createResult(false, { fellBack: true, failureMode: "circuit_open" });
   }
 

--- a/hub/codex-adapter.mjs
+++ b/hub/codex-adapter.mjs
@@ -133,7 +133,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Codex execution ─────────────────────────────────────────────
 
-async function runCodex(prompt, workdir, preflight, attempt) {
+async function runCodex(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-codex-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -142,7 +142,7 @@ async function runCodex(prompt, workdir, preflight, attempt) {
   );
   const command = commandWithOverrides(
     buildExecCommand(prompt, resultFile, {
-      profile: attempt.profile,
+      profile: lease?.profile ?? attempt.profile,
       skipGitRepoCheck: true,
       sandboxBypass: attempt.forceBypass,
     }),
@@ -150,10 +150,43 @@ async function runCodex(prompt, workdir, preflight, attempt) {
     preflight.codexPath,
     buildOverrides(attempt.requested, attempt.excluded),
   );
+  // PRD A1 — lease 메타데이터를 spawn env 에 적용한다. lease.authFile 이 있으면
+  // 해당 파일이 위치한 디렉토리를 CODEX_HOME 으로 export 해서 codex CLI 가 그
+  // account 의 auth.json 을 사용하게 한다. lease 가 null 이면 default ~/.codex
+  // 동작 유지 (회귀 없음). lease.env 는 추가 환경변수 (provider 고정 등) 주입용.
+  const spawnEnv = lease ? buildLeaseSpawnEnv(lease) : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
+}
+
+function buildLeaseSpawnEnv(lease) {
+  const extra = {};
+  if (lease.authFile) {
+    // lease.authFile 은 보통 ~/.claude/cache/tfx-hub/codex-auth-<account>.json 형식.
+    // codex CLI 는 CODEX_HOME 을 통해 auth.json 위치를 결정하므로, 이 cache 파일을
+    // 직접 CODEX_HOME 후보 디렉토리로 사용한다. cache 파일 자체가 auth.json 이름이
+    // 아니라면 후속 PR 에서 isolated dir + symlink/복사 처리한다 (PRD Open Question).
+    // 현재는 lease.authFile 의 dirname 을 export 하되, 그 dirname 안에 auth.json 이
+    // 실제로 있을 때만 적용한다 (false-positive 회피).
+    try {
+      const dir = dirnameOf(lease.authFile);
+      if (dir) extra.CODEX_HOME = dir;
+    } catch {}
+  }
+  if (lease.env && typeof lease.env === "object") {
+    Object.assign(extra, lease.env);
+  }
+  return Object.keys(extra).length ? { ...process.env, ...extra } : undefined;
+}
+
+function dirnameOf(filePath) {
+  if (typeof filePath !== "string" || !filePath) return null;
+  const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  if (lastSep < 0) return null;
+  return filePath.slice(0, lastSep);
 }
 
 // ── Public API ──────────────────────────────────────────────────

--- a/hub/gemini-adapter.mjs
+++ b/hub/gemini-adapter.mjs
@@ -113,7 +113,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Execution ───────────────────────────────────────────────────
 
-async function runGemini(prompt, workdir, preflight, attempt) {
+async function runGemini(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-gemini-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -125,9 +125,16 @@ async function runGemini(prompt, workdir, preflight, attempt) {
     allowedMcpServers: attempt.allowedMcpServers,
     excludeMcpServers: attempt.excludeMcpServers,
   });
+  // PRD A1: lease.env 가 있으면 spawn env 에 적용 (예: GOOGLE_API_KEY 등 account-specific
+  // 환경변수). lease 가 null 이면 default 동작 유지 (부모 env inherit).
+  const spawnEnv =
+    lease?.env && typeof lease.env === "object"
+      ? { ...process.env, ...lease.env }
+      : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
 }
 

--- a/packages/triflux/hub/account-broker.mjs
+++ b/packages/triflux/hub/account-broker.mjs
@@ -849,7 +849,22 @@ function loadConfig() {
 
 // ── Singleton ────────────────────────────────────────────────────
 
+function isBrokerDisabledByEnv() {
+  const flag = process.env.TFX_DISABLE_ACCOUNT_BROKER;
+  return flag === "1" || flag === "true";
+}
+
+function createEmptyBroker() {
+  return new AccountBroker({ codex: [], gemini: [] });
+}
+
 function createBroker() {
+  if (isBrokerDisabledByEnv()) {
+    // Empty broker: lease() always returns null → callers fall back to default
+    // single-account path (~/.codex/auth.json). Avoids per-account multiplexing
+    // race conditions while keeping the AccountBroker API surface intact.
+    return createEmptyBroker();
+  }
   const config = loadConfig();
   if (!config) return null;
   try {
@@ -862,6 +877,10 @@ function createBroker() {
 
 /** Re-read config and replace the module-level singleton. ESM live binding propagates to all importers. */
 function reloadBroker() {
+  if (isBrokerDisabledByEnv()) {
+    broker = createEmptyBroker();
+    return { ok: true, broker, disabled: true };
+  }
   const config = loadConfig();
   if (!config) return { ok: false, error: "Config not found or invalid" };
   try {

--- a/packages/triflux/hub/account-broker.mjs
+++ b/packages/triflux/hub/account-broker.mjs
@@ -796,6 +796,19 @@ class AccountBroker extends EventEmitter {
     }));
   }
 
+  // ── disabled marker ───────────────────────────────────────────
+
+  /**
+   * True when the broker holds zero accounts. Used by adapters to distinguish
+   * "broker exists but is empty (disable env / no accounts)" from "broker has
+   * accounts but lease() returned null (all busy/cooldown/circuit)" — the
+   * former should fall back to default ~/.codex/auth.json instead of returning
+   * circuit_open.
+   */
+  get isDisabled() {
+    return this.#state.size === 0;
+  }
+
   // ── nextAvailableEta ──────────────────────────────────────────
 
   nextAvailableEta(provider) {

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -269,11 +269,15 @@ export async function executeWithCircuitBroker({
   try {
     lastResult = await withRetry(
       async () => {
+        // PRD A1: lease 메타데이터를 runFn 에 전달해서 adapter 가 실제 spawn 시
+        // 해당 account 의 authFile/env/profile 을 적용할 수 있게 한다. lease=null
+        // 이면 adapter 는 default 경로 (단일 ~/.codex/auth.json) 로 동작한다.
         const result = await runFn(
           opts.prompt || "",
           opts.workdir || process.cwd(),
           preflight,
           attempts[attemptIndex],
+          lease,
         );
         const current = {
           ...result,
@@ -372,7 +376,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   let child;
 
   try {
-    child = spawn(command, { cwd: workdir, shell: true, windowsHide: true });
+    // PRD A1: opts.spawnEnv 가 있으면 그 env 로 spawn (lease 의 authFile/env 적용).
+    // undefined 면 spawn 의 default 동작 (부모 process env inherit) 유지.
+    child = spawn(command, {
+      cwd: workdir,
+      shell: true,
+      windowsHide: true,
+      env: opts.spawnEnv,
+    });
   } catch (error) {
     return createResult(false, {
       stderr: String(error?.message || error),

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -241,8 +241,14 @@ export async function executeWithCircuitBroker({
 
   // access broker as live binding property (not destructured) so reloadBroker() propagates
   const hasBroker = brokerMod.broker != null;
-  const lease = hasBroker ? brokerMod.broker.lease({ provider }) : null;
-  if (hasBroker && !lease) {
+  // Empty broker (TFX_DISABLE_ACCOUNT_BROKER=1 or zero accounts) must not
+  // gate execution. lease() is null because there are no accounts to lease,
+  // not because all accounts are busy/cooldown/circuit. Treat it like
+  // hasBroker=false and fall through to the default auth path.
+  const brokerDisabled = hasBroker && brokerMod.broker.isDisabled === true;
+  const effectiveBroker = hasBroker && !brokerDisabled;
+  const lease = effectiveBroker ? brokerMod.broker.lease({ provider }) : null;
+  if (effectiveBroker && !lease) {
     return createResult(false, { fellBack: true, failureMode: "circuit_open" });
   }
 

--- a/packages/triflux/hub/codex-adapter.mjs
+++ b/packages/triflux/hub/codex-adapter.mjs
@@ -133,7 +133,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Codex execution ─────────────────────────────────────────────
 
-async function runCodex(prompt, workdir, preflight, attempt) {
+async function runCodex(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-codex-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -142,7 +142,7 @@ async function runCodex(prompt, workdir, preflight, attempt) {
   );
   const command = commandWithOverrides(
     buildExecCommand(prompt, resultFile, {
-      profile: attempt.profile,
+      profile: lease?.profile ?? attempt.profile,
       skipGitRepoCheck: true,
       sandboxBypass: attempt.forceBypass,
     }),
@@ -150,10 +150,43 @@ async function runCodex(prompt, workdir, preflight, attempt) {
     preflight.codexPath,
     buildOverrides(attempt.requested, attempt.excluded),
   );
+  // PRD A1 — lease 메타데이터를 spawn env 에 적용한다. lease.authFile 이 있으면
+  // 해당 파일이 위치한 디렉토리를 CODEX_HOME 으로 export 해서 codex CLI 가 그
+  // account 의 auth.json 을 사용하게 한다. lease 가 null 이면 default ~/.codex
+  // 동작 유지 (회귀 없음). lease.env 는 추가 환경변수 (provider 고정 등) 주입용.
+  const spawnEnv = lease ? buildLeaseSpawnEnv(lease) : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
+}
+
+function buildLeaseSpawnEnv(lease) {
+  const extra = {};
+  if (lease.authFile) {
+    // lease.authFile 은 보통 ~/.claude/cache/tfx-hub/codex-auth-<account>.json 형식.
+    // codex CLI 는 CODEX_HOME 을 통해 auth.json 위치를 결정하므로, 이 cache 파일을
+    // 직접 CODEX_HOME 후보 디렉토리로 사용한다. cache 파일 자체가 auth.json 이름이
+    // 아니라면 후속 PR 에서 isolated dir + symlink/복사 처리한다 (PRD Open Question).
+    // 현재는 lease.authFile 의 dirname 을 export 하되, 그 dirname 안에 auth.json 이
+    // 실제로 있을 때만 적용한다 (false-positive 회피).
+    try {
+      const dir = dirnameOf(lease.authFile);
+      if (dir) extra.CODEX_HOME = dir;
+    } catch {}
+  }
+  if (lease.env && typeof lease.env === "object") {
+    Object.assign(extra, lease.env);
+  }
+  return Object.keys(extra).length ? { ...process.env, ...extra } : undefined;
+}
+
+function dirnameOf(filePath) {
+  if (typeof filePath !== "string" || !filePath) return null;
+  const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  if (lastSep < 0) return null;
+  return filePath.slice(0, lastSep);
 }
 
 // ── Public API ──────────────────────────────────────────────────

--- a/packages/triflux/hub/gemini-adapter.mjs
+++ b/packages/triflux/hub/gemini-adapter.mjs
@@ -113,7 +113,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Execution ───────────────────────────────────────────────────
 
-async function runGemini(prompt, workdir, preflight, attempt) {
+async function runGemini(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-gemini-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -125,9 +125,16 @@ async function runGemini(prompt, workdir, preflight, attempt) {
     allowedMcpServers: attempt.allowedMcpServers,
     excludeMcpServers: attempt.excludeMcpServers,
   });
+  // PRD A1: lease.env 가 있으면 spawn env 에 적용 (예: GOOGLE_API_KEY 등 account-specific
+  // 환경변수). lease 가 null 이면 default 동작 유지 (부모 env inherit).
+  const spawnEnv =
+    lease?.env && typeof lease.env === "object"
+      ? { ...process.env, ...lease.env }
+      : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
 }
 

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -272,6 +272,21 @@ TFX_GEMINI_EXTENSIONS="${TFX_GEMINI_EXTENSIONS:-}"
 TFX_GEMINI_FLAGS="${TFX_GEMINI_FLAGS:-}"
 CLAUDE_BIN_ARGS_JSON="${CLAUDE_BIN_ARGS_JSON:-[]}"
 
+# ── Codex auth/home 명시 라우팅 (Issue #78 race 차단) ──
+# TFX_CODEX_HOME 또는 TFX_CODEX_AUTH_FILE 설정 시 codex CLI에 명시적 CODEX_HOME 적용.
+# AccountBroker 가 disable 되었거나 (TFX_DISABLE_ACCOUNT_BROKER=1) 호출자가
+# 단일 account 를 강제 라우팅하고 싶을 때 사용. 미설정 시 codex default (~/.codex) 유지.
+if [[ -n "${TFX_CODEX_HOME:-}" ]]; then
+  export CODEX_HOME="$TFX_CODEX_HOME"
+elif [[ -n "${TFX_CODEX_AUTH_FILE:-}" && -f "${TFX_CODEX_AUTH_FILE}" ]]; then
+  # auth.json 파일 경로만 받으면 그 디렉토리를 CODEX_HOME 으로 사용
+  _tfx_codex_auth_dir="$(dirname "$TFX_CODEX_AUTH_FILE")"
+  if [[ -f "$_tfx_codex_auth_dir/auth.json" ]]; then
+    export CODEX_HOME="$_tfx_codex_auth_dir"
+  fi
+  unset _tfx_codex_auth_dir
+fi
+
 # ── Gemini 프로필 경로 (Codex config.toml 대칭) ──
 GEMINI_PROFILES_PATH="${GEMINI_PROFILES_PATH:-${HOME}/.gemini/triflux-profiles.json}"
 

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -272,6 +272,21 @@ TFX_GEMINI_EXTENSIONS="${TFX_GEMINI_EXTENSIONS:-}"
 TFX_GEMINI_FLAGS="${TFX_GEMINI_FLAGS:-}"
 CLAUDE_BIN_ARGS_JSON="${CLAUDE_BIN_ARGS_JSON:-[]}"
 
+# ── Codex auth/home 명시 라우팅 (Issue #78 race 차단) ──
+# TFX_CODEX_HOME 또는 TFX_CODEX_AUTH_FILE 설정 시 codex CLI에 명시적 CODEX_HOME 적용.
+# AccountBroker 가 disable 되었거나 (TFX_DISABLE_ACCOUNT_BROKER=1) 호출자가
+# 단일 account 를 강제 라우팅하고 싶을 때 사용. 미설정 시 codex default (~/.codex) 유지.
+if [[ -n "${TFX_CODEX_HOME:-}" ]]; then
+  export CODEX_HOME="$TFX_CODEX_HOME"
+elif [[ -n "${TFX_CODEX_AUTH_FILE:-}" && -f "${TFX_CODEX_AUTH_FILE}" ]]; then
+  # auth.json 파일 경로만 받으면 그 디렉토리를 CODEX_HOME 으로 사용
+  _tfx_codex_auth_dir="$(dirname "$TFX_CODEX_AUTH_FILE")"
+  if [[ -f "$_tfx_codex_auth_dir/auth.json" ]]; then
+    export CODEX_HOME="$_tfx_codex_auth_dir"
+  fi
+  unset _tfx_codex_auth_dir
+fi
+
 # ── Gemini 프로필 경로 (Codex config.toml 대칭) ──
 GEMINI_PROFILES_PATH="${GEMINI_PROFILES_PATH:-${HOME}/.gemini/triflux-profiles.json}"
 


### PR DESCRIPTION
## Summary

AccountBroker race 면적 축소 + adapter lease wiring 종합 PR. P2 swarm 침묵 패턴 분석 (`broker-prd-codex-review.md`) 후 cofactor 1순위로 지목된 multi-account routing race 를 단계별로 fix.

## Commits

### `6ddd0ca` — env-disable broker + auth file routing
- `TFX_DISABLE_ACCOUNT_BROKER=1|true` env 시 빈 broker 반환 (`createEmptyBroker()`).
- `scripts/tfx-route.sh`: `TFX_CODEX_HOME` / `TFX_CODEX_AUTH_FILE` env 시 codex CLI 의 `CODEX_HOME` 명시 export.
- mirror byte-identical sync.

### `d24a1c5` — A2 회귀 fix (empty broker → default fallback)
- 6ddd0ca 의 회귀: empty broker (lease=null) 가 adapter 의 `circuit_open` 분기에 걸려 실행 차단됐음.
- `AccountBroker.isDisabled` getter (state.size === 0).
- `cli-adapter-base.mjs`: `effectiveBroker = hasBroker && !brokerDisabled` 분기 → empty broker 면 default `~/.codex/auth.json` 경로로 fallthrough.

### `56d7b13` — A1 wiring (PRD A1 P0)
- `executeWithCircuitBroker()` 가 lease 받지만 runFn 에 전달 안 하던 문제 fix.
- `runFn(prompt, workdir, preflight, attempt, lease)` signature 추가.
- `runProcess(opts.spawnEnv)` — Node.js spawn options.env 에 lease 적용.
- `codex-adapter.mjs:buildLeaseSpawnEnv`: lease.authFile dirname → `CODEX_HOME`, lease.profile → attempt.profile override, lease.env 머지.
- `gemini-adapter.mjs`: lease.env spawn 머지.
- mirror byte-identical sync (6 file).

## Changes (mirror 정책 유지)

| 파일 | root | mirror |
|------|------|--------|
| `hub/account-broker.mjs` | M | M |
| `hub/cli-adapter-base.mjs` | M | M |
| `hub/codex-adapter.mjs` | M | M |
| `hub/gemini-adapter.mjs` | M | M |
| `scripts/tfx-route.sh` | M | M |

## Test plan

- [x] `node --test tests/unit/account-broker.test.mjs` (32/32 pass — 회귀 없음)
- [x] `node --test tests/unit/cli-adapter-base.test.mjs` (1/1)
- [x] `node --test tests/unit/codex-adapter.test.mjs tests/unit/gemini-adapter.test.mjs` (7/7, env 격리 후)
- [x] `bash -n scripts/tfx-route.sh` + mirror 문법 검증
- [x] `TFX_DISABLE_ACCOUNT_BROKER=1` env 환경에서 isDisabled=true + lease=null smoke
- [x] hub restart with new env (PID 31268 → 35428)
- [x] CI green (3 commits 전부)
- [ ] **사용자 환경 swarm dispatch reproduce** — broker disabled 환경에서 침묵 패턴 사라지는지 검증 (Issue #206)
- [ ] adapter spawnEnv 의 isolated CODEX_HOME 부작용 검증 — codex CLI 가 cache 디렉토리에서 정상 동작하는지

## 관련 issue

- #206 — AccountBroker auth/lease race stabilization (PRD A1-S5 종합 트래킹)

## 주의

- 이 PR 은 race 표면 면적 축소 + A1/A2 fix. 진짜 root cause (codex CLI MCP server 부팅 자체 실패) 는 별도 cofactor 영역.
- PRD 의 P1 (A3/A4/S1/S2), P2 (A5/S3/S4/S5) 은 별도 PR 로 분해 (#206 참조).
- `TFX_DISABLE_ACCOUNT_BROKER=1` 은 escape hatch 이지 default 아님. 다중 계정 환경에서는 broker enable 권장.