### PR TITLE
feat(mcp-guard): proactive registry sync at SessionStart with denylist policy

### DIFF
--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -2,6 +2,9 @@
   "$schema": "mcp-registry-schema",
   "version": 1,
   "description": "MCP 서버 중앙 레지스트리 — 진실의 원천",
+  "policy_notes": {
+    "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
+  },
   "defaults": {
     "transport": "hub-url",
     "hub_base": "http://127.0.0.1:27888"
@@ -18,6 +21,7 @@
   "policies": {
     "stdio_action": "replace-with-hub",
     "unknown_server_action": "warn",
+    "sync_denylist": [],
     "watched_paths": [
       "~/.gemini/settings.json",
       "~/.codex/config.toml",

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-proactive-sync.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-proactive-sync.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(TEST_DIR, "..", "..");
+const SAFETY_GUARD_PATH = join(PROJECT_ROOT, "scripts", "mcp-safety-guard.mjs");
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_HUB_PORT: process.env.TFX_HUB_PORT,
+  TFX_TEST: process.env.TFX_TEST,
+};
+const originalCwd = process.cwd();
+const tempRoots = [];
+
+function makeTempRoot(prefix = "mcp-guard-proactive-") {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function useHome(homeDir) {
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+}
+
+function writeGeminiSettings(homeDir, settings) {
+  const settingsPath = join(homeDir, ".gemini", "settings.json");
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+  return settingsPath;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function registryFor(settingsPath, overrides = {}) {
+  return {
+    version: 1,
+    defaults: {
+      transport: "hub-url",
+      hub_base: "http://127.0.0.1:27888",
+    },
+    servers: {
+      "tfx-hub": {
+        transport: "hub-url",
+        url: "http://127.0.0.1:27888/mcp",
+        safe: true,
+        targets: ["gemini"],
+        description: "triflux Hub MCP 서버",
+      },
+      ...(overrides.servers || {}),
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      unknown_server_action: "warn",
+      sync_denylist: [],
+      watched_paths: [settingsPath],
+      ...(overrides.policies || {}),
+    },
+  };
+}
+
+beforeEach(() => {
+  restoreEnv();
+  process.env.TFX_HUB_PORT = "30123";
+  process.env.TFX_TEST = "1";
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  restoreEnv();
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root?.startsWith(tmpdir())) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("mcp guard proactive registry sync", () => {
+  it("creates tfx-hub for empty Gemini mcpServers with resolved Hub URL", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+
+    const result = syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.equal(
+      updated.mcpServers["tfx-hub"].url,
+      "http://127.0.0.1:30123/mcp",
+    );
+    assert.equal(
+      result.actions.some((action) => action.status === "updated"),
+      true,
+    );
+  });
+
+  it("adds only tfx-hub and preserves unrelated Gemini MCP servers", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const unrelated = {
+      url: "https://example.com/mcp",
+      header: "keep-me",
+    };
+    const settingsPath = writeGeminiSettings(homeDir, {
+      mcpServers: {
+        unrelated,
+      },
+    });
+
+    syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.deepEqual(updated.mcpServers.unrelated, unrelated);
+    assert.deepEqual(Object.keys(updated.mcpServers).sort(), [
+      "tfx-hub",
+      "unrelated",
+    ]);
+  });
+
+  it("remediates stdio entries and adds the Hub entry in the combined flow", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, {
+      mcpServers: {
+        "unsafe-stdio": { command: "node", args: ["server.js"] },
+      },
+    });
+
+    const result = syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.equal(Object.hasOwn(updated.mcpServers, "unsafe-stdio"), false);
+    assert.equal(
+      updated.mcpServers["tfx-hub"].url,
+      "http://127.0.0.1:30123/mcp",
+    );
+    assert.equal(
+      result.actions.some(
+        (action) => action.type === "remediate" && action.status === "updated",
+      ),
+      true,
+    );
+  });
+
+  it("skips missing managed entries when sync_denylist contains gemini:tfx-hub", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(settingsPath, {
+        policies: { sync_denylist: ["gemini:tfx-hub"] },
+      }),
+    });
+    const updated = readJson(settingsPath);
+    const policySkips = result.actions.filter(
+      (action) => action.status === "policy-skip",
+    );
+
+    assert.deepEqual(updated.mcpServers, {});
+    assert.equal(policySkips.length, 1);
+    assert.equal(
+      policySkips[0].message,
+      "[mcp-guard] policy skip: gemini:tfx-hub",
+    );
+    assert.equal(policySkips[0].message.includes("\n"), false);
+  });
+
+  it("does not write again when syncRegistryTargets runs twice", async () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+    const registry = registryFor(settingsPath);
+
+    syncRegistryTargets({ registry });
+    const beforeContent = readFileSync(settingsPath, "utf8");
+    const beforeMtime = statSync(settingsPath).mtimeMs;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const second = syncRegistryTargets({ registry });
+    const afterContent = readFileSync(settingsPath, "utf8");
+    const afterMtime = statSync(settingsPath).mtimeMs;
+
+    assert.equal(
+      second.actions.filter((action) => action.status === "updated").length,
+      0,
+    );
+    assert.equal(afterContent, beforeContent);
+    assert.equal(afterMtime, beforeMtime);
+  });
+
+  it("leaves parse-error JSON untouched and the hook exits 0 with a warning", async () => {
+    const homeDir = makeTempRoot();
+    const projectDir = makeTempRoot("mcp-guard-project-");
+    useHome(homeDir);
+    process.chdir(projectDir);
+
+    const settingsPath = join(homeDir, ".gemini", "settings.json");
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, "{broken-json", "utf8");
+
+    const guardUrl = `${pathToFileURL(SAFETY_GUARD_PATH).href}?case=${Date.now()}`;
+    const { run } = await import(guardUrl);
+    const result = await run();
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /\[mcp-guard\] 설정 파싱 실패:/);
+    assert.equal(readFileSync(settingsPath, "utf8"), "{broken-json");
+    assert.equal(existsSync(`${settingsPath}.bak`), false);
+  });
+});

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -33,6 +33,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   policies: {
     stdio_action: "replace-with-hub",
     unknown_server_action: "warn",
+    sync_denylist: [],
     watched_paths: [
       "~/.gemini/settings.json",
       "~/.codex/config.toml",
@@ -280,6 +281,27 @@ function serverTargets(serverConfig) {
 
 function serverAppliesToClient(serverConfig, client) {
   return serverTargets(serverConfig).includes(client);
+}
+
+function syncDenylistEntries(policy = {}) {
+  if (!Array.isArray(policy?.sync_denylist)) return new Set();
+  return new Set(
+    policy.sync_denylist
+      .map((entry) =>
+        String(entry || "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+}
+
+function syncDenylistKey(client, serverName) {
+  return `${String(client || "")
+    .trim()
+    .toLowerCase()}:${String(serverName || "")
+    .trim()
+    .toLowerCase()}`;
 }
 
 function buildDesiredServerRecord(name, serverConfig, filePath) {
@@ -572,6 +594,22 @@ export function validateRegistry(registry) {
   } else {
     if (!Array.isArray(registry.policies.watched_paths)) {
       errors.push("registry.policies.watched_paths must be an array");
+    }
+    if (
+      registry.policies.sync_denylist !== undefined &&
+      !Array.isArray(registry.policies.sync_denylist)
+    ) {
+      errors.push("registry.policies.sync_denylist must be an array");
+    }
+    if (Array.isArray(registry.policies.sync_denylist)) {
+      for (const entry of registry.policies.sync_denylist) {
+        if (typeof entry !== "string" || !entry.includes(":")) {
+          errors.push(
+            "registry.policies.sync_denylist entries must use client:server format",
+          );
+          break;
+        }
+      }
     }
     if (
       registry.policies.stdio_action &&
@@ -1032,10 +1070,13 @@ export function removeServerFromTargets(name, options = {}) {
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
   const actions = [];
+  const invalidConfigs = new Set();
+  const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of listManagedConfigTargets(registry)) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
+      invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
         type: "sync",
         filePath: target.filePath,
@@ -1065,13 +1106,49 @@ export function syncRegistryTargets(options = {}) {
   }
 
   for (const target of listPrimaryConfigTargets(registry)) {
-    const updates = Object.entries(registry.servers || {})
-      .filter(([, serverConfig]) =>
-        serverAppliesToClient(serverConfig, target.client),
-      )
-      .map(([name, serverConfig]) =>
+    const snapshot = scanConfig(target.filePath);
+    const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.parseError) {
+      if (!invalidConfigs.has(targetKey)) {
+        actions.push({
+          type: "sync",
+          filePath: target.filePath,
+          label: target.label,
+          status: "invalid-config",
+          message: snapshot.parseError.message,
+        });
+      }
+      continue;
+    }
+
+    const updates = [];
+    for (const [name, serverConfig] of Object.entries(registry.servers || {})) {
+      if (serverConfig?.safe !== true) continue;
+      if (!serverAppliesToClient(serverConfig, target.client)) continue;
+
+      const denyKey = syncDenylistKey(target.client, name);
+      if (denylist.has(denyKey)) {
+        const existing = snapshot.servers.find(
+          (server) => server.name === name,
+        );
+        if (!existing) {
+          actions.push({
+            type: "sync",
+            filePath: target.filePath,
+            label: target.label,
+            status: "policy-skip",
+            server: name,
+            client: target.client,
+            message: `[mcp-guard] policy skip: ${denyKey}`,
+          });
+        }
+        continue;
+      }
+
+      updates.push(
         buildDesiredServerRecord(name, serverConfig, target.filePath),
       );
+    }
 
     if (updates.length === 0) continue;
 

--- a/packages/triflux/scripts/mcp-safety-guard.mjs
+++ b/packages/triflux/scripts/mcp-safety-guard.mjs
@@ -10,6 +10,7 @@ import {
   loadRegistry,
   remediate,
   scanForStdioServers,
+  syncRegistryTargets,
 } from "./lib/mcp-guard-engine.mjs";
 
 const GEMINI_SETTINGS = join(homedir(), ".gemini", "settings.json");
@@ -20,40 +21,57 @@ export async function run(stdinData) {
   let registry;
   try {
     registry = loadRegistry();
-  } catch {
-    return { code: 0, stdout: "", stderr: "" };
+  } catch (error) {
+    return {
+      code: 0,
+      stdout: `[mcp-safety] MCP registry invalid: ${error.message}\n`,
+      stderr: "",
+    };
   }
 
   const stdioServers = scanForStdioServers(GEMINI_SETTINGS);
-
-  if (stdioServers.length === 0) {
-    return { code: 0, stdout: "", stderr: "" };
-  }
-
-  const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
-  const names = stdioServers.map((server) => server.name).join(", ");
   const stdout = [];
 
-  if (result.modified) {
-    const actionLabel = result.replacement ? "자동 치환" : "자동 제거";
-    stdout.push(
-      `[mcp-safety] ${stdioServers.length}개 stdio MCP ${actionLabel}: ${names}`,
-    );
-    if (result.replacement?.name && result.replacement?.url) {
+  if (stdioServers.length > 0) {
+    const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
+    const names = stdioServers.map((server) => server.name).join(", ");
+
+    if (result.modified) {
+      const actionLabel = result.replacement ? "자동 치환" : "자동 제거";
       stdout.push(
-        `[mcp-safety] 대체 서버: ${result.replacement.name} -> ${result.replacement.url}`,
+        `[mcp-safety] ${stdioServers.length}개 stdio MCP ${actionLabel}: ${names}`,
+      );
+      if (result.replacement?.name && result.replacement?.url) {
+        stdout.push(
+          `[mcp-safety] 대체 서버: ${result.replacement.name} -> ${result.replacement.url}`,
+        );
+      }
+      if (result.backupPath) {
+        stdout.push(`[mcp-safety] 백업: ${result.backupPath}`);
+      }
+      stdout.push(
+        "[mcp-safety] Gemini는 Hub URL만 사용합니다. stdio MCP는 spawn EPERM을 유발합니다.",
       );
     }
-    if (result.backupPath) {
-      stdout.push(`[mcp-safety] 백업: ${result.backupPath}`);
+
+    for (const warning of result.warnings || []) {
+      stdout.push(warning);
     }
-    stdout.push(
-      "[mcp-safety] Gemini는 Hub URL만 사용합니다. stdio MCP는 spawn EPERM을 유발합니다.",
-    );
   }
 
-  for (const warning of result.warnings || []) {
-    stdout.push(warning);
+  const syncResult = syncRegistryTargets({ registry });
+  for (const action of syncResult.actions) {
+    if (action.status === "updated") {
+      stdout.push(
+        `[mcp-safety] registry sync: ${action.label} -> ${action.filePath}`,
+      );
+    } else if (action.status === "invalid-config") {
+      stdout.push(
+        `[mcp-guard] 설정 파싱 실패: ${action.filePath} (${action.message})`,
+      );
+    } else if (action.status === "policy-skip") {
+      stdout.push(action.message);
+    }
   }
 
   return {

--- a/scripts/__tests__/mcp-guard-engine-proactive-sync.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-proactive-sync.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(TEST_DIR, "..", "..");
+const SAFETY_GUARD_PATH = join(PROJECT_ROOT, "scripts", "mcp-safety-guard.mjs");
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_HUB_PORT: process.env.TFX_HUB_PORT,
+  TFX_TEST: process.env.TFX_TEST,
+};
+const originalCwd = process.cwd();
+const tempRoots = [];
+
+function makeTempRoot(prefix = "mcp-guard-proactive-") {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function useHome(homeDir) {
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+}
+
+function writeGeminiSettings(homeDir, settings) {
+  const settingsPath = join(homeDir, ".gemini", "settings.json");
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+  return settingsPath;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function registryFor(settingsPath, overrides = {}) {
+  return {
+    version: 1,
+    defaults: {
+      transport: "hub-url",
+      hub_base: "http://127.0.0.1:27888",
+    },
+    servers: {
+      "tfx-hub": {
+        transport: "hub-url",
+        url: "http://127.0.0.1:27888/mcp",
+        safe: true,
+        targets: ["gemini"],
+        description: "triflux Hub MCP 서버",
+      },
+      ...(overrides.servers || {}),
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      unknown_server_action: "warn",
+      sync_denylist: [],
+      watched_paths: [settingsPath],
+      ...(overrides.policies || {}),
+    },
+  };
+}
+
+beforeEach(() => {
+  restoreEnv();
+  process.env.TFX_HUB_PORT = "30123";
+  process.env.TFX_TEST = "1";
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  restoreEnv();
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root?.startsWith(tmpdir())) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("mcp guard proactive registry sync", () => {
+  it("creates tfx-hub for empty Gemini mcpServers with resolved Hub URL", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+
+    const result = syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.equal(
+      updated.mcpServers["tfx-hub"].url,
+      "http://127.0.0.1:30123/mcp",
+    );
+    assert.equal(
+      result.actions.some((action) => action.status === "updated"),
+      true,
+    );
+  });
+
+  it("adds only tfx-hub and preserves unrelated Gemini MCP servers", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const unrelated = {
+      url: "https://example.com/mcp",
+      header: "keep-me",
+    };
+    const settingsPath = writeGeminiSettings(homeDir, {
+      mcpServers: {
+        unrelated,
+      },
+    });
+
+    syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.deepEqual(updated.mcpServers.unrelated, unrelated);
+    assert.deepEqual(Object.keys(updated.mcpServers).sort(), [
+      "tfx-hub",
+      "unrelated",
+    ]);
+  });
+
+  it("remediates stdio entries and adds the Hub entry in the combined flow", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, {
+      mcpServers: {
+        "unsafe-stdio": { command: "node", args: ["server.js"] },
+      },
+    });
+
+    const result = syncRegistryTargets({ registry: registryFor(settingsPath) });
+    const updated = readJson(settingsPath);
+
+    assert.equal(Object.hasOwn(updated.mcpServers, "unsafe-stdio"), false);
+    assert.equal(
+      updated.mcpServers["tfx-hub"].url,
+      "http://127.0.0.1:30123/mcp",
+    );
+    assert.equal(
+      result.actions.some(
+        (action) => action.type === "remediate" && action.status === "updated",
+      ),
+      true,
+    );
+  });
+
+  it("skips missing managed entries when sync_denylist contains gemini:tfx-hub", () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(settingsPath, {
+        policies: { sync_denylist: ["gemini:tfx-hub"] },
+      }),
+    });
+    const updated = readJson(settingsPath);
+    const policySkips = result.actions.filter(
+      (action) => action.status === "policy-skip",
+    );
+
+    assert.deepEqual(updated.mcpServers, {});
+    assert.equal(policySkips.length, 1);
+    assert.equal(
+      policySkips[0].message,
+      "[mcp-guard] policy skip: gemini:tfx-hub",
+    );
+    assert.equal(policySkips[0].message.includes("\n"), false);
+  });
+
+  it("does not write again when syncRegistryTargets runs twice", async () => {
+    const homeDir = makeTempRoot();
+    useHome(homeDir);
+    const settingsPath = writeGeminiSettings(homeDir, { mcpServers: {} });
+    const registry = registryFor(settingsPath);
+
+    syncRegistryTargets({ registry });
+    const beforeContent = readFileSync(settingsPath, "utf8");
+    const beforeMtime = statSync(settingsPath).mtimeMs;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const second = syncRegistryTargets({ registry });
+    const afterContent = readFileSync(settingsPath, "utf8");
+    const afterMtime = statSync(settingsPath).mtimeMs;
+
+    assert.equal(
+      second.actions.filter((action) => action.status === "updated").length,
+      0,
+    );
+    assert.equal(afterContent, beforeContent);
+    assert.equal(afterMtime, beforeMtime);
+  });
+
+  it("leaves parse-error JSON untouched and the hook exits 0 with a warning", async () => {
+    const homeDir = makeTempRoot();
+    const projectDir = makeTempRoot("mcp-guard-project-");
+    useHome(homeDir);
+    process.chdir(projectDir);
+
+    const settingsPath = join(homeDir, ".gemini", "settings.json");
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, "{broken-json", "utf8");
+
+    const guardUrl = `${pathToFileURL(SAFETY_GUARD_PATH).href}?case=${Date.now()}`;
+    const { run } = await import(guardUrl);
+    const result = await run();
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /\[mcp-guard\] 설정 파싱 실패:/);
+    assert.equal(readFileSync(settingsPath, "utf8"), "{broken-json");
+    assert.equal(existsSync(`${settingsPath}.bak`), false);
+  });
+});

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -33,6 +33,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   policies: {
     stdio_action: "replace-with-hub",
     unknown_server_action: "warn",
+    sync_denylist: [],
     watched_paths: [
       "~/.gemini/settings.json",
       "~/.codex/config.toml",
@@ -280,6 +281,27 @@ function serverTargets(serverConfig) {
 
 function serverAppliesToClient(serverConfig, client) {
   return serverTargets(serverConfig).includes(client);
+}
+
+function syncDenylistEntries(policy = {}) {
+  if (!Array.isArray(policy?.sync_denylist)) return new Set();
+  return new Set(
+    policy.sync_denylist
+      .map((entry) =>
+        String(entry || "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+}
+
+function syncDenylistKey(client, serverName) {
+  return `${String(client || "")
+    .trim()
+    .toLowerCase()}:${String(serverName || "")
+    .trim()
+    .toLowerCase()}`;
 }
 
 function buildDesiredServerRecord(name, serverConfig, filePath) {
@@ -572,6 +594,22 @@ export function validateRegistry(registry) {
   } else {
     if (!Array.isArray(registry.policies.watched_paths)) {
       errors.push("registry.policies.watched_paths must be an array");
+    }
+    if (
+      registry.policies.sync_denylist !== undefined &&
+      !Array.isArray(registry.policies.sync_denylist)
+    ) {
+      errors.push("registry.policies.sync_denylist must be an array");
+    }
+    if (Array.isArray(registry.policies.sync_denylist)) {
+      for (const entry of registry.policies.sync_denylist) {
+        if (typeof entry !== "string" || !entry.includes(":")) {
+          errors.push(
+            "registry.policies.sync_denylist entries must use client:server format",
+          );
+          break;
+        }
+      }
     }
     if (
       registry.policies.stdio_action &&
@@ -1032,10 +1070,13 @@ export function removeServerFromTargets(name, options = {}) {
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
   const actions = [];
+  const invalidConfigs = new Set();
+  const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of listManagedConfigTargets(registry)) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
+      invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
         type: "sync",
         filePath: target.filePath,
@@ -1065,13 +1106,49 @@ export function syncRegistryTargets(options = {}) {
   }
 
   for (const target of listPrimaryConfigTargets(registry)) {
-    const updates = Object.entries(registry.servers || {})
-      .filter(([, serverConfig]) =>
-        serverAppliesToClient(serverConfig, target.client),
-      )
-      .map(([name, serverConfig]) =>
+    const snapshot = scanConfig(target.filePath);
+    const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.parseError) {
+      if (!invalidConfigs.has(targetKey)) {
+        actions.push({
+          type: "sync",
+          filePath: target.filePath,
+          label: target.label,
+          status: "invalid-config",
+          message: snapshot.parseError.message,
+        });
+      }
+      continue;
+    }
+
+    const updates = [];
+    for (const [name, serverConfig] of Object.entries(registry.servers || {})) {
+      if (serverConfig?.safe !== true) continue;
+      if (!serverAppliesToClient(serverConfig, target.client)) continue;
+
+      const denyKey = syncDenylistKey(target.client, name);
+      if (denylist.has(denyKey)) {
+        const existing = snapshot.servers.find(
+          (server) => server.name === name,
+        );
+        if (!existing) {
+          actions.push({
+            type: "sync",
+            filePath: target.filePath,
+            label: target.label,
+            status: "policy-skip",
+            server: name,
+            client: target.client,
+            message: `[mcp-guard] policy skip: ${denyKey}`,
+          });
+        }
+        continue;
+      }
+
+      updates.push(
         buildDesiredServerRecord(name, serverConfig, target.filePath),
       );
+    }
 
     if (updates.length === 0) continue;
 

--- a/scripts/mcp-safety-guard.mjs
+++ b/scripts/mcp-safety-guard.mjs
@@ -10,6 +10,7 @@ import {
   loadRegistry,
   remediate,
   scanForStdioServers,
+  syncRegistryTargets,
 } from "./lib/mcp-guard-engine.mjs";
 
 const GEMINI_SETTINGS = join(homedir(), ".gemini", "settings.json");
@@ -20,40 +21,57 @@ export async function run(stdinData) {
   let registry;
   try {
     registry = loadRegistry();
-  } catch {
-    return { code: 0, stdout: "", stderr: "" };
+  } catch (error) {
+    return {
+      code: 0,
+      stdout: `[mcp-safety] MCP registry invalid: ${error.message}\n`,
+      stderr: "",
+    };
   }
 
   const stdioServers = scanForStdioServers(GEMINI_SETTINGS);
-
-  if (stdioServers.length === 0) {
-    return { code: 0, stdout: "", stderr: "" };
-  }
-
-  const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
-  const names = stdioServers.map((server) => server.name).join(", ");
   const stdout = [];
 
-  if (result.modified) {
-    const actionLabel = result.replacement ? "자동 치환" : "자동 제거";
-    stdout.push(
-      `[mcp-safety] ${stdioServers.length}개 stdio MCP ${actionLabel}: ${names}`,
-    );
-    if (result.replacement?.name && result.replacement?.url) {
+  if (stdioServers.length > 0) {
+    const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
+    const names = stdioServers.map((server) => server.name).join(", ");
+
+    if (result.modified) {
+      const actionLabel = result.replacement ? "자동 치환" : "자동 제거";
       stdout.push(
-        `[mcp-safety] 대체 서버: ${result.replacement.name} -> ${result.replacement.url}`,
+        `[mcp-safety] ${stdioServers.length}개 stdio MCP ${actionLabel}: ${names}`,
+      );
+      if (result.replacement?.name && result.replacement?.url) {
+        stdout.push(
+          `[mcp-safety] 대체 서버: ${result.replacement.name} -> ${result.replacement.url}`,
+        );
+      }
+      if (result.backupPath) {
+        stdout.push(`[mcp-safety] 백업: ${result.backupPath}`);
+      }
+      stdout.push(
+        "[mcp-safety] Gemini는 Hub URL만 사용합니다. stdio MCP는 spawn EPERM을 유발합니다.",
       );
     }
-    if (result.backupPath) {
-      stdout.push(`[mcp-safety] 백업: ${result.backupPath}`);
+
+    for (const warning of result.warnings || []) {
+      stdout.push(warning);
     }
-    stdout.push(
-      "[mcp-safety] Gemini는 Hub URL만 사용합니다. stdio MCP는 spawn EPERM을 유발합니다.",
-    );
   }
 
-  for (const warning of result.warnings || []) {
-    stdout.push(warning);
+  const syncResult = syncRegistryTargets({ registry });
+  for (const action of syncResult.actions) {
+    if (action.status === "updated") {
+      stdout.push(
+        `[mcp-safety] registry sync: ${action.label} -> ${action.filePath}`,
+      );
+    } else if (action.status === "invalid-config") {
+      stdout.push(
+        `[mcp-guard] 설정 파싱 실패: ${action.filePath} (${action.message})`,
+      );
+    } else if (action.status === "policy-skip") {
+      stdout.push(action.message);
+    }
   }
 
   return {

--- a/tests/regression/session-start-fast.test.mjs
+++ b/tests/regression/session-start-fast.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const PROJECT_ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+describe("SessionStart MCP guard ordering", () => {
+  it("invokes registry sync from the safety guard before hub-ensure runs", () => {
+    const sessionStartSource = readFileSync(
+      join(PROJECT_ROOT, "hooks", "session-start-fast.mjs"),
+      "utf8",
+    );
+    const guardSource = readFileSync(
+      join(PROJECT_ROOT, "scripts", "mcp-safety-guard.mjs"),
+      "utf8",
+    );
+
+    const guardRunIndex = sessionStartSource.indexOf("guard.run()");
+    const hubEnsureIndex = sessionStartSource.indexOf(
+      'join(SCRIPTS, "hub-ensure.mjs")',
+    );
+    const syncCallIndex = guardSource.indexOf(
+      "syncRegistryTargets({ registry })",
+    );
+    const remediationIndex = guardSource.indexOf("remediate(");
+
+    assert.ok(guardRunIndex >= 0, "SessionStart guard.run() call missing");
+    assert.ok(hubEnsureIndex >= 0, "hub-ensure import path missing");
+    assert.ok(
+      guardRunIndex < hubEnsureIndex,
+      "mcp-safety-guard must run before hub-ensure",
+    );
+    assert.ok(syncCallIndex >= 0, "registry sync call missing from guard");
+    assert.ok(
+      remediationIndex >= 0 && remediationIndex < syncCallIndex,
+      "guard must remediate stdio before proactive registry sync",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- SessionStart guard now calls `syncRegistryTargets()` unconditionally after stdio remediation, healing missing managed entries (e.g. Gemini drift incident 2026-04-29).
- Adds `registry.policies.sync_denylist` for intentional opt-out (format: `client:server`, e.g. `"gemini:tfx-hub"`).
- Allowlist: only `safe:true` servers with target membership are auto-restored.

## Background — Gemini drift incident 2026-04-29

`~/.gemini/settings.json` was missing the managed `tfx-hub` MCP entry while the central registry still declared `tfx-hub` as a Gemini target. The existing SessionStart guard only handled stdio removal; it did not call `syncRegistryTargets()` to heal missing managed entries. Result: split-brain MCP state where the registry and the live client config disagreed.

## Implements

PRD: `.triflux/plans/mcp-guard-proactive-sync-prd.md` (local artifact, `.triflux/` is gitignored by policy).

**Option C — SessionStart guard + hub-ensure both, with denylist policy boundary.**

Trigger evaluation:
- Option A (hub-ensure only): rejected — `hub-ensure` runs after `mcp-safety-guard`, so Gemini stays drifted during guard phase.
- Option B (SessionStart only): partial — heals missing entries but loses `hub-ensure`'s URL refresh after Hub readiness.
- Option C (both): accepted — both paths converge on the same registry state idempotently. `mcp-safety-guard` owns config safety, `hub-ensure` owns Hub availability.

## Files changed

- `config/mcp-registry.json` (+4/-0) — `policies.sync_denylist: []` + `policy_notes`
- `scripts/lib/mcp-guard-engine.mjs` (+87/-9) — denylist filter, allowlist (`safe:true` + target), idempotent sync, `policy-skip` log
- `scripts/mcp-safety-guard.mjs` (+45/-19) — proactive sync after stdio remediation, quiet by default
- `scripts/__tests__/mcp-guard-engine-proactive-sync.test.mjs` (new, 235 lines) — T1-T6
- `tests/regression/session-start-fast.test.mjs` (new, 39 lines) — T7

## Test plan

- [x] T1-T6 (proactive-sync.test.mjs): empty / unrelated / stdio / denylist / idempotence / parse-error → 6/6 pass
- [x] T7 (session-start-fast.test.mjs): guard runs sync **before** `hub-ensure` → 1/1 pass
- [x] MCP regression suite (mcp-guard-engine, mcp-guard-fallback, mcp-bootstrap-no-hang, session-start-fast): 17/17 pass
- [x] Full \`npm test\` suite: EXIT=0 on second clean run (first run flaked on unrelated \`hub quota refresh non-blocking regression\`)

## Follow-up PRs (sibling PRDs drafted in same session)

- `.triflux/plans/mcp-singleton-redesign-prd.md` — Option A unified hub default; Q1 benchmark first; Option C (hybrid parent + per-CLI MCP frontends) as future split.
- `.triflux/plans/mcp-registry-stdio-headers-prd.md` — Option B HTTP+headers schema; stdio direct registration deferred.

Both are local-only artifacts pending sibling PRs.