### PR TITLE
fix(tfx-route): tier-aware codex profile fallback for ChatGPT account (Issue #211)

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1902,15 +1902,51 @@ run_codex_exec() {
   # -c flags는 codex exec에서 MCP enabled 제어 불가 — config swap으로 대체
   # config swap은 codex 블록 최상단(_codex_config_swap "filter")에서 실행됨
 
-  # `--` end-of-options: prompt가 '--'/'---' (front-matter 등)로 시작하면
-  # clap이 flag로 파싱하는 것을 방지. fallback path에서 특히 중요.
-  if [[ "$use_tee_flag" == "true" ]]; then
-    "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null 2>"$STDERR_LOG" | tee "$STDOUT_LOG" &
-  else
-    "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+  _attempt_codex_run() {
+    exit_code_local=0
+    # `--` end-of-options: prompt가 '--'/'---' (front-matter 등)로 시작하면
+    # clap이 flag로 파싱하는 것을 방지. fallback path에서 특히 중요.
+    if [[ "$use_tee_flag" == "true" ]]; then
+      "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null 2>"$STDERR_LOG" | tee "$STDOUT_LOG" &
+    else
+      "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+    fi
+    worker_pid=$!
+    _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
+  }
+
+  _attempt_codex_run
+
+  # Tier-fallback: ChatGPT account (Plus tier 등) 가 gpt-5.5 거부 시 같은 effort 의
+  # gpt-5.4 로 1회 강등 재시도. effort 는 그대로, model 만 한 단계 낮춤.
+  # 매핑: gpt55_xhigh→gpt54_xhigh, gpt55_high→gpt54_high, gpt55_med/low→gpt54_low.
+  # 출처: Issue #211 — codex CLI tier-aware fallback.
+  if [[ "$exit_code_local" -ne 0 ]] && grep -qE "is not supported when using Codex with a ChatGPT account" "$STDERR_LOG" 2>/dev/null; then
+    local fallback_profile=""
+    case "$CLI_EFFORT" in
+      gpt55_xhigh) fallback_profile="gpt54_xhigh" ;;
+      gpt55_high)  fallback_profile="gpt54_high" ;;
+      gpt55_med)   fallback_profile="gpt54_low" ;;
+      gpt55_low)   fallback_profile="gpt54_low" ;;
+    esac
+    if [[ -n "$fallback_profile" ]]; then
+      echo "[tfx-route] tier fallback: $CLI_EFFORT not supported on ChatGPT account → retry with $fallback_profile" >&2
+      local -a new_args=()
+      local skip_next=0
+      for arg in "${codex_args[@]}"; do
+        if [[ "$skip_next" -eq 1 ]]; then
+          new_args+=("$fallback_profile"); skip_next=0
+        elif [[ "$arg" == "--profile" ]]; then
+          new_args+=("$arg"); skip_next=1
+        else
+          new_args+=("$arg")
+        fi
+      done
+      codex_args=("${new_args[@]}")
+      CLI_EFFORT="$fallback_profile"
+      _attempt_codex_run
+    fi
   fi
-  worker_pid=$!
-  _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
 
   recover_codex_stdout
 

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1902,15 +1902,51 @@ run_codex_exec() {
   # -c flags는 codex exec에서 MCP enabled 제어 불가 — config swap으로 대체
   # config swap은 codex 블록 최상단(_codex_config_swap "filter")에서 실행됨
 
-  # `--` end-of-options: prompt가 '--'/'---' (front-matter 등)로 시작하면
-  # clap이 flag로 파싱하는 것을 방지. fallback path에서 특히 중요.
-  if [[ "$use_tee_flag" == "true" ]]; then
-    "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null 2>"$STDERR_LOG" | tee "$STDOUT_LOG" &
-  else
-    "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+  _attempt_codex_run() {
+    exit_code_local=0
+    # `--` end-of-options: prompt가 '--'/'---' (front-matter 등)로 시작하면
+    # clap이 flag로 파싱하는 것을 방지. fallback path에서 특히 중요.
+    if [[ "$use_tee_flag" == "true" ]]; then
+      "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null 2>"$STDERR_LOG" | tee "$STDOUT_LOG" &
+    else
+      "$TIMEOUT_BIN" "$TIMEOUT_SEC" "$CLI_CMD" "${codex_args[@]}" -- "$prompt" < /dev/null >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+    fi
+    worker_pid=$!
+    _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
+  }
+
+  _attempt_codex_run
+
+  # Tier-fallback: ChatGPT account (Plus tier 등) 가 gpt-5.5 거부 시 같은 effort 의
+  # gpt-5.4 로 1회 강등 재시도. effort 는 그대로, model 만 한 단계 낮춤.
+  # 매핑: gpt55_xhigh→gpt54_xhigh, gpt55_high→gpt54_high, gpt55_med/low→gpt54_low.
+  # 출처: Issue #211 — codex CLI tier-aware fallback.
+  if [[ "$exit_code_local" -ne 0 ]] && grep -qE "is not supported when using Codex with a ChatGPT account" "$STDERR_LOG" 2>/dev/null; then
+    local fallback_profile=""
+    case "$CLI_EFFORT" in
+      gpt55_xhigh) fallback_profile="gpt54_xhigh" ;;
+      gpt55_high)  fallback_profile="gpt54_high" ;;
+      gpt55_med)   fallback_profile="gpt54_low" ;;
+      gpt55_low)   fallback_profile="gpt54_low" ;;
+    esac
+    if [[ -n "$fallback_profile" ]]; then
+      echo "[tfx-route] tier fallback: $CLI_EFFORT not supported on ChatGPT account → retry with $fallback_profile" >&2
+      local -a new_args=()
+      local skip_next=0
+      for arg in "${codex_args[@]}"; do
+        if [[ "$skip_next" -eq 1 ]]; then
+          new_args+=("$fallback_profile"); skip_next=0
+        elif [[ "$arg" == "--profile" ]]; then
+          new_args+=("$arg"); skip_next=1
+        else
+          new_args+=("$arg")
+        fi
+      done
+      codex_args=("${new_args[@]}")
+      CLI_EFFORT="$fallback_profile"
+      _attempt_codex_run
+    fi
   fi
-  worker_pid=$!
-  _wait_with_heartbeat "$worker_pid" || exit_code_local=$?
 
   recover_codex_stdout
 


### PR DESCRIPTION
## Summary

ChatGPT account (Plus tier 등) 가 gpt-5.5 호출을 거부할 때 `run_codex_exec` 가 같은 effort 의 gpt-5.4 profile 로 1회 강등 재시도하도록 추가. tfx-route.sh 의 reviewer/scientist/document-specialist 등 hardcoded gpt55_* 사용 agent 가 hard-stop 되는 문제 해결.

Closes #211

## Root cause

`scripts/tfx-route.sh` 의 다음 agent 그룹은 모두 hardcoded gpt55_high/xhigh profile 사용:

- code-reviewer, quality-reviewer (gpt55_high)
- security-reviewer (gpt55_xhigh)
- scientist, document-specialist (gpt55_high)
- planner, analyst, architect (gpt55_xhigh)

ChatGPT account 의 tier (Pro vs Plus) 에 따라 codex CLI 의 gpt-5.5 가용성이 달라진다. Plus tier 에서 codex 가 gpt-5.5 호출 시 즉시 거부:

```
ERROR: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.
```

Pro 한도 소진 → 동일 ChatGPT account 가 Plus 로 폴백 → 위 agent 들 전부 hard-stop. 발견 정황: 2026-04-28 codex 메타 검증 시도 시 exit_code=1 + 위 stderr 패턴.

## 변경 사항

`run_codex_exec` 에 nested helper `_attempt_codex_run` 분리 + tier-fallback 분기 추가:

1. 1차 codex 호출
2. exit_code != 0 이고 stderr 에 위 패턴 매칭 시 fallback profile 결정
3. codex_args 의 --profile 값을 fallback 으로 교체 (다른 인자는 보존)
4. 1회 retry. 결과를 그대로 recover_codex_stdout 로 흘려보냄

매핑:

| from | to | 비고 |
|------|----|------|
| gpt55_xhigh | gpt54_xhigh | effort 보존 |
| gpt55_high  | gpt54_high  | effort 보존 |
| gpt55_med   | gpt54_low   | gpt54_med 미존재 → low 로 fallback |
| gpt55_low   | gpt54_low   | effort 보존 |

설계 원칙:

- **모델 강등 only, effort 보존** — effort 줄이지 않고 model tier 한 단계 낮춤
- **persistent state 없음** — in-flight retry 1회 한정. Pro 한도 reset 시 다음 호출은 자동으로 5.5 로 복귀
- **stderr 가시성 보존** — fallback 발생 시 `[tfx-route] tier fallback: $CLI_EFFORT not supported on ChatGPT account → retry with $fallback_profile` 메시지를 caller stderr 로 출력
- **mirror byte-identity 유지** — root scripts/tfx-route.sh 와 packages/triflux/scripts/tfx-route.sh 동일 패치 (sha256 46cff47d)

## Followups (out of scope for this PR)

- gpt55_* 외 다른 미지원 model 패턴 일반화
- ~/.codex/auth.json plan 정보 read 로 사전 감지 (Issue #211 옵션 B) — 현재는 reactive (stderr 감지)
- escalation chain (gpt54 도 안 되면 gpt-5.3-codex) — 현재는 1회만
- 회귀 테스트 — codex CLI mock 이 비-trivial. follow-up commit 권장

## Test plan

- [x] bash -n 양 mirror syntax check
- [x] sha256 mirror byte-identity 확인 (46cff47dded4d00babce93869a5edf5e4541bc2d352b18bb7b80843e648de0cb)
- [ ] 실제 ChatGPT Plus tier 환경에서 reviewer 호출 → fallback stderr 메시지 + 정상 결과 (수동, follow-up)
- [ ] 기존 unit test 통과 (codex-exec-recovery, heartbeat-visibility, tfx-route-preflight-all-dead)

## Related

- Issue #211 (codex CLI tier-aware fallback)
- 메모리 feedback_codex_chatgpt_account_tier
- 메모리 feedback_codex_config_reset_recurrence (mirror sync 사례 family)