### PR TITLE
fix(codex-mcp,tfx-route): noise-only silent-success guard + stderr fallback recovery (Track G2)

### DIFF
--- a/hub/workers/codex-mcp.mjs
+++ b/hub/workers/codex-mcp.mjs
@@ -116,6 +116,22 @@ function withTimeout(promise, timeoutMs, message) {
   });
 }
 
+// Known noise-only output patterns from codex MCP that indicate transport failure
+// despite exitCode=0. Each entry is matched after trim() against the full output
+// string. Length cap is applied separately to avoid masking real responses that
+// happen to contain a noise substring as a header line.
+const NOISE_ONLY_OUTPUT_PATTERNS = Object.freeze([
+  /^MCP issues detected\.\s*Run \/mcp list for status\.?$/i,
+]);
+const NOISE_ONLY_MAX_BYTES = 256;
+
+function isNoiseOnlyOutput(text) {
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > NOISE_ONLY_MAX_BYTES) return false;
+  return NOISE_ONLY_OUTPUT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 function watchBootstrapClose(transport) {
   let active = true;
   const promise = new Promise((_, reject) => {
@@ -610,6 +626,7 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     const result = await worker.execute(options.prompt, options);
     const hasOutput =
       typeof result.output === "string" && result.output.trim().length > 0;
+    const noiseOnly = hasOutput && isNoiseOnlyOutput(result.output);
     if (hasOutput) {
       process.stdout.write(result.output);
       if (!result.output.endsWith("\n")) {
@@ -622,11 +639,23 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     // response. Without this guard, tfx-route.sh sees STDOUT_LOG=0 bytes and
     // treats it as success — caller gets nothing back.
     // Promote to a transport failure so the wrapper falls back to `codex exec`.
+    //
+    // Noise-only guard (codex 0.125.0+, P2 swarm signature):
+    // codex MCP can also return exitCode=0 with a short noise-only message like
+    // "MCP issues detected. Run /mcp list for status." (~48 bytes) instead of
+    // an actual response payload. trim().length > 0 passes the empty-output
+    // check, so the previous guard misses this case. Pattern-match known noise
+    // strings under a small length cap and promote to transport failure too.
     if (result.error?.code === "CODEX_TRANSPORT_ERROR") {
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else if (!hasOutput && result.exitCode === 0) {
       console.error(
         "[codex-mcp] WARNING: empty output with exit 0 — treating as transport failure (codex 0.124.0 silent-flush regression). Wrapper will fall back to exec path.",
+      );
+      process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
+    } else if (noiseOnly && result.exitCode === 0) {
+      console.error(
+        "[codex-mcp] WARNING: noise-only output (codex MCP error string without payload) with exit 0 — treating as transport failure. Wrapper will fall back to exec path.",
       );
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else {

--- a/packages/triflux/hub/workers/codex-mcp.mjs
+++ b/packages/triflux/hub/workers/codex-mcp.mjs
@@ -116,6 +116,22 @@ function withTimeout(promise, timeoutMs, message) {
   });
 }
 
+// Known noise-only output patterns from codex MCP that indicate transport failure
+// despite exitCode=0. Each entry is matched after trim() against the full output
+// string. Length cap is applied separately to avoid masking real responses that
+// happen to contain a noise substring as a header line.
+const NOISE_ONLY_OUTPUT_PATTERNS = Object.freeze([
+  /^MCP issues detected\.\s*Run \/mcp list for status\.?$/i,
+]);
+const NOISE_ONLY_MAX_BYTES = 256;
+
+function isNoiseOnlyOutput(text) {
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > NOISE_ONLY_MAX_BYTES) return false;
+  return NOISE_ONLY_OUTPUT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 function watchBootstrapClose(transport) {
   let active = true;
   const promise = new Promise((_, reject) => {
@@ -610,6 +626,7 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     const result = await worker.execute(options.prompt, options);
     const hasOutput =
       typeof result.output === "string" && result.output.trim().length > 0;
+    const noiseOnly = hasOutput && isNoiseOnlyOutput(result.output);
     if (hasOutput) {
       process.stdout.write(result.output);
       if (!result.output.endsWith("\n")) {
@@ -622,11 +639,23 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     // response. Without this guard, tfx-route.sh sees STDOUT_LOG=0 bytes and
     // treats it as success — caller gets nothing back.
     // Promote to a transport failure so the wrapper falls back to `codex exec`.
+    //
+    // Noise-only guard (codex 0.125.0+, P2 swarm signature):
+    // codex MCP can also return exitCode=0 with a short noise-only message like
+    // "MCP issues detected. Run /mcp list for status." (~48 bytes) instead of
+    // an actual response payload. trim().length > 0 passes the empty-output
+    // check, so the previous guard misses this case. Pattern-match known noise
+    // strings under a small length cap and promote to transport failure too.
     if (result.error?.code === "CODEX_TRANSPORT_ERROR") {
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else if (!hasOutput && result.exitCode === 0) {
       console.error(
         "[codex-mcp] WARNING: empty output with exit 0 — treating as transport failure (codex 0.124.0 silent-flush regression). Wrapper will fall back to exec path.",
+      );
+      process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
+    } else if (noiseOnly && result.exitCode === 0) {
+      console.error(
+        "[codex-mcp] WARNING: noise-only output (codex MCP error string without payload) with exit 0 — treating as transport failure. Wrapper will fall back to exec path.",
       );
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else {

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1891,10 +1891,29 @@ run_codex_exec() {
       ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
     fi
 
+    # 3차: 마커/parser 둘 다 실패하면 stderr 의 마지막 chunk 를 응답 후보로 보존.
+    # codex 가 응답을 markdown/diff format 으로 출력하고 마지막에 "tokens used"
+    # 마커로 끝나는 패턴이 안정적이므로, "tokens used" 직전까지의 tail 을 사용한다.
+    if [[ ! -s "$STDOUT_LOG" ]]; then
+      sed 's/\r$//' "$STDERR_LOG" \
+        | awk '
+            /^tokens used/ { exit }
+            { buf[NR]=$0 }
+            END {
+              start=NR-200; if (start<1) start=1
+              for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+            }' \
+        > "$STDOUT_LOG"
+    fi
+
     if [[ -s "$STDOUT_LOG" ]]; then
       echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
     else
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패" >&2
+      # 4차: 모든 복구 실패. stderr.log path 를 사용자에게 명확히 노출해
+      # silent exit 가 진짜로 응답을 잃은 게 아니라 단순히 stdout 회수 실패임을 알린다.
+      # marker 형식은 grep 으로 잡기 쉽도록 고정 prefix 사용.
+      echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
     fi
   fi
 

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1891,10 +1891,29 @@ run_codex_exec() {
       ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
     fi
 
+    # 3차: 마커/parser 둘 다 실패하면 stderr 의 마지막 chunk 를 응답 후보로 보존.
+    # codex 가 응답을 markdown/diff format 으로 출력하고 마지막에 "tokens used"
+    # 마커로 끝나는 패턴이 안정적이므로, "tokens used" 직전까지의 tail 을 사용한다.
+    if [[ ! -s "$STDOUT_LOG" ]]; then
+      sed 's/\r$//' "$STDERR_LOG" \
+        | awk '
+            /^tokens used/ { exit }
+            { buf[NR]=$0 }
+            END {
+              start=NR-200; if (start<1) start=1
+              for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+            }' \
+        > "$STDOUT_LOG"
+    fi
+
     if [[ -s "$STDOUT_LOG" ]]; then
       echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
     else
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패" >&2
+      # 4차: 모든 복구 실패. stderr.log path 를 사용자에게 명확히 노출해
+      # silent exit 가 진짜로 응답을 잃은 게 아니라 단순히 stdout 회수 실패임을 알린다.
+      # marker 형식은 grep 으로 잡기 쉽도록 고정 prefix 사용.
+      echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
     fi
   fi
 


### PR DESCRIPTION
## Summary

Track G2 (Issue #206) — codex CLI silent exit 패턴의 잔존 layer fix. PR #185 (codex 0.124.0 silent-flush detect, 2026-04-25 머지) 머지 후에도 두 패턴이 reproduce.

## 진단 (검증된 fact)

1. **PR #185 의 silent-flush guard 정상 작동**: `[tfx-route] Codex MCP 모듈 로드 실패` 로그 + `CODEX_MCP_TRANSPORT_EXIT_CODE` 승격 + exec fallback 진입 모두 확인됨.
2. **그러나 두 잔존 패턴 발견**:
   - **Pattern 1 (noise-only)**: codex MCP 가 exitCode=0 + `"MCP issues detected. Run /mcp list for status."` (~48 byte) 반환. `hasOutput = trim().length > 0` 통과 → silent guard miss. P2 swarm worker.txt 48 byte signature 의 직접 cause.
   - **Pattern 2 (stdout 회수 실패)**: codex exec fallback 경로에서 codex 가 응답을 stderr.log 로 흘리는 케이스 (markdown/diff format). 기존 fallback recovery (codex marker / node parser) 가 못 잡아 stdout.log 0 byte. 2026-04-28 broker-research dispatch 에서 직접 reproduce (stdout.log 0 byte / stderr.log 2.2MB 에 정상 98K 응답 보존됨).

## 변경

### `hub/workers/codex-mcp.mjs` (+mirror)
- `NOISE_ONLY_OUTPUT_PATTERNS` regex + `isNoiseOnlyOutput` helper 추가.
- 길이 cap `NOISE_ONLY_MAX_BYTES = 256` (real 응답이 noise substring 만 포함하는 false positive 회피).
- `runCodexMcpCli()` 분기 추가: `noiseOnly && exitCode === 0` → `CODEX_MCP_TRANSPORT_EXIT_CODE` 로 승격해 wrapper 의 exec fallback 트리거.
- 기존 empty silent-flush guard (PR #185) 와 분리된 별도 분기.

### `scripts/tfx-route.sh:1892~` `run_codex_exec` fallback recovery (+mirror)
- **3차 fallback** 추가: 1차 codex marker / 2차 node parser 실패 시 `'tokens used'` 마커 직전까지의 stderr tail 마지막 200 line 을 `STDOUT_LOG` 에 보존. codex 가 markdown/diff 로 응답을 stderr 에 흘리는 패턴을 안전망으로 잡는다.
- **4차 안내**: 모든 복구 실패 시 stderr.log 절대경로를 `FALLBACK_FAILED stderr_log=<path>` marker 로 stderr 에 출력. 사용자가 raw codex 출력을 즉시 찾을 수 있게 fixed prefix.

## Test plan

- [x] `isNoiseOnlyOutput` 7/7 unit smoke (exact / case-insensitive / whitespace 변형 / 길이 초과 / null / 정상 응답 / "noise + real content" mixed)
- [x] `node --test tests/unit/account-broker.test.mjs` 32/32 pass (회귀 없음)
- [x] `bash -n scripts/tfx-route.sh` + mirror 문법 검증
- [ ] `node --test tests/unit/codex-mcp-worker.test.mjs` — 로컬 환경 `@modelcontextprotocol/sdk` 미설치로 skip. CI 에서 검증 필요.
- [ ] **사용자 환경 swarm dispatch reproduce** — Track G (ground truth). 본 PR 머지 후 P2 swarm 시 worker.txt 48 byte signature 가 사라지고 fallback 안내 메시지 또는 정상 응답이 나오는지 확인.

## 관련

- PR #185 (silent-flush 1차 fix, 머지됨) — 본 PR 은 그 fix 이후 잔존 회귀 영역.
- Issue #206 — AccountBroker auth/lease race stabilization (PRD A1-S5 종합 트래킹). 본 PR 은 codex CLI 영역 G2.
- PR #205 (broker race 표면 축소, OPEN) — 영역 분리. 독립 머지 가능.

## 의미

- PR #205 = broker race cofactor mitigation
- 본 PR (G2) = codex CLI silent exit 본질 영역 (사용자가 "1순위" 로 지목)
- 둘 다 머지되면 P2 swarm 침묵 패턴이 (a) 진단 메시지 (FALLBACK_FAILED) 또는 (b) 실제 응답 보존으로 변환되어 사용자가 즉시 원인 파악 가능.