### PR TITLE
feat(mcp-registry): HTTP transport + optional headers schema (Option B)

### DIFF
--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -9,6 +9,11 @@
     "transport": "hub-url",
     "hub_base": "http://127.0.0.1:27888"
   },
+  "policy_notes": {
+    "transport": "Server transport accepts \"hub-url\" for the existing triflux Hub URL flow or \"http\" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.",
+    "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
+    "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers."
+  },
   "servers": {
     "tfx-hub": {
       "transport": "hub-url",

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  buildDesiredServerRecord,
+  validateRegistry,
+} from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+  TFX_OTHER_TOKEN: process.env.TFX_OTHER_TOKEN,
+};
+
+function registryWith(server) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: { auth: server },
+    policies: { watched_paths: [] },
+  };
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("mcp guard HTTP transport + headers schema", () => {
+  it("validates http transport with no headers, literal headers, env headers, and prefixed env headers", () => {
+    const cases = [
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": { value: "triflux" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-API-Key": { env: "TFX_TEST_TOKEN" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+        },
+      },
+    ];
+
+    for (const server of cases) {
+      assert.deepEqual(validateRegistry(registryWith(server)), []);
+    }
+  });
+
+  it("rejects malformed header descriptors and stdio-shaped registry servers", () => {
+    const invalidServers = [
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "Bad Header": { value: "x" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": "triflux" },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-API-Key": { env: "" } },
+      },
+      {
+        transport: "stdio",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": { value: "triflux" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        command: "node",
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        args: ["server.js"],
+      },
+    ];
+
+    for (const server of invalidServers) {
+      assert.notDeepEqual(validateRegistry(registryWith(server)), []);
+    }
+  });
+
+  it("builds header-aware desired records for Codex TOML targets", () => {
+    process.env.TFX_TEST_TOKEN = "secret-token";
+
+    const desired = buildDesiredServerRecord(
+      "auth",
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      },
+      join("home", ".codex", "config.toml"),
+    );
+
+    assert.deepEqual(desired.config, {
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "X-Client": "triflux",
+      },
+    });
+    assert.deepEqual(desired.codex, {
+      bearer_token_env_var: "TFX_TEST_TOKEN",
+      env_http_headers: {},
+      http_headers: { "X-Client": "triflux" },
+    });
+    assert.deepEqual(desired.warnings, []);
+  });
+
+  it("builds header-aware desired records for JSON MCP targets", () => {
+    process.env.TFX_TEST_TOKEN = "secret-token";
+    process.env.TFX_OTHER_TOKEN = "other-token";
+
+    const desired = buildDesiredServerRecord(
+      "auth",
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-API-Key": { env: "TFX_OTHER_TOKEN" },
+          "X-Client": { value: "triflux" },
+        },
+      },
+      join("repo", ".mcp.json"),
+    );
+
+    assert.deepEqual(desired.config, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "X-API-Key": "other-token",
+        "X-Client": "triflux",
+      },
+    });
+    assert.deepEqual(desired.warnings, []);
+  });
+
+  it("keeps hub-url records URL-only when no headers are configured", () => {
+    const desired = buildDesiredServerRecord(
+      "tfx-hub",
+      {
+        transport: "hub-url",
+        url: "http://127.0.0.1:27888/mcp",
+      },
+      join("repo", ".mcp.json"),
+    );
+
+    assert.deepEqual(desired.config, {
+      type: "http",
+      url: "http://127.0.0.1:27888/mcp",
+    });
+  });
+});

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_CODEX_CONFIG_SYNC: process.env.TFX_CODEX_CONFIG_SYNC,
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+  TFX_MISSING_TOKEN: process.env.TFX_MISSING_TOKEN,
+};
+
+function createHomeDir(prefix = "mcp-guard-sync-") {
+  const base = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(join(base, ".codex"), { recursive: true });
+  return base;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function registryFor(homeDir, extraServer) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: {
+      auth: extraServer,
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      watched_paths: [
+        join(homeDir, ".codex", "config.toml"),
+        join(homeDir, "repo", ".mcp.json"),
+      ],
+    },
+  };
+}
+
+afterEach(restoreEnv);
+
+describe("syncRegistryTargets HTTP headers", () => {
+  it("writes authenticated HTTP records to Codex TOML and .mcp.json configs", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      }),
+    });
+
+    assert.equal(
+      result.actions.every((action) => action.status === "updated"),
+      true,
+    );
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.match(codexToml, /\[mcp_servers\.auth\]/);
+    assert.match(codexToml, /url = "https:\/\/example\.com\/mcp"/);
+    assert.match(codexToml, /bearer_token_env_var = "TFX_TEST_TOKEN"/);
+    assert.match(codexToml, /http_headers = \{ "X-Client" = "triflux" \}/);
+    assert.doesNotMatch(codexToml, /sync-secret/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.deepEqual(projectConfig.mcpServers.auth, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer sync-secret",
+        "X-Client": "triflux",
+      },
+    });
+  });
+
+  it("preserves unrelated MCP entries and unrelated fields on the managed server", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const codexPath = join(homeDir, ".codex", "config.toml");
+    writeFileSync(
+      codexPath,
+      [
+        'model = "gpt-5"',
+        "",
+        "[mcp_servers.auth]",
+        'command = "node"',
+        'args = ["old.js"]',
+        "enabled = false",
+        "",
+        "[mcp_servers.auth.tools.read]",
+        'approval_mode = "auto"',
+        "",
+        "[mcp_servers.other]",
+        'url = "https://other.example/mcp"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+    writeFileSync(
+      projectMcpPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            auth: {
+              type: "http",
+              url: "https://old.example/mcp",
+              disabled: true,
+            },
+            other: { url: "https://other.example/mcp" },
+          },
+          workspace: "keep",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+        },
+      }),
+    });
+
+    const codexToml = readFileSync(codexPath, "utf8");
+    assert.match(codexToml, /^model = "gpt-5"/m);
+    assert.match(codexToml, /^enabled = false$/m);
+    assert.match(codexToml, /\[mcp_servers\.auth\.tools\.read\]/);
+    assert.match(codexToml, /approval_mode = "auto"/);
+    assert.match(codexToml, /\[mcp_servers\.other\]/);
+    assert.doesNotMatch(codexToml, /command = "node"/);
+    assert.doesNotMatch(codexToml, /args = \["old\.js"\]/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.equal(projectConfig.workspace, "keep");
+    assert.deepEqual(projectConfig.mcpServers.other, {
+      url: "https://other.example/mcp",
+    });
+    assert.equal(projectConfig.mcpServers.auth.disabled, true);
+    assert.equal(projectConfig.mcpServers.auth.url, "https://example.com/mcp");
+    assert.deepEqual(projectConfig.mcpServers.auth.headers, {
+      Authorization: "Bearer sync-secret",
+    });
+  });
+
+  it("warns on missing env vars without writing empty secret headers", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    delete process.env.TFX_MISSING_TOKEN;
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_MISSING_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      }),
+    });
+
+    assert.ok(
+      result.actions.some((action) =>
+        (action.warnings || []).some((warning) =>
+          warning.includes("TFX_MISSING_TOKEN"),
+        ),
+      ),
+    );
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.doesNotMatch(codexToml, /Authorization/);
+    assert.doesNotMatch(codexToml, /bearer_token_env_var/);
+    assert.doesNotMatch(codexToml, /""/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.deepEqual(projectConfig.mcpServers.auth.headers, {
+      "X-Client": "triflux",
+    });
+  });
+});

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -35,7 +35,7 @@ function registryFor(homeDir, extraServer) {
     version: 1,
     defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
     servers: {
-      auth: extraServer,
+      auth: { safe: true, ...extraServer },
     },
     policies: {
       stdio_action: "replace-with-hub",

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  remediate,
+  scanForStdioServers,
+  validateRegistry,
+} from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+};
+
+function tempPath(name) {
+  return join(
+    tmpdir(),
+    `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+}
+
+afterEach(() => {
+  if (originalEnv.TFX_TEST_TOKEN === undefined)
+    delete process.env.TFX_TEST_TOKEN;
+  else process.env.TFX_TEST_TOKEN = originalEnv.TFX_TEST_TOKEN;
+});
+
+describe("watched MCP remediation with HTTP headers", () => {
+  it("replaces a stdio offender with an HTTP registry server that includes headers", () => {
+    process.env.TFX_TEST_TOKEN = "watch-secret";
+    const filePath = join(tempPath("mcp-watch"), ".mcp.json");
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            auth: { command: "node", args: ["server.js"] },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const registry = {
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        auth: {
+          transport: "http",
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+            "X-Client": { value: "triflux" },
+          },
+        },
+      },
+      policies: { watched_paths: [filePath], stdio_action: "replace-with-hub" },
+    };
+
+    const result = remediate(filePath, scanForStdioServers(filePath), {
+      ...registry.policies,
+      registry,
+    });
+    const updated = JSON.parse(readFileSync(filePath, "utf8"));
+
+    assert.equal(result.modified, true);
+    assert.deepEqual(updated.mcpServers.auth, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer watch-secret",
+        "X-Client": "triflux",
+      },
+    });
+  });
+
+  it("redacts secret values from remediation output", () => {
+    process.env.TFX_TEST_TOKEN = "watch-secret";
+    const filePath = join(tempPath("mcp-watch-redact"), ".mcp.json");
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        { mcpServers: { auth: { command: "node", args: ["server.js"] } } },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const registry = {
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        auth: {
+          transport: "http",
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          },
+        },
+      },
+      policies: { watched_paths: [filePath], stdio_action: "replace-with-hub" },
+    };
+
+    const result = remediate(filePath, scanForStdioServers(filePath), {
+      ...registry.policies,
+      registry,
+    });
+
+    assert.doesNotMatch(JSON.stringify(result), /watch-secret/);
+    assert.match(JSON.stringify(result), /\*\*\*REDACTED\*\*\*/);
+  });
+
+  it("keeps stdio-only registry entries unsupported", () => {
+    const errors = validateRegistry({
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        stdio: {
+          transport: "stdio",
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+      policies: { watched_paths: [] },
+    });
+
+    assert.ok(errors.some((error) => error.includes("transport")));
+    assert.ok(errors.some((error) => error.includes("command")));
+    assert.ok(errors.some((error) => error.includes("args")));
+  });
+});

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -10,7 +10,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
-const REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
+const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
 const DEFAULT_REGISTRY = Object.freeze({
@@ -20,6 +20,14 @@ const DEFAULT_REGISTRY = Object.freeze({
   defaults: {
     transport: "hub-url",
     hub_base: "http://127.0.0.1:27888",
+  },
+  policy_notes: {
+    transport:
+      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+    headers:
+      'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
+    secret_safety:
+      "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
   },
   servers: {
     "tfx-hub": {
@@ -82,6 +90,12 @@ function readJsonFile(filePath) {
 function writeJsonFile(filePath, data) {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function registryPath() {
+  return process.env.TFX_MCP_REGISTRY_PATH
+    ? resolve(process.env.TFX_MCP_REGISTRY_PATH)
+    : DEFAULT_REGISTRY_PATH;
 }
 
 function ensureBackup(filePath) {
@@ -176,10 +190,57 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("{") && value.endsWith("}")) {
+    return parseTomlInlineTable(value);
+  }
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlInlineTable(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return {};
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  const table = {};
+  for (const part of parts) {
+    const match = part.match(
+      /^\s*(?:"((?:\\"|[^"])*)"|([A-Za-z0-9_-]+))\s*=\s*(.+?)\s*$/,
+    );
+    if (!match) continue;
+    const key = (match[1] || match[2] || "")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
+    table[key] = parseTomlScalar(match[3]);
+  }
+  return table;
 }
 
 function parseCodexMcpServers(raw) {
@@ -210,6 +271,179 @@ function parseCodexMcpServers(raw) {
   return servers;
 }
 
+function isValidHeaderName(name) {
+  return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
+}
+
+function normalizeHeaderDescriptors(headers = {}) {
+  const normalized = {};
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(headers)) {
+    if (!isValidHeaderName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor)
+    ) {
+      if (
+        Object.hasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
+      ) {
+        normalized[name] = { value: descriptor.value };
+      } else if (
+        Object.hasOwn(descriptor, "env") &&
+        typeof descriptor.env === "string" &&
+        descriptor.env.trim()
+      ) {
+        normalized[name] = { env: descriptor.env.trim() };
+        if (typeof descriptor.prefix === "string") {
+          normalized[name].prefix = descriptor.prefix;
+        }
+      }
+    }
+  }
+  return normalized;
+}
+
+function resolveHeaderDescriptors(name, serverConfig, filePath) {
+  const descriptors = normalizeHeaderDescriptors(serverConfig?.headers || {});
+  const headers = {};
+  const warnings = [];
+  const codex = {
+    bearer_token_env_var: null,
+    env_http_headers: {},
+    http_headers: {},
+  };
+  const codexTarget = isCodexConfig(filePath);
+
+  for (const [headerName, descriptor] of Object.entries(descriptors)) {
+    if (Object.hasOwn(descriptor, "value")) {
+      headers[headerName] = descriptor.value;
+      if (codexTarget) codex.http_headers[headerName] = descriptor.value;
+      continue;
+    }
+
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    const prefix = descriptor.prefix || "";
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+
+    headers[headerName] = `${prefix}${envValue}`;
+
+    if (!codexTarget) continue;
+
+    if (
+      headerName.toLowerCase() === "authorization" &&
+      /^Bearer\s+$/i.test(prefix)
+    ) {
+      codex.bearer_token_env_var = envName;
+    } else if (!prefix) {
+      codex.env_http_headers[headerName] = envName;
+    } else {
+      codex.http_headers[headerName] = `${prefix}${envValue}`;
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header uses resolved literal in Codex TOML because prefixed env headers are unsupported`,
+      );
+    }
+  }
+
+  return {
+    descriptors,
+    headers,
+    warnings,
+    codex: {
+      ...(codex.bearer_token_env_var
+        ? { bearer_token_env_var: codex.bearer_token_env_var }
+        : {}),
+      env_http_headers: codex.env_http_headers,
+      http_headers: codex.http_headers,
+    },
+  };
+}
+
+function hasOwnEntries(value) {
+  return value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function redactHeaders(headers = {}) {
+  const redacted = {};
+  for (const key of Object.keys(headers || {})) {
+    redacted[key] = "***REDACTED***";
+  }
+  return redacted;
+}
+
+function redactServerConfig(config = {}) {
+  if (!config || typeof config !== "object") return config;
+  return {
+    ...config,
+    ...(config.headers ? { headers: redactHeaders(config.headers) } : {}),
+  };
+}
+
+function descriptorsFromCodexConfig(config = {}) {
+  const descriptors = {};
+  if (typeof config.bearer_token_env_var === "string") {
+    descriptors.Authorization = {
+      env: config.bearer_token_env_var,
+      prefix: "Bearer ",
+    };
+  }
+  if (config.env_http_headers && typeof config.env_http_headers === "object") {
+    for (const [name, envName] of Object.entries(config.env_http_headers)) {
+      if (typeof envName === "string") descriptors[name] = { env: envName };
+    }
+  }
+  if (config.http_headers && typeof config.http_headers === "object") {
+    for (const [name, value] of Object.entries(config.http_headers)) {
+      if (typeof value === "string") descriptors[name] = { value };
+    }
+  }
+  return descriptors;
+}
+
+function descriptorsFromJsonConfig(config = {}) {
+  const descriptors = {};
+  if (!config?.headers || typeof config.headers !== "object") {
+    return descriptors;
+  }
+  for (const [name, value] of Object.entries(config.headers)) {
+    if (typeof value === "string") descriptors[name] = { value };
+  }
+  return descriptors;
+}
+
+function headerNames(headers = {}) {
+  return Object.keys(headers || {}).sort();
+}
+
+function sameHeaderDescriptors(left = {}, right = {}) {
+  const leftNames = headerNames(left);
+  const rightNames = headerNames(right);
+  if (JSON.stringify(leftNames) !== JSON.stringify(rightNames)) return false;
+  return leftNames.every(
+    (name) => JSON.stringify(left[name]) === JSON.stringify(right[name]),
+  );
+}
+
+function headerStatus(expected = {}, actual = {}) {
+  const expectedNames = headerNames(expected);
+  const actualNames = headerNames(actual);
+  if (expectedNames.length === 0 && actualNames.length === 0) return "ok";
+  if (expectedNames.some((name) => !Object.hasOwn(actual, name))) {
+    return "missing";
+  }
+  if (!sameHeaderDescriptors(expected, actual)) return "stale";
+  return "ok";
+}
+
 function removeTomlSection(raw, sectionName) {
   const lines = String(raw || "").split(/\r?\n/);
   const output = [];
@@ -236,12 +470,68 @@ function removeTomlSection(raw, sectionName) {
   return cleaned.length > 0 ? cleaned.replace(/\n{3,}/g, "\n\n") : "";
 }
 
-function upsertTomlUrlServer(raw, name, url) {
-  const section = [`[mcp_servers.${name}]`, `url = ${formatTomlString(url)}`];
-  const withoutExisting = removeTomlSection(raw, name).trimEnd();
-  return withoutExisting.length > 0
-    ? `${withoutExisting}\n\n${section.join("\n")}\n`
-    : `${section.join("\n")}\n`;
+function formatTomlInlineTable(data = {}) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return null;
+  return `{ ${entries
+    .map(
+      ([key, value]) => `${formatTomlString(key)} = ${formatTomlString(value)}`,
+    )
+    .join(", ")} }`;
+}
+
+function upsertTomlServer(raw, name, config, codex = {}) {
+  const lines = String(raw || "").split(/\r?\n/);
+  const header = `[mcp_servers.${name}]`;
+  const managedKeys = new Set([
+    "url",
+    "command",
+    "args",
+    "bearer_token_env_var",
+    "http_headers",
+    "env_http_headers",
+  ]);
+  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  if (codex.bearer_token_env_var) {
+    nextManagedLines.push(
+      `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
+    );
+  }
+  const httpHeaders = formatTomlInlineTable(codex.http_headers || {});
+  if (httpHeaders) nextManagedLines.push(`http_headers = ${httpHeaders}`);
+  const envHttpHeaders = formatTomlInlineTable(codex.env_http_headers || {});
+  if (envHttpHeaders) {
+    nextManagedLines.push(`env_http_headers = ${envHttpHeaders}`);
+  }
+
+  const sectionStart = lines.findIndex((line) => line.trim() === header);
+  if (sectionStart < 0) {
+    const section = [header, ...nextManagedLines].join("\n");
+    const withoutTrailing = String(raw || "").trimEnd();
+    return withoutTrailing.length > 0
+      ? `${withoutTrailing}\n\n${section}\n`
+      : `${section}\n`;
+  }
+
+  const output = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    output.push(lines[index]);
+    if (index !== sectionStart) continue;
+
+    index += 1;
+    const preserved = [];
+    while (index < lines.length && !/^\s*\[/.test(lines[index])) {
+      const keyMatch = lines[index].match(/^\s*([A-Za-z0-9_]+)\s*=/);
+      if (!keyMatch || !managedKeys.has(keyMatch[1])) {
+        preserved.push(lines[index]);
+      }
+      index += 1;
+    }
+    output.push(...nextManagedLines, ...preserved.filter(Boolean));
+    index -= 1;
+  }
+
+  return output.join("\n");
 }
 
 function getHubServerEntry(registry) {
@@ -304,22 +594,48 @@ function syncDenylistKey(client, serverName) {
     .toLowerCase()}`;
 }
 
-function buildDesiredServerRecord(name, serverConfig, filePath) {
+export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
       : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
+  const resolvedHeaders = resolveHeaderDescriptors(
+    name,
+    serverConfig,
+    filePath,
+  );
+  const headerConfig = hasOwnEntries(resolvedHeaders.headers)
+    ? { headers: resolvedHeaders.headers }
+    : {};
 
   if (basenameValue === ".mcp.json" || isClaudeProjectMcpConfig(filePath)) {
-    return { name, config: { type: "http", url } };
+    return {
+      name,
+      config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
   if (isCodexConfig(filePath)) {
-    return { name, config: { url } };
+    return {
+      name,
+      config: { url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
-  return { name, config: { url } };
+  return {
+    name,
+    config: { url, ...headerConfig },
+    headerDescriptors: resolvedHeaders.descriptors,
+    codex: resolvedHeaders.codex,
+    warnings: resolvedHeaders.warnings,
+  };
 }
 
 function scanJsonConfig(filePath) {
@@ -354,6 +670,17 @@ function scanJsonConfig(filePath) {
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
               type: typeof config.type === "string" ? config.type : "",
+              headers:
+                config.headers &&
+                typeof config.headers === "object" &&
+                !Array.isArray(config.headers)
+                  ? Object.fromEntries(
+                      Object.entries(config.headers).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
+              headerDescriptors: descriptorsFromJsonConfig(config),
               transport:
                 typeof config.url === "string" && config.url
                   ? "url"
@@ -405,6 +732,11 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      headers:
+        config.http_headers && typeof config.http_headers === "object"
+          ? config.http_headers
+          : {},
+      headerDescriptors: descriptorsFromCodexConfig(config),
       transport:
         typeof config.url === "string" && config.url
           ? "url"
@@ -472,6 +804,9 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (!Object.hasOwn(update.config, "headers")) {
+      delete nextConfig.headers;
+    }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
     if (changed) {
@@ -506,7 +841,7 @@ function updateCodexConfig(filePath, updates = [], removals = []) {
   }
 
   for (const update of updates) {
-    raw = upsertTomlUrlServer(raw, update.name, update.config.url);
+    raw = upsertTomlServer(raw, update.name, update.config, update.codex || {});
   }
 
   const finalRaw = raw.trim().length > 0 ? `${raw.trimEnd()}\n` : "";
@@ -539,7 +874,7 @@ function scanConfig(filePath) {
 }
 
 export function getRegistryPath() {
-  return REGISTRY_PATH;
+  return registryPath();
 }
 
 export function createDefaultRegistry() {
@@ -578,6 +913,104 @@ export function validateRegistry(registry) {
       }
       if (typeof server.url !== "string" || !server.url.trim()) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
+      }
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url or http`,
+        );
+      }
+      if (server.command !== undefined) {
+        errors.push(
+          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.args !== undefined) {
+        errors.push(
+          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.headers !== undefined) {
+        if (!["hub-url", "http"].includes(transport)) {
+          errors.push(
+            `registry.servers.${name}.headers is allowed only for HTTP-compatible transports`,
+          );
+        }
+        if (
+          !server.headers ||
+          typeof server.headers !== "object" ||
+          Array.isArray(server.headers)
+        ) {
+          errors.push(`registry.servers.${name}.headers must be an object`);
+        } else {
+          for (const [headerName, descriptor] of Object.entries(
+            server.headers,
+          )) {
+            if (!isValidHeaderName(headerName)) {
+              errors.push(
+                `registry.servers.${name}.headers contains invalid header name ${headerName}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            const hasValue = Object.hasOwn(descriptor, "value");
+            const hasEnv = Object.hasOwn(descriptor, "env");
+            if (hasValue && hasEnv) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use either value or env`,
+              );
+            } else if (hasValue) {
+              if (
+                keys.length !== 1 ||
+                typeof descriptor.value !== "string" ||
+                descriptor.value.length === 0
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.value must be a non-empty string`,
+                );
+              }
+            } else if (hasEnv) {
+              if (
+                !["env", "prefix"].every((key) => keys.includes(key)) &&
+                keys.some((key) => !["env", "prefix"].includes(key))
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName} supports only env and optional prefix`,
+                );
+              }
+              if (
+                typeof descriptor.env !== "string" ||
+                !descriptor.env.trim()
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.env must be a non-empty string`,
+                );
+              }
+              if (
+                descriptor.prefix !== undefined &&
+                typeof descriptor.prefix !== "string"
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.prefix must be a string`,
+                );
+              }
+            } else {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use value or env`,
+              );
+            }
+          }
+        }
       }
       if (server.targets !== undefined && !Array.isArray(server.targets)) {
         errors.push(`registry.servers.${name}.targets must be an array`);
@@ -625,9 +1058,9 @@ export function validateRegistry(registry) {
 }
 
 export function inspectRegistry() {
-  if (!existsSync(REGISTRY_PATH)) {
+  if (!existsSync(registryPath())) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: false,
       valid: false,
       errors: ["registry file missing"],
@@ -636,10 +1069,10 @@ export function inspectRegistry() {
   }
 
   try {
-    const registry = readJsonFile(REGISTRY_PATH);
+    const registry = readJsonFile(registryPath());
     const errors = validateRegistry(registry);
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: errors.length === 0,
       errors,
@@ -647,7 +1080,7 @@ export function inspectRegistry() {
     };
   } catch (error) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: false,
       errors: [error.message],
@@ -689,7 +1122,7 @@ export function saveRegistry(registry) {
   if (errors.length > 0) {
     throw new Error(`MCP registry invalid: ${errors.join("; ")}`);
   }
-  writeJsonFile(REGISTRY_PATH, registry);
+  writeJsonFile(registryPath(), registry);
   return registry;
 }
 
@@ -736,13 +1169,19 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
     );
 
     for (const [name, serverConfig] of managedServers) {
-      const expectedUrl = buildDesiredServerRecord(
+      const desired = buildDesiredServerRecord(
         name,
         serverConfig,
         config.filePath,
-      ).config.url;
+      );
+      const expectedUrl = desired.config.url;
+      const expectedHeaders = isCodexConfig(config.filePath)
+        ? desired.headerDescriptors || {}
+        : descriptorsFromJsonConfig(desired.config);
       const actual =
         config.servers.find((server) => server.name === name) || null;
+      const actualHeaders = actual?.headerDescriptors || {};
+      const currentHeaderStatus = headerStatus(expectedHeaders, actualHeaders);
       let status = "missing";
 
       if (!config.exists) {
@@ -754,7 +1193,7 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
-        status = "present";
+        status = currentHeaderStatus === "ok" ? "present" : "mismatch";
       } else {
         status = "mismatch";
       }
@@ -768,6 +1207,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         expectedUrl,
         actualUrl: actual?.url || "",
         status,
+        headerStatus: currentHeaderStatus,
+        expectedHeaderNames: headerNames(expectedHeaders),
+        actualHeaderNames: headerNames(actualHeaders),
       });
     }
 
@@ -866,14 +1308,19 @@ export function remediate(filePath, stdioServers, policy = {}) {
   let replacement = null;
 
   if (action === "replace-with-hub") {
-    const registry = loadRegistryOrDefault();
-    const [hubServerName, hubServerConfig] = getHubServerEntry(registry);
+    const registry = policy.registry || loadRegistryOrDefault();
+    const matchingOffender = offenders.find((server) =>
+      Object.hasOwn(registry.servers || {}, server.name),
+    );
+    const [hubServerName, hubServerConfig] = matchingOffender
+      ? [matchingOffender.name, registry.servers[matchingOffender.name]]
+      : getHubServerEntry(registry);
     const desired = buildDesiredServerRecord(
       hubServerName,
       hubServerConfig,
       resolvedPath,
     );
-    replacement = { name: desired.name, ...desired.config };
+    replacement = { name: desired.name, ...redactServerConfig(desired.config) };
     updates.push(desired);
   }
 
@@ -884,7 +1331,7 @@ export function remediate(filePath, stdioServers, policy = {}) {
     backupPath,
     removedServers: removals,
     replacement,
-    warnings: [],
+    warnings: updates.flatMap((update) => update.warnings || []),
   };
 }
 
@@ -1088,11 +1535,10 @@ export function syncRegistryTargets(options = {}) {
     }
 
     if (snapshot.stdioServers.length > 0) {
-      const remediation = remediate(
-        target.filePath,
-        snapshot.stdioServers,
-        registry.policies,
-      );
+      const remediation = remediate(target.filePath, snapshot.stdioServers, {
+        ...registry.policies,
+        registry,
+      });
       actions.push({
         type: "remediate",
         filePath: target.filePath,
@@ -1167,6 +1613,7 @@ export function syncRegistryTargets(options = {}) {
       label: target.label,
       status: result.modified ? "updated" : "ok",
       serverCount: updates.length,
+      warnings: updates.flatMap((update) => update.warnings || []),
     });
   }
 

--- a/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  buildDesiredServerRecord,
+  validateRegistry,
+} from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+  TFX_OTHER_TOKEN: process.env.TFX_OTHER_TOKEN,
+};
+
+function registryWith(server) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: { auth: server },
+    policies: { watched_paths: [] },
+  };
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("mcp guard HTTP transport + headers schema", () => {
+  it("validates http transport with no headers, literal headers, env headers, and prefixed env headers", () => {
+    const cases = [
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": { value: "triflux" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-API-Key": { env: "TFX_TEST_TOKEN" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+        },
+      },
+    ];
+
+    for (const server of cases) {
+      assert.deepEqual(validateRegistry(registryWith(server)), []);
+    }
+  });
+
+  it("rejects malformed header descriptors and stdio-shaped registry servers", () => {
+    const invalidServers = [
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "Bad Header": { value: "x" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": "triflux" },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: { "X-API-Key": { env: "" } },
+      },
+      {
+        transport: "stdio",
+        url: "https://example.com/mcp",
+        headers: { "X-Client": { value: "triflux" } },
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        command: "node",
+      },
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        args: ["server.js"],
+      },
+    ];
+
+    for (const server of invalidServers) {
+      assert.notDeepEqual(validateRegistry(registryWith(server)), []);
+    }
+  });
+
+  it("builds header-aware desired records for Codex TOML targets", () => {
+    process.env.TFX_TEST_TOKEN = "secret-token";
+
+    const desired = buildDesiredServerRecord(
+      "auth",
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      },
+      join("home", ".codex", "config.toml"),
+    );
+
+    assert.deepEqual(desired.config, {
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "X-Client": "triflux",
+      },
+    });
+    assert.deepEqual(desired.codex, {
+      bearer_token_env_var: "TFX_TEST_TOKEN",
+      env_http_headers: {},
+      http_headers: { "X-Client": "triflux" },
+    });
+    assert.deepEqual(desired.warnings, []);
+  });
+
+  it("builds header-aware desired records for JSON MCP targets", () => {
+    process.env.TFX_TEST_TOKEN = "secret-token";
+    process.env.TFX_OTHER_TOKEN = "other-token";
+
+    const desired = buildDesiredServerRecord(
+      "auth",
+      {
+        transport: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-API-Key": { env: "TFX_OTHER_TOKEN" },
+          "X-Client": { value: "triflux" },
+        },
+      },
+      join("repo", ".mcp.json"),
+    );
+
+    assert.deepEqual(desired.config, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "X-API-Key": "other-token",
+        "X-Client": "triflux",
+      },
+    });
+    assert.deepEqual(desired.warnings, []);
+  });
+
+  it("keeps hub-url records URL-only when no headers are configured", () => {
+    const desired = buildDesiredServerRecord(
+      "tfx-hub",
+      {
+        transport: "hub-url",
+        url: "http://127.0.0.1:27888/mcp",
+      },
+      join("repo", ".mcp.json"),
+    );
+
+    assert.deepEqual(desired.config, {
+      type: "http",
+      url: "http://127.0.0.1:27888/mcp",
+    });
+  });
+});

--- a/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_CODEX_CONFIG_SYNC: process.env.TFX_CODEX_CONFIG_SYNC,
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+  TFX_MISSING_TOKEN: process.env.TFX_MISSING_TOKEN,
+};
+
+function createHomeDir(prefix = "mcp-guard-sync-") {
+  const base = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(join(base, ".codex"), { recursive: true });
+  return base;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function registryFor(homeDir, extraServer) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: {
+      auth: extraServer,
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      watched_paths: [
+        join(homeDir, ".codex", "config.toml"),
+        join(homeDir, "repo", ".mcp.json"),
+      ],
+    },
+  };
+}
+
+afterEach(restoreEnv);
+
+describe("syncRegistryTargets HTTP headers", () => {
+  it("writes authenticated HTTP records to Codex TOML and .mcp.json configs", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      }),
+    });
+
+    assert.equal(
+      result.actions.every((action) => action.status === "updated"),
+      true,
+    );
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.match(codexToml, /\[mcp_servers\.auth\]/);
+    assert.match(codexToml, /url = "https:\/\/example\.com\/mcp"/);
+    assert.match(codexToml, /bearer_token_env_var = "TFX_TEST_TOKEN"/);
+    assert.match(codexToml, /http_headers = \{ "X-Client" = "triflux" \}/);
+    assert.doesNotMatch(codexToml, /sync-secret/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.deepEqual(projectConfig.mcpServers.auth, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer sync-secret",
+        "X-Client": "triflux",
+      },
+    });
+  });
+
+  it("preserves unrelated MCP entries and unrelated fields on the managed server", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const codexPath = join(homeDir, ".codex", "config.toml");
+    writeFileSync(
+      codexPath,
+      [
+        'model = "gpt-5"',
+        "",
+        "[mcp_servers.auth]",
+        'command = "node"',
+        'args = ["old.js"]',
+        "enabled = false",
+        "",
+        "[mcp_servers.auth.tools.read]",
+        'approval_mode = "auto"',
+        "",
+        "[mcp_servers.other]",
+        'url = "https://other.example/mcp"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+    writeFileSync(
+      projectMcpPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            auth: {
+              type: "http",
+              url: "https://old.example/mcp",
+              disabled: true,
+            },
+            other: { url: "https://other.example/mcp" },
+          },
+          workspace: "keep",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+        },
+      }),
+    });
+
+    const codexToml = readFileSync(codexPath, "utf8");
+    assert.match(codexToml, /^model = "gpt-5"/m);
+    assert.match(codexToml, /^enabled = false$/m);
+    assert.match(codexToml, /\[mcp_servers\.auth\.tools\.read\]/);
+    assert.match(codexToml, /approval_mode = "auto"/);
+    assert.match(codexToml, /\[mcp_servers\.other\]/);
+    assert.doesNotMatch(codexToml, /command = "node"/);
+    assert.doesNotMatch(codexToml, /args = \["old\.js"\]/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.equal(projectConfig.workspace, "keep");
+    assert.deepEqual(projectConfig.mcpServers.other, {
+      url: "https://other.example/mcp",
+    });
+    assert.equal(projectConfig.mcpServers.auth.disabled, true);
+    assert.equal(projectConfig.mcpServers.auth.url, "https://example.com/mcp");
+    assert.deepEqual(projectConfig.mcpServers.auth.headers, {
+      Authorization: "Bearer sync-secret",
+    });
+  });
+
+  it("warns on missing env vars without writing empty secret headers", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    delete process.env.TFX_MISSING_TOKEN;
+
+    const projectMcpPath = join(homeDir, "repo", ".mcp.json");
+    mkdirSync(dirname(projectMcpPath), { recursive: true });
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, {
+        transport: "http",
+        url: "https://example.com/mcp",
+        targets: ["codex", "claude"],
+        headers: {
+          Authorization: { env: "TFX_MISSING_TOKEN", prefix: "Bearer " },
+          "X-Client": { value: "triflux" },
+        },
+      }),
+    });
+
+    assert.ok(
+      result.actions.some((action) =>
+        (action.warnings || []).some((warning) =>
+          warning.includes("TFX_MISSING_TOKEN"),
+        ),
+      ),
+    );
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.doesNotMatch(codexToml, /Authorization/);
+    assert.doesNotMatch(codexToml, /bearer_token_env_var/);
+    assert.doesNotMatch(codexToml, /""/);
+
+    const projectConfig = JSON.parse(readFileSync(projectMcpPath, "utf8"));
+    assert.deepEqual(projectConfig.mcpServers.auth.headers, {
+      "X-Client": "triflux",
+    });
+  });
+});

--- a/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -35,7 +35,7 @@ function registryFor(homeDir, extraServer) {
     version: 1,
     defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
     servers: {
-      auth: extraServer,
+      auth: { safe: true, ...extraServer },
     },
     policies: {
       stdio_action: "replace-with-hub",

--- a/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  remediate,
+  scanForStdioServers,
+  validateRegistry,
+} from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  TFX_TEST_TOKEN: process.env.TFX_TEST_TOKEN,
+};
+
+function tempPath(name) {
+  return join(
+    tmpdir(),
+    `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+}
+
+afterEach(() => {
+  if (originalEnv.TFX_TEST_TOKEN === undefined)
+    delete process.env.TFX_TEST_TOKEN;
+  else process.env.TFX_TEST_TOKEN = originalEnv.TFX_TEST_TOKEN;
+});
+
+describe("watched MCP remediation with HTTP headers", () => {
+  it("replaces a stdio offender with an HTTP registry server that includes headers", () => {
+    process.env.TFX_TEST_TOKEN = "watch-secret";
+    const filePath = join(tempPath("mcp-watch"), ".mcp.json");
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            auth: { command: "node", args: ["server.js"] },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const registry = {
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        auth: {
+          transport: "http",
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+            "X-Client": { value: "triflux" },
+          },
+        },
+      },
+      policies: { watched_paths: [filePath], stdio_action: "replace-with-hub" },
+    };
+
+    const result = remediate(filePath, scanForStdioServers(filePath), {
+      ...registry.policies,
+      registry,
+    });
+    const updated = JSON.parse(readFileSync(filePath, "utf8"));
+
+    assert.equal(result.modified, true);
+    assert.deepEqual(updated.mcpServers.auth, {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer watch-secret",
+        "X-Client": "triflux",
+      },
+    });
+  });
+
+  it("redacts secret values from remediation output", () => {
+    process.env.TFX_TEST_TOKEN = "watch-secret";
+    const filePath = join(tempPath("mcp-watch-redact"), ".mcp.json");
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(
+      filePath,
+      JSON.stringify(
+        { mcpServers: { auth: { command: "node", args: ["server.js"] } } },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const registry = {
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        auth: {
+          transport: "http",
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+          },
+        },
+      },
+      policies: { watched_paths: [filePath], stdio_action: "replace-with-hub" },
+    };
+
+    const result = remediate(filePath, scanForStdioServers(filePath), {
+      ...registry.policies,
+      registry,
+    });
+
+    assert.doesNotMatch(JSON.stringify(result), /watch-secret/);
+    assert.match(JSON.stringify(result), /\*\*\*REDACTED\*\*\*/);
+  });
+
+  it("keeps stdio-only registry entries unsupported", () => {
+    const errors = validateRegistry({
+      version: 1,
+      defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+      servers: {
+        stdio: {
+          transport: "stdio",
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+      policies: { watched_paths: [] },
+    });
+
+    assert.ok(errors.some((error) => error.includes("transport")));
+    assert.ok(errors.some((error) => error.includes("command")));
+    assert.ok(errors.some((error) => error.includes("args")));
+  });
+});

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -10,7 +10,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
-const REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
+const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
 const DEFAULT_REGISTRY = Object.freeze({
@@ -20,6 +20,14 @@ const DEFAULT_REGISTRY = Object.freeze({
   defaults: {
     transport: "hub-url",
     hub_base: "http://127.0.0.1:27888",
+  },
+  policy_notes: {
+    transport:
+      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+    headers:
+      'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
+    secret_safety:
+      "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
   },
   servers: {
     "tfx-hub": {
@@ -82,6 +90,12 @@ function readJsonFile(filePath) {
 function writeJsonFile(filePath, data) {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function registryPath() {
+  return process.env.TFX_MCP_REGISTRY_PATH
+    ? resolve(process.env.TFX_MCP_REGISTRY_PATH)
+    : DEFAULT_REGISTRY_PATH;
 }
 
 function ensureBackup(filePath) {
@@ -176,10 +190,57 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("{") && value.endsWith("}")) {
+    return parseTomlInlineTable(value);
+  }
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlInlineTable(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return {};
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  const table = {};
+  for (const part of parts) {
+    const match = part.match(
+      /^\s*(?:"((?:\\"|[^"])*)"|([A-Za-z0-9_-]+))\s*=\s*(.+?)\s*$/,
+    );
+    if (!match) continue;
+    const key = (match[1] || match[2] || "")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
+    table[key] = parseTomlScalar(match[3]);
+  }
+  return table;
 }
 
 function parseCodexMcpServers(raw) {
@@ -210,6 +271,179 @@ function parseCodexMcpServers(raw) {
   return servers;
 }
 
+function isValidHeaderName(name) {
+  return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
+}
+
+function normalizeHeaderDescriptors(headers = {}) {
+  const normalized = {};
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(headers)) {
+    if (!isValidHeaderName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor)
+    ) {
+      if (
+        Object.hasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
+      ) {
+        normalized[name] = { value: descriptor.value };
+      } else if (
+        Object.hasOwn(descriptor, "env") &&
+        typeof descriptor.env === "string" &&
+        descriptor.env.trim()
+      ) {
+        normalized[name] = { env: descriptor.env.trim() };
+        if (typeof descriptor.prefix === "string") {
+          normalized[name].prefix = descriptor.prefix;
+        }
+      }
+    }
+  }
+  return normalized;
+}
+
+function resolveHeaderDescriptors(name, serverConfig, filePath) {
+  const descriptors = normalizeHeaderDescriptors(serverConfig?.headers || {});
+  const headers = {};
+  const warnings = [];
+  const codex = {
+    bearer_token_env_var: null,
+    env_http_headers: {},
+    http_headers: {},
+  };
+  const codexTarget = isCodexConfig(filePath);
+
+  for (const [headerName, descriptor] of Object.entries(descriptors)) {
+    if (Object.hasOwn(descriptor, "value")) {
+      headers[headerName] = descriptor.value;
+      if (codexTarget) codex.http_headers[headerName] = descriptor.value;
+      continue;
+    }
+
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    const prefix = descriptor.prefix || "";
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+
+    headers[headerName] = `${prefix}${envValue}`;
+
+    if (!codexTarget) continue;
+
+    if (
+      headerName.toLowerCase() === "authorization" &&
+      /^Bearer\s+$/i.test(prefix)
+    ) {
+      codex.bearer_token_env_var = envName;
+    } else if (!prefix) {
+      codex.env_http_headers[headerName] = envName;
+    } else {
+      codex.http_headers[headerName] = `${prefix}${envValue}`;
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header uses resolved literal in Codex TOML because prefixed env headers are unsupported`,
+      );
+    }
+  }
+
+  return {
+    descriptors,
+    headers,
+    warnings,
+    codex: {
+      ...(codex.bearer_token_env_var
+        ? { bearer_token_env_var: codex.bearer_token_env_var }
+        : {}),
+      env_http_headers: codex.env_http_headers,
+      http_headers: codex.http_headers,
+    },
+  };
+}
+
+function hasOwnEntries(value) {
+  return value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function redactHeaders(headers = {}) {
+  const redacted = {};
+  for (const key of Object.keys(headers || {})) {
+    redacted[key] = "***REDACTED***";
+  }
+  return redacted;
+}
+
+function redactServerConfig(config = {}) {
+  if (!config || typeof config !== "object") return config;
+  return {
+    ...config,
+    ...(config.headers ? { headers: redactHeaders(config.headers) } : {}),
+  };
+}
+
+function descriptorsFromCodexConfig(config = {}) {
+  const descriptors = {};
+  if (typeof config.bearer_token_env_var === "string") {
+    descriptors.Authorization = {
+      env: config.bearer_token_env_var,
+      prefix: "Bearer ",
+    };
+  }
+  if (config.env_http_headers && typeof config.env_http_headers === "object") {
+    for (const [name, envName] of Object.entries(config.env_http_headers)) {
+      if (typeof envName === "string") descriptors[name] = { env: envName };
+    }
+  }
+  if (config.http_headers && typeof config.http_headers === "object") {
+    for (const [name, value] of Object.entries(config.http_headers)) {
+      if (typeof value === "string") descriptors[name] = { value };
+    }
+  }
+  return descriptors;
+}
+
+function descriptorsFromJsonConfig(config = {}) {
+  const descriptors = {};
+  if (!config?.headers || typeof config.headers !== "object") {
+    return descriptors;
+  }
+  for (const [name, value] of Object.entries(config.headers)) {
+    if (typeof value === "string") descriptors[name] = { value };
+  }
+  return descriptors;
+}
+
+function headerNames(headers = {}) {
+  return Object.keys(headers || {}).sort();
+}
+
+function sameHeaderDescriptors(left = {}, right = {}) {
+  const leftNames = headerNames(left);
+  const rightNames = headerNames(right);
+  if (JSON.stringify(leftNames) !== JSON.stringify(rightNames)) return false;
+  return leftNames.every(
+    (name) => JSON.stringify(left[name]) === JSON.stringify(right[name]),
+  );
+}
+
+function headerStatus(expected = {}, actual = {}) {
+  const expectedNames = headerNames(expected);
+  const actualNames = headerNames(actual);
+  if (expectedNames.length === 0 && actualNames.length === 0) return "ok";
+  if (expectedNames.some((name) => !Object.hasOwn(actual, name))) {
+    return "missing";
+  }
+  if (!sameHeaderDescriptors(expected, actual)) return "stale";
+  return "ok";
+}
+
 function removeTomlSection(raw, sectionName) {
   const lines = String(raw || "").split(/\r?\n/);
   const output = [];
@@ -236,12 +470,68 @@ function removeTomlSection(raw, sectionName) {
   return cleaned.length > 0 ? cleaned.replace(/\n{3,}/g, "\n\n") : "";
 }
 
-function upsertTomlUrlServer(raw, name, url) {
-  const section = [`[mcp_servers.${name}]`, `url = ${formatTomlString(url)}`];
-  const withoutExisting = removeTomlSection(raw, name).trimEnd();
-  return withoutExisting.length > 0
-    ? `${withoutExisting}\n\n${section.join("\n")}\n`
-    : `${section.join("\n")}\n`;
+function formatTomlInlineTable(data = {}) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return null;
+  return `{ ${entries
+    .map(
+      ([key, value]) => `${formatTomlString(key)} = ${formatTomlString(value)}`,
+    )
+    .join(", ")} }`;
+}
+
+function upsertTomlServer(raw, name, config, codex = {}) {
+  const lines = String(raw || "").split(/\r?\n/);
+  const header = `[mcp_servers.${name}]`;
+  const managedKeys = new Set([
+    "url",
+    "command",
+    "args",
+    "bearer_token_env_var",
+    "http_headers",
+    "env_http_headers",
+  ]);
+  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  if (codex.bearer_token_env_var) {
+    nextManagedLines.push(
+      `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
+    );
+  }
+  const httpHeaders = formatTomlInlineTable(codex.http_headers || {});
+  if (httpHeaders) nextManagedLines.push(`http_headers = ${httpHeaders}`);
+  const envHttpHeaders = formatTomlInlineTable(codex.env_http_headers || {});
+  if (envHttpHeaders) {
+    nextManagedLines.push(`env_http_headers = ${envHttpHeaders}`);
+  }
+
+  const sectionStart = lines.findIndex((line) => line.trim() === header);
+  if (sectionStart < 0) {
+    const section = [header, ...nextManagedLines].join("\n");
+    const withoutTrailing = String(raw || "").trimEnd();
+    return withoutTrailing.length > 0
+      ? `${withoutTrailing}\n\n${section}\n`
+      : `${section}\n`;
+  }
+
+  const output = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    output.push(lines[index]);
+    if (index !== sectionStart) continue;
+
+    index += 1;
+    const preserved = [];
+    while (index < lines.length && !/^\s*\[/.test(lines[index])) {
+      const keyMatch = lines[index].match(/^\s*([A-Za-z0-9_]+)\s*=/);
+      if (!keyMatch || !managedKeys.has(keyMatch[1])) {
+        preserved.push(lines[index]);
+      }
+      index += 1;
+    }
+    output.push(...nextManagedLines, ...preserved.filter(Boolean));
+    index -= 1;
+  }
+
+  return output.join("\n");
 }
 
 function getHubServerEntry(registry) {
@@ -304,22 +594,48 @@ function syncDenylistKey(client, serverName) {
     .toLowerCase()}`;
 }
 
-function buildDesiredServerRecord(name, serverConfig, filePath) {
+export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
       : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
+  const resolvedHeaders = resolveHeaderDescriptors(
+    name,
+    serverConfig,
+    filePath,
+  );
+  const headerConfig = hasOwnEntries(resolvedHeaders.headers)
+    ? { headers: resolvedHeaders.headers }
+    : {};
 
   if (basenameValue === ".mcp.json" || isClaudeProjectMcpConfig(filePath)) {
-    return { name, config: { type: "http", url } };
+    return {
+      name,
+      config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
   if (isCodexConfig(filePath)) {
-    return { name, config: { url } };
+    return {
+      name,
+      config: { url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
-  return { name, config: { url } };
+  return {
+    name,
+    config: { url, ...headerConfig },
+    headerDescriptors: resolvedHeaders.descriptors,
+    codex: resolvedHeaders.codex,
+    warnings: resolvedHeaders.warnings,
+  };
 }
 
 function scanJsonConfig(filePath) {
@@ -354,6 +670,17 @@ function scanJsonConfig(filePath) {
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
               type: typeof config.type === "string" ? config.type : "",
+              headers:
+                config.headers &&
+                typeof config.headers === "object" &&
+                !Array.isArray(config.headers)
+                  ? Object.fromEntries(
+                      Object.entries(config.headers).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
+              headerDescriptors: descriptorsFromJsonConfig(config),
               transport:
                 typeof config.url === "string" && config.url
                   ? "url"
@@ -405,6 +732,11 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      headers:
+        config.http_headers && typeof config.http_headers === "object"
+          ? config.http_headers
+          : {},
+      headerDescriptors: descriptorsFromCodexConfig(config),
       transport:
         typeof config.url === "string" && config.url
           ? "url"
@@ -472,6 +804,9 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (!Object.hasOwn(update.config, "headers")) {
+      delete nextConfig.headers;
+    }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
     if (changed) {
@@ -506,7 +841,7 @@ function updateCodexConfig(filePath, updates = [], removals = []) {
   }
 
   for (const update of updates) {
-    raw = upsertTomlUrlServer(raw, update.name, update.config.url);
+    raw = upsertTomlServer(raw, update.name, update.config, update.codex || {});
   }
 
   const finalRaw = raw.trim().length > 0 ? `${raw.trimEnd()}\n` : "";
@@ -539,7 +874,7 @@ function scanConfig(filePath) {
 }
 
 export function getRegistryPath() {
-  return REGISTRY_PATH;
+  return registryPath();
 }
 
 export function createDefaultRegistry() {
@@ -578,6 +913,104 @@ export function validateRegistry(registry) {
       }
       if (typeof server.url !== "string" || !server.url.trim()) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
+      }
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url or http`,
+        );
+      }
+      if (server.command !== undefined) {
+        errors.push(
+          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.args !== undefined) {
+        errors.push(
+          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.headers !== undefined) {
+        if (!["hub-url", "http"].includes(transport)) {
+          errors.push(
+            `registry.servers.${name}.headers is allowed only for HTTP-compatible transports`,
+          );
+        }
+        if (
+          !server.headers ||
+          typeof server.headers !== "object" ||
+          Array.isArray(server.headers)
+        ) {
+          errors.push(`registry.servers.${name}.headers must be an object`);
+        } else {
+          for (const [headerName, descriptor] of Object.entries(
+            server.headers,
+          )) {
+            if (!isValidHeaderName(headerName)) {
+              errors.push(
+                `registry.servers.${name}.headers contains invalid header name ${headerName}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            const hasValue = Object.hasOwn(descriptor, "value");
+            const hasEnv = Object.hasOwn(descriptor, "env");
+            if (hasValue && hasEnv) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use either value or env`,
+              );
+            } else if (hasValue) {
+              if (
+                keys.length !== 1 ||
+                typeof descriptor.value !== "string" ||
+                descriptor.value.length === 0
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.value must be a non-empty string`,
+                );
+              }
+            } else if (hasEnv) {
+              if (
+                !["env", "prefix"].every((key) => keys.includes(key)) &&
+                keys.some((key) => !["env", "prefix"].includes(key))
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName} supports only env and optional prefix`,
+                );
+              }
+              if (
+                typeof descriptor.env !== "string" ||
+                !descriptor.env.trim()
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.env must be a non-empty string`,
+                );
+              }
+              if (
+                descriptor.prefix !== undefined &&
+                typeof descriptor.prefix !== "string"
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.prefix must be a string`,
+                );
+              }
+            } else {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use value or env`,
+              );
+            }
+          }
+        }
       }
       if (server.targets !== undefined && !Array.isArray(server.targets)) {
         errors.push(`registry.servers.${name}.targets must be an array`);
@@ -625,9 +1058,9 @@ export function validateRegistry(registry) {
 }
 
 export function inspectRegistry() {
-  if (!existsSync(REGISTRY_PATH)) {
+  if (!existsSync(registryPath())) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: false,
       valid: false,
       errors: ["registry file missing"],
@@ -636,10 +1069,10 @@ export function inspectRegistry() {
   }
 
   try {
-    const registry = readJsonFile(REGISTRY_PATH);
+    const registry = readJsonFile(registryPath());
     const errors = validateRegistry(registry);
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: errors.length === 0,
       errors,
@@ -647,7 +1080,7 @@ export function inspectRegistry() {
     };
   } catch (error) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: false,
       errors: [error.message],
@@ -689,7 +1122,7 @@ export function saveRegistry(registry) {
   if (errors.length > 0) {
     throw new Error(`MCP registry invalid: ${errors.join("; ")}`);
   }
-  writeJsonFile(REGISTRY_PATH, registry);
+  writeJsonFile(registryPath(), registry);
   return registry;
 }
 
@@ -736,13 +1169,19 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
     );
 
     for (const [name, serverConfig] of managedServers) {
-      const expectedUrl = buildDesiredServerRecord(
+      const desired = buildDesiredServerRecord(
         name,
         serverConfig,
         config.filePath,
-      ).config.url;
+      );
+      const expectedUrl = desired.config.url;
+      const expectedHeaders = isCodexConfig(config.filePath)
+        ? desired.headerDescriptors || {}
+        : descriptorsFromJsonConfig(desired.config);
       const actual =
         config.servers.find((server) => server.name === name) || null;
+      const actualHeaders = actual?.headerDescriptors || {};
+      const currentHeaderStatus = headerStatus(expectedHeaders, actualHeaders);
       let status = "missing";
 
       if (!config.exists) {
@@ -754,7 +1193,7 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
-        status = "present";
+        status = currentHeaderStatus === "ok" ? "present" : "mismatch";
       } else {
         status = "mismatch";
       }
@@ -768,6 +1207,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         expectedUrl,
         actualUrl: actual?.url || "",
         status,
+        headerStatus: currentHeaderStatus,
+        expectedHeaderNames: headerNames(expectedHeaders),
+        actualHeaderNames: headerNames(actualHeaders),
       });
     }
 
@@ -866,14 +1308,19 @@ export function remediate(filePath, stdioServers, policy = {}) {
   let replacement = null;
 
   if (action === "replace-with-hub") {
-    const registry = loadRegistryOrDefault();
-    const [hubServerName, hubServerConfig] = getHubServerEntry(registry);
+    const registry = policy.registry || loadRegistryOrDefault();
+    const matchingOffender = offenders.find((server) =>
+      Object.hasOwn(registry.servers || {}, server.name),
+    );
+    const [hubServerName, hubServerConfig] = matchingOffender
+      ? [matchingOffender.name, registry.servers[matchingOffender.name]]
+      : getHubServerEntry(registry);
     const desired = buildDesiredServerRecord(
       hubServerName,
       hubServerConfig,
       resolvedPath,
     );
-    replacement = { name: desired.name, ...desired.config };
+    replacement = { name: desired.name, ...redactServerConfig(desired.config) };
     updates.push(desired);
   }
 
@@ -884,7 +1331,7 @@ export function remediate(filePath, stdioServers, policy = {}) {
     backupPath,
     removedServers: removals,
     replacement,
-    warnings: [],
+    warnings: updates.flatMap((update) => update.warnings || []),
   };
 }
 
@@ -1088,11 +1535,10 @@ export function syncRegistryTargets(options = {}) {
     }
 
     if (snapshot.stdioServers.length > 0) {
-      const remediation = remediate(
-        target.filePath,
-        snapshot.stdioServers,
-        registry.policies,
-      );
+      const remediation = remediate(target.filePath, snapshot.stdioServers, {
+        ...registry.policies,
+        registry,
+      });
       actions.push({
         type: "remediate",
         filePath: target.filePath,
@@ -1167,6 +1613,7 @@ export function syncRegistryTargets(options = {}) {
       label: target.label,
       status: result.modified ? "updated" : "ok",
       serverCount: updates.length,
+      warnings: updates.flatMap((update) => update.warnings || []),
     });
   }
 

--- a/tests/regression/mcp-registry-http-headers.test.mjs
+++ b/tests/regression/mcp-registry-http-headers.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
+const TFX_BIN = join(REPO_ROOT, "bin", "triflux.mjs");
+
+function createFixture(name) {
+  const root = join(
+    tmpdir(),
+    `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  const home = join(root, "home");
+  const project = join(root, "project");
+  mkdirSync(join(home, ".codex"), { recursive: true });
+  mkdirSync(project, { recursive: true });
+  return { root, home, project };
+}
+
+function writeRegistry(filePath, home, project, server) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        version: 1,
+        defaults: {
+          transport: "hub-url",
+          hub_base: "http://127.0.0.1:27888",
+        },
+        servers: {
+          "tfx-hub": {
+            transport: "hub-url",
+            url: "http://127.0.0.1:27888/mcp",
+            safe: true,
+            targets: ["codex", "claude"],
+            description: "triflux Hub MCP 서버",
+          },
+          ...(server ? { auth: server } : {}),
+        },
+        policies: {
+          stdio_action: "replace-with-hub",
+          watched_paths: [
+            join(home, ".codex", "config.toml"),
+            join(project, ".mcp.json"),
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+function runTfx(args, env, cwd) {
+  return execFileSync(process.execPath, [TFX_BIN, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("tfx mcp HTTP headers regression", () => {
+  it("syncs HTTP headers and reports header status without leaking secrets", () => {
+    const { root, home, project } = createFixture("tfx-mcp-http-headers");
+    const registryPath = join(root, "mcp-registry.json");
+    writeRegistry(registryPath, home, project, {
+      transport: "http",
+      url: "https://example.com/mcp",
+      targets: ["codex", "claude"],
+      headers: {
+        Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+        "X-Client": { value: "triflux" },
+      },
+    });
+
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      TFX_CODEX_CONFIG_SYNC: "1",
+      TFX_MCP_REGISTRY_PATH: registryPath,
+      TFX_TEST_TOKEN: "regression-secret",
+    };
+
+    const syncResult = JSON.parse(
+      runTfx(["mcp", "sync", "--json"], env, project),
+    );
+    assert.ok(syncResult.actions.length >= 2);
+
+    const codexToml = readFileSync(join(home, ".codex", "config.toml"), "utf8");
+    assert.match(codexToml, /\[mcp_servers\.tfx-hub\]/);
+    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:27888\/mcp"/);
+    assert.match(codexToml, /\[mcp_servers\.auth\]/);
+    assert.match(codexToml, /bearer_token_env_var = "TFX_TEST_TOKEN"/);
+    assert.doesNotMatch(codexToml, /regression-secret/);
+
+    const projectConfig = JSON.parse(
+      readFileSync(join(project, ".mcp.json"), "utf8"),
+    );
+    assert.deepEqual(projectConfig.mcpServers["tfx-hub"], {
+      type: "http",
+      url: "http://127.0.0.1:27888/mcp",
+    });
+    assert.equal(
+      projectConfig.mcpServers.auth.headers.Authorization,
+      "Bearer regression-secret",
+    );
+
+    const listResultRaw = runTfx(["mcp", "list", "--json"], env, project);
+    assert.doesNotMatch(listResultRaw, /regression-secret/);
+    const listResult = JSON.parse(listResultRaw);
+    const authRows = listResult.rows.filter((row) => row.name === "auth");
+    assert.ok(authRows.length >= 2);
+    assert.ok(authRows.every((row) => row.headerStatus === "ok"));
+    assert.ok(
+      authRows.every((row) =>
+        row.expectedHeaderNames.includes("Authorization"),
+      ),
+    );
+  });
+
+  it("keeps existing tfx-hub URL-only sync unchanged", () => {
+    const { root, home, project } = createFixture("tfx-mcp-hub-url-only");
+    const registryPath = join(root, "mcp-registry.json");
+    writeRegistry(registryPath, home, project, null);
+
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      TFX_CODEX_CONFIG_SYNC: "1",
+      TFX_MCP_REGISTRY_PATH: registryPath,
+    };
+
+    runTfx(["mcp", "sync", "--json"], env, project);
+
+    assert.equal(
+      readFileSync(join(home, ".codex", "config.toml"), "utf8"),
+      '[mcp_servers.tfx-hub]\nurl = "http://127.0.0.1:27888/mcp"\n',
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(project, ".mcp.json"), "utf8")).mcpServers[
+        "tfx-hub"
+      ],
+      {
+        type: "http",
+        url: "http://127.0.0.1:27888/mcp",
+      },
+    );
+  });
+});

--- a/tests/regression/mcp-registry-http-headers.test.mjs
+++ b/tests/regression/mcp-registry-http-headers.test.mjs
@@ -39,7 +39,7 @@ function writeRegistry(filePath, home, project, server) {
             targets: ["codex", "claude"],
             description: "triflux Hub MCP 서버",
           },
-          ...(server ? { auth: server } : {}),
+          ...(server ? { auth: { safe: true, ...server } } : {}),
         },
         policies: {
           stdio_action: "replace-with-hub",


### PR DESCRIPTION
## Summary

- Registry schema accepts `transport: "http"` alongside existing `"hub-url"`.
- Optional `headers` map with descriptor types: `{value}` | `{env}` | `{env, prefix}`.
- Resolves env-based secrets at sync time; **no literal secrets persisted** to registry or config.
- Codex TOML and `.mcp.json` sync emit header-aware records; unrelated fields preserved.
- Missing env vars produce warnings without writing empty secret headers.
- **stdio direct registration intentionally NOT supported** (Option B keeps HTTP-only direction).

## Implements

PRD: `.triflux/plans/mcp-registry-stdio-headers-prd.md` (local artifact, `.triflux/` is gitignored by policy).

**Option B** chosen over Option A (stdio direct registration) and Option C (hybrid). Stdio remains explicitly unsupported because the product direction is to replace fragile local stdio launches with remote HTTP endpoints or hub-mediated HTTP adapters.

## Schema additions

```json
{
  "transport": "http",
  "url": "https://example.com/mcp",
  "headers": {
    "Authorization": { "env": "EXAMPLE_MCP_API_KEY", "prefix": "Bearer " },
    "X-Client": { "value": "triflux" }
  },
  "safe": true,
  "targets": ["codex", "claude"]
}
```

Validation rules: header names non-empty strings; values must be `{value}` or `{env}` or `{env, prefix}`; mixed `value`+`env` rejected; raw string values rejected; headers on non-HTTP transports rejected.

## Files changed (10 files, +2197/-62)

Source:
- `scripts/lib/mcp-guard-engine.mjs` (+509/-62) — `validateRegistry`, `buildDesiredServerRecord`, `updateCodexConfig`, `updateJsonConfig`, `inspectRegistryStatus`, `remediate` extended for HTTP+headers
- `packages/triflux/scripts/lib/mcp-guard-engine.mjs` (+509/-62) — byte-identical mirror
- `config/mcp-registry.json` (+5/-0) — `policy_notes` doc block

Tests (4 new + 3 mirror = 7 new files):
- `scripts/__tests__/mcp-guard-engine-http-headers.test.mjs` (+177) — 5 tests
- `scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs` (+229) — 3 tests
- `scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs` (+137) — 3 tests
- `tests/regression/mcp-registry-http-headers.test.mjs` (+155) — 2 tests
- `packages/triflux/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs` (+177 mirror)
- `packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs` (+229 mirror)
- `packages/triflux/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs` (+137 mirror)

## Implementation highlights

- **Codex TOML routing**: `Authorization` + `Bearer ` prefix → `bearer_token_env_var`. Plain env → `env_http_headers`. Prefixed env (non-Authorization) → literal `http_headers` with warning. Preserves unrelated keys including `approval_mode` (memory: feedback_codex_mcp_tool_approval_reversion).
- **JSON merge**: preserves unrelated server fields (e.g. `disabled`), unrelated `mcpServers` entries, top-level keys (e.g. `workspace`).
- **`inspectRegistryStatus`**: reports `headerStatus` (`ok`/`missing`/`stale`), `expectedHeaderNames`, `actualHeaderNames`. **Never emits resolved literal secrets.**
- **`remediate`**: HTTP-aware replacement for stdio offenders. Uses `redactServerConfig`/`redactHeaders` to mask secret values as `***REDACTED***`.
- **Backward compat**: existing `hub-url` URL-only entries validate and sync identically. Missing `headers` = empty header set.

## Test plan

- [x] 4 new test files (root): 13/13 pass
- [x] Existing `scripts/__tests__/mcp-guard-engine.test.mjs`: 7/7 pass (regression)
- [x] 3 packages mirror tests: 18/18 pass (parity)
- [x] `npm test`: 3272 tests, 3264 pass, **4 pre-existing failures on main HEAD `9a500e7`** (`hub-quota-nonblocking` x2, `codex-adapter`, `gemini-adapter`) — verified independent, NOT caused by this PR.

## Follow-up PRs

- PR #216 (PRD D — proactive sync with denylist) — sibling, in flight.
- `.triflux/plans/mcp-singleton-redesign-prd.md` (PRD B) — Q1 benchmark + Option C hybrid; deferred until measurement baseline ready.