### PR TITLE
test: G2 codex-exec-recovery 4-path unit mock (Track 1)

### DIFF
--- a/packages/triflux/scripts/lib/codex-recovery.sh
+++ b/packages/triflux/scripts/lib/codex-recovery.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# codex-recovery.sh — codex exec stdout 4계단 recovery helper.
+# 사용: STDOUT_LOG / STDERR_LOG env 설정 후 `source` + `recover_codex_stdout`.
+#
+# 1차 codex marker  → stderr 의 마지막 "codex" 라인 이후 본문 회수
+# 2차 node parser   → MCP/header/sandbox 로그 제외, 응답 부분만 추출
+# 3차 stderr tail   → "tokens used" 직전까지 tail buffer 회수
+# 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
+
+recover_codex_stdout() {
+  if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
+    return 0
+  fi
+
+  # 1차: codex marker
+  sed 's/\r$//' "$STDERR_LOG" \
+    | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
+    > "$STDOUT_LOG"
+
+  # 2차: node parser (MCP/header/sandbox 로그 제외)
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    node -e '
+      const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
+      const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
+      const out=lines.filter(l=>!skip.test(l));
+      if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
+    ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
+  fi
+
+  # 3차: stderr tail before "tokens used"
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    sed 's/\r$//' "$STDERR_LOG" \
+      | awk '
+          /^tokens used/ { exit }
+          { buf[NR]=$0 }
+          END {
+            start=NR-200; if (start<1) start=1
+            for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+          }' \
+      > "$STDOUT_LOG"
+  fi
+
+  if [[ -s "$STDOUT_LOG" ]]; then
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
+  else
+    # 4차: FALLBACK_FAILED
+    echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
+  fi
+}

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1869,6 +1869,11 @@ _codex_config_swap() {
   fi
 }
 
+# codex-recovery.sh 의 recover_codex_stdout 헬퍼 사용. STDOUT_LOG/STDERR_LOG env.
+_TFX_ROUTE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/codex-recovery.sh
+source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+
 run_codex_exec() {
   local prompt="$1"
   local use_tee_flag="$2"
@@ -1889,48 +1894,7 @@ run_codex_exec() {
   worker_pid=$!
   _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
 
-  if [[ ! -s "$STDOUT_LOG" && -s "$STDERR_LOG" ]]; then
-    # stderr에서 마지막 "codex" 마커 이후의 텍스트를 stdout으로 복구
-    # 1차: "codex" 마커 기반 (Windows \r 제거 후 매칭)
-    sed 's/\r$//' "$STDERR_LOG" \
-      | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
-      > "$STDOUT_LOG"
-
-    # 2차: 마커 없을 때 node fallback (MCP/헤더/sandbox 로그 제외, 응답 부분만 추출)
-    if [[ ! -s "$STDOUT_LOG" ]]; then
-      node -e '
-        const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
-        const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
-        const out=lines.filter(l=>!skip.test(l));
-        if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
-      ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
-    fi
-
-    # 3차: 마커/parser 둘 다 실패하면 stderr 의 마지막 chunk 를 응답 후보로 보존.
-    # codex 가 응답을 markdown/diff format 으로 출력하고 마지막에 "tokens used"
-    # 마커로 끝나는 패턴이 안정적이므로, "tokens used" 직전까지의 tail 을 사용한다.
-    if [[ ! -s "$STDOUT_LOG" ]]; then
-      sed 's/\r$//' "$STDERR_LOG" \
-        | awk '
-            /^tokens used/ { exit }
-            { buf[NR]=$0 }
-            END {
-              start=NR-200; if (start<1) start=1
-              for (i=start; i<=NR; i++) if (i in buf) print buf[i]
-            }' \
-        > "$STDOUT_LOG"
-    fi
-
-    if [[ -s "$STDOUT_LOG" ]]; then
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
-    else
-      # 4차: 모든 복구 실패. stderr.log path 를 사용자에게 명확히 노출해
-      # silent exit 가 진짜로 응답을 잃은 게 아니라 단순히 stdout 회수 실패임을 알린다.
-      # marker 형식은 grep 으로 잡기 쉽도록 고정 prefix 사용.
-      echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
-    fi
-  fi
+  recover_codex_stdout
 
   return "$exit_code_local"
 }

--- a/scripts/lib/codex-recovery.sh
+++ b/scripts/lib/codex-recovery.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# codex-recovery.sh — codex exec stdout 4계단 recovery helper.
+# 사용: STDOUT_LOG / STDERR_LOG env 설정 후 `source` + `recover_codex_stdout`.
+#
+# 1차 codex marker  → stderr 의 마지막 "codex" 라인 이후 본문 회수
+# 2차 node parser   → MCP/header/sandbox 로그 제외, 응답 부분만 추출
+# 3차 stderr tail   → "tokens used" 직전까지 tail buffer 회수
+# 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
+
+recover_codex_stdout() {
+  if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
+    return 0
+  fi
+
+  # 1차: codex marker
+  sed 's/\r$//' "$STDERR_LOG" \
+    | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
+    > "$STDOUT_LOG"
+
+  # 2차: node parser (MCP/header/sandbox 로그 제외)
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    node -e '
+      const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
+      const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
+      const out=lines.filter(l=>!skip.test(l));
+      if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
+    ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
+  fi
+
+  # 3차: stderr tail before "tokens used"
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    sed 's/\r$//' "$STDERR_LOG" \
+      | awk '
+          /^tokens used/ { exit }
+          { buf[NR]=$0 }
+          END {
+            start=NR-200; if (start<1) start=1
+            for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+          }' \
+      > "$STDOUT_LOG"
+  fi
+
+  if [[ -s "$STDOUT_LOG" ]]; then
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
+  else
+    # 4차: FALLBACK_FAILED
+    echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
+  fi
+}

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1869,6 +1869,11 @@ _codex_config_swap() {
   fi
 }
 
+# codex-recovery.sh 의 recover_codex_stdout 헬퍼 사용. STDOUT_LOG/STDERR_LOG env.
+_TFX_ROUTE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/codex-recovery.sh
+source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+
 run_codex_exec() {
   local prompt="$1"
   local use_tee_flag="$2"
@@ -1889,48 +1894,7 @@ run_codex_exec() {
   worker_pid=$!
   _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
 
-  if [[ ! -s "$STDOUT_LOG" && -s "$STDERR_LOG" ]]; then
-    # stderr에서 마지막 "codex" 마커 이후의 텍스트를 stdout으로 복구
-    # 1차: "codex" 마커 기반 (Windows \r 제거 후 매칭)
-    sed 's/\r$//' "$STDERR_LOG" \
-      | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
-      > "$STDOUT_LOG"
-
-    # 2차: 마커 없을 때 node fallback (MCP/헤더/sandbox 로그 제외, 응답 부분만 추출)
-    if [[ ! -s "$STDOUT_LOG" ]]; then
-      node -e '
-        const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
-        const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
-        const out=lines.filter(l=>!skip.test(l));
-        if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
-      ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
-    fi
-
-    # 3차: 마커/parser 둘 다 실패하면 stderr 의 마지막 chunk 를 응답 후보로 보존.
-    # codex 가 응답을 markdown/diff format 으로 출력하고 마지막에 "tokens used"
-    # 마커로 끝나는 패턴이 안정적이므로, "tokens used" 직전까지의 tail 을 사용한다.
-    if [[ ! -s "$STDOUT_LOG" ]]; then
-      sed 's/\r$//' "$STDERR_LOG" \
-        | awk '
-            /^tokens used/ { exit }
-            { buf[NR]=$0 }
-            END {
-              start=NR-200; if (start<1) start=1
-              for (i=start; i<=NR; i++) if (i in buf) print buf[i]
-            }' \
-        > "$STDOUT_LOG"
-    fi
-
-    if [[ -s "$STDOUT_LOG" ]]; then
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
-    else
-      # 4차: 모든 복구 실패. stderr.log path 를 사용자에게 명확히 노출해
-      # silent exit 가 진짜로 응답을 잃은 게 아니라 단순히 stdout 회수 실패임을 알린다.
-      # marker 형식은 grep 으로 잡기 쉽도록 고정 prefix 사용.
-      echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
-      echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
-    fi
-  fi
+  recover_codex_stdout
 
   return "$exit_code_local"
 }

--- a/tests/fixtures/codex-exec-recovery/path1-codex-marker.stderr.log
+++ b/tests/fixtures/codex-exec-recovery/path1-codex-marker.stderr.log
@@ -1,0 +1,7 @@
+OpenAI Codex
+--------
+workdir: /tmp/codex
+codex
+This is the actual response content from path 1.
+It has multiple lines.
+And ends here without tokens marker.

--- a/tests/fixtures/codex-exec-recovery/path2-node-parser.stderr.log
+++ b/tests/fixtures/codex-exec-recovery/path2-node-parser.stderr.log
@@ -1,0 +1,13 @@
+mcp: connected
+OpenAI Codex
+--------
+workdir: /tmp/codex
+model: gpt-5
+provider: openai
+approval: never
+sandbox: workspace-write
+reasoning high
+This is the path 2 response content extracted by node parser.
+It survives the skip filter.
+tokens used 50
+EXIT: 0

--- a/tests/fixtures/codex-exec-recovery/path3-stderr-tail.stderr.log
+++ b/tests/fixtures/codex-exec-recovery/path3-stderr-tail.stderr.log
@@ -1,0 +1,10 @@
+mcp: connected
+OpenAI Codex
+--------
+workdir: /tmp/codex
+model: gpt-5
+provider: openai
+approval: never
+sandbox: workspace-write
+reasoning high
+tokens used 75

--- a/tests/fixtures/codex-exec-recovery/path4-fallback-failed.stderr.log
+++ b/tests/fixtures/codex-exec-recovery/path4-fallback-failed.stderr.log
@@ -1,0 +1,1 @@
+tokens used 50

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -29,6 +29,19 @@ function invokeRecovery(stderrContent) {
   return { stdout, stderr, exit: res.status };
 }
 
+const FIXTURE_DIR = "tests/fixtures/codex-exec-recovery";
+
+function loadFixture(name) {
+  return readFileSync(`${FIXTURE_DIR}/${name}`, "utf-8");
+}
+
+function invokeWithFixture(name) {
+  return invokeRecovery(loadFixture(name));
+}
+
+const RECOVERED_MARKER = "stderr에서 응답 복구";
+const FALLBACK_FAILED_MARKER = "FALLBACK_FAILED stderr_log=";
+
 describe("recover_codex_stdout", () => {
   it("function is sourceable and returns 0 on empty STDERR_LOG", () => {
     const res = invokeRecovery("");

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -51,4 +51,29 @@ describe("recover_codex_stdout", () => {
       `helper should exit 0 on empty stderr; got status=${res.exit}, stderr=${res.stderr}`,
     );
   });
+
+  it("1차 codex marker: extracts content after last 'codex' line", () => {
+    const { stdout, stderr, exit } = invokeWithFixture("path1-codex-marker.stderr.log");
+    assert.equal(exit, 0);
+    assert.match(
+      stdout,
+      /This is the actual response content from path 1/,
+      "1차 should preserve real response content",
+    );
+    assert.match(stdout, /And ends here without tokens marker/);
+    assert.doesNotMatch(
+      stdout,
+      /^OpenAI Codex/m,
+      "header before 'codex' marker must not leak into stdout",
+    );
+    assert.doesNotMatch(
+      stdout,
+      /^workdir:/m,
+      "header before 'codex' marker must not leak into stdout",
+    );
+    assert.ok(
+      stderr.includes(RECOVERED_MARKER),
+      `expected '복구' marker; stderr=${stderr}`,
+    );
+  });
 });

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -95,4 +95,22 @@ describe("recover_codex_stdout", () => {
       `expected '복구' marker; stderr=${stderr}`,
     );
   });
+
+  it("3차 stderr tail: dumps everything before 'tokens used' when 1·2차 fail", () => {
+    const { stdout, stderr, exit } = invokeWithFixture("path3-stderr-tail.stderr.log");
+    assert.equal(exit, 0);
+    // 3차 dumps lines that 2차 would have filtered, distinguishing it from 2차.
+    assert.match(stdout, /^mcp: connected/m, "3차 retains mcp: line that 2차 would filter");
+    assert.match(stdout, /^workdir:/m, "3차 retains workdir: line that 2차 would filter");
+    assert.match(stdout, /^reasoning high/m, "3차 retains reasoning line");
+    assert.doesNotMatch(
+      stdout,
+      /^tokens used/m,
+      "3차 awk exits at 'tokens used' before buffering it",
+    );
+    assert.ok(
+      stderr.includes(RECOVERED_MARKER),
+      `expected '복구' marker; stderr=${stderr}`,
+    );
+  });
 });

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -113,4 +113,24 @@ describe("recover_codex_stdout", () => {
       `expected '복구' marker; stderr=${stderr}`,
     );
   });
+
+  it("4차 FALLBACK_FAILED: emits marker when all 3 recovery paths fail", () => {
+    const { stdout, stderr, exit } = invokeWithFixture("path4-fallback-failed.stderr.log");
+    assert.equal(exit, 0, "helper still returns 0 even when recovery fails");
+    assert.equal(stdout, "", "stdout must remain empty when all paths fail");
+    assert.ok(
+      stderr.includes(FALLBACK_FAILED_MARKER),
+      `expected '${FALLBACK_FAILED_MARKER}' marker; stderr=${stderr}`,
+    );
+    assert.match(
+      stderr,
+      /stderr 복구도 실패/,
+      "expected human-readable stderr 복구 실패 message",
+    );
+    assert.doesNotMatch(
+      stderr,
+      new RegExp(RECOVERED_MARKER),
+      "복구 marker must NOT appear when no recovery succeeded",
+    );
+  });
 });

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -76,4 +76,23 @@ describe("recover_codex_stdout", () => {
       `expected '복구' marker; stderr=${stderr}`,
     );
   });
+
+  it("2차 node parser: filters skip patterns when codex marker absent", () => {
+    const { stdout, stderr, exit } = invokeWithFixture("path2-node-parser.stderr.log");
+    assert.equal(exit, 0);
+    assert.match(
+      stdout,
+      /This is the path 2 response content extracted by node parser/,
+      "2차 should preserve content lines that don't match skip regex",
+    );
+    assert.match(stdout, /It survives the skip filter/);
+    assert.doesNotMatch(stdout, /^mcp:/m, "skip regex must drop mcp: lines");
+    assert.doesNotMatch(stdout, /^workdir:/m, "skip regex must drop workdir: lines");
+    assert.doesNotMatch(stdout, /^tokens used/m, "skip regex must drop tokens used line");
+    assert.doesNotMatch(stdout, /^EXIT:/m, "skip regex must drop EXIT: line");
+    assert.ok(
+      stderr.includes(RECOVERED_MARKER),
+      `expected '복구' marker; stderr=${stderr}`,
+    );
+  });
 });

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const LIB = "scripts/lib/codex-recovery.sh";
+
+function invokeRecovery(stderrContent) {
+  const tmp = mkdtempSync(join(tmpdir(), "codex-exec-recovery-"));
+  const stdoutLog = join(tmp, "stdout.log");
+  const stderrLog = join(tmp, "stderr.log");
+  writeFileSync(stdoutLog, "");
+  writeFileSync(stderrLog, stderrContent);
+
+  const res = spawnSync(
+    "bash",
+    [
+      "-c",
+      `source "${LIB}"; STDOUT_LOG="${stdoutLog}" STDERR_LOG="${stderrLog}" recover_codex_stdout`,
+    ],
+    { encoding: "utf-8" },
+  );
+
+  const stdout = readFileSync(stdoutLog, "utf-8");
+  const stderr = res.stderr || "";
+  rmSync(tmp, { recursive: true, force: true });
+  return { stdout, stderr, exit: res.status };
+}
+
+describe("recover_codex_stdout", () => {
+  it("function is sourceable and returns 0 on empty STDERR_LOG", () => {
+    const res = invokeRecovery("");
+    assert.equal(
+      res.exit,
+      0,
+      `helper should exit 0 on empty stderr; got status=${res.exit}, stderr=${res.stderr}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `run_codex_exec` 4-path stdout recovery ladder into sourceable helper `scripts/lib/codex-recovery.sh` (no behavior change).
- Add 4 fixtures + 5 unit tests covering each path: 1차 codex marker, 2차 node parser, 3차 stderr tail, 4차 FALLBACK_FAILED.
- Permanent regression guard for the recovery ladder introduced in #207 (Track G2 silent stdout fix).

## Test plan
- [x] `node --test tests/unit/codex-exec-recovery.test.mjs` — 5/5 PASS (~480ms)
- [x] 3x consecutive runs — stable, no flakes, no temp leaks
- [x] `tests/unit/tfx-route-preflight-all-dead.test.mjs` mirror byte-identity — 20/20 PASS

## Files
- NEW `scripts/lib/codex-recovery.sh` (50 lines) — `recover_codex_stdout` helper, env contract `STDOUT_LOG`/`STDERR_LOG`
- MODIFIED `scripts/tfx-route.sh` — source block + inline 41 LoC → 1 LoC call
- MIRRORED `packages/triflux/scripts/...` — byte-identical (enforced by preflight test)
- NEW `tests/unit/codex-exec-recovery.test.mjs` (~110 lines) — 5 tests with bash subshell harness
- NEW `tests/fixtures/codex-exec-recovery/path{1..4}-*.stderr.log` — 4 fixtures

## Out of scope (deferred)
- Track 2 (`_wait_with_heartbeat` 회귀 진단) — needs diagnosis-then-fix plan
- Track 3 (`--async` wrapper bg 서브쉘 사망) — needs diagnosis-then-fix plan
- Both touch `scripts/tfx-route.sh` outside this PR's scope; separate plans to follow.

## Followups (non-blocking)
- 1차 awk multi-codex drop behavior (last block only) — could use a one-line doc comment
- 3차 awk 200-line cap — could use a one-line doc comment