### PR TITLE
fix(tfx-route): restore heartbeat visibility for non-TTY callers (Track 2)

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1537,13 +1537,31 @@ _wait_with_heartbeat() {
   if [[ -t 2 ]]; then
     heartbeat_monitor "$wpid" &
   else
-    heartbeat_monitor "$wpid" < /dev/null >>"$STDERR_LOG" 2>&1 &
+    # < /dev/null 은 git bash sleep 자식의 caller pipe 점유를 막는 핵심 (1b31a63).
+    # stderr redirect 는 의도치 않게 caller heartbeat 를 STDERR_LOG 로 흡수했으므로 제거.
+    heartbeat_monitor "$wpid" < /dev/null &
   fi
   hb_pid=$!
   wait "$wpid" || ec=$?
   kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null
   return "$ec"
 }
+
+# Inert self-test surface for unit tests. Bypasses CLI dispatch.
+if [[ "${1:-}" == "--inert-self-test" ]]; then
+  shift
+  case "${1:-}" in
+    heartbeat-3s)
+      sleep 3 &
+      _wait_with_heartbeat $! 1
+      exit 0
+      ;;
+    *)
+      echo "[tfx-route] unknown self-test target: ${1:-<empty>}" >&2
+      exit 2
+      ;;
+  esac
+fi
 
 resolve_worker_runner_script() {
   _resolve_script "${TFX_ROUTE_WORKER_RUNNER:-}" "$(_get_script_dir)/tfx-route-worker.mjs"

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1545,6 +1545,22 @@ _wait_with_heartbeat() {
   return "$ec"
 }
 
+# Inert self-test surface for unit tests. Bypasses CLI dispatch.
+if [[ "${1:-}" == "--inert-self-test" ]]; then
+  shift
+  case "${1:-}" in
+    heartbeat-3s)
+      sleep 3 &
+      _wait_with_heartbeat $! 1
+      exit 0
+      ;;
+    *)
+      echo "[tfx-route] unknown self-test target: ${1:-<empty>}" >&2
+      exit 2
+      ;;
+  esac
+fi
+
 resolve_worker_runner_script() {
   _resolve_script "${TFX_ROUTE_WORKER_RUNNER:-}" "$(_get_script_dir)/tfx-route-worker.mjs"
 }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1537,7 +1537,9 @@ _wait_with_heartbeat() {
   if [[ -t 2 ]]; then
     heartbeat_monitor "$wpid" &
   else
-    heartbeat_monitor "$wpid" < /dev/null >>"$STDERR_LOG" 2>&1 &
+    # < /dev/null 은 git bash sleep 자식의 caller pipe 점유를 막는 핵심 (1b31a63).
+    # stderr redirect 는 의도치 않게 caller heartbeat 를 STDERR_LOG 로 흡수했으므로 제거.
+    heartbeat_monitor "$wpid" < /dev/null &
   fi
   hb_pid=$!
   wait "$wpid" || ec=$?

--- a/tests/unit/heartbeat-visibility.test.mjs
+++ b/tests/unit/heartbeat-visibility.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = "scripts/tfx-route.sh";
+
+describe("heartbeat visibility for non-TTY callers", () => {
+  it("emits [tfx-heartbeat] markers to caller stderr when invoked with redirected stderr", () => {
+    // Caller stderr is captured by spawnSync (non-TTY by default).
+    // The inert self-test runs `sleep 3` under _wait_with_heartbeat with interval=1.
+    // Expected (after Task 3 fix): at least 1 [tfx-heartbeat] line in stderr.
+    // Current (before fix): 0 lines (regression — heartbeat goes to STDERR_LOG file).
+    const res = spawnSync(
+      "bash",
+      [SCRIPT, "--inert-self-test", "heartbeat-3s"],
+      {
+        encoding: "utf-8",
+        timeout: 15_000,
+        env: { ...process.env, TFX_HEARTBEAT_INTERVAL: "1", TFX_HEARTBEAT: "1" },
+      },
+    );
+    assert.match(
+      res.stderr || "",
+      /\[tfx-heartbeat\]/,
+      `expected at least one [tfx-heartbeat] marker in caller stderr; got stderr=${(res.stderr || "").slice(0, 500)}; status=${res.status}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Drop `>>"$STDERR_LOG" 2>&1` redirect in `_wait_with_heartbeat` non-TTY branch (introduced by #192/`1b31a63`).
- Keep `< /dev/null` — that is the actual hang-prevention mechanism.
- Heartbeat now flows to caller stderr in non-TTY contexts (Claude Code Bash, CI, headless wrappers).

## Root cause
Commit `1b31a63` over-corrected when adding the TTY guard. The redirect was unnecessary — closing stdin alone solves the pipe-hold hang. The redirect silently hid heartbeat from every non-interactive caller.

## Test plan
- [x] `node --test tests/unit/heartbeat-visibility.test.mjs` — 1/1 PASS (heartbeat marker visible in caller stderr)
- [x] `node --test tests/regression/mcp-bootstrap-no-hang.test.mjs` — 1/1 PASS (`1b31a63` hang regression preserved)
- [x] `node --test tests/unit/tfx-route-preflight-all-dead.test.mjs` — 20/20 PASS (mirror byte-identity)
- [x] `node --test tests/unit/tfx-route-args.test.mjs` — 16/16 PASS (no regression)

## Diagnosis
`.omc/artifacts/track2-heartbeat-missing-diagnosis.md` (H1 LIKELY root cause)

## Notes
- Adds `--inert-self-test heartbeat-3s` surface used only by the unit test (lines 1548-1563)
- Mirror synced via `node scripts/release/check-packages-mirror.mjs --fix`