### PR TITLE
fix(hub/workers): lazy-import codex-mcp (Gemini exit 70)

### DIFF
--- a/hub/workers/factory.mjs
+++ b/hub/workers/factory.mjs
@@ -13,11 +13,8 @@
 // existing `requestJson` helper. Callers can override by passing their own
 // `publishCallback` or swap the transport with `requestJsonFn`.
 
-import { requestJson } from "../bridge.mjs";
 import { ClaudeWorker } from "./claude-worker.mjs";
 import { CodexAppServerWorker } from "./codex-app-server-worker.mjs";
-import { CodexMcpWorker } from "./codex-mcp.mjs";
-import { DelegatorMcpWorker } from "./delegator-mcp.mjs";
 import { GeminiWorker } from "./gemini-worker.mjs";
 
 /**
@@ -27,10 +24,12 @@ import { GeminiWorker } from "./gemini-worker.mjs";
  * @param {(path: string, opts?: object) => Promise<unknown>} [requestJsonFn]
  * @returns {(publishMessage: object) => Promise<void>}
  */
-function defaultPublishCallback(requestJsonFn = requestJson) {
+function defaultPublishCallback(requestJsonFn = null) {
   return async (publishMessage) => {
     try {
-      await requestJsonFn("/bridge/publish", { body: publishMessage });
+      const publishRequestJson =
+        requestJsonFn || (await import("../bridge.mjs")).requestJson;
+      await publishRequestJson("/bridge/publish", { body: publishMessage });
     } catch {
       // best-effort; publish failures must not crash the worker
     }
@@ -49,7 +48,7 @@ function defaultPublishCallback(requestJsonFn = requestJson) {
  *
  * @param {object} [opts]
  */
-function createCodexWorker(opts = {}) {
+async function createCodexWorker(opts = {}) {
   const { transport, requestJsonFn, publishCallback, ...rest } = opts;
 
   if (transport === "app-server") {
@@ -72,15 +71,16 @@ function createCodexWorker(opts = {}) {
   }
 
   // Default (and transport === 'mcp'): CodexMcpWorker with zero new deps.
+  const { CodexMcpWorker } = await import("./codex-mcp.mjs");
   return new CodexMcpWorker(rest);
 }
 
 /**
  * @param {'gemini'|'claude'|'codex'|'codex-app-server'|'delegator'} type
  * @param {object} [opts]
- * @returns {import('./interface.mjs').IWorker}
+ * @returns {Promise<import('./interface.mjs').IWorker>}
  */
-export function createWorker(type, opts = {}) {
+export async function createWorker(type, opts = {}) {
   switch (type) {
     case "gemini":
       return new GeminiWorker(opts);
@@ -90,8 +90,10 @@ export function createWorker(type, opts = {}) {
       return createCodexWorker(opts);
     case "codex-app-server":
       return createCodexWorker({ ...opts, transport: "app-server" });
-    case "delegator":
+    case "delegator": {
+      const { DelegatorMcpWorker } = await import("./delegator-mcp.mjs");
       return new DelegatorMcpWorker(opts);
+    }
     default:
       throw new Error(`Unknown worker type: ${type}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3259,7 +3259,7 @@
       }
     },
     "packages/triflux": {
-      "version": "10.16.0",
+      "version": "10.17.4",
       "license": "MIT",
       "dependencies": {
         "@triflux/core": "10.0.1",

--- a/packages/remote/hub/workers/factory.mjs
+++ b/packages/remote/hub/workers/factory.mjs
@@ -13,11 +13,8 @@
 // existing `requestJson` helper. Callers can override by passing their own
 // `publishCallback` or swap the transport with `requestJsonFn`.
 
-import { requestJson } from "@triflux/core/hub/bridge.mjs";
 import { ClaudeWorker } from "./claude-worker.mjs";
 import { CodexAppServerWorker } from "./codex-app-server-worker.mjs";
-import { CodexMcpWorker } from "./codex-mcp.mjs";
-import { DelegatorMcpWorker } from "./delegator-mcp.mjs";
 import { GeminiWorker } from "./gemini-worker.mjs";
 
 /**
@@ -27,10 +24,13 @@ import { GeminiWorker } from "./gemini-worker.mjs";
  * @param {(path: string, opts?: object) => Promise<unknown>} [requestJsonFn]
  * @returns {(publishMessage: object) => Promise<void>}
  */
-function defaultPublishCallback(requestJsonFn = requestJson) {
+function defaultPublishCallback(requestJsonFn = null) {
   return async (publishMessage) => {
     try {
-      await requestJsonFn("/bridge/publish", { body: publishMessage });
+      const publishRequestJson =
+        requestJsonFn ||
+        (await import("@triflux/core/hub/bridge.mjs")).requestJson;
+      await publishRequestJson("/bridge/publish", { body: publishMessage });
     } catch {
       // best-effort; publish failures must not crash the worker
     }
@@ -49,7 +49,7 @@ function defaultPublishCallback(requestJsonFn = requestJson) {
  *
  * @param {object} [opts]
  */
-function createCodexWorker(opts = {}) {
+async function createCodexWorker(opts = {}) {
   const { transport, requestJsonFn, publishCallback, ...rest } = opts;
 
   if (transport === "app-server") {
@@ -72,15 +72,16 @@ function createCodexWorker(opts = {}) {
   }
 
   // Default (and transport === 'mcp'): CodexMcpWorker with zero new deps.
+  const { CodexMcpWorker } = await import("./codex-mcp.mjs");
   return new CodexMcpWorker(rest);
 }
 
 /**
  * @param {'gemini'|'claude'|'codex'|'codex-app-server'|'delegator'} type
  * @param {object} [opts]
- * @returns {import('./interface.mjs').IWorker}
+ * @returns {Promise<import('./interface.mjs').IWorker>}
  */
-export function createWorker(type, opts = {}) {
+export async function createWorker(type, opts = {}) {
   switch (type) {
     case "gemini":
       return new GeminiWorker(opts);
@@ -90,8 +91,10 @@ export function createWorker(type, opts = {}) {
       return createCodexWorker(opts);
     case "codex-app-server":
       return createCodexWorker({ ...opts, transport: "app-server" });
-    case "delegator":
+    case "delegator": {
+      const { DelegatorMcpWorker } = await import("./delegator-mcp.mjs");
       return new DelegatorMcpWorker(opts);
+    }
     default:
       throw new Error(`Unknown worker type: ${type}`);
   }

--- a/packages/triflux/hub/workers/factory.mjs
+++ b/packages/triflux/hub/workers/factory.mjs
@@ -13,11 +13,8 @@
 // existing `requestJson` helper. Callers can override by passing their own
 // `publishCallback` or swap the transport with `requestJsonFn`.
 
-import { requestJson } from "../bridge.mjs";
 import { ClaudeWorker } from "./claude-worker.mjs";
 import { CodexAppServerWorker } from "./codex-app-server-worker.mjs";
-import { CodexMcpWorker } from "./codex-mcp.mjs";
-import { DelegatorMcpWorker } from "./delegator-mcp.mjs";
 import { GeminiWorker } from "./gemini-worker.mjs";
 
 /**
@@ -27,10 +24,12 @@ import { GeminiWorker } from "./gemini-worker.mjs";
  * @param {(path: string, opts?: object) => Promise<unknown>} [requestJsonFn]
  * @returns {(publishMessage: object) => Promise<void>}
  */
-function defaultPublishCallback(requestJsonFn = requestJson) {
+function defaultPublishCallback(requestJsonFn = null) {
   return async (publishMessage) => {
     try {
-      await requestJsonFn("/bridge/publish", { body: publishMessage });
+      const publishRequestJson =
+        requestJsonFn || (await import("../bridge.mjs")).requestJson;
+      await publishRequestJson("/bridge/publish", { body: publishMessage });
     } catch {
       // best-effort; publish failures must not crash the worker
     }
@@ -49,7 +48,7 @@ function defaultPublishCallback(requestJsonFn = requestJson) {
  *
  * @param {object} [opts]
  */
-function createCodexWorker(opts = {}) {
+async function createCodexWorker(opts = {}) {
   const { transport, requestJsonFn, publishCallback, ...rest } = opts;
 
   if (transport === "app-server") {
@@ -72,15 +71,16 @@ function createCodexWorker(opts = {}) {
   }
 
   // Default (and transport === 'mcp'): CodexMcpWorker with zero new deps.
+  const { CodexMcpWorker } = await import("./codex-mcp.mjs");
   return new CodexMcpWorker(rest);
 }
 
 /**
  * @param {'gemini'|'claude'|'codex'|'codex-app-server'|'delegator'} type
  * @param {object} [opts]
- * @returns {import('./interface.mjs').IWorker}
+ * @returns {Promise<import('./interface.mjs').IWorker>}
  */
-export function createWorker(type, opts = {}) {
+export async function createWorker(type, opts = {}) {
   switch (type) {
     case "gemini":
       return new GeminiWorker(opts);
@@ -90,8 +90,10 @@ export function createWorker(type, opts = {}) {
       return createCodexWorker(opts);
     case "codex-app-server":
       return createCodexWorker({ ...opts, transport: "app-server" });
-    case "delegator":
+    case "delegator": {
+      const { DelegatorMcpWorker } = await import("./delegator-mcp.mjs");
       return new DelegatorMcpWorker(opts);
+    }
     default:
       throw new Error(`Unknown worker type: ${type}`);
   }

--- a/packages/triflux/scripts/tfx-route-worker.mjs
+++ b/packages/triflux/scripts/tfx-route-worker.mjs
@@ -199,7 +199,7 @@ async function runWorker(worker, type, prompt) {
 const args = parseArgs(process.argv.slice(2));
 const prompt = readPromptFromStdin();
 
-const worker = createWorker(args.type, {
+const worker = await createWorker(args.type, {
   command: args.command,
   commandArgs: parseJsonArray(args.commandArgsJson, "--command-args-json"),
   model: args.model,

--- a/scripts/tfx-route-worker.mjs
+++ b/scripts/tfx-route-worker.mjs
@@ -199,7 +199,7 @@ async function runWorker(worker, type, prompt) {
 const args = parseArgs(process.argv.slice(2));
 const prompt = readPromptFromStdin();
 
-const worker = createWorker(args.type, {
+const worker = await createWorker(args.type, {
   command: args.command,
   commandArgs: parseJsonArray(args.commandArgsJson, "--command-args-json"),
   model: args.model,

--- a/tests/integration/codex-app-server-streaming.test.mjs
+++ b/tests/integration/codex-app-server-streaming.test.mjs
@@ -91,7 +91,7 @@ describe("codex-app-server integration — fake app-server + factory", () => {
     timeout: 15_000,
   }, async () => {
     const publishes = [];
-    const worker = createWorker("codex", {
+    const worker = await createWorker("codex", {
       transport: "app-server",
       command: process.execPath,
       args: [FAKE_SERVER],
@@ -179,7 +179,7 @@ describe("codex-app-server integration — full stack (no mocks)", () => {
     // Real JsonRpcStdioClient path via `WildcardOrderAdapter` — still a real
     // pipe, real child, real protocol parser. The adapter only patches the
     // wildcard arg order (see header note for the PRD-1/2 bug handoff).
-    const worker = createWorker("codex-app-server", {
+    const worker = await createWorker("codex-app-server", {
       command: process.execPath,
       args: [FAKE_SERVER],
       env: { FAKE_MODE: "ok", FAKE_DELTAS: "PONG" },
@@ -252,7 +252,7 @@ describe("codex-app-server integration — AC-15 PID zombie check", () => {
     const pidState = {};
     const wrappedSpawn = makePidCapturingSpawn(pidState);
 
-    const worker = createWorker("codex", {
+    const worker = await createWorker("codex", {
       transport: "app-server",
       command: process.execPath,
       args: [FAKE_SERVER],
@@ -290,7 +290,7 @@ describe("codex-app-server integration — real codex (env-gated)", () => {
     skip: !REAL_CODEX_ENABLED,
   }, async () => {
     const publishes = [];
-    const worker = createWorker("codex-app-server", {
+    const worker = await createWorker("codex-app-server", {
       bootstrapTimeoutMs: 15_000,
       publishCallback: (msg) => {
         publishes.push(msg);

--- a/tests/integration/workers.test.mjs
+++ b/tests/integration/workers.test.mjs
@@ -89,14 +89,20 @@ describe("ClaudeWorker", { timeout: 15000 }, () => {
 });
 
 describe("createWorker()", { timeout: 15000 }, () => {
-  it("타입별 worker 인스턴스를 생성해야 한다", () => {
-    assert.equal(createWorker("gemini").constructor.name, "GeminiWorker");
-    assert.equal(createWorker("claude").constructor.name, "ClaudeWorker");
+  it("타입별 worker 인스턴스를 생성해야 한다", async () => {
     assert.equal(
-      createWorker("delegator").constructor.name,
+      (await createWorker("gemini")).constructor.name,
+      "GeminiWorker",
+    );
+    assert.equal(
+      (await createWorker("claude")).constructor.name,
+      "ClaudeWorker",
+    );
+    assert.equal(
+      (await createWorker("delegator")).constructor.name,
       "DelegatorMcpWorker",
     );
-    assert.throws(() => createWorker("unknown"), /Unknown worker type/);
+    await assert.rejects(() => createWorker("unknown"), /Unknown worker type/);
   });
 });
 

--- a/tests/unit/factory-lazy-import.test.mjs
+++ b/tests/unit/factory-lazy-import.test.mjs
@@ -1,0 +1,81 @@
+// tests/unit/factory-lazy-import.test.mjs — SDK-missing factory import guard
+
+import assert from "node:assert/strict";
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { createWorker as createInstalledWorker } from "../../hub/workers/factory.mjs";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(TEST_DIR, "..", "..");
+const WORKERS_DIR = resolve(PROJECT_ROOT, "hub", "workers");
+
+async function importFactoryFromSdkMissingTree() {
+  const root = mkdtempSync(join(tmpdir(), "triflux-factory-no-sdk-"));
+  mkdirSync(join(root, "hub"), { recursive: true });
+  cpSync(WORKERS_DIR, join(root, "hub", "workers"), { recursive: true });
+
+  try {
+    const factoryUrl = pathToFileURL(
+      join(root, "hub", "workers", "factory.mjs"),
+    ).href;
+    return {
+      root,
+      factory: await import(factoryUrl),
+    };
+  } catch (error) {
+    rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function removeTree(path) {
+  rmSync(path, { recursive: true, force: true });
+}
+
+describe("worker factory lazy imports SDK-dependent workers", () => {
+  it("creates GeminiWorker when @modelcontextprotocol/sdk is absent", async () => {
+    const { root, factory } = await importFactoryFromSdkMissingTree();
+    try {
+      const worker = await factory.createWorker("gemini");
+      assert.equal(worker.constructor.name, "GeminiWorker");
+      assert.equal(worker.type, "gemini");
+    } finally {
+      removeTree(root);
+    }
+  });
+
+  it("creates ClaudeWorker when @modelcontextprotocol/sdk is absent", async () => {
+    const { root, factory } = await importFactoryFromSdkMissingTree();
+    try {
+      const worker = await factory.createWorker("claude");
+      assert.equal(worker.constructor.name, "ClaudeWorker");
+      assert.equal(worker.type, "claude");
+    } finally {
+      removeTree(root);
+    }
+  });
+
+  it("rejects codex-mcp creation clearly when @modelcontextprotocol/sdk is absent", async () => {
+    const { root, factory } = await importFactoryFromSdkMissingTree();
+    try {
+      await assert.rejects(
+        () => factory.createWorker("codex", { transport: "mcp" }),
+        (error) =>
+          error?.code === "ERR_MODULE_NOT_FOUND" &&
+          /@modelcontextprotocol\/sdk/.test(error.message),
+      );
+    } finally {
+      removeTree(root);
+    }
+  });
+
+  it("creates CodexMcpWorker when @modelcontextprotocol/sdk is installed", async () => {
+    const worker = await createInstalledWorker("codex", { transport: "mcp" });
+    assert.equal(worker.constructor.name, "CodexMcpWorker");
+    assert.equal(worker.type, "codex");
+  });
+});

--- a/tests/unit/worker-factory.test.mjs
+++ b/tests/unit/worker-factory.test.mjs
@@ -16,8 +16,8 @@ import { CodexMcpWorker } from "../../hub/workers/codex-mcp.mjs";
 import { createWorker } from "../../hub/workers/factory.mjs";
 
 describe("worker factory — AC-9 dispatch", () => {
-  it("1. createWorker('codex') returns CodexMcpWorker (AC-11 regression, zero default change)", () => {
-    const worker = createWorker("codex");
+  it("1. createWorker('codex') returns CodexMcpWorker (AC-11 regression, zero default change)", async () => {
+    const worker = await createWorker("codex");
     assert.ok(
       worker instanceof CodexMcpWorker,
       "default codex type must remain MCP transport",
@@ -25,8 +25,8 @@ describe("worker factory — AC-9 dispatch", () => {
     assert.equal(worker.type, "codex");
   });
 
-  it("2. createWorker('codex', { transport: 'app-server' }) returns CodexAppServerWorker", () => {
-    const worker = createWorker("codex", { transport: "app-server" });
+  it("2. createWorker('codex', { transport: 'app-server' }) returns CodexAppServerWorker", async () => {
+    const worker = await createWorker("codex", { transport: "app-server" });
     assert.ok(
       worker instanceof CodexAppServerWorker,
       "transport=app-server must route to app-server worker",
@@ -35,23 +35,23 @@ describe("worker factory — AC-9 dispatch", () => {
     assert.equal(worker.transport, "app-server");
   });
 
-  it("3. createWorker('codex-app-server') returns CodexAppServerWorker (explicit name)", () => {
-    const worker = createWorker("codex-app-server");
+  it("3. createWorker('codex-app-server') returns CodexAppServerWorker (explicit name)", async () => {
+    const worker = await createWorker("codex-app-server");
     assert.ok(
       worker instanceof CodexAppServerWorker,
       "explicit codex-app-server type must route to app-server worker",
     );
   });
 
-  it("4. createWorker('codex', { transport: 'mcp' }) explicitly returns CodexMcpWorker", () => {
-    const worker = createWorker("codex", { transport: "mcp" });
+  it("4. createWorker('codex', { transport: 'mcp' }) explicitly returns CodexMcpWorker", async () => {
+    const worker = await createWorker("codex", { transport: "mcp" });
     assert.ok(worker instanceof CodexMcpWorker);
   });
 });
 
 describe("worker factory — AC-10 publishCallback wiring", () => {
-  it("5. app-server worker gets a default publishCallback function when none is provided", () => {
-    const worker = createWorker("codex", { transport: "app-server" });
+  it("5. app-server worker gets a default publishCallback function when none is provided", async () => {
+    const worker = await createWorker("codex", { transport: "app-server" });
     assert.equal(
       typeof worker.publishCallback,
       "function",
@@ -59,9 +59,9 @@ describe("worker factory — AC-10 publishCallback wiring", () => {
     );
   });
 
-  it("6. factory passes through a user-provided publishCallback unchanged", () => {
+  it("6. factory passes through a user-provided publishCallback unchanged", async () => {
     const userCallback = async () => {};
-    const worker = createWorker("codex", {
+    const worker = await createWorker("codex", {
       transport: "app-server",
       publishCallback: userCallback,
     });
@@ -79,7 +79,7 @@ describe("worker factory — AC-10 publishCallback wiring", () => {
       return { ok: true };
     };
 
-    const worker = createWorker("codex", {
+    const worker = await createWorker("codex", {
       transport: "app-server",
       requestJsonFn: fakeRequestJson,
     });
@@ -108,7 +108,7 @@ describe("worker factory — AC-10 publishCallback wiring", () => {
     const fakeRequestJson = async () => {
       throw new Error("bridge down");
     };
-    const worker = createWorker("codex-app-server", {
+    const worker = await createWorker("codex-app-server", {
       requestJsonFn: fakeRequestJson,
     });
 
@@ -120,28 +120,31 @@ describe("worker factory — AC-10 publishCallback wiring", () => {
 });
 
 describe("worker factory — AC-11 regression", () => {
-  it("9. no opts → CodexMcpWorker (unchanged behavior for existing callers)", () => {
-    const worker = createWorker("codex");
+  it("9. no opts → CodexMcpWorker (unchanged behavior for existing callers)", async () => {
+    const worker = await createWorker("codex");
     assert.ok(worker instanceof CodexMcpWorker);
     assert.ok(!(worker instanceof CodexAppServerWorker));
   });
 
-  it("10. unknown worker type still throws a recognizable error", () => {
-    assert.throws(() => createWorker("nonexistent"), /Unknown worker type/);
+  it("10. unknown worker type still rejects with a recognizable error", async () => {
+    await assert.rejects(
+      () => createWorker("nonexistent"),
+      /Unknown worker type/,
+    );
   });
 });
 
 describe("worker factory — Issue #95 P1 #4 approvalPolicy validation", () => {
-  it("11. app-server transport + approvalPolicy='never' is accepted", () => {
-    const worker = createWorker("codex", {
+  it("11. app-server transport + approvalPolicy='never' is accepted", async () => {
+    const worker = await createWorker("codex", {
       transport: "app-server",
       approvalPolicy: "never",
     });
     assert.ok(worker instanceof CodexAppServerWorker);
   });
 
-  it("12. app-server transport + approvalPolicy='on-failure' throws", () => {
-    assert.throws(
+  it("12. app-server transport + approvalPolicy='on-failure' rejects", async () => {
+    await assert.rejects(
       () =>
         createWorker("codex", {
           transport: "app-server",
@@ -151,22 +154,22 @@ describe("worker factory — Issue #95 P1 #4 approvalPolicy validation", () => {
     );
   });
 
-  it("13. app-server transport + approvalPolicy='untrusted' throws", () => {
-    assert.throws(
+  it("13. app-server transport + approvalPolicy='untrusted' rejects", async () => {
+    await assert.rejects(
       () => createWorker("codex-app-server", { approvalPolicy: "untrusted" }),
       /approvalPolicy='never'/,
     );
   });
 
-  it("14. app-server transport + undefined approvalPolicy defaults OK", () => {
-    const worker = createWorker("codex", { transport: "app-server" });
+  it("14. app-server transport + undefined approvalPolicy defaults OK", async () => {
+    const worker = await createWorker("codex", { transport: "app-server" });
     assert.ok(worker instanceof CodexAppServerWorker);
   });
 
-  it("15. mcp transport with non-never approvalPolicy is NOT blocked (no regression)", () => {
+  it("15. mcp transport with non-never approvalPolicy is NOT blocked (no regression)", async () => {
     // The restriction only applies to the app-server transport; the legacy MCP
     // path continues to accept any approvalPolicy value.
-    const worker = createWorker("codex", {
+    const worker = await createWorker("codex", {
       transport: "mcp",
       approvalPolicy: "on-failure",
     });


### PR DESCRIPTION
## Problem
factory.mjs eagerly imported SDK-dependent CodexMcpWorker/DelegatorMcpWorker; when @modelcontextprotocol/sdk was unresolvable the entire factory crashed during ESM evaluation, taking Gemini and Claude workers down with exit 70.

## Fix
Lazy-import codex-mcp and delegator-mcp only inside the branches that need them. createWorker is now async and callers/tests await factory construction. The app-server publish callback also lazy-loads bridge.mjs unless a requestJsonFn is injected.

## Test
- Restored @modelcontextprotocol/sdk via npm install (node_modules package present; package-lock refreshed).
- Added tests/unit/factory-lazy-import.test.mjs covering Gemini/Claude creation under an SDK-missing temp module tree and codex-mcp failure isolation.
- Focused factory/codex/Gemini/Claude tests pass locally:
  - node scripts/test-lock.mjs --test --test-force-exit tests/unit/factory-lazy-import.test.mjs tests/unit/worker-factory.test.mjs tests/unit/codex-mcp-worker.test.mjs tests/unit/codex-exec-recovery.test.mjs tests/integration/workers.test.mjs tests/integration/codex-app-server-streaming.test.mjs
- npm run release:check-mirror passes.
- Full npm test currently has unrelated existing failures in hub-quota-nonblocking and codex/gemini adapter circuit-breaker tests; tfx-route-team-bridge passed on focused rerun.
- npm run lint still reports pre-existing formatter drift outside this change plus no errors in the touched files checked with npx biome check.

## Notes
- Found via session checkpoint from 2026-04-29: Gemini bridge.mjs missing was a false lead. Real root cause is eager static import.