### PR TITLE
feat(hub/mcp): Step 1 lifecycle trace + per-CLI label + /status?include_metrics opt-in

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -27,3 +27,31 @@
 **Context:** Synapse v1 eng review(2026-04-11)에서 Approach C로 검토됨. Effort XL, Completeness 10/10. v1은 git 기반으로 진행, v2에서 jj 백엔드를 선택적 실험.
 
 **Depends on:** Synapse v1 완료 (Layer 1-3)
+
+## [Tier 2] MCP hub Option C cleanup ownership 설계
+
+**What:** Option C (parent hub + per-CLI MCP frontends) 우선 작업 시 cleanup ownership 명시. orphan node, psmux session, fsmonitor daemon, stale process cleanup 의 단일 owner 1개 고정.
+
+**Why:** PR #200 (fsmonitor cleanup) / Issue #214 (다중 worktree 회귀) 가 보여줬듯 cleanup ownership 모호하면 race + 누락 발생. PRD B Option C 가 cleanup을 acknowledge 만 하고 메커니즘 미정의 → Codex outside voice도 동일 지적.
+
+**Pros:** parent/frontend 양측에서 동일 cleanup 발화 시 race 방지. 'who owns orphan reaping' 명확. 디버깅 시 'which process killed it' 추적 가능.
+
+**Cons:** ownership 결정이 토폴로지에 결합 → Option C 채택 후에만 의미 있음. 지금 결정하면 premature.
+
+**Context:** PRD B (`.triflux/plans/mcp-singleton-redesign-prd.md`) eng review (2026-04-30) Issue 4 + Codex outside voice. PRD Migration Path Step 6+ 에서 적용. 현재 hub/server.mjs:1845-1891 의 orphan cleanup, 1893-1905 rate-limit eviction 이 single-owner 패턴 — Option C 분리 시 이 패턴 깨짐.
+
+**Depends on:** PRD B Step 1 trace 완료 → Step 5 (registry compatibility) → Step 6 (Option C prototype). 이 셋 모두 선행.
+
+## [Tier 2] Q1 benchmark harness real-client lifecycle 재현
+
+**What:** PRD B Step 2 benchmark harness 가 합성 N×M×K 매트릭스 대신 실제 Claude/Codex/Gemini CLI 의 initialize/list/call 호출 주기를 재현해야 함. 합성은 실제 client 가 만들지 않는 워크로드 측정 위험.
+
+**Why:** Codex outside voice (2026-04-30): "Many MCP clients initialize once, list tools once, then serialize or lightly parallelize calls. A synthetic K=8 session model could measure a workload no real Claude/Codex/Gemini lifecycle creates." 합성 측정은 hub topology 결정을 잘못된 데이터로 유도.
+
+**Pros:** Q1 결정의 신뢰도 상승. fairness/saturation 의 진짜 원인을 측정. tools/list 가중치 같은 weak metric 함정 회피.
+
+**Cons:** real CLI 구동 시 외부 모델 latency 노이즈 유입 (mock 가능 영역 줄어듦). 테스트 비용 증가.
+
+**Context:** PRD B Migration Path Step 2 ("Build the Q1 benchmark harness"). 현재 PRD는 합성 N×M×K 스펙. Codex outside voice + 내부 review 모두 합성 < 실제 lifecycle 우선 권장. tools/list initialize 가중치 과다 우려와 동반 검토.
+
+**Depends on:** PRD B Step 1 trace (실제 client lifecycle 데이터 확보) → Step 2 harness 설계.

--- a/hub/lib/trace-recorder.mjs
+++ b/hub/lib/trace-recorder.mjs
@@ -1,0 +1,153 @@
+const VALID_CLIENTS = new Set(["codex", "claude", "gemini", "unknown"]);
+const VALID_PHASES = new Set(["ingress", "handler", "store", "event-loop"]);
+const SAMPLE_LIMIT = 1000;
+
+const categories = new Map();
+const workerDurations = [];
+const workerCounts = {
+  spawned: 0,
+  exited: 0,
+};
+
+function debugInvalid(kind, details) {
+  if (process.env.TFX_TRACE_DEBUG !== "1") return;
+  console.debug(`[trace-recorder] ignored invalid ${kind}`, details);
+}
+
+function normalizeClient(client) {
+  const value = String(client || "unknown").toLowerCase();
+  return VALID_CLIENTS.has(value) ? value : "unknown";
+}
+
+function normalizePhase(phase) {
+  const value = String(phase || "handler");
+  return VALID_PHASES.has(value) ? value : "handler";
+}
+
+function validDuration(durMs) {
+  return Number.isFinite(durMs) && durMs >= 0;
+}
+
+function emptyStats() {
+  return {
+    count: 0,
+    total: 0,
+    min: null,
+    max: null,
+    samples: [],
+    phases: {},
+  };
+}
+
+function addDuration(stats, durMs, phase) {
+  stats.count += 1;
+  stats.total += durMs;
+  stats.min = stats.min == null ? durMs : Math.min(stats.min, durMs);
+  stats.max = stats.max == null ? durMs : Math.max(stats.max, durMs);
+  stats.samples.push(durMs);
+  if (stats.samples.length > SAMPLE_LIMIT) {
+    stats.samples.splice(0, stats.samples.length - SAMPLE_LIMIT);
+  }
+
+  const phaseStats = stats.phases[phase] || emptyPhaseStats();
+  phaseStats.count += 1;
+  phaseStats.total += durMs;
+  phaseStats.min =
+    phaseStats.min == null ? durMs : Math.min(phaseStats.min, durMs);
+  phaseStats.max =
+    phaseStats.max == null ? durMs : Math.max(phaseStats.max, durMs);
+  stats.phases[phase] = phaseStats;
+}
+
+function emptyPhaseStats() {
+  return { count: 0, total: 0, min: null, max: null };
+}
+
+function percentile(samples, percentileValue) {
+  if (!samples.length) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+function publicStats(stats) {
+  return {
+    count: stats.count,
+    total: stats.total,
+    min: stats.min,
+    max: stats.max,
+    p50: percentile(stats.samples, 50),
+    p95: percentile(stats.samples, 95),
+    p99: percentile(stats.samples, 99),
+    phases: stats.phases,
+  };
+}
+
+export function recordRequest(
+  category,
+  durMs,
+  client = "unknown",
+  phase = "handler",
+) {
+  if (!category || typeof category !== "string") return;
+  if (!validDuration(durMs)) {
+    debugInvalid("request duration", { category, durMs, client, phase });
+    return;
+  }
+
+  const clientKey = normalizeClient(client);
+  const phaseKey = normalizePhase(phase);
+  const bucket = categories.get(category) || new Map();
+  const stats = bucket.get(clientKey) || emptyStats();
+  addDuration(stats, durMs, phaseKey);
+  bucket.set(clientKey, stats);
+  categories.set(category, bucket);
+}
+
+export function recordWorker(workerId, kind, command, durMs) {
+  if (!workerId || typeof workerId !== "string") return;
+  if (kind === "spawned") {
+    workerCounts.spawned += 1;
+    return;
+  }
+  if (kind !== "exited") return;
+
+  workerCounts.exited += 1;
+  if (durMs == null) return;
+  if (!validDuration(durMs)) {
+    debugInvalid("worker duration", { workerId, kind, command, durMs });
+    return;
+  }
+  workerDurations.push(durMs);
+  if (workerDurations.length > SAMPLE_LIMIT) {
+    workerDurations.splice(0, workerDurations.length - SAMPLE_LIMIT);
+  }
+}
+
+export function snapshot() {
+  const categorySnapshot = {};
+  for (const [category, bucket] of categories.entries()) {
+    categorySnapshot[category] = {};
+    for (const [client, stats] of bucket.entries()) {
+      categorySnapshot[category][client] = publicStats(stats);
+    }
+  }
+
+  return {
+    categories: categorySnapshot,
+    workers: {
+      spawned: workerCounts.spawned,
+      exited: workerCounts.exited,
+      p50: percentile(workerDurations, 50),
+      p95: percentile(workerDurations, 95),
+      p99: percentile(workerDurations, 99),
+    },
+  };
+}
+
+export function reset() {
+  categories.clear();
+  workerDurations.length = 0;
+  workerCounts.spawned = 0;
+  workerCounts.exited = 0;
+}

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -13,6 +13,7 @@ import {
 import { createServer as createHttpServer } from "node:http";
 import { homedir } from "node:os";
 import { extname, join, resolve, sep } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -33,6 +34,11 @@ import {
   cleanupStaleFsmonitorDaemons,
 } from "./lib/process-utils.mjs";
 import * as spawnTrace from "./lib/spawn-trace.mjs";
+import {
+  recordRequest,
+  recordWorker,
+  snapshot as traceSnapshot,
+} from "./lib/trace-recorder.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
@@ -199,6 +205,12 @@ function isInitializeRequest(body) {
   if (Array.isArray(body))
     return body.some((message) => message.method === "initialize");
   return false;
+}
+
+function parseTfxClientHeader(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const client = String(raw || "unknown").toLowerCase();
+  return ["codex", "claude", "gemini"].includes(client) ? client : "unknown";
 }
 
 async function parseBody(req) {
@@ -960,6 +972,7 @@ export async function startHub({
   const assignCallbacks = createAssignCallbackServer({ store, sessionId });
   const tools = createTools(store, router, hitl, pipe);
   const transports = new Map();
+  const workerSpans = new Map();
 
   async function closeMcpTransportSession(sid, session, reason) {
     if (!sid) return;
@@ -993,38 +1006,81 @@ export async function startHub({
     }
   }
 
-  function createMcpForSession() {
+  function getTraceClient(clientRef) {
+    return clientRef?.client || "unknown";
+  }
+
+  function finishWorkerTrace(workerId, kind) {
+    if (!workerId || typeof workerId !== "string") return;
+    const span = workerSpans.get(workerId);
+    if (!span) return;
+    workerSpans.delete(workerId);
+    recordWorker(
+      workerId,
+      "exited",
+      span.command || kind,
+      performance.now() - span.startedAt,
+    );
+  }
+
+  function createMcpForSession(clientRef = { client: "unknown" }) {
     const mcp = new Server(
       { name: "tfx-hub", version: "1.0.0" },
       { capabilities: { tools: {} } },
     );
 
-    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-      })),
-    }));
+    mcp.setRequestHandler(ListToolsRequestSchema, async () => {
+      const started = performance.now();
+      try {
+        return {
+          tools: tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        };
+      } finally {
+        recordRequest(
+          "tools.list",
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
+      }
+    });
 
     mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-      const tool = tools.find((candidate) => candidate.name === name);
-      if (!tool) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                ok: false,
-                error: { code: "UNKNOWN_TOOL", message: `도구 없음: ${name}` },
-              }),
-            },
-          ],
-          isError: true,
-        };
+      const category = `tools.call.${name || "unknown"}`;
+      const started = performance.now();
+      try {
+        const tool = tools.find((candidate) => candidate.name === name);
+        if (!tool) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  ok: false,
+                  error: {
+                    code: "UNKNOWN_TOOL",
+                    message: `도구 없음: ${name}`,
+                  },
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return tool.handler(args || {});
+      } finally {
+        recordRequest(
+          category,
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
       }
-      return tool.handler(args || {});
     });
 
     return mcp;
@@ -1079,7 +1135,11 @@ export async function startHub({
 
       if (path === "/" || path === "/status") {
         const status = router.getStatus("hub").data;
-        return writeJson(res, 200, {
+        const includeMetrics =
+          new URL(req.url, `http://${host}`).searchParams.get(
+            "include_metrics",
+          ) === "1";
+        const body = {
           ...status,
           sessions: transports.size,
           pid: process.pid,
@@ -1096,7 +1156,11 @@ export async function startHub({
             max_total_descendants: spawnTrace.MAX_TOTAL_DESCENDANTS,
           },
           version,
-        });
+        };
+        if (includeMetrics) {
+          body.metrics = traceSnapshot();
+        }
+        return writeJson(res, 200, body);
       }
 
       if (path === "/health" || path === "/healthz") {
@@ -1327,6 +1391,17 @@ export async function startHub({
               });
             }
 
+            const command =
+              body.command ||
+              metadata?.command ||
+              metadata?.cmd ||
+              metadata?.task ||
+              cli;
+            workerSpans.set(agent_id, {
+              command,
+              startedAt: performance.now(),
+            });
+            recordWorker(agent_id, "spawned", command, 0);
             const heartbeat_ttl_ms = (timeout_sec + 120) * 1000;
             const result = await pipe.executeCommand("register", {
               agent_id,
@@ -1400,7 +1475,17 @@ export async function startHub({
           }
 
           if (path === "/bridge/publish" && req.method === "POST") {
-            const result = router.handlePublish(normalizePublishBody(body));
+            const normalized = normalizePublishBody(body);
+            const result = router.handlePublish(normalized);
+            if (result.ok) {
+              finishWorkerTrace(
+                normalized.from ||
+                  normalized.agent_id ||
+                  normalized.worker_agent ||
+                  normalized.from_agent,
+                "publish",
+              );
+            }
             return writeJson(res, result.ok ? 200 : 400, result);
           }
 
@@ -1696,6 +1781,9 @@ export async function startHub({
             const result = await pipe.executeCommand("deregister", {
               agent_id,
             });
+            if (result.ok) {
+              finishWorkerTrace(agent_id, "deregister");
+            }
             return writeJson(res, 200, result);
           }
 
@@ -1732,11 +1820,20 @@ export async function startHub({
             session.transport._lastActivity = Date.now();
             await session.transport.handleRequest(req, res, body);
           } else if (!sessionIdHeader && isInitializeRequest(body)) {
+            const client = parseTfxClientHeader(req.headers["x-tfx-client"]);
+            const clientRef = { client };
+            const initializeStarted = performance.now();
             const transport = new StreamableHTTPServerTransport({
               sessionIdGenerator: () => randomUUID(),
               onsessioninitialized: (sid) => {
                 transport._lastActivity = Date.now();
-                transports.set(sid, { transport, mcp, closing: false });
+                transports.set(sid, {
+                  transport,
+                  mcp,
+                  closing: false,
+                  client,
+                  createdAt: Date.now(),
+                });
               },
             });
             transport.onclose = () => {
@@ -1748,9 +1845,18 @@ export async function startHub({
                   "transport.onclose",
                 );
             };
-            const mcp = createMcpForSession();
+            const mcp = createMcpForSession(clientRef);
             await mcp.connect(transport);
-            await transport.handleRequest(req, res, body);
+            try {
+              await transport.handleRequest(req, res, body);
+            } finally {
+              recordRequest(
+                "initialize",
+                performance.now() - initializeStarted,
+                client,
+                "ingress",
+              );
+            }
           } else {
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(
@@ -2148,6 +2254,13 @@ export async function startHub({
             assignCallbacks,
             delegatorService,
             delegatorWorker,
+            getMcpSessions: () =>
+              Array.from(transports.entries()).map(([id, session]) => ({
+                id,
+                client: session.client || "unknown",
+                createdAt: session.createdAt ?? null,
+                closing: Boolean(session.closing),
+              })),
             stop: stopFn,
           });
         } catch (error) {

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -1397,11 +1397,7 @@ export async function startHub({
               metadata?.cmd ||
               metadata?.task ||
               cli;
-            workerSpans.set(agent_id, {
-              command,
-              startedAt: performance.now(),
-            });
-            recordWorker(agent_id, "spawned", command, 0);
+            const workerStartedAt = performance.now();
             const heartbeat_ttl_ms = (timeout_sec + 120) * 1000;
             const result = await pipe.executeCommand("register", {
               agent_id,
@@ -1411,6 +1407,13 @@ export async function startHub({
               heartbeat_ttl_ms,
               metadata,
             });
+            if (result.ok) {
+              workerSpans.set(agent_id, {
+                command,
+                startedAt: workerStartedAt,
+              });
+              recordWorker(agent_id, "spawned", command, 0);
+            }
             return writeJson(res, 200, result);
           }
 

--- a/packages/triflux/hub/lib/trace-recorder.mjs
+++ b/packages/triflux/hub/lib/trace-recorder.mjs
@@ -1,0 +1,153 @@
+const VALID_CLIENTS = new Set(["codex", "claude", "gemini", "unknown"]);
+const VALID_PHASES = new Set(["ingress", "handler", "store", "event-loop"]);
+const SAMPLE_LIMIT = 1000;
+
+const categories = new Map();
+const workerDurations = [];
+const workerCounts = {
+  spawned: 0,
+  exited: 0,
+};
+
+function debugInvalid(kind, details) {
+  if (process.env.TFX_TRACE_DEBUG !== "1") return;
+  console.debug(`[trace-recorder] ignored invalid ${kind}`, details);
+}
+
+function normalizeClient(client) {
+  const value = String(client || "unknown").toLowerCase();
+  return VALID_CLIENTS.has(value) ? value : "unknown";
+}
+
+function normalizePhase(phase) {
+  const value = String(phase || "handler");
+  return VALID_PHASES.has(value) ? value : "handler";
+}
+
+function validDuration(durMs) {
+  return Number.isFinite(durMs) && durMs >= 0;
+}
+
+function emptyStats() {
+  return {
+    count: 0,
+    total: 0,
+    min: null,
+    max: null,
+    samples: [],
+    phases: {},
+  };
+}
+
+function addDuration(stats, durMs, phase) {
+  stats.count += 1;
+  stats.total += durMs;
+  stats.min = stats.min == null ? durMs : Math.min(stats.min, durMs);
+  stats.max = stats.max == null ? durMs : Math.max(stats.max, durMs);
+  stats.samples.push(durMs);
+  if (stats.samples.length > SAMPLE_LIMIT) {
+    stats.samples.splice(0, stats.samples.length - SAMPLE_LIMIT);
+  }
+
+  const phaseStats = stats.phases[phase] || emptyPhaseStats();
+  phaseStats.count += 1;
+  phaseStats.total += durMs;
+  phaseStats.min =
+    phaseStats.min == null ? durMs : Math.min(phaseStats.min, durMs);
+  phaseStats.max =
+    phaseStats.max == null ? durMs : Math.max(phaseStats.max, durMs);
+  stats.phases[phase] = phaseStats;
+}
+
+function emptyPhaseStats() {
+  return { count: 0, total: 0, min: null, max: null };
+}
+
+function percentile(samples, percentileValue) {
+  if (!samples.length) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+function publicStats(stats) {
+  return {
+    count: stats.count,
+    total: stats.total,
+    min: stats.min,
+    max: stats.max,
+    p50: percentile(stats.samples, 50),
+    p95: percentile(stats.samples, 95),
+    p99: percentile(stats.samples, 99),
+    phases: stats.phases,
+  };
+}
+
+export function recordRequest(
+  category,
+  durMs,
+  client = "unknown",
+  phase = "handler",
+) {
+  if (!category || typeof category !== "string") return;
+  if (!validDuration(durMs)) {
+    debugInvalid("request duration", { category, durMs, client, phase });
+    return;
+  }
+
+  const clientKey = normalizeClient(client);
+  const phaseKey = normalizePhase(phase);
+  const bucket = categories.get(category) || new Map();
+  const stats = bucket.get(clientKey) || emptyStats();
+  addDuration(stats, durMs, phaseKey);
+  bucket.set(clientKey, stats);
+  categories.set(category, bucket);
+}
+
+export function recordWorker(workerId, kind, command, durMs) {
+  if (!workerId || typeof workerId !== "string") return;
+  if (kind === "spawned") {
+    workerCounts.spawned += 1;
+    return;
+  }
+  if (kind !== "exited") return;
+
+  workerCounts.exited += 1;
+  if (durMs == null) return;
+  if (!validDuration(durMs)) {
+    debugInvalid("worker duration", { workerId, kind, command, durMs });
+    return;
+  }
+  workerDurations.push(durMs);
+  if (workerDurations.length > SAMPLE_LIMIT) {
+    workerDurations.splice(0, workerDurations.length - SAMPLE_LIMIT);
+  }
+}
+
+export function snapshot() {
+  const categorySnapshot = {};
+  for (const [category, bucket] of categories.entries()) {
+    categorySnapshot[category] = {};
+    for (const [client, stats] of bucket.entries()) {
+      categorySnapshot[category][client] = publicStats(stats);
+    }
+  }
+
+  return {
+    categories: categorySnapshot,
+    workers: {
+      spawned: workerCounts.spawned,
+      exited: workerCounts.exited,
+      p50: percentile(workerDurations, 50),
+      p95: percentile(workerDurations, 95),
+      p99: percentile(workerDurations, 99),
+    },
+  };
+}
+
+export function reset() {
+  categories.clear();
+  workerDurations.length = 0;
+  workerCounts.spawned = 0;
+  workerCounts.exited = 0;
+}

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -13,6 +13,7 @@ import {
 import { createServer as createHttpServer } from "node:http";
 import { homedir } from "node:os";
 import { extname, join, resolve, sep } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -33,6 +34,11 @@ import {
   cleanupStaleFsmonitorDaemons,
 } from "./lib/process-utils.mjs";
 import * as spawnTrace from "./lib/spawn-trace.mjs";
+import {
+  recordRequest,
+  recordWorker,
+  snapshot as traceSnapshot,
+} from "./lib/trace-recorder.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
@@ -199,6 +205,12 @@ function isInitializeRequest(body) {
   if (Array.isArray(body))
     return body.some((message) => message.method === "initialize");
   return false;
+}
+
+function parseTfxClientHeader(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const client = String(raw || "unknown").toLowerCase();
+  return ["codex", "claude", "gemini"].includes(client) ? client : "unknown";
 }
 
 async function parseBody(req) {
@@ -960,6 +972,7 @@ export async function startHub({
   const assignCallbacks = createAssignCallbackServer({ store, sessionId });
   const tools = createTools(store, router, hitl, pipe);
   const transports = new Map();
+  const workerSpans = new Map();
 
   async function closeMcpTransportSession(sid, session, reason) {
     if (!sid) return;
@@ -993,38 +1006,81 @@ export async function startHub({
     }
   }
 
-  function createMcpForSession() {
+  function getTraceClient(clientRef) {
+    return clientRef?.client || "unknown";
+  }
+
+  function finishWorkerTrace(workerId, kind) {
+    if (!workerId || typeof workerId !== "string") return;
+    const span = workerSpans.get(workerId);
+    if (!span) return;
+    workerSpans.delete(workerId);
+    recordWorker(
+      workerId,
+      "exited",
+      span.command || kind,
+      performance.now() - span.startedAt,
+    );
+  }
+
+  function createMcpForSession(clientRef = { client: "unknown" }) {
     const mcp = new Server(
       { name: "tfx-hub", version: "1.0.0" },
       { capabilities: { tools: {} } },
     );
 
-    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-      })),
-    }));
+    mcp.setRequestHandler(ListToolsRequestSchema, async () => {
+      const started = performance.now();
+      try {
+        return {
+          tools: tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        };
+      } finally {
+        recordRequest(
+          "tools.list",
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
+      }
+    });
 
     mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-      const tool = tools.find((candidate) => candidate.name === name);
-      if (!tool) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                ok: false,
-                error: { code: "UNKNOWN_TOOL", message: `도구 없음: ${name}` },
-              }),
-            },
-          ],
-          isError: true,
-        };
+      const category = `tools.call.${name || "unknown"}`;
+      const started = performance.now();
+      try {
+        const tool = tools.find((candidate) => candidate.name === name);
+        if (!tool) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  ok: false,
+                  error: {
+                    code: "UNKNOWN_TOOL",
+                    message: `도구 없음: ${name}`,
+                  },
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return tool.handler(args || {});
+      } finally {
+        recordRequest(
+          category,
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
       }
-      return tool.handler(args || {});
     });
 
     return mcp;
@@ -1079,7 +1135,11 @@ export async function startHub({
 
       if (path === "/" || path === "/status") {
         const status = router.getStatus("hub").data;
-        return writeJson(res, 200, {
+        const includeMetrics =
+          new URL(req.url, `http://${host}`).searchParams.get(
+            "include_metrics",
+          ) === "1";
+        const body = {
           ...status,
           sessions: transports.size,
           pid: process.pid,
@@ -1096,7 +1156,11 @@ export async function startHub({
             max_total_descendants: spawnTrace.MAX_TOTAL_DESCENDANTS,
           },
           version,
-        });
+        };
+        if (includeMetrics) {
+          body.metrics = traceSnapshot();
+        }
+        return writeJson(res, 200, body);
       }
 
       if (path === "/health" || path === "/healthz") {
@@ -1327,6 +1391,17 @@ export async function startHub({
               });
             }
 
+            const command =
+              body.command ||
+              metadata?.command ||
+              metadata?.cmd ||
+              metadata?.task ||
+              cli;
+            workerSpans.set(agent_id, {
+              command,
+              startedAt: performance.now(),
+            });
+            recordWorker(agent_id, "spawned", command, 0);
             const heartbeat_ttl_ms = (timeout_sec + 120) * 1000;
             const result = await pipe.executeCommand("register", {
               agent_id,
@@ -1400,7 +1475,17 @@ export async function startHub({
           }
 
           if (path === "/bridge/publish" && req.method === "POST") {
-            const result = router.handlePublish(normalizePublishBody(body));
+            const normalized = normalizePublishBody(body);
+            const result = router.handlePublish(normalized);
+            if (result.ok) {
+              finishWorkerTrace(
+                normalized.from ||
+                  normalized.agent_id ||
+                  normalized.worker_agent ||
+                  normalized.from_agent,
+                "publish",
+              );
+            }
             return writeJson(res, result.ok ? 200 : 400, result);
           }
 
@@ -1696,6 +1781,9 @@ export async function startHub({
             const result = await pipe.executeCommand("deregister", {
               agent_id,
             });
+            if (result.ok) {
+              finishWorkerTrace(agent_id, "deregister");
+            }
             return writeJson(res, 200, result);
           }
 
@@ -1732,11 +1820,20 @@ export async function startHub({
             session.transport._lastActivity = Date.now();
             await session.transport.handleRequest(req, res, body);
           } else if (!sessionIdHeader && isInitializeRequest(body)) {
+            const client = parseTfxClientHeader(req.headers["x-tfx-client"]);
+            const clientRef = { client };
+            const initializeStarted = performance.now();
             const transport = new StreamableHTTPServerTransport({
               sessionIdGenerator: () => randomUUID(),
               onsessioninitialized: (sid) => {
                 transport._lastActivity = Date.now();
-                transports.set(sid, { transport, mcp, closing: false });
+                transports.set(sid, {
+                  transport,
+                  mcp,
+                  closing: false,
+                  client,
+                  createdAt: Date.now(),
+                });
               },
             });
             transport.onclose = () => {
@@ -1748,9 +1845,18 @@ export async function startHub({
                   "transport.onclose",
                 );
             };
-            const mcp = createMcpForSession();
+            const mcp = createMcpForSession(clientRef);
             await mcp.connect(transport);
-            await transport.handleRequest(req, res, body);
+            try {
+              await transport.handleRequest(req, res, body);
+            } finally {
+              recordRequest(
+                "initialize",
+                performance.now() - initializeStarted,
+                client,
+                "ingress",
+              );
+            }
           } else {
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(
@@ -2148,6 +2254,13 @@ export async function startHub({
             assignCallbacks,
             delegatorService,
             delegatorWorker,
+            getMcpSessions: () =>
+              Array.from(transports.entries()).map(([id, session]) => ({
+                id,
+                client: session.client || "unknown",
+                createdAt: session.createdAt ?? null,
+                closing: Boolean(session.closing),
+              })),
             stop: stopFn,
           });
         } catch (error) {

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -1397,11 +1397,7 @@ export async function startHub({
               metadata?.cmd ||
               metadata?.task ||
               cli;
-            workerSpans.set(agent_id, {
-              command,
-              startedAt: performance.now(),
-            });
-            recordWorker(agent_id, "spawned", command, 0);
+            const workerStartedAt = performance.now();
             const heartbeat_ttl_ms = (timeout_sec + 120) * 1000;
             const result = await pipe.executeCommand("register", {
               agent_id,
@@ -1411,6 +1407,13 @@ export async function startHub({
               heartbeat_ttl_ms,
               metadata,
             });
+            if (result.ok) {
+              workerSpans.set(agent_id, {
+                command,
+                startedAt: workerStartedAt,
+              });
+              recordWorker(agent_id, "spawned", command, 0);
+            }
             return writeJson(res, 200, result);
           }
 

--- a/tests/integration/mcp-trace-lifecycle.test.mjs
+++ b/tests/integration/mcp-trace-lifecycle.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import {
+  recordRequest,
+  reset,
+  snapshot,
+} from "../../hub/lib/trace-recorder.mjs";
+import { startHub } from "../../hub/server.mjs";
+import { releaseLock } from "../../hub/state.mjs";
+
+const TEST_PORT = 27989 + Math.floor(Math.random() * 1000);
+let hub;
+let baseUrl;
+let dbDir;
+let testHome;
+let previousToken;
+let previousNodeEnv;
+let previousTestHome;
+
+function parseJsonResponse(text, contentType) {
+  if (!text || !contentType.includes("application/json")) return null;
+  return JSON.parse(text);
+}
+
+async function postMcp(body, headers = {}) {
+  const res = await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return {
+    res,
+    text,
+    json: parseJsonResponse(text, res.headers.get("content-type") || ""),
+  };
+}
+
+async function initialize(headers = {}) {
+  const result = await postMcp(
+    {
+      jsonrpc: "2.0",
+      id: randomUUID(),
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "triflux-test", version: "1.0.0" },
+      },
+    },
+    headers,
+  );
+  assert.equal(result.res.status, 200, result.text);
+  const sessionId = result.res.headers.get("mcp-session-id");
+  assert.ok(sessionId, "initialize response must include mcp-session-id");
+  return sessionId;
+}
+
+async function notifyInitialized(sessionId) {
+  const result = await postMcp(
+    {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    },
+    { "mcp-session-id": sessionId },
+  );
+  assert.ok([200, 202].includes(result.res.status), result.text);
+}
+
+describe("MCP lifecycle trace", () => {
+  before(async () => {
+    previousToken = process.env.TFX_HUB_TOKEN;
+    previousNodeEnv = process.env.NODE_ENV;
+    previousTestHome = process.env.TRIFLUX_TEST_HOME;
+    delete process.env.TFX_HUB_TOKEN;
+    process.env.NODE_ENV = "test";
+    reset();
+    dbDir = join(tmpdir(), `tfx-mcp-trace-${randomUUID()}`);
+    testHome = join(dbDir, "home");
+    mkdirSync(dbDir, { recursive: true });
+    mkdirSync(testHome, { recursive: true });
+    process.env.TRIFLUX_TEST_HOME = testHome;
+    hub = await startHub({
+      port: TEST_PORT,
+      dbPath: join(dbDir, "hub.db"),
+      host: "127.0.0.1",
+      sessionId: `mcp-trace-${TEST_PORT}`,
+    });
+    baseUrl = `http://127.0.0.1:${TEST_PORT}`;
+  });
+
+  after(async () => {
+    if (hub?.stop) {
+      await Promise.race([hub.stop(), new Promise((r) => setTimeout(r, 5000))]);
+    }
+    releaseLock();
+    rmSync(dbDir, { recursive: true, force: true });
+    if (previousToken == null) {
+      delete process.env.TFX_HUB_TOKEN;
+    } else {
+      process.env.TFX_HUB_TOKEN = previousToken;
+    }
+    if (previousNodeEnv == null) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    if (previousTestHome == null) {
+      delete process.env.TRIFLUX_TEST_HOME;
+    } else {
+      process.env.TRIFLUX_TEST_HOME = previousTestHome;
+    }
+  });
+
+  it("binds X-TFX-Client from initialize to the transport session", async () => {
+    const sessionId = await initialize({ "X-TFX-Client": "codex" });
+    const session = hub
+      .getMcpSessions()
+      .find((entry) => entry.id === sessionId);
+
+    assert.ok(session);
+    assert.equal(session.client, "codex");
+    assert.equal(typeof session.createdAt, "number");
+  });
+
+  it("uses unknown when initialize has no X-TFX-Client header", async () => {
+    const sessionId = await initialize();
+    const session = hub
+      .getMcpSessions()
+      .find((entry) => entry.id === sessionId);
+
+    assert.ok(session);
+    assert.equal(session.client, "unknown");
+  });
+
+  it("records tools/list and tools/call in separate per-client buckets", async () => {
+    reset();
+    const sessionId = await initialize({ "X-TFX-Client": "codex" });
+    await notifyInitialized(sessionId);
+
+    const listResult = await postMcp(
+      { jsonrpc: "2.0", id: randomUUID(), method: "tools/list", params: {} },
+      { "mcp-session-id": sessionId },
+    );
+    assert.equal(listResult.res.status, 200, listResult.text);
+
+    const callResult = await postMcp(
+      {
+        jsonrpc: "2.0",
+        id: randomUUID(),
+        method: "tools/call",
+        params: { name: "__missing_trace_test__", arguments: {} },
+      },
+      { "mcp-session-id": sessionId },
+    );
+    assert.equal(callResult.res.status, 200, callResult.text);
+
+    const metricsRes = await fetch(`${baseUrl}/status?include_metrics=1`);
+    assert.equal(metricsRes.status, 200);
+    const metrics = (await metricsRes.json()).metrics;
+    assert.equal(metrics.categories.initialize.codex.count, 1);
+    assert.equal(metrics.categories["tools.list"].codex.count, 1);
+    assert.equal(
+      metrics.categories["tools.call.__missing_trace_test__"].codex.count,
+      1,
+    );
+  });
+
+  it("ignores invalid durations without throwing", () => {
+    reset();
+    recordRequest("tools.list", -1, "codex", "handler");
+    recordRequest("tools.list", Number.NaN, "codex", "handler");
+
+    assert.deepEqual(snapshot().categories, {});
+  });
+});

--- a/tests/regression/status-include-metrics.test.mjs
+++ b/tests/regression/status-include-metrics.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import { startHub } from "../../hub/server.mjs";
+import { releaseLock } from "../../hub/state.mjs";
+
+const TEST_PORT = 27889 + Math.floor(Math.random() * 1000);
+let hub;
+let baseUrl;
+let dbDir;
+let testHome;
+let previousToken;
+let previousNodeEnv;
+let previousTestHome;
+
+const BASELINE_FIELDS = [
+  "hub",
+  "queues",
+  "assigns",
+  "sessions",
+  "pid",
+  "port",
+  "auth_mode",
+  "idle_timeout_ms",
+  "last_request_at",
+  "pipe_path",
+  "pipe",
+  "assign_callback_pipe_path",
+  "assign_callback_pipe",
+  "spawn_trace",
+  "version",
+];
+
+describe("/status include_metrics opt-in", () => {
+  before(async () => {
+    previousToken = process.env.TFX_HUB_TOKEN;
+    previousNodeEnv = process.env.NODE_ENV;
+    previousTestHome = process.env.TRIFLUX_TEST_HOME;
+    delete process.env.TFX_HUB_TOKEN;
+    process.env.NODE_ENV = "test";
+    dbDir = join(tmpdir(), `tfx-status-metrics-${randomUUID()}`);
+    testHome = join(dbDir, "home");
+    mkdirSync(dbDir, { recursive: true });
+    mkdirSync(testHome, { recursive: true });
+    process.env.TRIFLUX_TEST_HOME = testHome;
+    hub = await startHub({
+      port: TEST_PORT,
+      dbPath: join(dbDir, "hub.db"),
+      host: "127.0.0.1",
+      sessionId: `status-metrics-${TEST_PORT}`,
+    });
+    baseUrl = `http://127.0.0.1:${TEST_PORT}`;
+  });
+
+  after(async () => {
+    if (hub?.stop) {
+      await Promise.race([hub.stop(), new Promise((r) => setTimeout(r, 5000))]);
+    }
+    releaseLock();
+    rmSync(dbDir, { recursive: true, force: true });
+    if (previousToken == null) {
+      delete process.env.TFX_HUB_TOKEN;
+    } else {
+      process.env.TFX_HUB_TOKEN = previousToken;
+    }
+    if (previousNodeEnv == null) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    if (previousTestHome == null) {
+      delete process.env.TRIFLUX_TEST_HOME;
+    } else {
+      process.env.TRIFLUX_TEST_HOME = previousTestHome;
+    }
+  });
+
+  it("preserves the default /status response fields without metrics", async () => {
+    const res = await fetch(`${baseUrl}/status`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    for (const field of BASELINE_FIELDS) {
+      assert.ok(field in body, `missing default /status field: ${field}`);
+    }
+    assert.equal("metrics" in body, false);
+  });
+
+  it("keeps /status?include_metrics=0 lean", async () => {
+    const res = await fetch(`${baseUrl}/status?include_metrics=0`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    for (const field of BASELINE_FIELDS) {
+      assert.ok(field in body, `missing include_metrics=0 field: ${field}`);
+    }
+    assert.equal("metrics" in body, false);
+  });
+
+  it("adds metrics only for /status?include_metrics=1", async () => {
+    const res = await fetch(`${baseUrl}/status?include_metrics=1`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    for (const field of BASELINE_FIELDS) {
+      assert.ok(field in body, `missing include_metrics=1 field: ${field}`);
+    }
+    assert.ok(body.metrics);
+    assert.ok(body.metrics.categories);
+    assert.ok(body.metrics.workers);
+  });
+
+  it("records bridge worker spawn and explicit exit without changing responses", async () => {
+    const agentId = `trace-worker-${randomUUID()}`;
+    const registerRes = await fetch(`${baseUrl}/bridge/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agent_id: agentId,
+        cli: "codex",
+        timeout_sec: 60,
+        metadata: { command: "node hub/bridge.mjs" },
+      }),
+    });
+    assert.equal(registerRes.status, 200);
+    const registerBody = await registerRes.json();
+    assert.equal(registerBody.ok, true);
+    assert.equal("metrics" in registerBody, false);
+
+    const deregisterRes = await fetch(`${baseUrl}/bridge/deregister`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent_id: agentId }),
+    });
+    assert.equal(deregisterRes.status, 200);
+    const deregisterBody = await deregisterRes.json();
+    assert.equal(deregisterBody.ok, true);
+    assert.equal("metrics" in deregisterBody, false);
+
+    const metricsRes = await fetch(`${baseUrl}/status?include_metrics=1`);
+    assert.equal(metricsRes.status, 200);
+    const metrics = (await metricsRes.json()).metrics;
+    assert.ok(metrics.workers.spawned >= 1);
+    assert.ok(metrics.workers.exited >= 1);
+    assert.equal(typeof metrics.workers.p50, "number");
+  });
+});

--- a/tests/unit/hub-mcp-session-close.test.mjs
+++ b/tests/unit/hub-mcp-session-close.test.mjs
@@ -12,7 +12,10 @@ describe("hub MCP session close lifecycle", () => {
     const start = src.indexOf("transport.onclose = () => {");
     assert.notEqual(start, -1, "transport.onclose handler must exist");
 
-    const end = src.indexOf("const mcp = createMcpForSession();", start);
+    const end = src.indexOf(
+      "const mcp = createMcpForSession(clientRef);",
+      start,
+    );
     assert.notEqual(end, -1, "transport.onclose block boundary must exist");
 
     const block = src.slice(start, end);
@@ -28,7 +31,7 @@ describe("hub MCP session close lifecycle", () => {
     const start = src.indexOf("async function closeMcpTransportSession");
     assert.notEqual(start, -1, "guarded closer must exist");
 
-    const end = src.indexOf("function createMcpForSession()", start);
+    const end = src.indexOf("function createMcpForSession(clientRef", start);
     assert.notEqual(end, -1, "guarded closer boundary must exist");
 
     const block = src.slice(start, end);


### PR DESCRIPTION
## Summary

PRD B Step 1 trace-first slice — D5 → T1 reverse from `/gstack-plan-eng-review` (2026-04-30). Codex outside voice 가 boil-the-lake 8-metric 일괄 instrumentation 을 trace-first lifecycle measurement 로 reverse: hub 가 보틀넥이라는 가설 자체를 실제 trace 데이터로 먼저 검증한 뒤, Step 2 에서 HDR histogram + N×M×K benchmark harness 진행.

Parent PRD `.triflux/plans/mcp-singleton-redesign-prd.md` 는 analysis-only 24KB. 본 PR 은 그 PRD 의 Step 1 슬라이스만 구현.

## Implementation

| File | Change | Lines |
|------|--------|-------|
| `hub/lib/trace-recorder.mjs` (new) | `recordRequest`, `recordWorker`, `snapshot`, `reset`. Reservoir sample (1000), p50/p95/p99, dur<0/NaN silent ignore, category × client × phase (ingress\|handler\|store\|event-loop) bucketing. Node-builtin only. | +153 |
| `hub/server.mjs` | X-TFX-Client header parse on `initialize` (codex\|claude\|gemini whitelist, others → `unknown`). `transports` map shape extends with `{client, createdAt}`. `createMcpForSession(clientRef)` closure. ListTools/CallTool handlers wrap duration via try/finally. `/status?include_metrics=1` opt-in branch (14 baseline fields preserved 100%). `/bridge/register` spawn span + `/bridge/publish`/`/bridge/deregister` exit span via `finishWorkerTrace()`. `getMcpSessions()` exposed for tests. | +131/-28 |
| `tests/regression/status-include-metrics.test.mjs` (new) | IRON RULE — default /status preservation: hub, queues, assigns, sessions, pid, port, auth_mode, idle_timeout_ms, last_request_at, pipe_path, pipe, assign_callback_pipe_path, assign_callback_pipe, spawn_trace, version 모두 보존. include_metrics=0 lean. include_metrics=1 adds metrics.{categories, workers}. | +151 |
| `tests/integration/mcp-trace-lifecycle.test.mjs` (new) | X-TFX-Client header → session.client binding (codex). No header → `unknown` (D4). tools/list and tools/call separate buckets (startup-weight trap avoided). recordRequest with dur<0/NaN silent ignore. | +186 |
| `packages/triflux/hub/server.mjs` + `lib/trace-recorder.mjs` | Mirror sync, byte-identical to root. | +284 |

**Total**: ~460 lines (실질, mirror 제외). 합계 905 lines (mirror 포함).

## Decisions consumed

- **D1** metrics retention — HDR histogram → Step 2. Step 1 = simpler 누적 (count, total, min, max + reservoir sample for percentile).
- **D2** per-CLI label — X-TFX-Client header on initialize → session ID lookup binding. T2 hard requirement. **applied**.
- **D3** thresholds — hybrid (absolute floor + relative ceiling) → Step 2.
- **D4** unknown CLI — 'unknown' bucket independent aggregation (total = sum of per-CLI). **applied**.
- **D5 → T1** reverse — trace-first, NOT 8-metric one-shot. **applied**.
- **N1** Codex finding — `node hub/bridge.mjs` subprocess trace via `/bridge/register|publish|deregister` handlers. **applied**.
- **N2** Q1 directive — Step 2 benchmark mode disable PR #216 proactive sync → Step 2.

## Critical Regression Rules (IRON RULE)

- `/status` baseline response (no `?include_metrics`) MUST preserve all 14 existing fields. HUD, mcp-guard, hub-client, team CLI parse this. Breaking it breaks every consumer.
- `createMcpForSession()` ListTools/CallTool response shape unchanged (instrumentation wrap only, response identical).
- `/bridge/*` `include_metrics=0` query convention preserved (no Step 1 changes here).
- New `metrics` field appears in response **only** when `?include_metrics=1`.

## Acceptance Criteria

- [x] `GET /status` (no opt-in) — all 14 baseline fields preserved (regression test pass)
- [x] `GET /status?include_metrics=1` — metrics object (per-CLI × per-category) returned
- [x] `GET /status?include_metrics=0` — metrics absent (matches baseline)
- [x] `POST /mcp` initialize + `X-TFX-Client: codex` → `transports.get(sid).client === "codex"`
- [x] `POST /mcp` initialize without header → `client === "unknown"`
- [x] subsequent `tools/call` inherits session client → metrics bucket tagged correctly
- [x] worker register → publish/deregister timestamp recorded, duration computed
- [x] `tools/list` separate category bucket from `tools.call.*` (startup-weight trap avoided)
- [x] phase classification span: `phase ∈ {ingress, handler, store, event-loop}`
- [x] simpler 누적 (count/total/min/max + reservoir sample); HDR histogram **NOT** implemented (Step 2)

## Test Plan

- `tests/regression/status-include-metrics.test.mjs` — **3/3 pass**
  - preserves the default /status response fields without metrics
  - keeps /status?include_metrics=0 lean
  - adds metrics only for /status?include_metrics=1
- `tests/integration/mcp-trace-lifecycle.test.mjs` — **4/4 pass**
  - binds X-TFX-Client from initialize to the transport session
  - uses unknown when initialize has no X-TFX-Client header
  - records tools/list and tools/call in separate per-client buckets
  - ignores invalid durations without throwing

```
ℹ tests 7
ℹ pass 7
ℹ fail 0
```

## Out of Scope (Step 2+)

- 8-metric one-shot instrumentation (D5 reverse)
- HDR histogram (`perf_hooks.monitorEventLoopDelay()` pattern) — Step 2
- N×M×K benchmark harness (`tests/perf/mcp-singleton-bench.mjs`) — separate PRD/PR
- 합성 fanout 시나리오 (real CLI lifecycle 우선)
- per-CLI fairness threshold 검증
- `/bridge/*` proactive sync disable directive

## Mirror byte-identity

`packages/triflux/hub/server.mjs` 와 `packages/triflux/hub/lib/trace-recorder.mjs` 가 root 와 byte-identical 동기화. `feedback_codex_exec_recovery_guard.md` 룰 준수.

## Commits

1. `feat(hub/mcp): add Step 1 lifecycle trace + per-CLI label + /status?include_metrics opt-in` — main feature
2. `docs(todos): add Tier 2 followups from PRD B eng review` — Tier 2 items dependent on Step 1 trace data
3. `fix(hub/mcp): record worker span only on successful register` — semantic correctness for register failure path

## Test plan

- [x] Run `node --test tests/regression/status-include-metrics.test.mjs` — 3/3 pass
- [x] Run `node --test tests/integration/mcp-trace-lifecycle.test.mjs` — 4/4 pass
- [x] biome lint clean for new files (`hub/lib/trace-recorder.mjs`, both new tests)
- [x] Mirror byte-identity verified
- [ ] (Reviewer) Confirm hub PID 22236 restart impact analysis if merged
- [ ] (Reviewer) Confirm /status consumer compatibility (HUD, mcp-guard, hub-client, team CLI)

## References

- Parent PRD: `.triflux/plans/mcp-singleton-redesign-prd.md` (analysis-only, gitignored)
- Sub-PRD: `.triflux/plans/mcp-singleton-step1-trace-slice.md` (gitignored, embedded above)
- Test plan: `~/.gstack/projects/tellang-triflux/tellang-main-eng-review-test-plan-20260430-111658.md`
- Eng review checkpoint: `~/.gstack/projects/tellang-triflux/checkpoints/20260430-113114-pr216-217-merged-prd-b-eng-reviewed-step1-trace-first.md`