### PR TITLE
chore(packages): sync packages/{core,remote} mirror with v10.18.0 hub state

### DIFF
--- a/packages/core/hub/account-broker.mjs
+++ b/packages/core/hub/account-broker.mjs
@@ -796,6 +796,19 @@ class AccountBroker extends EventEmitter {
     }));
   }
 
+  // ── disabled marker ───────────────────────────────────────────
+
+  /**
+   * True when the broker holds zero accounts. Used by adapters to distinguish
+   * "broker exists but is empty (disable env / no accounts)" from "broker has
+   * accounts but lease() returned null (all busy/cooldown/circuit)" — the
+   * former should fall back to default ~/.codex/auth.json instead of returning
+   * circuit_open.
+   */
+  get isDisabled() {
+    return this.#state.size === 0;
+  }
+
   // ── nextAvailableEta ──────────────────────────────────────────
 
   nextAvailableEta(provider) {
@@ -849,7 +862,22 @@ function loadConfig() {
 
 // ── Singleton ────────────────────────────────────────────────────
 
+function isBrokerDisabledByEnv() {
+  const flag = process.env.TFX_DISABLE_ACCOUNT_BROKER;
+  return flag === "1" || flag === "true";
+}
+
+function createEmptyBroker() {
+  return new AccountBroker({ codex: [], gemini: [] });
+}
+
 function createBroker() {
+  if (isBrokerDisabledByEnv()) {
+    // Empty broker: lease() always returns null → callers fall back to default
+    // single-account path (~/.codex/auth.json). Avoids per-account multiplexing
+    // race conditions while keeping the AccountBroker API surface intact.
+    return createEmptyBroker();
+  }
   const config = loadConfig();
   if (!config) return null;
   try {
@@ -862,6 +890,10 @@ function createBroker() {
 
 /** Re-read config and replace the module-level singleton. ESM live binding propagates to all importers. */
 function reloadBroker() {
+  if (isBrokerDisabledByEnv()) {
+    broker = createEmptyBroker();
+    return { ok: true, broker, disabled: true };
+  }
   const config = loadConfig();
   if (!config) return { ok: false, error: "Config not found or invalid" };
   try {

--- a/packages/core/hub/cli-adapter-base.mjs
+++ b/packages/core/hub/cli-adapter-base.mjs
@@ -241,8 +241,14 @@ export async function executeWithCircuitBroker({
 
   // access broker as live binding property (not destructured) so reloadBroker() propagates
   const hasBroker = brokerMod.broker != null;
-  const lease = hasBroker ? brokerMod.broker.lease({ provider }) : null;
-  if (hasBroker && !lease) {
+  // Empty broker (TFX_DISABLE_ACCOUNT_BROKER=1 or zero accounts) must not
+  // gate execution. lease() is null because there are no accounts to lease,
+  // not because all accounts are busy/cooldown/circuit. Treat it like
+  // hasBroker=false and fall through to the default auth path.
+  const brokerDisabled = hasBroker && brokerMod.broker.isDisabled === true;
+  const effectiveBroker = hasBroker && !brokerDisabled;
+  const lease = effectiveBroker ? brokerMod.broker.lease({ provider }) : null;
+  if (effectiveBroker && !lease) {
     return createResult(false, { fellBack: true, failureMode: "circuit_open" });
   }
 
@@ -263,11 +269,15 @@ export async function executeWithCircuitBroker({
   try {
     lastResult = await withRetry(
       async () => {
+        // PRD A1: lease 메타데이터를 runFn 에 전달해서 adapter 가 실제 spawn 시
+        // 해당 account 의 authFile/env/profile 을 적용할 수 있게 한다. lease=null
+        // 이면 adapter 는 default 경로 (단일 ~/.codex/auth.json) 로 동작한다.
         const result = await runFn(
           opts.prompt || "",
           opts.workdir || process.cwd(),
           preflight,
           attempts[attemptIndex],
+          lease,
         );
         const current = {
           ...result,
@@ -366,7 +376,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   let child;
 
   try {
-    child = spawn(command, { cwd: workdir, shell: true, windowsHide: true });
+    // PRD A1: opts.spawnEnv 가 있으면 그 env 로 spawn (lease 의 authFile/env 적용).
+    // undefined 면 spawn 의 default 동작 (부모 process env inherit) 유지.
+    child = spawn(command, {
+      cwd: workdir,
+      shell: true,
+      windowsHide: true,
+      env: opts.spawnEnv,
+    });
   } catch (error) {
     return createResult(false, {
       stderr: String(error?.message || error),

--- a/packages/core/hub/codex-adapter.mjs
+++ b/packages/core/hub/codex-adapter.mjs
@@ -133,7 +133,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Codex execution ─────────────────────────────────────────────
 
-async function runCodex(prompt, workdir, preflight, attempt) {
+async function runCodex(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-codex-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -142,7 +142,7 @@ async function runCodex(prompt, workdir, preflight, attempt) {
   );
   const command = commandWithOverrides(
     buildExecCommand(prompt, resultFile, {
-      profile: attempt.profile,
+      profile: lease?.profile ?? attempt.profile,
       skipGitRepoCheck: true,
       sandboxBypass: attempt.forceBypass,
     }),
@@ -150,10 +150,43 @@ async function runCodex(prompt, workdir, preflight, attempt) {
     preflight.codexPath,
     buildOverrides(attempt.requested, attempt.excluded),
   );
+  // PRD A1 — lease 메타데이터를 spawn env 에 적용한다. lease.authFile 이 있으면
+  // 해당 파일이 위치한 디렉토리를 CODEX_HOME 으로 export 해서 codex CLI 가 그
+  // account 의 auth.json 을 사용하게 한다. lease 가 null 이면 default ~/.codex
+  // 동작 유지 (회귀 없음). lease.env 는 추가 환경변수 (provider 고정 등) 주입용.
+  const spawnEnv = lease ? buildLeaseSpawnEnv(lease) : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
+}
+
+function buildLeaseSpawnEnv(lease) {
+  const extra = {};
+  if (lease.authFile) {
+    // lease.authFile 은 보통 ~/.claude/cache/tfx-hub/codex-auth-<account>.json 형식.
+    // codex CLI 는 CODEX_HOME 을 통해 auth.json 위치를 결정하므로, 이 cache 파일을
+    // 직접 CODEX_HOME 후보 디렉토리로 사용한다. cache 파일 자체가 auth.json 이름이
+    // 아니라면 후속 PR 에서 isolated dir + symlink/복사 처리한다 (PRD Open Question).
+    // 현재는 lease.authFile 의 dirname 을 export 하되, 그 dirname 안에 auth.json 이
+    // 실제로 있을 때만 적용한다 (false-positive 회피).
+    try {
+      const dir = dirnameOf(lease.authFile);
+      if (dir) extra.CODEX_HOME = dir;
+    } catch {}
+  }
+  if (lease.env && typeof lease.env === "object") {
+    Object.assign(extra, lease.env);
+  }
+  return Object.keys(extra).length ? { ...process.env, ...extra } : undefined;
+}
+
+function dirnameOf(filePath) {
+  if (typeof filePath !== "string" || !filePath) return null;
+  const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  if (lastSep < 0) return null;
+  return filePath.slice(0, lastSep);
 }
 
 // ── Public API ──────────────────────────────────────────────────

--- a/packages/core/hub/gemini-adapter.mjs
+++ b/packages/core/hub/gemini-adapter.mjs
@@ -113,7 +113,7 @@ export function buildExecArgs(opts = {}) {
 
 // ── Execution ───────────────────────────────────────────────────
 
-async function runGemini(prompt, workdir, preflight, attempt) {
+async function runGemini(prompt, workdir, preflight, attempt, lease) {
   const dir = join(tmpdir(), "triflux-gemini-exec");
   mkdirSync(dir, { recursive: true });
   const resultFile = join(
@@ -125,9 +125,16 @@ async function runGemini(prompt, workdir, preflight, attempt) {
     allowedMcpServers: attempt.allowedMcpServers,
     excludeMcpServers: attempt.excludeMcpServers,
   });
+  // PRD A1: lease.env 가 있으면 spawn env 에 적용 (예: GOOGLE_API_KEY 등 account-specific
+  // 환경변수). lease 가 null 이면 default 동작 유지 (부모 env inherit).
+  const spawnEnv =
+    lease?.env && typeof lease.env === "object"
+      ? { ...process.env, ...lease.env }
+      : undefined;
   return runProcess(command, workdir, attempt.timeout, {
     resultFile,
     inferStallMode,
+    spawnEnv,
   });
 }
 

--- a/packages/core/hub/lib/process-utils.mjs
+++ b/packages/core/hub/lib/process-utils.mjs
@@ -1,7 +1,7 @@
 // hub/lib/process-utils.mjs
 // 프로세스 관련 공유 유틸리티
 
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -18,8 +18,23 @@ const SCAN_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "scan-processes.ps1");
 const TREE_SCRIPT_PATH = join(CLEANUP_SCRIPT_DIR, "get-ancestor-tree.ps1");
 
 // 스크립트 버전 — 내용 변경 시 증가하여 캐시된 스크립트를 갱신
-const SCRIPT_VERSION = 3;
+const SCRIPT_VERSION = 4;
 const VERSION_FILE = join(CLEANUP_SCRIPT_DIR, ".version");
+const FSMONITOR_DAEMON_MARKER = "fsmonitor--daemon run --detach";
+const FSMONITOR_DAEMON_PATTERN =
+  /(^|\s)fsmonitor--daemon\s+run\s+--detach(\s|$)/;
+const DEFAULT_FSMONITOR_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const LEGACY_ORPHAN_KILLABLE_NAMES = new Set([
+  "node.exe",
+  "bash.exe",
+  "cmd.exe",
+  "uvx.exe",
+]);
+const LIVE_CLI_SESSION_ROOT_NAMES = new Set([
+  "codex.exe",
+  "claude.exe",
+  "gemini.exe",
+]);
 
 /**
  * 주어진 PID의 프로세스가 살아있는지 확인한다.
@@ -203,9 +218,7 @@ function hasLiveAncestorChain(pid, procMap, protectedPids) {
       // 프로세스 맵에 없음 → 살아있는지 직접 확인
       return isPidAlive(current);
     }
-    if (
-      LIVE_CLI_SESSION_ROOT_NAMES.has(String(info.name || "").toLowerCase())
-    ) {
+    if (LIVE_CLI_SESSION_ROOT_NAMES.has(normalizeName(info.name))) {
       return true;
     }
 
@@ -226,10 +239,10 @@ function hasLiveAncestorChain(pid, procMap, protectedPids) {
 
 function hasLiveCliDescendant(pid, procMap) {
   const children = new Map();
-  for (const [childPid, proc] of procMap) {
+  for (const proc of procMap.values()) {
     if (!Number.isFinite(proc.ppid) || proc.ppid <= 0) continue;
     const list = children.get(proc.ppid) || [];
-    list.push({ pid: childPid, ...proc });
+    list.push(proc);
     children.set(proc.ppid, list);
   }
 
@@ -239,9 +252,7 @@ function hasLiveCliDescendant(pid, procMap) {
     const proc = stack.pop();
     if (!proc || visited.has(proc.pid)) continue;
     visited.add(proc.pid);
-    if (
-      LIVE_CLI_SESSION_ROOT_NAMES.has(String(proc.name || "").toLowerCase())
-    ) {
+    if (LIVE_CLI_SESSION_ROOT_NAMES.has(normalizeName(proc.name))) {
       return true;
     }
     stack.push(...(children.get(proc.pid) || []));
@@ -249,41 +260,134 @@ function hasLiveCliDescendant(pid, procMap) {
   return false;
 }
 
-// kill 대상 프로세스 이름 (Windows)
-// codex/claude는 활성 세션 루트로만 취급한다. 전역 orphan sweep이
-// 사용자 Claude Code/Codex 세션을 직접 종료하면 안 된다.
-const KILLABLE_NAMES = new Set([
-  "node.exe",
-  "bash.exe",
-  "cmd.exe",
-  "uvx.exe",
-]);
-const LIVE_CLI_SESSION_ROOT_NAMES = new Set([
-  "codex.exe",
-  "claude.exe",
-  "gemini.exe",
-]);
-
 /**
- * 고아 프로세스 트리를 정리한다 (node.exe + bash.exe + cmd.exe + uvx.exe).
- * Windows 전용 — Agent 서브프로세스가 MCP 서버, bash 래퍼, cmd 래퍼를 남기는 문제 대응.
- *
- * 전략: 부모 체인을 루트까지 추적하여, 체인 중간에 죽은 프로세스가 있으면
- * 해당 프로세스 아래의 전체 트리를 고아로 판정하고 정리.
- * 스캔 범위에는 codex/claude/pwsh도 포함하여 체인 추적 정확도를 높인다.
- *
- * 보호 대상: 현재 프로세스 조상 트리, Hub PID
- * @returns {{ killed: number, remaining: number }}
+ * Legacy wrapper for scoped orphan node runtime cleanup.
+ * @param {Parameters<typeof cleanupOrphanRuntimeProcesses>[0]} opts
+ * @returns {{ killed: number, remaining: number, killedProcesses: Array<{pid: number, ppid: number, name: string, commandLine: string, killReason: string}> }}
  */
-export function cleanupOrphanNodeProcesses() {
-  if (!IS_WINDOWS) return cleanupOrphansUnix();
+export function cleanupOrphanNodeProcesses(opts = {}) {
+  return cleanupOrphanRuntimeProcesses({ ...opts, legacy: true });
+}
 
-  ensureHelperScripts();
+function normalizePowerShellJson(output) {
+  const trimmed = String(output || "").trim();
+  if (!trimmed || trimmed === "null") return [];
+  const parsed = JSON.parse(trimmed);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
 
-  const myPid = process.pid;
+function parseCreationDateMs(value) {
+  if (!value) return NaN;
+  if (value instanceof Date) return value.getTime();
 
-  // Hub PID 보호
-  let hubPid = null;
+  const text = String(value);
+  const dotNetMatch = /\/Date\((-?\d+)\)\//.exec(text);
+  if (dotNetMatch) return Number.parseInt(dotNetMatch[1], 10);
+
+  const ms = Date.parse(text);
+  return Number.isFinite(ms) ? ms : NaN;
+}
+
+function normalizePid(value) {
+  const pid = Number(value);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function normalizeName(name) {
+  return String(name || "").toLowerCase();
+}
+
+function normalizeCommandLine(commandLine) {
+  return String(commandLine || "").replace(/\//g, "\\");
+}
+
+function processRecordFromCim(record) {
+  const pid = normalizePid(record?.ProcessId ?? record?.pid);
+  if (!pid) return null;
+  const ppid = Number(record?.ParentProcessId ?? record?.ppid ?? 0);
+  return {
+    pid,
+    ppid: Number.isFinite(ppid) ? ppid : 0,
+    name: String(record?.Name ?? record?.name ?? ""),
+    commandLine: String(record?.CommandLine ?? record?.commandLine ?? ""),
+    creationDate: record?.CreationDate,
+  };
+}
+
+function runSpawn(spawnSyncFn, command, args, options = {}) {
+  return spawnSyncFn(command, args, {
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+function runPowerShellJson(spawnSyncFn, command) {
+  const result = runSpawn(spawnSyncFn, "powershell", [
+    "-NoProfile",
+    "-WindowStyle",
+    "Hidden",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    command,
+  ]);
+  if (result.status !== 0) {
+    throw new Error(
+      String(result.stderr || result.error || "PowerShell failed"),
+    );
+  }
+  return normalizePowerShellJson(result.stdout);
+}
+
+function getWindowsProcessSnapshot(spawnSyncFn = spawnSync) {
+  const records = runPowerShellJson(
+    spawnSyncFn,
+    "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine,CreationDate | ConvertTo-Json -Depth 3 -Compress",
+  );
+  return records.map(processRecordFromCim).filter(Boolean);
+}
+
+function parsePosixProcessSnapshot(output) {
+  const processes = [];
+  for (const line of String(output || "")
+    .split(/\r?\n/)
+    .slice(1)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = /^(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/.exec(trimmed);
+    if (!match) continue;
+    processes.push({
+      pid: Number.parseInt(match[1], 10),
+      ppid: Number.parseInt(match[2], 10),
+      name: match[3],
+      commandLine: match[4] || match[3],
+    });
+  }
+  return processes;
+}
+
+function getPosixProcessSnapshot(spawnSyncFn = spawnSync) {
+  const result = runSpawn(spawnSyncFn, "ps", ["-eo", "pid,ppid,comm,args"]);
+  if (result.status !== 0) return [];
+  return parsePosixProcessSnapshot(result.stdout);
+}
+
+function getProcessSnapshot({
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+} = {}) {
+  try {
+    return isWindows
+      ? getWindowsProcessSnapshot(spawnSyncFn)
+      : getPosixProcessSnapshot(spawnSyncFn);
+  } catch {
+    return [];
+  }
+}
+
+function addHubPid(protectedPids) {
   try {
     const hubPidPath = join(
       homedir(),
@@ -294,85 +398,566 @@ export function cleanupOrphanNodeProcesses() {
     );
     if (existsSync(hubPidPath)) {
       const hubInfo = JSON.parse(readFileSync(hubPidPath, "utf8"));
-      hubPid = Number(hubInfo?.pid);
+      const hubPid = normalizePid(hubInfo?.pid);
+      if (hubPid) protectedPids.add(hubPid);
     }
   } catch {}
+}
 
-  // 보호 PID 세트: 현재 프로세스 + Hub + 현재 프로세스의 조상 트리
-  const protectedPids = new Set();
-  protectedPids.add(myPid);
-  if (Number.isFinite(hubPid) && hubPid > 0) protectedPids.add(hubPid);
+function getProtectedPids({
+  protectedPids,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  includeAncestorScan = false,
+} = {}) {
+  const result = new Set(protectedPids || []);
+  result.add(process.pid);
+  if (Number.isInteger(process.ppid) && process.ppid > 0) {
+    result.add(process.ppid);
+  }
+  addHubPid(result);
+  if (!includeAncestorScan) return result;
 
-  try {
-    const treeOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${TREE_SCRIPT_PATH}" -StartPid ${myPid}`,
-      {
-        encoding: "utf8",
-        timeout: 8000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-    for (const line of treeOutput.split(/\r?\n/)) {
-      const pid = Number.parseInt(line.trim(), 10);
-      if (Number.isFinite(pid) && pid > 0) protectedPids.add(pid);
-    }
-  } catch {}
-
-  // 전체 프로세스 맵 구축 (node + bash + cmd + codex + claude + pwsh + uvx)
-  const procMap = new Map();
-  try {
-    const output = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${SCAN_SCRIPT_PATH}"`,
-      {
-        encoding: "utf8",
-        timeout: 15000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      },
-    );
-
-    for (const line of output.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      const [pidStr, ppidStr, name] = trimmed.split(",");
-      const pid = Number.parseInt(pidStr, 10);
-      const ppid = Number.parseInt(ppidStr, 10);
-      if (Number.isFinite(pid) && pid > 0) {
-        procMap.set(pid, { ppid, name: name || "unknown" });
-      }
-    }
-  } catch {}
-
-  // 고아 판정 + 정리 (SIGTERM → 3s → SIGKILL 에스컬레이션)
-  // CLI 도구(codex/claude/pwsh)는 체인 추적용으로만 스캔 — kill 대상에서 제외
-  const orphanPids = [];
-  for (const [pid, info] of procMap) {
-    if (protectedPids.has(pid)) continue;
-    if (!KILLABLE_NAMES.has(info.name?.toLowerCase())) continue;
-    if (hasLiveAncestorChain(pid, procMap, protectedPids)) continue;
-    if (hasLiveCliDescendant(pid, procMap)) continue;
-    orphanPids.push(pid);
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  const byPid = new Map(snapshot.map((proc) => [proc.pid, proc]));
+  let current = process.pid;
+  const seen = new Set();
+  while (current > 0 && !seen.has(current)) {
+    seen.add(current);
+    result.add(current);
+    const parent = byPid.get(current)?.ppid;
+    if (!Number.isInteger(parent) || parent <= 0) break;
+    current = parent;
   }
 
-  const killed = killWithEscalation(orphanPids, procMap);
+  return result;
+}
 
-  // 남은 프로세스 수 확인
-  let remaining = 0;
+function collectDescendants(rootPid, processes) {
+  const childrenByParent = new Map();
+  for (const proc of processes) {
+    if (!childrenByParent.has(proc.ppid)) childrenByParent.set(proc.ppid, []);
+    childrenByParent.get(proc.ppid).push(proc);
+  }
+
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const root = byPid.get(rootPid) || {
+    pid: rootPid,
+    ppid: 0,
+    name: "",
+    commandLine: "",
+  };
+  const result = [];
+  const queue = [root];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const proc = queue.shift();
+    if (!proc || seen.has(proc.pid)) continue;
+    seen.add(proc.pid);
+    result.push(proc);
+    for (const child of childrenByParent.get(proc.pid) || []) {
+      queue.push(child);
+    }
+  }
+
+  return result;
+}
+
+function snapshotPids(snapshot) {
+  const values = Array.isArray(snapshot) ? snapshot : [snapshot];
+  return values
+    .map((item) => normalizePid(typeof item === "object" ? item?.pid : item))
+    .filter(Boolean);
+}
+
+function matchesPattern(commandLine, pattern, { exact = false } = {}) {
+  if (pattern instanceof RegExp) return pattern.test(commandLine);
+  const text = String(pattern || "");
+  if (!text) return false;
+  return exact ? commandLine === text : commandLine.includes(text);
+}
+
+function hasExactGbrainServe(commandLine) {
+  const normalized = commandLine.trim();
+  return (
+    /^("?[^"\s]*bun(?:\.exe)?"?\s+)?gbrain\s+serve$/i.test(normalized) ||
+    /^("?[^"\s]*bun(?:\.exe)?"?\s+)"?[^"]*gbrain[\\/]+src[\\/]+cli\.ts"?\s+serve$/i.test(
+      normalized,
+    )
+  );
+}
+
+function hasGbrainServeCommand(commandLine) {
+  return /(^|\s)gbrain\s+serve(\s|$)/i.test(commandLine.trim());
+}
+
+function hasFsmonitorDaemonCommand(commandLine) {
+  return FSMONITOR_DAEMON_PATTERN.test(commandLine);
+}
+
+function categoryForShardProcess(proc, context) {
+  const name = normalizeName(proc.name);
+  const commandLine = normalizeCommandLine(proc.commandLine);
+  const worktreePath = normalizeCommandLine(context.worktreePath || "");
+  const shardMarker = context.shardName
+    ? `.codex-swarm\\wt-${context.shardName}`
+    : "";
+  const hasWorktree = worktreePath && commandLine.includes(worktreePath);
+  const hasShardMarker = shardMarker && commandLine.includes(shardMarker);
+
+  if (name === "node.exe" || name === "node") {
+    if (hasWorktree || hasShardMarker) return "node";
+  }
+
+  if (name === "bash.exe" || name === "bash" || name === "sh") {
+    if (hasWorktree) return "bash";
+  }
+
+  if (name === "conhost.exe" || name === "conhost") {
+    if (
+      context.sessionIds?.length > 0 &&
+      context.sessionIds.some((id) => id && commandLine.includes(id))
+    ) {
+      return "conhost";
+    }
+  }
+
+  if (name === "bun.exe" || name === "bun") {
+    if ((hasWorktree || hasShardMarker) && hasGbrainServeCommand(commandLine)) {
+      return "bun";
+    }
+  }
+
+  if (name === "git.exe" || name === "git") {
+    if (
+      (hasWorktree || hasShardMarker) &&
+      hasFsmonitorDaemonCommand(commandLine)
+    ) {
+      return "git";
+    }
+  }
+
+  return null;
+}
+
+function killPid(
+  pid,
+  { killFn = process.kill, protectedPids = new Set() } = {},
+) {
+  if (protectedPids.has(pid)) return false;
+  killFn(pid, "SIGKILL");
+  return true;
+}
+
+/**
+ * Return a process tree rooted at `rootPid`.
+ *
+ * Windows queries `Get-CimInstance Win32_Process` once and builds a
+ * ParentProcessId map. POSIX uses `ps` as a best-effort fallback.
+ *
+ * @param {number} rootPid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync}} opts
+ * @returns {Array<{pid: number, ppid: number, name: string, commandLine: string}>}
+ */
+export function findProcessTree(
+  rootPid,
+  { isWindows = IS_WINDOWS, spawnSyncFn = spawnSync } = {},
+) {
+  const pid = normalizePid(rootPid);
+  if (!pid) return [];
+  const snapshot = getProcessSnapshot({ isWindows, spawnSyncFn });
+  return collectDescendants(pid, snapshot).map((proc) => ({
+    pid: proc.pid,
+    ppid: proc.ppid,
+    name: proc.name,
+    commandLine: proc.commandLine,
+  }));
+}
+
+/**
+ * Kill a process tree.
+ *
+ * Windows tries `taskkill /T /F /PID <pid>` first. If that fails, it falls
+ * back to a CIM process snapshot and kills descendants recursively. POSIX
+ * first targets the process group, then the PID itself.
+ *
+ * @param {number} pid
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{ok: boolean, killed: number, errors: Array}}
+ */
+export function killProcessTree(
+  pid,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids,
+  } = {},
+) {
+  const rootPid = normalizePid(pid);
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+  });
+  const errors = [];
+  if (!rootPid) return { ok: false, killed: 0, errors: ["invalid pid"] };
+  if (protectedSet.has(rootPid)) {
+    return { ok: false, killed: 0, errors: ["protected pid"] };
+  }
+
+  if (isWindows) {
+    const result = runSpawn(spawnSyncFn, "taskkill", [
+      "/T",
+      "/F",
+      "/PID",
+      String(rootPid),
+    ]);
+    if (result.status === 0) return { ok: true, killed: 1, errors };
+    errors.push(String(result.stderr || result.error || "taskkill failed"));
+
+    const tree = findProcessTree(rootPid, { isWindows, spawnSyncFn })
+      .filter((proc) => proc.pid !== rootPid)
+      .reverse();
+    let killed = 0;
+    for (const proc of tree) {
+      if (protectedSet.has(proc.pid) || !isPidAliveFn(proc.pid)) continue;
+      try {
+        killFn(proc.pid, "SIGKILL");
+        killed++;
+      } catch (error) {
+        errors.push({ pid: proc.pid, error: String(error?.message || error) });
+      }
+    }
+    return { ok: killed > 0, killed, errors };
+  }
+
+  let killed = 0;
   try {
-    const countOutput = execSync(
-      `powershell -NoProfile -WindowStyle Hidden -Command "(Get-Process node -ErrorAction SilentlyContinue).Count"`,
+    killFn(-rootPid, "SIGKILL");
+    killed++;
+  } catch (error) {
+    errors.push({ pid: -rootPid, error: String(error?.message || error) });
+    try {
+      killFn(rootPid, "SIGKILL");
+      killed++;
+    } catch (fallbackError) {
+      errors.push({
+        pid: rootPid,
+        error: String(fallbackError?.message || fallbackError),
+      });
+    }
+  }
+
+  return { ok: killed > 0, killed, errors };
+}
+
+/**
+ * Kill a previously captured PID snapshot with SIGKILL.
+ *
+ * This is used when a parent process has already died and tree lookup can no
+ * longer reconstruct the original descendants.
+ *
+ * @param {Array<number | {pid: number}>} snapshot
+ * @param {{killFn?: typeof process.kill, isPidAliveFn?: typeof isPidAlive, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, missing: number}}
+ */
+export function killProcessTreeSnapshot(
+  snapshot,
+  {
+    killFn = process.kill,
+    isPidAliveFn = isPidAlive,
+    protectedPids = new Set(),
+  } = {},
+) {
+  let killed = 0;
+  let missing = 0;
+  for (const pid of snapshotPids(snapshot)) {
+    if (protectedPids.has(pid)) continue;
+    if (!isPidAliveFn(pid)) {
+      missing++;
+      continue;
+    }
+    try {
+      killFn(pid, "SIGKILL");
+      killed++;
+    } catch {
+      missing++;
+    }
+  }
+  return { killed, missing };
+}
+
+/**
+ * Find processes whose command line matches any string or RegExp pattern.
+ *
+ * String patterns use substring matching by default; pass `exact: true` for
+ * exact command-line equality.
+ *
+ * @param {Array<RegExp | string>} patterns
+ * @param {{isWindows?: boolean, spawnSyncFn?: typeof spawnSync, exact?: boolean, nowMs?: number}} opts
+ * @returns {Array<{pid: number, name: string, commandLine: string, ageMs?: number}>}
+ */
+export function findProcessesByCommandLine(
+  patterns,
+  {
+    isWindows = IS_WINDOWS,
+    spawnSyncFn = spawnSync,
+    exact = false,
+    nowMs = Date.now(),
+  } = {},
+) {
+  const list = Array.isArray(patterns) ? patterns : [patterns];
+  if (list.length === 0) return [];
+
+  return getProcessSnapshot({ isWindows, spawnSyncFn })
+    .filter((proc) =>
+      list.some((pattern) =>
+        matchesPattern(proc.commandLine, pattern, { exact }),
+      ),
+    )
+    .map((proc) => {
+      const creationMs = parseCreationDateMs(proc.creationDate);
+      const result = {
+        pid: proc.pid,
+        name: proc.name,
+        commandLine: proc.commandLine,
+      };
+      if (Number.isFinite(creationMs)) result.ageMs = nowMs - creationMs;
+      return result;
+    });
+}
+
+/**
+ * Cleanup processes associated with a swarm shard.
+ *
+ * Sequence: kill known top PID snapshots, scan scoped command lines, skip
+ * protected PIDs, and kill only narrowly gated runtime categories.
+ *
+ * @param {{worktreePath?: string, sessionIds?: string[], topPids?: Array<number | {pid: number}>, runId?: string, shardName?: string, dryRun?: boolean, isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, scanned: number, skipped: number, byCategory: {node: number, bash: number, conhost: number, bun: number, git: number}}}
+ */
+export function cleanupShardProcesses({
+  worktreePath,
+  sessionIds = [],
+  topPids = [],
+  runId,
+  shardName,
+  dryRun = false,
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+    includeAncestorScan: true,
+  });
+  const byCategory = { node: 0, bash: 0, conhost: 0, bun: 0, git: 0 };
+  let killed = 0;
+  let skipped = 0;
+
+  if (!dryRun && topPids.length > 0) {
+    killed += killProcessTreeSnapshot(topPids, {
+      killFn,
+      protectedPids: protectedSet,
+    }).killed;
+  }
+
+  const scanned = getProcessSnapshot({ isWindows, spawnSyncFn });
+
+  for (const proc of scanned) {
+    const category = categoryForShardProcess(proc, {
+      worktreePath,
+      sessionIds,
+      shardName,
+    });
+    if (!category) continue;
+    byCategory[category]++;
+    if (protectedSet.has(proc.pid)) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) continue;
+    try {
+      if (killPid(proc.pid, { killFn, protectedPids: protectedSet })) killed++;
+    } catch {}
+  }
+
+  return { killed, scanned: scanned.length, skipped, byCategory };
+}
+
+/**
+ * Cleanup narrowly gated orphan runtime processes.
+ *
+ * Windows scans node/bash/bun and optional conhost command lines. POSIX is a
+ * best-effort fallback. `legacy: true` preserves `cleanupOrphanNodeProcesses`
+ * behavior by targeting scoped orphan node runtimes only.
+ *
+ * @param {{legacy?: boolean, includeConhost?: boolean, sessionIds?: string[], isWindows?: boolean, spawnSyncFn?: typeof spawnSync, killFn?: typeof process.kill, protectedPids?: Set<number>}} opts
+ * @returns {{killed: number, remaining: number, killedProcesses: Array<{pid: number, ppid: number, name: string, commandLine: string, killReason: string}>}}
+ */
+export function cleanupOrphanRuntimeProcesses({
+  legacy = false,
+  includeConhost = false,
+  sessionIds = [],
+  isWindows = IS_WINDOWS,
+  spawnSyncFn = spawnSync,
+  killFn = process.kill,
+  protectedPids,
+} = {}) {
+  if (!isWindows) return cleanupOrphansUnix();
+
+  const protectedSet = getProtectedPids({
+    protectedPids,
+    isWindows,
+    spawnSyncFn,
+    includeAncestorScan: legacy,
+  });
+  const processes = getProcessSnapshot({ isWindows, spawnSyncFn });
+  let killed = 0;
+  const killedProcesses = [];
+  const procMap = legacy
+    ? new Map(processes.map((proc) => [proc.pid, proc]))
+    : new Map(processes.map((proc) => [proc.pid, proc]));
+
+  for (const proc of processes) {
+    if (protectedSet.has(proc.pid)) continue;
+    const name = normalizeName(proc.name);
+    const commandLine = normalizeCommandLine(proc.commandLine);
+    let shouldKill = false;
+    let killReason = null;
+
+    if (legacy) {
+      if (
+        LEGACY_ORPHAN_KILLABLE_NAMES.has(name) &&
+        !hasLiveAncestorChain(proc.pid, procMap, protectedSet) &&
+        !hasLiveCliDescendant(proc.pid, procMap)
+      ) {
+        shouldKill = true;
+        killReason = "legacy_orphan_ancestor_chain_dead";
+      }
+    } else if (name === "bun.exe") {
+      if (
+        hasExactGbrainServe(proc.commandLine) &&
+        !hasLiveAncestorChain(proc.pid, procMap, protectedSet) &&
+        !hasLiveCliDescendant(proc.pid, procMap)
+      ) {
+        shouldKill = true;
+        killReason = "bun_gbrain_serve_orphan";
+      }
+    } else if (includeConhost && name === "conhost.exe") {
+      if (
+        sessionIds.length > 0 &&
+        sessionIds.some((id) => id && commandLine.includes(id))
+      ) {
+        shouldKill = true;
+        killReason = "conhost_session_match";
+      }
+    }
+
+    if (!shouldKill) continue;
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+      killedProcesses.push({
+        pid: proc.pid,
+        ppid: proc.ppid,
+        name: proc.name,
+        commandLine: String(proc.commandLine || "").slice(0, 200),
+        killReason,
+      });
+    } catch {}
+  }
+
+  const remaining = processes.length - killed;
+  return { killed, remaining, killedProcesses };
+}
+
+/**
+ * Find stale git fsmonitor--daemon processes.
+ *
+ * Windows only. The CIM query is scoped to git.exe and the command line marker
+ * is intentionally narrow so foreground git commands are never targeted.
+ *
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean}} opts
+ * @returns {Array<{pid: number, parentPid: number, creationDate: string, ageMs: number, commandLine: string}>}
+ */
+export function findFsmonitorDaemons({
+  minAgeMs = DEFAULT_FSMONITOR_MIN_AGE_MS,
+  execSyncFn = execSync,
+  nowMs = Date.now(),
+  isWindows = IS_WINDOWS,
+} = {}) {
+  if (!isWindows) return [];
+
+  ensureHelperScripts();
+
+  let records;
+  try {
+    const output = execSyncFn(
+      `powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process -Filter \\"Name='git.exe'\\" | Where-Object { $_.CommandLine -match '(^|\\s)fsmonitor--daemon run --detach(\\s|$)' } | Select-Object ProcessId,ParentProcessId,CreationDate,CommandLine | ConvertTo-Json -Compress"`,
       {
         encoding: "utf8",
-        timeout: 5000,
-        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 10000,
+        stdio: ["ignore", "pipe", "ignore"],
         windowsHide: true,
       },
     );
-    remaining = Number.parseInt(countOutput.trim(), 10) || 0;
-  } catch {}
+    records = normalizePowerShellJson(output);
+  } catch {
+    return [];
+  }
 
-  return { killed, remaining };
+  const stale = [];
+  for (const record of records) {
+    const pid = Number(record?.ProcessId);
+    const parentPid = Number(record?.ParentProcessId);
+    const commandLine = String(record?.CommandLine || "");
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (!commandLine.includes(FSMONITOR_DAEMON_MARKER)) continue;
+    if (!FSMONITOR_DAEMON_PATTERN.test(commandLine)) continue;
+
+    const creationMs = parseCreationDateMs(record?.CreationDate);
+    const ageMs = Number.isFinite(creationMs) ? nowMs - creationMs : NaN;
+    if (!Number.isFinite(ageMs) || ageMs < minAgeMs) continue;
+
+    stale.push({
+      pid,
+      parentPid: Number.isFinite(parentPid) ? parentPid : 0,
+      creationDate: String(record?.CreationDate || ""),
+      ageMs,
+      commandLine,
+    });
+  }
+
+  return stale;
+}
+
+/**
+ * Cleanup stale git fsmonitor--daemon processes.
+ * @param {{minAgeMs?: number, execSyncFn?: typeof execSync, nowMs?: number, isWindows?: boolean, killFn?: typeof process.kill}} opts
+ * @returns {{killed: number, stale: Array}}
+ */
+export function cleanupStaleFsmonitorDaemons({
+  killFn = process.kill,
+  ...findOpts
+} = {}) {
+  const stale = findFsmonitorDaemons(findOpts);
+  let killed = 0;
+
+  for (const proc of stale) {
+    try {
+      killFn(proc.pid, "SIGKILL");
+      killed++;
+    } catch {}
+  }
+
+  return { killed, stale };
 }
 
 /**

--- a/packages/core/hub/lib/trace-recorder.mjs
+++ b/packages/core/hub/lib/trace-recorder.mjs
@@ -1,0 +1,153 @@
+const VALID_CLIENTS = new Set(["codex", "claude", "gemini", "unknown"]);
+const VALID_PHASES = new Set(["ingress", "handler", "store", "event-loop"]);
+const SAMPLE_LIMIT = 1000;
+
+const categories = new Map();
+const workerDurations = [];
+const workerCounts = {
+  spawned: 0,
+  exited: 0,
+};
+
+function debugInvalid(kind, details) {
+  if (process.env.TFX_TRACE_DEBUG !== "1") return;
+  console.debug(`[trace-recorder] ignored invalid ${kind}`, details);
+}
+
+function normalizeClient(client) {
+  const value = String(client || "unknown").toLowerCase();
+  return VALID_CLIENTS.has(value) ? value : "unknown";
+}
+
+function normalizePhase(phase) {
+  const value = String(phase || "handler");
+  return VALID_PHASES.has(value) ? value : "handler";
+}
+
+function validDuration(durMs) {
+  return Number.isFinite(durMs) && durMs >= 0;
+}
+
+function emptyStats() {
+  return {
+    count: 0,
+    total: 0,
+    min: null,
+    max: null,
+    samples: [],
+    phases: {},
+  };
+}
+
+function addDuration(stats, durMs, phase) {
+  stats.count += 1;
+  stats.total += durMs;
+  stats.min = stats.min == null ? durMs : Math.min(stats.min, durMs);
+  stats.max = stats.max == null ? durMs : Math.max(stats.max, durMs);
+  stats.samples.push(durMs);
+  if (stats.samples.length > SAMPLE_LIMIT) {
+    stats.samples.splice(0, stats.samples.length - SAMPLE_LIMIT);
+  }
+
+  const phaseStats = stats.phases[phase] || emptyPhaseStats();
+  phaseStats.count += 1;
+  phaseStats.total += durMs;
+  phaseStats.min =
+    phaseStats.min == null ? durMs : Math.min(phaseStats.min, durMs);
+  phaseStats.max =
+    phaseStats.max == null ? durMs : Math.max(phaseStats.max, durMs);
+  stats.phases[phase] = phaseStats;
+}
+
+function emptyPhaseStats() {
+  return { count: 0, total: 0, min: null, max: null };
+}
+
+function percentile(samples, percentileValue) {
+  if (!samples.length) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.ceil((percentileValue / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+function publicStats(stats) {
+  return {
+    count: stats.count,
+    total: stats.total,
+    min: stats.min,
+    max: stats.max,
+    p50: percentile(stats.samples, 50),
+    p95: percentile(stats.samples, 95),
+    p99: percentile(stats.samples, 99),
+    phases: stats.phases,
+  };
+}
+
+export function recordRequest(
+  category,
+  durMs,
+  client = "unknown",
+  phase = "handler",
+) {
+  if (!category || typeof category !== "string") return;
+  if (!validDuration(durMs)) {
+    debugInvalid("request duration", { category, durMs, client, phase });
+    return;
+  }
+
+  const clientKey = normalizeClient(client);
+  const phaseKey = normalizePhase(phase);
+  const bucket = categories.get(category) || new Map();
+  const stats = bucket.get(clientKey) || emptyStats();
+  addDuration(stats, durMs, phaseKey);
+  bucket.set(clientKey, stats);
+  categories.set(category, bucket);
+}
+
+export function recordWorker(workerId, kind, command, durMs) {
+  if (!workerId || typeof workerId !== "string") return;
+  if (kind === "spawned") {
+    workerCounts.spawned += 1;
+    return;
+  }
+  if (kind !== "exited") return;
+
+  workerCounts.exited += 1;
+  if (durMs == null) return;
+  if (!validDuration(durMs)) {
+    debugInvalid("worker duration", { workerId, kind, command, durMs });
+    return;
+  }
+  workerDurations.push(durMs);
+  if (workerDurations.length > SAMPLE_LIMIT) {
+    workerDurations.splice(0, workerDurations.length - SAMPLE_LIMIT);
+  }
+}
+
+export function snapshot() {
+  const categorySnapshot = {};
+  for (const [category, bucket] of categories.entries()) {
+    categorySnapshot[category] = {};
+    for (const [client, stats] of bucket.entries()) {
+      categorySnapshot[category][client] = publicStats(stats);
+    }
+  }
+
+  return {
+    categories: categorySnapshot,
+    workers: {
+      spawned: workerCounts.spawned,
+      exited: workerCounts.exited,
+      p50: percentile(workerDurations, 50),
+      p95: percentile(workerDurations, 95),
+      p99: percentile(workerDurations, 99),
+    },
+  };
+}
+
+export function reset() {
+  categories.clear();
+  workerDurations.length = 0;
+  workerCounts.spawned = 0;
+  workerCounts.exited = 0;
+}

--- a/packages/core/scripts/lib/codex-recovery.sh
+++ b/packages/core/scripts/lib/codex-recovery.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# codex-recovery.sh — codex exec stdout 4계단 recovery helper.
+# 사용: STDOUT_LOG / STDERR_LOG env 설정 후 `source` + `recover_codex_stdout`.
+#
+# 1차 codex marker  → stderr 의 마지막 "codex" 라인 이후 본문 회수
+# 2차 node parser   → MCP/header/sandbox 로그 제외, 응답 부분만 추출
+# 3차 stderr tail   → "tokens used" 직전까지 tail buffer 회수
+# 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
+
+recover_codex_stdout() {
+  if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
+    return 0
+  fi
+
+  # 1차: codex marker
+  sed 's/\r$//' "$STDERR_LOG" \
+    | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
+    > "$STDOUT_LOG"
+
+  # 2차: node parser (MCP/header/sandbox 로그 제외)
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    node -e '
+      const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
+      const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
+      const out=lines.filter(l=>!skip.test(l));
+      if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
+    ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
+  fi
+
+  # 3차: stderr tail before "tokens used"
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    sed 's/\r$//' "$STDERR_LOG" \
+      | awk '
+          /^tokens used/ { exit }
+          { buf[NR]=$0 }
+          END {
+            start=NR-200; if (start<1) start=1
+            for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+          }' \
+      > "$STDOUT_LOG"
+  fi
+
+  if [[ -s "$STDOUT_LOG" ]]; then
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
+  else
+    # 4차: FALLBACK_FAILED
+    echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
+  fi
+}

--- a/packages/core/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/core/scripts/lib/mcp-guard-engine.mjs
@@ -10,7 +10,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
-const REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
+const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
 const DEFAULT_REGISTRY = Object.freeze({
@@ -20,6 +20,14 @@ const DEFAULT_REGISTRY = Object.freeze({
   defaults: {
     transport: "hub-url",
     hub_base: "http://127.0.0.1:27888",
+  },
+  policy_notes: {
+    transport:
+      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+    headers:
+      'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
+    secret_safety:
+      "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
   },
   servers: {
     "tfx-hub": {
@@ -33,6 +41,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   policies: {
     stdio_action: "replace-with-hub",
     unknown_server_action: "warn",
+    sync_denylist: [],
     watched_paths: [
       "~/.gemini/settings.json",
       "~/.codex/config.toml",
@@ -81,6 +90,12 @@ function readJsonFile(filePath) {
 function writeJsonFile(filePath, data) {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function registryPath() {
+  return process.env.TFX_MCP_REGISTRY_PATH
+    ? resolve(process.env.TFX_MCP_REGISTRY_PATH)
+    : DEFAULT_REGISTRY_PATH;
 }
 
 function ensureBackup(filePath) {
@@ -175,10 +190,57 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("{") && value.endsWith("}")) {
+    return parseTomlInlineTable(value);
+  }
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlInlineTable(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return {};
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  const table = {};
+  for (const part of parts) {
+    const match = part.match(
+      /^\s*(?:"((?:\\"|[^"])*)"|([A-Za-z0-9_-]+))\s*=\s*(.+?)\s*$/,
+    );
+    if (!match) continue;
+    const key = (match[1] || match[2] || "")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
+    table[key] = parseTomlScalar(match[3]);
+  }
+  return table;
 }
 
 function parseCodexMcpServers(raw) {
@@ -209,6 +271,179 @@ function parseCodexMcpServers(raw) {
   return servers;
 }
 
+function isValidHeaderName(name) {
+  return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
+}
+
+function normalizeHeaderDescriptors(headers = {}) {
+  const normalized = {};
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(headers)) {
+    if (!isValidHeaderName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor)
+    ) {
+      if (
+        Object.hasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
+      ) {
+        normalized[name] = { value: descriptor.value };
+      } else if (
+        Object.hasOwn(descriptor, "env") &&
+        typeof descriptor.env === "string" &&
+        descriptor.env.trim()
+      ) {
+        normalized[name] = { env: descriptor.env.trim() };
+        if (typeof descriptor.prefix === "string") {
+          normalized[name].prefix = descriptor.prefix;
+        }
+      }
+    }
+  }
+  return normalized;
+}
+
+function resolveHeaderDescriptors(name, serverConfig, filePath) {
+  const descriptors = normalizeHeaderDescriptors(serverConfig?.headers || {});
+  const headers = {};
+  const warnings = [];
+  const codex = {
+    bearer_token_env_var: null,
+    env_http_headers: {},
+    http_headers: {},
+  };
+  const codexTarget = isCodexConfig(filePath);
+
+  for (const [headerName, descriptor] of Object.entries(descriptors)) {
+    if (Object.hasOwn(descriptor, "value")) {
+      headers[headerName] = descriptor.value;
+      if (codexTarget) codex.http_headers[headerName] = descriptor.value;
+      continue;
+    }
+
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    const prefix = descriptor.prefix || "";
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+
+    headers[headerName] = `${prefix}${envValue}`;
+
+    if (!codexTarget) continue;
+
+    if (
+      headerName.toLowerCase() === "authorization" &&
+      /^Bearer\s+$/i.test(prefix)
+    ) {
+      codex.bearer_token_env_var = envName;
+    } else if (!prefix) {
+      codex.env_http_headers[headerName] = envName;
+    } else {
+      codex.http_headers[headerName] = `${prefix}${envValue}`;
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header uses resolved literal in Codex TOML because prefixed env headers are unsupported`,
+      );
+    }
+  }
+
+  return {
+    descriptors,
+    headers,
+    warnings,
+    codex: {
+      ...(codex.bearer_token_env_var
+        ? { bearer_token_env_var: codex.bearer_token_env_var }
+        : {}),
+      env_http_headers: codex.env_http_headers,
+      http_headers: codex.http_headers,
+    },
+  };
+}
+
+function hasOwnEntries(value) {
+  return value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function redactHeaders(headers = {}) {
+  const redacted = {};
+  for (const key of Object.keys(headers || {})) {
+    redacted[key] = "***REDACTED***";
+  }
+  return redacted;
+}
+
+function redactServerConfig(config = {}) {
+  if (!config || typeof config !== "object") return config;
+  return {
+    ...config,
+    ...(config.headers ? { headers: redactHeaders(config.headers) } : {}),
+  };
+}
+
+function descriptorsFromCodexConfig(config = {}) {
+  const descriptors = {};
+  if (typeof config.bearer_token_env_var === "string") {
+    descriptors.Authorization = {
+      env: config.bearer_token_env_var,
+      prefix: "Bearer ",
+    };
+  }
+  if (config.env_http_headers && typeof config.env_http_headers === "object") {
+    for (const [name, envName] of Object.entries(config.env_http_headers)) {
+      if (typeof envName === "string") descriptors[name] = { env: envName };
+    }
+  }
+  if (config.http_headers && typeof config.http_headers === "object") {
+    for (const [name, value] of Object.entries(config.http_headers)) {
+      if (typeof value === "string") descriptors[name] = { value };
+    }
+  }
+  return descriptors;
+}
+
+function descriptorsFromJsonConfig(config = {}) {
+  const descriptors = {};
+  if (!config?.headers || typeof config.headers !== "object") {
+    return descriptors;
+  }
+  for (const [name, value] of Object.entries(config.headers)) {
+    if (typeof value === "string") descriptors[name] = { value };
+  }
+  return descriptors;
+}
+
+function headerNames(headers = {}) {
+  return Object.keys(headers || {}).sort();
+}
+
+function sameHeaderDescriptors(left = {}, right = {}) {
+  const leftNames = headerNames(left);
+  const rightNames = headerNames(right);
+  if (JSON.stringify(leftNames) !== JSON.stringify(rightNames)) return false;
+  return leftNames.every(
+    (name) => JSON.stringify(left[name]) === JSON.stringify(right[name]),
+  );
+}
+
+function headerStatus(expected = {}, actual = {}) {
+  const expectedNames = headerNames(expected);
+  const actualNames = headerNames(actual);
+  if (expectedNames.length === 0 && actualNames.length === 0) return "ok";
+  if (expectedNames.some((name) => !Object.hasOwn(actual, name))) {
+    return "missing";
+  }
+  if (!sameHeaderDescriptors(expected, actual)) return "stale";
+  return "ok";
+}
+
 function removeTomlSection(raw, sectionName) {
   const lines = String(raw || "").split(/\r?\n/);
   const output = [];
@@ -235,12 +470,68 @@ function removeTomlSection(raw, sectionName) {
   return cleaned.length > 0 ? cleaned.replace(/\n{3,}/g, "\n\n") : "";
 }
 
-function upsertTomlUrlServer(raw, name, url) {
-  const section = [`[mcp_servers.${name}]`, `url = ${formatTomlString(url)}`];
-  const withoutExisting = removeTomlSection(raw, name).trimEnd();
-  return withoutExisting.length > 0
-    ? `${withoutExisting}\n\n${section.join("\n")}\n`
-    : `${section.join("\n")}\n`;
+function formatTomlInlineTable(data = {}) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return null;
+  return `{ ${entries
+    .map(
+      ([key, value]) => `${formatTomlString(key)} = ${formatTomlString(value)}`,
+    )
+    .join(", ")} }`;
+}
+
+function upsertTomlServer(raw, name, config, codex = {}) {
+  const lines = String(raw || "").split(/\r?\n/);
+  const header = `[mcp_servers.${name}]`;
+  const managedKeys = new Set([
+    "url",
+    "command",
+    "args",
+    "bearer_token_env_var",
+    "http_headers",
+    "env_http_headers",
+  ]);
+  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  if (codex.bearer_token_env_var) {
+    nextManagedLines.push(
+      `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
+    );
+  }
+  const httpHeaders = formatTomlInlineTable(codex.http_headers || {});
+  if (httpHeaders) nextManagedLines.push(`http_headers = ${httpHeaders}`);
+  const envHttpHeaders = formatTomlInlineTable(codex.env_http_headers || {});
+  if (envHttpHeaders) {
+    nextManagedLines.push(`env_http_headers = ${envHttpHeaders}`);
+  }
+
+  const sectionStart = lines.findIndex((line) => line.trim() === header);
+  if (sectionStart < 0) {
+    const section = [header, ...nextManagedLines].join("\n");
+    const withoutTrailing = String(raw || "").trimEnd();
+    return withoutTrailing.length > 0
+      ? `${withoutTrailing}\n\n${section}\n`
+      : `${section}\n`;
+  }
+
+  const output = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    output.push(lines[index]);
+    if (index !== sectionStart) continue;
+
+    index += 1;
+    const preserved = [];
+    while (index < lines.length && !/^\s*\[/.test(lines[index])) {
+      const keyMatch = lines[index].match(/^\s*([A-Za-z0-9_]+)\s*=/);
+      if (!keyMatch || !managedKeys.has(keyMatch[1])) {
+        preserved.push(lines[index]);
+      }
+      index += 1;
+    }
+    output.push(...nextManagedLines, ...preserved.filter(Boolean));
+    index -= 1;
+  }
+
+  return output.join("\n");
 }
 
 function getHubServerEntry(registry) {
@@ -282,22 +573,69 @@ function serverAppliesToClient(serverConfig, client) {
   return serverTargets(serverConfig).includes(client);
 }
 
-function buildDesiredServerRecord(name, serverConfig, filePath) {
+function syncDenylistEntries(policy = {}) {
+  if (!Array.isArray(policy?.sync_denylist)) return new Set();
+  return new Set(
+    policy.sync_denylist
+      .map((entry) =>
+        String(entry || "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+}
+
+function syncDenylistKey(client, serverName) {
+  return `${String(client || "")
+    .trim()
+    .toLowerCase()}:${String(serverName || "")
+    .trim()
+    .toLowerCase()}`;
+}
+
+export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
       : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
+  const resolvedHeaders = resolveHeaderDescriptors(
+    name,
+    serverConfig,
+    filePath,
+  );
+  const headerConfig = hasOwnEntries(resolvedHeaders.headers)
+    ? { headers: resolvedHeaders.headers }
+    : {};
 
   if (basenameValue === ".mcp.json" || isClaudeProjectMcpConfig(filePath)) {
-    return { name, config: { type: "http", url } };
+    return {
+      name,
+      config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
   if (isCodexConfig(filePath)) {
-    return { name, config: { url } };
+    return {
+      name,
+      config: { url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
-  return { name, config: { url } };
+  return {
+    name,
+    config: { url, ...headerConfig },
+    headerDescriptors: resolvedHeaders.descriptors,
+    codex: resolvedHeaders.codex,
+    warnings: resolvedHeaders.warnings,
+  };
 }
 
 function scanJsonConfig(filePath) {
@@ -332,6 +670,17 @@ function scanJsonConfig(filePath) {
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
               type: typeof config.type === "string" ? config.type : "",
+              headers:
+                config.headers &&
+                typeof config.headers === "object" &&
+                !Array.isArray(config.headers)
+                  ? Object.fromEntries(
+                      Object.entries(config.headers).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
+              headerDescriptors: descriptorsFromJsonConfig(config),
               transport:
                 typeof config.url === "string" && config.url
                   ? "url"
@@ -383,6 +732,11 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      headers:
+        config.http_headers && typeof config.http_headers === "object"
+          ? config.http_headers
+          : {},
+      headerDescriptors: descriptorsFromCodexConfig(config),
       transport:
         typeof config.url === "string" && config.url
           ? "url"
@@ -450,6 +804,9 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (!Object.hasOwn(update.config, "headers")) {
+      delete nextConfig.headers;
+    }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
     if (changed) {
@@ -484,7 +841,7 @@ function updateCodexConfig(filePath, updates = [], removals = []) {
   }
 
   for (const update of updates) {
-    raw = upsertTomlUrlServer(raw, update.name, update.config.url);
+    raw = upsertTomlServer(raw, update.name, update.config, update.codex || {});
   }
 
   const finalRaw = raw.trim().length > 0 ? `${raw.trimEnd()}\n` : "";
@@ -517,7 +874,7 @@ function scanConfig(filePath) {
 }
 
 export function getRegistryPath() {
-  return REGISTRY_PATH;
+  return registryPath();
 }
 
 export function createDefaultRegistry() {
@@ -557,6 +914,104 @@ export function validateRegistry(registry) {
       if (typeof server.url !== "string" || !server.url.trim()) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url or http`,
+        );
+      }
+      if (server.command !== undefined) {
+        errors.push(
+          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.args !== undefined) {
+        errors.push(
+          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.headers !== undefined) {
+        if (!["hub-url", "http"].includes(transport)) {
+          errors.push(
+            `registry.servers.${name}.headers is allowed only for HTTP-compatible transports`,
+          );
+        }
+        if (
+          !server.headers ||
+          typeof server.headers !== "object" ||
+          Array.isArray(server.headers)
+        ) {
+          errors.push(`registry.servers.${name}.headers must be an object`);
+        } else {
+          for (const [headerName, descriptor] of Object.entries(
+            server.headers,
+          )) {
+            if (!isValidHeaderName(headerName)) {
+              errors.push(
+                `registry.servers.${name}.headers contains invalid header name ${headerName}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            const hasValue = Object.hasOwn(descriptor, "value");
+            const hasEnv = Object.hasOwn(descriptor, "env");
+            if (hasValue && hasEnv) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use either value or env`,
+              );
+            } else if (hasValue) {
+              if (
+                keys.length !== 1 ||
+                typeof descriptor.value !== "string" ||
+                descriptor.value.length === 0
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.value must be a non-empty string`,
+                );
+              }
+            } else if (hasEnv) {
+              if (
+                !["env", "prefix"].every((key) => keys.includes(key)) &&
+                keys.some((key) => !["env", "prefix"].includes(key))
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName} supports only env and optional prefix`,
+                );
+              }
+              if (
+                typeof descriptor.env !== "string" ||
+                !descriptor.env.trim()
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.env must be a non-empty string`,
+                );
+              }
+              if (
+                descriptor.prefix !== undefined &&
+                typeof descriptor.prefix !== "string"
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.prefix must be a string`,
+                );
+              }
+            } else {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use value or env`,
+              );
+            }
+          }
+        }
+      }
       if (server.targets !== undefined && !Array.isArray(server.targets)) {
         errors.push(`registry.servers.${name}.targets must be an array`);
       }
@@ -574,6 +1029,22 @@ export function validateRegistry(registry) {
       errors.push("registry.policies.watched_paths must be an array");
     }
     if (
+      registry.policies.sync_denylist !== undefined &&
+      !Array.isArray(registry.policies.sync_denylist)
+    ) {
+      errors.push("registry.policies.sync_denylist must be an array");
+    }
+    if (Array.isArray(registry.policies.sync_denylist)) {
+      for (const entry of registry.policies.sync_denylist) {
+        if (typeof entry !== "string" || !entry.includes(":")) {
+          errors.push(
+            "registry.policies.sync_denylist entries must use client:server format",
+          );
+          break;
+        }
+      }
+    }
+    if (
       registry.policies.stdio_action &&
       !["replace-with-hub", "warn"].includes(registry.policies.stdio_action)
     ) {
@@ -587,9 +1058,9 @@ export function validateRegistry(registry) {
 }
 
 export function inspectRegistry() {
-  if (!existsSync(REGISTRY_PATH)) {
+  if (!existsSync(registryPath())) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: false,
       valid: false,
       errors: ["registry file missing"],
@@ -598,10 +1069,10 @@ export function inspectRegistry() {
   }
 
   try {
-    const registry = readJsonFile(REGISTRY_PATH);
+    const registry = readJsonFile(registryPath());
     const errors = validateRegistry(registry);
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: errors.length === 0,
       errors,
@@ -609,7 +1080,7 @@ export function inspectRegistry() {
     };
   } catch (error) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: false,
       errors: [error.message],
@@ -651,7 +1122,7 @@ export function saveRegistry(registry) {
   if (errors.length > 0) {
     throw new Error(`MCP registry invalid: ${errors.join("; ")}`);
   }
-  writeJsonFile(REGISTRY_PATH, registry);
+  writeJsonFile(registryPath(), registry);
   return registry;
 }
 
@@ -698,13 +1169,19 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
     );
 
     for (const [name, serverConfig] of managedServers) {
-      const expectedUrl = buildDesiredServerRecord(
+      const desired = buildDesiredServerRecord(
         name,
         serverConfig,
         config.filePath,
-      ).config.url;
+      );
+      const expectedUrl = desired.config.url;
+      const expectedHeaders = isCodexConfig(config.filePath)
+        ? desired.headerDescriptors || {}
+        : descriptorsFromJsonConfig(desired.config);
       const actual =
         config.servers.find((server) => server.name === name) || null;
+      const actualHeaders = actual?.headerDescriptors || {};
+      const currentHeaderStatus = headerStatus(expectedHeaders, actualHeaders);
       let status = "missing";
 
       if (!config.exists) {
@@ -716,7 +1193,7 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
-        status = "present";
+        status = currentHeaderStatus === "ok" ? "present" : "mismatch";
       } else {
         status = "mismatch";
       }
@@ -730,6 +1207,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         expectedUrl,
         actualUrl: actual?.url || "",
         status,
+        headerStatus: currentHeaderStatus,
+        expectedHeaderNames: headerNames(expectedHeaders),
+        actualHeaderNames: headerNames(actualHeaders),
       });
     }
 
@@ -828,14 +1308,19 @@ export function remediate(filePath, stdioServers, policy = {}) {
   let replacement = null;
 
   if (action === "replace-with-hub") {
-    const registry = loadRegistryOrDefault();
-    const [hubServerName, hubServerConfig] = getHubServerEntry(registry);
+    const registry = policy.registry || loadRegistryOrDefault();
+    const matchingOffender = offenders.find((server) =>
+      Object.hasOwn(registry.servers || {}, server.name),
+    );
+    const [hubServerName, hubServerConfig] = matchingOffender
+      ? [matchingOffender.name, registry.servers[matchingOffender.name]]
+      : getHubServerEntry(registry);
     const desired = buildDesiredServerRecord(
       hubServerName,
       hubServerConfig,
       resolvedPath,
     );
-    replacement = { name: desired.name, ...desired.config };
+    replacement = { name: desired.name, ...redactServerConfig(desired.config) };
     updates.push(desired);
   }
 
@@ -846,7 +1331,7 @@ export function remediate(filePath, stdioServers, policy = {}) {
     backupPath,
     removedServers: removals,
     replacement,
-    warnings: [],
+    warnings: updates.flatMap((update) => update.warnings || []),
   };
 }
 
@@ -1032,10 +1517,13 @@ export function removeServerFromTargets(name, options = {}) {
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
   const actions = [];
+  const invalidConfigs = new Set();
+  const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of listManagedConfigTargets(registry)) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
+      invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
         type: "sync",
         filePath: target.filePath,
@@ -1047,11 +1535,10 @@ export function syncRegistryTargets(options = {}) {
     }
 
     if (snapshot.stdioServers.length > 0) {
-      const remediation = remediate(
-        target.filePath,
-        snapshot.stdioServers,
-        registry.policies,
-      );
+      const remediation = remediate(target.filePath, snapshot.stdioServers, {
+        ...registry.policies,
+        registry,
+      });
       actions.push({
         type: "remediate",
         filePath: target.filePath,
@@ -1065,13 +1552,49 @@ export function syncRegistryTargets(options = {}) {
   }
 
   for (const target of listPrimaryConfigTargets(registry)) {
-    const updates = Object.entries(registry.servers || {})
-      .filter(([, serverConfig]) =>
-        serverAppliesToClient(serverConfig, target.client),
-      )
-      .map(([name, serverConfig]) =>
+    const snapshot = scanConfig(target.filePath);
+    const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.parseError) {
+      if (!invalidConfigs.has(targetKey)) {
+        actions.push({
+          type: "sync",
+          filePath: target.filePath,
+          label: target.label,
+          status: "invalid-config",
+          message: snapshot.parseError.message,
+        });
+      }
+      continue;
+    }
+
+    const updates = [];
+    for (const [name, serverConfig] of Object.entries(registry.servers || {})) {
+      if (serverConfig?.safe !== true) continue;
+      if (!serverAppliesToClient(serverConfig, target.client)) continue;
+
+      const denyKey = syncDenylistKey(target.client, name);
+      if (denylist.has(denyKey)) {
+        const existing = snapshot.servers.find(
+          (server) => server.name === name,
+        );
+        if (!existing) {
+          actions.push({
+            type: "sync",
+            filePath: target.filePath,
+            label: target.label,
+            status: "policy-skip",
+            server: name,
+            client: target.client,
+            message: `[mcp-guard] policy skip: ${denyKey}`,
+          });
+        }
+        continue;
+      }
+
+      updates.push(
         buildDesiredServerRecord(name, serverConfig, target.filePath),
       );
+    }
 
     if (updates.length === 0) continue;
 
@@ -1090,6 +1613,7 @@ export function syncRegistryTargets(options = {}) {
       label: target.label,
       status: result.modified ? "updated" : "ok",
       serverCount: updates.length,
+      warnings: updates.flatMap((update) => update.warnings || []),
     });
   }
 

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -13,6 +13,7 @@ import {
 import { createServer as createHttpServer } from "node:http";
 import { homedir } from "node:os";
 import { extname, join, resolve, sep } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -27,8 +28,17 @@ import { createAdaptiveEngine } from "@triflux/core/hub/adaptive.mjs";
 import { createAssignCallbackServer } from "@triflux/core/hub/assign-callbacks.mjs";
 import { DelegatorService } from "@triflux/core/hub/delegator/index.mjs";
 import { createHitlManager } from "@triflux/core/hub/hitl.mjs";
-import { cleanupOrphanNodeProcesses } from "@triflux/core/hub/lib/process-utils.mjs";
+import {
+  cleanupOrphanNodeProcesses,
+  cleanupOrphanRuntimeProcesses,
+  cleanupStaleFsmonitorDaemons,
+} from "@triflux/core/hub/lib/process-utils.mjs";
 import * as spawnTrace from "@triflux/core/hub/lib/spawn-trace.mjs";
+import {
+  recordRequest,
+  recordWorker,
+  snapshot as traceSnapshot,
+} from "@triflux/core/hub/lib/trace-recorder.mjs";
 import { logQuotaRefreshFailures } from "@triflux/core/hub/middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "@triflux/core/hub/middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
@@ -195,6 +205,12 @@ function isInitializeRequest(body) {
   if (Array.isArray(body))
     return body.some((message) => message.method === "initialize");
   return false;
+}
+
+function parseTfxClientHeader(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const client = String(raw || "unknown").toLowerCase();
+  return ["codex", "claude", "gemini"].includes(client) ? client : "unknown";
 }
 
 async function parseBody(req) {
@@ -956,39 +972,115 @@ export async function startHub({
   const assignCallbacks = createAssignCallbackServer({ store, sessionId });
   const tools = createTools(store, router, hitl, pipe);
   const transports = new Map();
+  const workerSpans = new Map();
 
-  function createMcpForSession() {
+  async function closeMcpTransportSession(sid, session, reason) {
+    if (!sid) return;
+    if (!session) {
+      transports.delete(sid);
+      return;
+    }
+    if (session.closing) {
+      transports.delete(sid);
+      return;
+    }
+
+    session.closing = true;
+    transports.delete(sid);
+
+    try {
+      await session.mcp.close();
+    } catch (error) {
+      hubLog.debug(
+        { sid, reason, err: String(error?.message || error) },
+        "hub.mcp_session_close_mcp_failed",
+      );
+    }
+    try {
+      await session.transport.close();
+    } catch (error) {
+      hubLog.debug(
+        { sid, reason, err: String(error?.message || error) },
+        "hub.mcp_session_close_transport_failed",
+      );
+    }
+  }
+
+  function getTraceClient(clientRef) {
+    return clientRef?.client || "unknown";
+  }
+
+  function finishWorkerTrace(workerId, kind) {
+    if (!workerId || typeof workerId !== "string") return;
+    const span = workerSpans.get(workerId);
+    if (!span) return;
+    workerSpans.delete(workerId);
+    recordWorker(
+      workerId,
+      "exited",
+      span.command || kind,
+      performance.now() - span.startedAt,
+    );
+  }
+
+  function createMcpForSession(clientRef = { client: "unknown" }) {
     const mcp = new Server(
       { name: "tfx-hub", version: "1.0.0" },
       { capabilities: { tools: {} } },
     );
 
-    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-      })),
-    }));
+    mcp.setRequestHandler(ListToolsRequestSchema, async () => {
+      const started = performance.now();
+      try {
+        return {
+          tools: tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        };
+      } finally {
+        recordRequest(
+          "tools.list",
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
+      }
+    });
 
     mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
-      const tool = tools.find((candidate) => candidate.name === name);
-      if (!tool) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({
-                ok: false,
-                error: { code: "UNKNOWN_TOOL", message: `도구 없음: ${name}` },
-              }),
-            },
-          ],
-          isError: true,
-        };
+      const category = `tools.call.${name || "unknown"}`;
+      const started = performance.now();
+      try {
+        const tool = tools.find((candidate) => candidate.name === name);
+        if (!tool) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  ok: false,
+                  error: {
+                    code: "UNKNOWN_TOOL",
+                    message: `도구 없음: ${name}`,
+                  },
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return tool.handler(args || {});
+      } finally {
+        recordRequest(
+          category,
+          performance.now() - started,
+          getTraceClient(clientRef),
+          "handler",
+        );
       }
-      return tool.handler(args || {});
     });
 
     return mcp;
@@ -1043,7 +1135,11 @@ export async function startHub({
 
       if (path === "/" || path === "/status") {
         const status = router.getStatus("hub").data;
-        return writeJson(res, 200, {
+        const includeMetrics =
+          new URL(req.url, `http://${host}`).searchParams.get(
+            "include_metrics",
+          ) === "1";
+        const body = {
           ...status,
           sessions: transports.size,
           pid: process.pid,
@@ -1060,7 +1156,11 @@ export async function startHub({
             max_total_descendants: spawnTrace.MAX_TOTAL_DESCENDANTS,
           },
           version,
-        });
+        };
+        if (includeMetrics) {
+          body.metrics = traceSnapshot();
+        }
+        return writeJson(res, 200, body);
       }
 
       if (path === "/health" || path === "/healthz") {
@@ -1291,6 +1391,13 @@ export async function startHub({
               });
             }
 
+            const command =
+              body.command ||
+              metadata?.command ||
+              metadata?.cmd ||
+              metadata?.task ||
+              cli;
+            const workerStartedAt = performance.now();
             const heartbeat_ttl_ms = (timeout_sec + 120) * 1000;
             const result = await pipe.executeCommand("register", {
               agent_id,
@@ -1300,6 +1407,13 @@ export async function startHub({
               heartbeat_ttl_ms,
               metadata,
             });
+            if (result.ok) {
+              workerSpans.set(agent_id, {
+                command,
+                startedAt: workerStartedAt,
+              });
+              recordWorker(agent_id, "spawned", command, 0);
+            }
             return writeJson(res, 200, result);
           }
 
@@ -1364,7 +1478,17 @@ export async function startHub({
           }
 
           if (path === "/bridge/publish" && req.method === "POST") {
-            const result = router.handlePublish(normalizePublishBody(body));
+            const normalized = normalizePublishBody(body);
+            const result = router.handlePublish(normalized);
+            if (result.ok) {
+              finishWorkerTrace(
+                normalized.from ||
+                  normalized.agent_id ||
+                  normalized.worker_agent ||
+                  normalized.from_agent,
+                "publish",
+              );
+            }
             return writeJson(res, result.ok ? 200 : 400, result);
           }
 
@@ -1660,6 +1784,9 @@ export async function startHub({
             const result = await pipe.executeCommand("deregister", {
               agent_id,
             });
+            if (result.ok) {
+              finishWorkerTrace(agent_id, "deregister");
+            }
             return writeJson(res, 200, result);
           }
 
@@ -1696,27 +1823,43 @@ export async function startHub({
             session.transport._lastActivity = Date.now();
             await session.transport.handleRequest(req, res, body);
           } else if (!sessionIdHeader && isInitializeRequest(body)) {
+            const client = parseTfxClientHeader(req.headers["x-tfx-client"]);
+            const clientRef = { client };
+            const initializeStarted = performance.now();
             const transport = new StreamableHTTPServerTransport({
               sessionIdGenerator: () => randomUUID(),
               onsessioninitialized: (sid) => {
                 transport._lastActivity = Date.now();
-                transports.set(sid, { transport, mcp });
+                transports.set(sid, {
+                  transport,
+                  mcp,
+                  closing: false,
+                  client,
+                  createdAt: Date.now(),
+                });
               },
             });
             transport.onclose = () => {
-              if (transport.sessionId) {
-                const session = transports.get(transport.sessionId);
-                if (session) {
-                  try {
-                    session.mcp.close();
-                  } catch {}
-                }
-                transports.delete(transport.sessionId);
-              }
+              const sid = transport.sessionId;
+              if (sid)
+                void closeMcpTransportSession(
+                  sid,
+                  transports.get(sid),
+                  "transport.onclose",
+                );
             };
-            const mcp = createMcpForSession();
+            const mcp = createMcpForSession(clientRef);
             await mcp.connect(transport);
-            await transport.handleRequest(req, res, body);
+            try {
+              await transport.handleRequest(req, res, body);
+            } finally {
+              recordRequest(
+                "initialize",
+                performance.now() - initializeStarted,
+                client,
+                "ingress",
+              );
+            }
           } else {
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(
@@ -1803,24 +1946,44 @@ export async function startHub({
     for (const [sid, session] of transports) {
       if (now - (session.transport._lastActivity || 0) <= SESSION_TTL_MS)
         continue;
-      try {
-        session.mcp.close();
-      } catch {}
-      try {
-        session.transport.close();
-      } catch {}
-      transports.delete(sid);
+      void closeMcpTransportSession(sid, session, "session_ttl");
     }
   }, 60000);
   sessionTimer.unref();
 
   // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
+  // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
   const orphanCleanupTimer = setInterval(
     () => {
+      if (process.env.TFX_DISABLE_ORPHAN_CLEANUP === "1") return;
       try {
-        const { killed } = cleanupOrphanNodeProcesses();
-        if (killed > 0) {
-          hubLog.info({ killed }, "hub.orphan_cleanup");
+        const { killed, killedProcesses = [] } = cleanupOrphanNodeProcesses();
+        const {
+          killed: runtimeKilled,
+          killedProcesses: runtimeKilledProcesses = [],
+        } = cleanupOrphanRuntimeProcesses();
+        const totalKilled = killed + runtimeKilled;
+        if (totalKilled > 0) {
+          hubLog.info(
+            {
+              killed: totalKilled,
+              processes: [...killedProcesses, ...runtimeKilledProcesses],
+              caller: "timer",
+            },
+            "hub.orphan_cleanup",
+          );
+        }
+
+        const { killed: fsmonitorKilled, stale } = cleanupStaleFsmonitorDaemons(
+          {
+            minAgeMs: 24 * 60 * 60 * 1000,
+          },
+        );
+        if (fsmonitorKilled > 0) {
+          hubLog.info(
+            { killed: fsmonitorKilled, stale: stale.length },
+            "hub.fsmonitor_cleanup",
+          );
         }
       } catch {}
 
@@ -2027,13 +2190,8 @@ export async function startHub({
               if (idleTimer) {
                 clearInterval(idleTimer);
               }
-              for (const [, session] of transports) {
-                try {
-                  await session.mcp.close();
-                } catch {}
-                try {
-                  await session.transport.close();
-                } catch {}
+              for (const [sid, session] of Array.from(transports)) {
+                await closeMcpTransportSession(sid, session, "hub.stop");
               }
               transports.clear();
               await pipe.stop();
@@ -2099,6 +2257,13 @@ export async function startHub({
             assignCallbacks,
             delegatorService,
             delegatorWorker,
+            getMcpSessions: () =>
+              Array.from(transports.entries()).map(([id, session]) => ({
+                id,
+                client: session.client || "unknown",
+                createdAt: session.createdAt ?? null,
+                closing: Boolean(session.closing),
+              })),
             stop: stopFn,
           });
         } catch (error) {
@@ -2484,7 +2649,34 @@ if (selfRun) {
       const shutdown = async (signal) => {
         hubLog.info({ signal }, "hub.stopping");
         try {
-          cleanupOrphanNodeProcesses();
+          if (process.env.TFX_DISABLE_ORPHAN_CLEANUP !== "1") {
+            const { killed: orphanKilled, killedProcesses = [] } =
+              cleanupOrphanNodeProcesses();
+            const {
+              killed: runtimeKilled,
+              killedProcesses: runtimeKilledProcesses = [],
+            } = cleanupOrphanRuntimeProcesses();
+            const totalKilled = orphanKilled + runtimeKilled;
+            if (totalKilled > 0) {
+              hubLog.info(
+                {
+                  killed: totalKilled,
+                  processes: [...killedProcesses, ...runtimeKilledProcesses],
+                  caller: "shutdown",
+                },
+                "hub.orphan_cleanup",
+              );
+            }
+          }
+          const { killed, stale } = cleanupStaleFsmonitorDaemons({
+            minAgeMs: 24 * 60 * 60 * 1000,
+          });
+          if (killed > 0) {
+            hubLog.info(
+              { killed, stale: stale.length },
+              "hub.fsmonitor_cleanup",
+            );
+          }
         } catch {}
         try {
           cleanupStaleSpawnSessions(hubLog);

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -20,6 +20,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "@triflux/core/hub/account-broker.mjs";
+import {
+  findProcessTree,
+  killProcessTree,
+  killProcessTreeSnapshot,
+} from "@triflux/core/hub/lib/process-utils.mjs";
 import { execFile, spawn } from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { killProcess } from "@triflux/core/hub/platform.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
@@ -152,6 +157,12 @@ function swapAuthFile(lease, agent, sessionId, eventLog) {
  */
 export function createConductor(opts = {}) {
   const spawnFn = opts.deps?.spawn || spawn;
+  const processUtils = {
+    killProcessTree: opts.deps?.killProcessTree || killProcessTree,
+    killProcessTreeSnapshot:
+      opts.deps?.killProcessTreeSnapshot || killProcessTreeSnapshot,
+    findProcessTree: opts.deps?.findProcessTree || findProcessTree,
+  };
   const {
     logsDir,
     maxRestarts = DEFAULT_MAX_RESTARTS,
@@ -324,6 +335,16 @@ export function createConductor(opts = {}) {
     const pid = child.pid;
     if (!pid) return;
 
+    try {
+      if (session.descendantSnapshot?.length > 0) {
+        processUtils.killProcessTreeSnapshot(session.descendantSnapshot);
+      }
+    } catch {
+      /* best-effort cleanup */
+    }
+
+    if (!session.alive) return;
+
     // SIGTERM 먼저
     try {
       child.kill("SIGTERM");
@@ -332,16 +353,24 @@ export function createConductor(opts = {}) {
     }
 
     // Grace period 대기
-    await new Promise((resolve) => {
+    const exited = await new Promise((resolve) => {
       const timer = setTimeout(() => {
-        forceKill(pid);
-        resolve();
+        resolve(false);
       }, graceMs);
       child.once("exit", () => {
         clearTimeout(timer);
-        resolve();
+        resolve(true);
       });
     });
+
+    if (!exited) {
+      try {
+        processUtils.killProcessTree(pid);
+      } catch {
+        forceKill(pid);
+      }
+      session.alive = false;
+    }
   }
 
   /**
@@ -430,7 +459,7 @@ export function createConductor(opts = {}) {
   /**
    * 실패 처리 — restart 또는 DEAD.
    */
-  function handleFailure(session, reason) {
+  async function handleFailure(session, reason) {
     if (TERMINAL_STATES.has(session.state)) return;
 
     transition(session, STATES.FAILED, reason);
@@ -452,6 +481,7 @@ export function createConductor(opts = {}) {
         }
       }, backoffMs);
     } else {
+      await cleanupChild(session);
       transition(session, STATES.DEAD, `maxRestarts(${maxRestarts})_exceeded`);
       emitter.emit("dead", { sessionId: session.id, reason });
 
@@ -569,6 +599,7 @@ export function createConductor(opts = {}) {
     session.child = child;
     session.outPath = outPath;
     session.errPath = errPath;
+    session.descendantSnapshot = [];
 
     // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
     // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
@@ -583,6 +614,19 @@ export function createConductor(opts = {}) {
       legacyCommand: launcher.command,
       restart: session.restarts,
     });
+
+    if (session._descendantSnapshotTimer) {
+      clearTimeout(session._descendantSnapshotTimer);
+    }
+    session._descendantSnapshotTimer = setTimeout(() => {
+      session._descendantSnapshotTimer = null;
+      if (session.child !== child) return;
+      try {
+        session.descendantSnapshot = processUtils.findProcessTree(child.pid);
+      } catch {
+        /* best-effort snapshot */
+      }
+    }, 200);
 
     // stdout+stderr 통합 추적 (F3 해결: stderr만 출력되는 경우도 advancing 판정)
     const trackOutput = (buf) => {
@@ -609,6 +653,10 @@ export function createConductor(opts = {}) {
 
     child.on("exit", (code, signal) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       try {
         outWs.end();
       } catch {
@@ -671,6 +719,10 @@ export function createConductor(opts = {}) {
 
     child.on("error", (err) => {
       session.alive = false;
+      if (session._descendantSnapshotTimer) {
+        clearTimeout(session._descendantSnapshotTimer);
+        session._descendantSnapshotTimer = null;
+      }
       eventLog.append("child_error", {
         session: session.id,
         error: err.message,
@@ -999,6 +1051,7 @@ export function createConductor(opts = {}) {
       outPath: null,
       errPath: null,
       createdAt: Date.now(),
+      descendantSnapshot: [],
     };
 
     sessions.set(resolvedConfig.id, session);
@@ -1087,12 +1140,21 @@ export function createConductor(opts = {}) {
 
     eventLog.append("shutdown", { reason, sessions: sessions.size });
 
+    const cleanedSessionIds = new Set();
     const cleanups = [...sessions.values()]
-      .filter((s) => !TERMINAL_STATES.has(s.state))
+      .filter((s) => {
+        if (cleanedSessionIds.has(s.id)) return false;
+        cleanedSessionIds.add(s.id);
+        return true;
+      })
       .map(async (s) => {
         if (s._respawnTimer) {
           clearTimeout(s._respawnTimer);
           s._respawnTimer = null;
+        }
+        if (s._descendantSnapshotTimer) {
+          clearTimeout(s._descendantSnapshotTimer);
+          s._descendantSnapshotTimer = null;
         }
         s.probe?.stop();
         await cleanupChild(s);

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { cleanupShardProcesses } from "@triflux/core/hub/lib/process-utils.mjs";
 import { getHostConfig } from "@triflux/core/hub/lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
@@ -35,10 +36,10 @@ import {
 } from "./worktree-lifecycle.mjs";
 
 let ensureHubAliveFn = null;
+let getHubInfoFn = null;
 try {
-  ({ ensureHubAlive: ensureHubAliveFn } = await import(
-    "./cli/services/hub-client.mjs"
-  ));
+  ({ ensureHubAlive: ensureHubAliveFn, getHubInfo: getHubInfoFn } =
+    await import("./cli/services/hub-client.mjs"));
 } catch {
   // hub-client 미설치 환경 — Hub 수동 관리 필요
 }
@@ -120,6 +121,35 @@ function createSharedRegistry(factory) {
   }
 }
 
+function hasOwnDep(deps, key) {
+  return Object.hasOwn(deps, key);
+}
+
+function formatHubHostForUrl(host) {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+function resolveHubStatusUrl(hub) {
+  if (!hub) return null;
+
+  if (typeof hub.url === "string" && hub.url.trim()) {
+    try {
+      const url = new URL(hub.url);
+      url.pathname = "/status";
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  const host = typeof hub.host === "string" ? hub.host.trim() : "";
+  const port = Number(hub.port);
+  if (!host || !Number.isFinite(port) || port <= 0) return null;
+  return `http://${formatHubHostForUrl(host)}:${port}/status`;
+}
+
 /**
  * Create a swarm hypervisor.
  * @param {object} opts
@@ -164,8 +194,16 @@ export function createSwarmHypervisor(opts) {
     _deps.rebaseShardOntoIntegration || rebaseShardOntoIntegration;
   const cleanupWorktreeImpl =
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
+  const cleanupShardProcessesImpl =
+    _deps.cleanupShardProcesses || cleanupShardProcesses;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
+  const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
+    ? _deps.ensureHubAlive
+    : ensureHubAliveFn;
+  const getHubInfoImpl = hasOwnDep(_deps, "getHubInfo")
+    ? _deps.getHubInfo
+    : getHubInfoFn;
   const emitter = new EventEmitter();
   const eventLog = createEventLog(join(logsDir, "swarm-events.jsonl"));
   const { registry: sharedRegistry, fallbackReason: meshRegistryFallback } =
@@ -184,6 +222,10 @@ export function createSwarmHypervisor(opts) {
   /** @type {Set<string>} shards that have fully completed (not just launched) */
   const completedShards = new Set();
   const cleanedWorktreePaths = new Set();
+  const processCleanupTotals = {
+    totalKilled: 0,
+    byCategory: {},
+  };
 
   const results = new Map(); // shardName → validated result
   const failures = new Map(); // shardName → failure info
@@ -199,6 +241,10 @@ export function createSwarmHypervisor(opts) {
     integrationFailures: [],
     skipped: [],
     integrationBranch: null,
+    processCleanup: {
+      totalKilled: 0,
+      byCategory: {},
+    },
     error: null,
   };
   const integrationPromise = new Promise((resolve) => {
@@ -263,6 +309,8 @@ export function createSwarmHypervisor(opts) {
       return integrationResult;
     }
 
+    const processCleanup = payload.processCleanup || getProcessCleanupSummary();
+
     integrationResult = Object.freeze({
       integrated: Object.freeze([...(payload.integrated || [])]),
       failed: Object.freeze([...(payload.failed || [])]),
@@ -272,6 +320,10 @@ export function createSwarmHypervisor(opts) {
       skipped: Object.freeze([...(payload.skipped || [])]),
       integrationBranch: payload.integrationBranch || null,
       results: Object.freeze([...(payload.results || [])]),
+      processCleanup: Object.freeze({
+        totalKilled: processCleanup.totalKilled || 0,
+        byCategory: Object.freeze({ ...(processCleanup.byCategory || {}) }),
+      }),
       partial:
         payload.partial ??
         (Array.isArray(payload.failed) && payload.failed.length > 0),
@@ -288,11 +340,37 @@ export function createSwarmHypervisor(opts) {
       integrationFailures: [...integrationResult.integrationFailures],
       skipped: [...integrationResult.skipped],
       integrationBranch: integrationResult.integrationBranch,
+      processCleanup: integrationResult.processCleanup,
       error: integrationResult.error,
     };
 
     resolveIntegrationPromise?.(integrationResult);
     return integrationResult;
+  }
+
+  function getProcessCleanupSummary() {
+    return {
+      totalKilled: processCleanupTotals.totalKilled,
+      byCategory: { ...processCleanupTotals.byCategory },
+    };
+  }
+
+  function recordProcessCleanup(result) {
+    if (!result) return getProcessCleanupSummary();
+
+    const killed = Number(result.killed ?? result.totalKilled ?? 0);
+    if (Number.isFinite(killed) && killed > 0) {
+      processCleanupTotals.totalKilled += killed;
+    }
+
+    for (const [category, count] of Object.entries(result.byCategory || {})) {
+      const numeric = Number(count);
+      if (!Number.isFinite(numeric) || numeric <= 0) continue;
+      processCleanupTotals.byCategory[category] =
+        (processCleanupTotals.byCategory[category] || 0) + numeric;
+    }
+
+    return getProcessCleanupSummary();
   }
 
   function git(args, cwd = workdir) {
@@ -1148,6 +1226,33 @@ export function createSwarmHypervisor(opts) {
     }
 
     try {
+      const snapshot = worker.conductor?.getSnapshot?.();
+      const processCleanup = await cleanupShardProcessesImpl({
+        worktreePath: worker.worktreePath,
+        sessionIds: [worker.sessionId || worker.sessionConfig?.id].filter(
+          Boolean,
+        ),
+        topPids: snapshot?.topPids ?? [],
+        runId: plan?.runId || runId,
+        shardName,
+      });
+      worker.processCleanup = processCleanup;
+      recordProcessCleanup(processCleanup);
+      eventLog.append("process_cleanup", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        killed: processCleanup?.killed ?? 0,
+        byCategory: processCleanup?.byCategory || {},
+      });
+    } catch (err) {
+      eventLog.append("process_cleanup_failed", {
+        shard: shardName,
+        worktreePath: worker.worktreePath,
+        error: err.message,
+      });
+    }
+
+    try {
       await cleanupWorktreeImpl({
         worktreePath: worker.worktreePath,
         branchName,
@@ -1282,6 +1387,12 @@ export function createSwarmHypervisor(opts) {
         integrationFailures: [...integrationPromiseState.integrationFailures],
         skipped: [...integrationPromiseState.skipped],
         integrationBranch: integrationPromiseState.integrationBranch,
+        processCleanup: Object.freeze({
+          totalKilled: integrationPromiseState.processCleanup.totalKilled,
+          byCategory: Object.freeze({
+            ...integrationPromiseState.processCleanup.byCategory,
+          }),
+        }),
         error: integrationPromiseState.error,
       }),
     });
@@ -1298,24 +1409,36 @@ export function createSwarmHypervisor(opts) {
   let hubKeepaliveTimer = null;
   function startHubKeepalive() {
     // 5분마다 Hub /status 핑 — crash 감지 시 ensureHubAlive로 재시작
-    const envPort = Number(process.env.TFX_HUB_PORT || "27888");
-    const hubPort = Number.isFinite(envPort) && envPort > 0 ? envPort : 27888;
     hubKeepaliveTimer = setInterval(
       async () => {
         try {
-          const resp = await fetch(`http://127.0.0.1:${hubPort}/status`);
-          if (!resp.ok && ensureHubAliveFn) {
+          const hub = getHubInfoImpl ? await getHubInfoImpl() : null;
+          const statusUrl = resolveHubStatusUrl(hub);
+          if (!statusUrl) {
+            if (ensureHubAliveImpl) {
+              eventLog.append("hub_keepalive_restart", {
+                reason: "hub_url_unresolved",
+              });
+              await ensureHubAliveImpl();
+            }
+            return;
+          }
+
+          const resp = await fetch(statusUrl, {
+            signal: AbortSignal.timeout(5000),
+          });
+          if (!resp.ok && ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {});
-            await ensureHubAliveFn();
+            await ensureHubAliveImpl();
           }
         } catch {
           // Hub 다운 — 재시작 시도
-          if (ensureHubAliveFn) {
+          if (ensureHubAliveImpl) {
             eventLog.append("hub_keepalive_restart", {
               reason: "fetch_failed",
             });
             try {
-              await ensureHubAliveFn();
+              await ensureHubAliveImpl();
             } catch {
               eventLog.append("hub_restart_failed", {});
             }
@@ -1342,8 +1465,8 @@ export function createSwarmHypervisor(opts) {
     markIntegrationPromisePending();
 
     // Hub alive 확인 — 죽어있으면 재시작
-    if (ensureHubAliveFn) {
-      ensureHubAliveFn()
+    if (ensureHubAliveImpl) {
+      ensureHubAliveImpl()
         .then((hub) => {
           eventLog.append("hub_ensured", { port: hub?.port });
         })
@@ -1438,11 +1561,21 @@ export function createSwarmHypervisor(opts) {
     await Promise.allSettled(shutdowns);
 
     if (!keepFailedWorktrees) {
-      for (const [shardName, failureInfo] of failures) {
-        const worker = workers.get(shardName);
+      const cleanupCandidates = new Map();
+      for (const [shardName, worker] of workers) {
+        cleanupCandidates.set(shardName, worker);
+      }
+      for (const [shardName, worker] of redundantWorkers) {
+        cleanupCandidates.set(`${shardName}:redundant`, worker);
+      }
+
+      for (const [candidateName, worker] of cleanupCandidates) {
+        const shardName = worker?.shardConfig?.name || candidateName;
+        const failureInfo = failures.get(shardName);
         const shard =
           worker?.shardConfig ||
           plan?.shards.find((item) => item.name === shardName);
+        if (!worker?.worktreePath) continue;
         await maybeCleanupWorktree(shardName, worker, shard, {
           force: true,
           failureReason: failureInfo?.mode || failureInfo?.reason || reason,

--- a/packages/remote/hub/team/worktree-lifecycle.mjs
+++ b/packages/remote/hub/team/worktree-lifecycle.mjs
@@ -84,6 +84,30 @@ function git(args, cwd) {
   });
 }
 
+/**
+ * Best-effort shutdown for the Git fsmonitor daemon attached to a worktree.
+ * Missing or already-stopped daemons are treated as successful no-ops because
+ * cleanup should not be blocked by watcher state.
+ *
+ * @param {string} worktreePath
+ * @param {(args: string[], cwd: string) => Promise<string>} [gitImpl=git]
+ * @returns {Promise<{ ok: boolean, stopped: boolean, reason?: 'not_running', error?: string }>}
+ */
+async function stopFsmonitorDaemon(worktreePath, gitImpl = git) {
+  try {
+    await gitImpl(["fsmonitor--daemon", "stop"], worktreePath);
+    return { ok: true, stopped: true };
+  } catch (err) {
+    const msg = String(err?.message || err || "");
+    if (
+      /not running|not watching|fsmonitor--daemon is not running/iu.test(msg)
+    ) {
+      return { ok: true, stopped: false, reason: "not_running" };
+    }
+    return { ok: false, stopped: false, error: msg };
+  }
+}
+
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -129,10 +153,10 @@ function resolveCleanupTarget(worktreePath, rootDir) {
   };
 }
 
-async function branchExists(branchName, rootDir) {
+async function branchExists(branchName, rootDir, gitImpl = git) {
   if (!branchName) return false;
   try {
-    const listed = await git(["branch", "--list", branchName], rootDir);
+    const listed = await gitImpl(["branch", "--list", branchName], rootDir);
     return listed.trim().length > 0;
   } catch {
     return false;
@@ -419,13 +443,15 @@ export async function cleanupWorktree({
   branchName,
   rootDir = process.cwd(),
   force = false,
+  _git = git,
 }) {
   const { resolvedWorktree } = resolveCleanupTarget(worktreePath, rootDir);
+  const fsmonitorStop = await stopFsmonitorDaemon(resolvedWorktree, _git);
   const forceArgs = force ? ["--force"] : [];
 
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      await git(
+      await _git(
         ["worktree", "remove", ...forceArgs, resolvedWorktree],
         rootDir,
       );
@@ -444,18 +470,20 @@ export async function cleanupWorktree({
 
   await sleep(SLEEP_MS);
   try {
-    await git(["worktree", "prune"], rootDir);
+    await _git(["worktree", "prune"], rootDir);
   } catch {
     /* best-effort */
   }
 
-  if (branchName && (await branchExists(branchName, rootDir))) {
+  if (branchName && (await branchExists(branchName, rootDir, _git))) {
     try {
-      await git(["branch", "-D", branchName], rootDir);
+      await _git(["branch", "-D", branchName], rootDir);
     } catch {
       /* branch may already be gone */
     }
   }
+
+  return { ok: true, fsmonitorStop };
 }
 
 /**
@@ -496,14 +524,14 @@ export async function pruneWorktree({
     }
   }
 
-  await cleanupWorktree({
+  const cleanupResult = await cleanupWorktree({
     worktreePath,
     branchName,
     rootDir,
     force,
   });
 
-  return { ok: true };
+  return { ok: true, fsmonitorStop: cleanupResult.fsmonitorStop };
 }
 
 /**
@@ -548,6 +576,7 @@ export async function pruneOrphanWorktrees({ rootDir = process.cwd() } = {}) {
     const normalized = normPath(fullPath);
     if (!registeredPaths.has(normalized)) {
       try {
+        await stopFsmonitorDaemon(fullPath).catch(() => null);
         await rm(fullPath, { recursive: true, force: true });
         removed.push(dir);
       } catch {

--- a/packages/remote/hub/workers/codex-mcp.mjs
+++ b/packages/remote/hub/workers/codex-mcp.mjs
@@ -116,6 +116,22 @@ function withTimeout(promise, timeoutMs, message) {
   });
 }
 
+// Known noise-only output patterns from codex MCP that indicate transport failure
+// despite exitCode=0. Each entry is matched after trim() against the full output
+// string. Length cap is applied separately to avoid masking real responses that
+// happen to contain a noise substring as a header line.
+const NOISE_ONLY_OUTPUT_PATTERNS = Object.freeze([
+  /^MCP issues detected\.\s*Run \/mcp list for status\.?$/i,
+]);
+const NOISE_ONLY_MAX_BYTES = 256;
+
+function isNoiseOnlyOutput(text) {
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > NOISE_ONLY_MAX_BYTES) return false;
+  return NOISE_ONLY_OUTPUT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 function watchBootstrapClose(transport) {
   let active = true;
   const promise = new Promise((_, reject) => {
@@ -610,6 +626,7 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     const result = await worker.execute(options.prompt, options);
     const hasOutput =
       typeof result.output === "string" && result.output.trim().length > 0;
+    const noiseOnly = hasOutput && isNoiseOnlyOutput(result.output);
     if (hasOutput) {
       process.stdout.write(result.output);
       if (!result.output.endsWith("\n")) {
@@ -622,11 +639,23 @@ export async function runCodexMcpCli(argv = process.argv.slice(2)) {
     // response. Without this guard, tfx-route.sh sees STDOUT_LOG=0 bytes and
     // treats it as success — caller gets nothing back.
     // Promote to a transport failure so the wrapper falls back to `codex exec`.
+    //
+    // Noise-only guard (codex 0.125.0+, P2 swarm signature):
+    // codex MCP can also return exitCode=0 with a short noise-only message like
+    // "MCP issues detected. Run /mcp list for status." (~48 bytes) instead of
+    // an actual response payload. trim().length > 0 passes the empty-output
+    // check, so the previous guard misses this case. Pattern-match known noise
+    // strings under a small length cap and promote to transport failure too.
     if (result.error?.code === "CODEX_TRANSPORT_ERROR") {
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else if (!hasOutput && result.exitCode === 0) {
       console.error(
         "[codex-mcp] WARNING: empty output with exit 0 — treating as transport failure (codex 0.124.0 silent-flush regression). Wrapper will fall back to exec path.",
+      );
+      process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
+    } else if (noiseOnly && result.exitCode === 0) {
+      console.error(
+        "[codex-mcp] WARNING: noise-only output (codex MCP error string without payload) with exit 0 — treating as transport failure. Wrapper will fall back to exec path.",
       );
       process.exitCode = CODEX_MCP_TRANSPORT_EXIT_CODE;
     } else {

--- a/packages/remote/hub/workers/factory.mjs
+++ b/packages/remote/hub/workers/factory.mjs
@@ -28,8 +28,7 @@ function defaultPublishCallback(requestJsonFn = null) {
   return async (publishMessage) => {
     try {
       const publishRequestJson =
-        requestJsonFn ||
-        (await import("@triflux/core/hub/bridge.mjs")).requestJson;
+        requestJsonFn || (await import("../bridge.mjs")).requestJson;
       await publishRequestJson("/bridge/publish", { body: publishMessage });
     } catch {
       // best-effort; publish failures must not crash the worker

--- a/packages/remote/scripts/lib/codex-recovery.sh
+++ b/packages/remote/scripts/lib/codex-recovery.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# codex-recovery.sh — codex exec stdout 4계단 recovery helper.
+# 사용: STDOUT_LOG / STDERR_LOG env 설정 후 `source` + `recover_codex_stdout`.
+#
+# 1차 codex marker  → stderr 의 마지막 "codex" 라인 이후 본문 회수
+# 2차 node parser   → MCP/header/sandbox 로그 제외, 응답 부분만 추출
+# 3차 stderr tail   → "tokens used" 직전까지 tail buffer 회수
+# 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
+
+recover_codex_stdout() {
+  if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
+    return 0
+  fi
+
+  # 1차: codex marker
+  sed 's/\r$//' "$STDERR_LOG" \
+    | awk '/^codex$/{found=NR;content=""} found && NR>found{content=content RS $0} END{if(content) print substr(content,2)}' \
+    > "$STDOUT_LOG"
+
+  # 2차: node parser (MCP/header/sandbox 로그 제외)
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    node -e '
+      const fs=require("fs"),lines=fs.readFileSync(process.argv[1],"utf-8").split(/\r?\n/);
+      const skip=/^(mcp[: ]|OpenAI Codex|--------|workdir:|model:|provider:|approval:|sandbox:|reasoning|session id:|user$|tokens used|EXIT:|exec$|"[A-Z]:|succeeded in |\s*$)/;
+      const out=lines.filter(l=>!skip.test(l));
+      if(out.length) fs.writeFileSync(process.argv[2],out.join("\n"));
+    ' -- "$STDERR_LOG" "$STDOUT_LOG" 2>/dev/null || true
+  fi
+
+  # 3차: stderr tail before "tokens used"
+  if [[ ! -s "$STDOUT_LOG" ]]; then
+    sed 's/\r$//' "$STDERR_LOG" \
+      | awk '
+          /^tokens used/ { exit }
+          { buf[NR]=$0 }
+          END {
+            start=NR-200; if (start<1) start=1
+            for (i=start; i<=NR; i++) if (i in buf) print buf[i]
+          }' \
+      > "$STDOUT_LOG"
+  fi
+
+  if [[ -s "$STDOUT_LOG" ]]; then
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr에서 응답 복구 ($(wc -c < "$STDOUT_LOG" | tr -d ' ') bytes)" >&2
+  else
+    # 4차: FALLBACK_FAILED
+    echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
+    echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
+  fi
+}

--- a/packages/remote/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/remote/scripts/lib/mcp-guard-engine.mjs
@@ -10,7 +10,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
-const REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
+const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
 const DEFAULT_REGISTRY = Object.freeze({
@@ -20,6 +20,14 @@ const DEFAULT_REGISTRY = Object.freeze({
   defaults: {
     transport: "hub-url",
     hub_base: "http://127.0.0.1:27888",
+  },
+  policy_notes: {
+    transport:
+      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+    headers:
+      'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
+    secret_safety:
+      "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
   },
   servers: {
     "tfx-hub": {
@@ -33,6 +41,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   policies: {
     stdio_action: "replace-with-hub",
     unknown_server_action: "warn",
+    sync_denylist: [],
     watched_paths: [
       "~/.gemini/settings.json",
       "~/.codex/config.toml",
@@ -81,6 +90,12 @@ function readJsonFile(filePath) {
 function writeJsonFile(filePath, data) {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function registryPath() {
+  return process.env.TFX_MCP_REGISTRY_PATH
+    ? resolve(process.env.TFX_MCP_REGISTRY_PATH)
+    : DEFAULT_REGISTRY_PATH;
 }
 
 function ensureBackup(filePath) {
@@ -175,10 +190,57 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("{") && value.endsWith("}")) {
+    return parseTomlInlineTable(value);
+  }
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlInlineTable(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return {};
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  const table = {};
+  for (const part of parts) {
+    const match = part.match(
+      /^\s*(?:"((?:\\"|[^"])*)"|([A-Za-z0-9_-]+))\s*=\s*(.+?)\s*$/,
+    );
+    if (!match) continue;
+    const key = (match[1] || match[2] || "")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
+    table[key] = parseTomlScalar(match[3]);
+  }
+  return table;
 }
 
 function parseCodexMcpServers(raw) {
@@ -209,6 +271,179 @@ function parseCodexMcpServers(raw) {
   return servers;
 }
 
+function isValidHeaderName(name) {
+  return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
+}
+
+function normalizeHeaderDescriptors(headers = {}) {
+  const normalized = {};
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(headers)) {
+    if (!isValidHeaderName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor)
+    ) {
+      if (
+        Object.hasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
+      ) {
+        normalized[name] = { value: descriptor.value };
+      } else if (
+        Object.hasOwn(descriptor, "env") &&
+        typeof descriptor.env === "string" &&
+        descriptor.env.trim()
+      ) {
+        normalized[name] = { env: descriptor.env.trim() };
+        if (typeof descriptor.prefix === "string") {
+          normalized[name].prefix = descriptor.prefix;
+        }
+      }
+    }
+  }
+  return normalized;
+}
+
+function resolveHeaderDescriptors(name, serverConfig, filePath) {
+  const descriptors = normalizeHeaderDescriptors(serverConfig?.headers || {});
+  const headers = {};
+  const warnings = [];
+  const codex = {
+    bearer_token_env_var: null,
+    env_http_headers: {},
+    http_headers: {},
+  };
+  const codexTarget = isCodexConfig(filePath);
+
+  for (const [headerName, descriptor] of Object.entries(descriptors)) {
+    if (Object.hasOwn(descriptor, "value")) {
+      headers[headerName] = descriptor.value;
+      if (codexTarget) codex.http_headers[headerName] = descriptor.value;
+      continue;
+    }
+
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    const prefix = descriptor.prefix || "";
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+
+    headers[headerName] = `${prefix}${envValue}`;
+
+    if (!codexTarget) continue;
+
+    if (
+      headerName.toLowerCase() === "authorization" &&
+      /^Bearer\s+$/i.test(prefix)
+    ) {
+      codex.bearer_token_env_var = envName;
+    } else if (!prefix) {
+      codex.env_http_headers[headerName] = envName;
+    } else {
+      codex.http_headers[headerName] = `${prefix}${envValue}`;
+      warnings.push(
+        `[mcp-guard] ${name}.${headerName} header uses resolved literal in Codex TOML because prefixed env headers are unsupported`,
+      );
+    }
+  }
+
+  return {
+    descriptors,
+    headers,
+    warnings,
+    codex: {
+      ...(codex.bearer_token_env_var
+        ? { bearer_token_env_var: codex.bearer_token_env_var }
+        : {}),
+      env_http_headers: codex.env_http_headers,
+      http_headers: codex.http_headers,
+    },
+  };
+}
+
+function hasOwnEntries(value) {
+  return value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function redactHeaders(headers = {}) {
+  const redacted = {};
+  for (const key of Object.keys(headers || {})) {
+    redacted[key] = "***REDACTED***";
+  }
+  return redacted;
+}
+
+function redactServerConfig(config = {}) {
+  if (!config || typeof config !== "object") return config;
+  return {
+    ...config,
+    ...(config.headers ? { headers: redactHeaders(config.headers) } : {}),
+  };
+}
+
+function descriptorsFromCodexConfig(config = {}) {
+  const descriptors = {};
+  if (typeof config.bearer_token_env_var === "string") {
+    descriptors.Authorization = {
+      env: config.bearer_token_env_var,
+      prefix: "Bearer ",
+    };
+  }
+  if (config.env_http_headers && typeof config.env_http_headers === "object") {
+    for (const [name, envName] of Object.entries(config.env_http_headers)) {
+      if (typeof envName === "string") descriptors[name] = { env: envName };
+    }
+  }
+  if (config.http_headers && typeof config.http_headers === "object") {
+    for (const [name, value] of Object.entries(config.http_headers)) {
+      if (typeof value === "string") descriptors[name] = { value };
+    }
+  }
+  return descriptors;
+}
+
+function descriptorsFromJsonConfig(config = {}) {
+  const descriptors = {};
+  if (!config?.headers || typeof config.headers !== "object") {
+    return descriptors;
+  }
+  for (const [name, value] of Object.entries(config.headers)) {
+    if (typeof value === "string") descriptors[name] = { value };
+  }
+  return descriptors;
+}
+
+function headerNames(headers = {}) {
+  return Object.keys(headers || {}).sort();
+}
+
+function sameHeaderDescriptors(left = {}, right = {}) {
+  const leftNames = headerNames(left);
+  const rightNames = headerNames(right);
+  if (JSON.stringify(leftNames) !== JSON.stringify(rightNames)) return false;
+  return leftNames.every(
+    (name) => JSON.stringify(left[name]) === JSON.stringify(right[name]),
+  );
+}
+
+function headerStatus(expected = {}, actual = {}) {
+  const expectedNames = headerNames(expected);
+  const actualNames = headerNames(actual);
+  if (expectedNames.length === 0 && actualNames.length === 0) return "ok";
+  if (expectedNames.some((name) => !Object.hasOwn(actual, name))) {
+    return "missing";
+  }
+  if (!sameHeaderDescriptors(expected, actual)) return "stale";
+  return "ok";
+}
+
 function removeTomlSection(raw, sectionName) {
   const lines = String(raw || "").split(/\r?\n/);
   const output = [];
@@ -235,12 +470,68 @@ function removeTomlSection(raw, sectionName) {
   return cleaned.length > 0 ? cleaned.replace(/\n{3,}/g, "\n\n") : "";
 }
 
-function upsertTomlUrlServer(raw, name, url) {
-  const section = [`[mcp_servers.${name}]`, `url = ${formatTomlString(url)}`];
-  const withoutExisting = removeTomlSection(raw, name).trimEnd();
-  return withoutExisting.length > 0
-    ? `${withoutExisting}\n\n${section.join("\n")}\n`
-    : `${section.join("\n")}\n`;
+function formatTomlInlineTable(data = {}) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return null;
+  return `{ ${entries
+    .map(
+      ([key, value]) => `${formatTomlString(key)} = ${formatTomlString(value)}`,
+    )
+    .join(", ")} }`;
+}
+
+function upsertTomlServer(raw, name, config, codex = {}) {
+  const lines = String(raw || "").split(/\r?\n/);
+  const header = `[mcp_servers.${name}]`;
+  const managedKeys = new Set([
+    "url",
+    "command",
+    "args",
+    "bearer_token_env_var",
+    "http_headers",
+    "env_http_headers",
+  ]);
+  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  if (codex.bearer_token_env_var) {
+    nextManagedLines.push(
+      `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
+    );
+  }
+  const httpHeaders = formatTomlInlineTable(codex.http_headers || {});
+  if (httpHeaders) nextManagedLines.push(`http_headers = ${httpHeaders}`);
+  const envHttpHeaders = formatTomlInlineTable(codex.env_http_headers || {});
+  if (envHttpHeaders) {
+    nextManagedLines.push(`env_http_headers = ${envHttpHeaders}`);
+  }
+
+  const sectionStart = lines.findIndex((line) => line.trim() === header);
+  if (sectionStart < 0) {
+    const section = [header, ...nextManagedLines].join("\n");
+    const withoutTrailing = String(raw || "").trimEnd();
+    return withoutTrailing.length > 0
+      ? `${withoutTrailing}\n\n${section}\n`
+      : `${section}\n`;
+  }
+
+  const output = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    output.push(lines[index]);
+    if (index !== sectionStart) continue;
+
+    index += 1;
+    const preserved = [];
+    while (index < lines.length && !/^\s*\[/.test(lines[index])) {
+      const keyMatch = lines[index].match(/^\s*([A-Za-z0-9_]+)\s*=/);
+      if (!keyMatch || !managedKeys.has(keyMatch[1])) {
+        preserved.push(lines[index]);
+      }
+      index += 1;
+    }
+    output.push(...nextManagedLines, ...preserved.filter(Boolean));
+    index -= 1;
+  }
+
+  return output.join("\n");
 }
 
 function getHubServerEntry(registry) {
@@ -282,22 +573,69 @@ function serverAppliesToClient(serverConfig, client) {
   return serverTargets(serverConfig).includes(client);
 }
 
-function buildDesiredServerRecord(name, serverConfig, filePath) {
+function syncDenylistEntries(policy = {}) {
+  if (!Array.isArray(policy?.sync_denylist)) return new Set();
+  return new Set(
+    policy.sync_denylist
+      .map((entry) =>
+        String(entry || "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+}
+
+function syncDenylistKey(client, serverName) {
+  return `${String(client || "")
+    .trim()
+    .toLowerCase()}:${String(serverName || "")
+    .trim()
+    .toLowerCase()}`;
+}
+
+export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
       : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
+  const resolvedHeaders = resolveHeaderDescriptors(
+    name,
+    serverConfig,
+    filePath,
+  );
+  const headerConfig = hasOwnEntries(resolvedHeaders.headers)
+    ? { headers: resolvedHeaders.headers }
+    : {};
 
   if (basenameValue === ".mcp.json" || isClaudeProjectMcpConfig(filePath)) {
-    return { name, config: { type: "http", url } };
+    return {
+      name,
+      config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
   if (isCodexConfig(filePath)) {
-    return { name, config: { url } };
+    return {
+      name,
+      config: { url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
   }
 
-  return { name, config: { url } };
+  return {
+    name,
+    config: { url, ...headerConfig },
+    headerDescriptors: resolvedHeaders.descriptors,
+    codex: resolvedHeaders.codex,
+    warnings: resolvedHeaders.warnings,
+  };
 }
 
 function scanJsonConfig(filePath) {
@@ -332,6 +670,17 @@ function scanJsonConfig(filePath) {
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
               type: typeof config.type === "string" ? config.type : "",
+              headers:
+                config.headers &&
+                typeof config.headers === "object" &&
+                !Array.isArray(config.headers)
+                  ? Object.fromEntries(
+                      Object.entries(config.headers).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
+              headerDescriptors: descriptorsFromJsonConfig(config),
               transport:
                 typeof config.url === "string" && config.url
                   ? "url"
@@ -383,6 +732,11 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      headers:
+        config.http_headers && typeof config.http_headers === "object"
+          ? config.http_headers
+          : {},
+      headerDescriptors: descriptorsFromCodexConfig(config),
       transport:
         typeof config.url === "string" && config.url
           ? "url"
@@ -450,6 +804,9 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (!Object.hasOwn(update.config, "headers")) {
+      delete nextConfig.headers;
+    }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
     if (changed) {
@@ -484,7 +841,7 @@ function updateCodexConfig(filePath, updates = [], removals = []) {
   }
 
   for (const update of updates) {
-    raw = upsertTomlUrlServer(raw, update.name, update.config.url);
+    raw = upsertTomlServer(raw, update.name, update.config, update.codex || {});
   }
 
   const finalRaw = raw.trim().length > 0 ? `${raw.trimEnd()}\n` : "";
@@ -517,7 +874,7 @@ function scanConfig(filePath) {
 }
 
 export function getRegistryPath() {
-  return REGISTRY_PATH;
+  return registryPath();
 }
 
 export function createDefaultRegistry() {
@@ -557,6 +914,104 @@ export function validateRegistry(registry) {
       if (typeof server.url !== "string" || !server.url.trim()) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url or http`,
+        );
+      }
+      if (server.command !== undefined) {
+        errors.push(
+          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.args !== undefined) {
+        errors.push(
+          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
+        );
+      }
+      if (server.headers !== undefined) {
+        if (!["hub-url", "http"].includes(transport)) {
+          errors.push(
+            `registry.servers.${name}.headers is allowed only for HTTP-compatible transports`,
+          );
+        }
+        if (
+          !server.headers ||
+          typeof server.headers !== "object" ||
+          Array.isArray(server.headers)
+        ) {
+          errors.push(`registry.servers.${name}.headers must be an object`);
+        } else {
+          for (const [headerName, descriptor] of Object.entries(
+            server.headers,
+          )) {
+            if (!isValidHeaderName(headerName)) {
+              errors.push(
+                `registry.servers.${name}.headers contains invalid header name ${headerName}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            const hasValue = Object.hasOwn(descriptor, "value");
+            const hasEnv = Object.hasOwn(descriptor, "env");
+            if (hasValue && hasEnv) {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use either value or env`,
+              );
+            } else if (hasValue) {
+              if (
+                keys.length !== 1 ||
+                typeof descriptor.value !== "string" ||
+                descriptor.value.length === 0
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.value must be a non-empty string`,
+                );
+              }
+            } else if (hasEnv) {
+              if (
+                !["env", "prefix"].every((key) => keys.includes(key)) &&
+                keys.some((key) => !["env", "prefix"].includes(key))
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName} supports only env and optional prefix`,
+                );
+              }
+              if (
+                typeof descriptor.env !== "string" ||
+                !descriptor.env.trim()
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.env must be a non-empty string`,
+                );
+              }
+              if (
+                descriptor.prefix !== undefined &&
+                typeof descriptor.prefix !== "string"
+              ) {
+                errors.push(
+                  `registry.servers.${name}.headers.${headerName}.prefix must be a string`,
+                );
+              }
+            } else {
+              errors.push(
+                `registry.servers.${name}.headers.${headerName} must use value or env`,
+              );
+            }
+          }
+        }
+      }
       if (server.targets !== undefined && !Array.isArray(server.targets)) {
         errors.push(`registry.servers.${name}.targets must be an array`);
       }
@@ -574,6 +1029,22 @@ export function validateRegistry(registry) {
       errors.push("registry.policies.watched_paths must be an array");
     }
     if (
+      registry.policies.sync_denylist !== undefined &&
+      !Array.isArray(registry.policies.sync_denylist)
+    ) {
+      errors.push("registry.policies.sync_denylist must be an array");
+    }
+    if (Array.isArray(registry.policies.sync_denylist)) {
+      for (const entry of registry.policies.sync_denylist) {
+        if (typeof entry !== "string" || !entry.includes(":")) {
+          errors.push(
+            "registry.policies.sync_denylist entries must use client:server format",
+          );
+          break;
+        }
+      }
+    }
+    if (
       registry.policies.stdio_action &&
       !["replace-with-hub", "warn"].includes(registry.policies.stdio_action)
     ) {
@@ -587,9 +1058,9 @@ export function validateRegistry(registry) {
 }
 
 export function inspectRegistry() {
-  if (!existsSync(REGISTRY_PATH)) {
+  if (!existsSync(registryPath())) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: false,
       valid: false,
       errors: ["registry file missing"],
@@ -598,10 +1069,10 @@ export function inspectRegistry() {
   }
 
   try {
-    const registry = readJsonFile(REGISTRY_PATH);
+    const registry = readJsonFile(registryPath());
     const errors = validateRegistry(registry);
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: errors.length === 0,
       errors,
@@ -609,7 +1080,7 @@ export function inspectRegistry() {
     };
   } catch (error) {
     return {
-      path: REGISTRY_PATH,
+      path: registryPath(),
       exists: true,
       valid: false,
       errors: [error.message],
@@ -651,7 +1122,7 @@ export function saveRegistry(registry) {
   if (errors.length > 0) {
     throw new Error(`MCP registry invalid: ${errors.join("; ")}`);
   }
-  writeJsonFile(REGISTRY_PATH, registry);
+  writeJsonFile(registryPath(), registry);
   return registry;
 }
 
@@ -698,13 +1169,19 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
     );
 
     for (const [name, serverConfig] of managedServers) {
-      const expectedUrl = buildDesiredServerRecord(
+      const desired = buildDesiredServerRecord(
         name,
         serverConfig,
         config.filePath,
-      ).config.url;
+      );
+      const expectedUrl = desired.config.url;
+      const expectedHeaders = isCodexConfig(config.filePath)
+        ? desired.headerDescriptors || {}
+        : descriptorsFromJsonConfig(desired.config);
       const actual =
         config.servers.find((server) => server.name === name) || null;
+      const actualHeaders = actual?.headerDescriptors || {};
+      const currentHeaderStatus = headerStatus(expectedHeaders, actualHeaders);
       let status = "missing";
 
       if (!config.exists) {
@@ -716,7 +1193,7 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
-        status = "present";
+        status = currentHeaderStatus === "ok" ? "present" : "mismatch";
       } else {
         status = "mismatch";
       }
@@ -730,6 +1207,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         expectedUrl,
         actualUrl: actual?.url || "",
         status,
+        headerStatus: currentHeaderStatus,
+        expectedHeaderNames: headerNames(expectedHeaders),
+        actualHeaderNames: headerNames(actualHeaders),
       });
     }
 
@@ -828,14 +1308,19 @@ export function remediate(filePath, stdioServers, policy = {}) {
   let replacement = null;
 
   if (action === "replace-with-hub") {
-    const registry = loadRegistryOrDefault();
-    const [hubServerName, hubServerConfig] = getHubServerEntry(registry);
+    const registry = policy.registry || loadRegistryOrDefault();
+    const matchingOffender = offenders.find((server) =>
+      Object.hasOwn(registry.servers || {}, server.name),
+    );
+    const [hubServerName, hubServerConfig] = matchingOffender
+      ? [matchingOffender.name, registry.servers[matchingOffender.name]]
+      : getHubServerEntry(registry);
     const desired = buildDesiredServerRecord(
       hubServerName,
       hubServerConfig,
       resolvedPath,
     );
-    replacement = { name: desired.name, ...desired.config };
+    replacement = { name: desired.name, ...redactServerConfig(desired.config) };
     updates.push(desired);
   }
 
@@ -846,7 +1331,7 @@ export function remediate(filePath, stdioServers, policy = {}) {
     backupPath,
     removedServers: removals,
     replacement,
-    warnings: [],
+    warnings: updates.flatMap((update) => update.warnings || []),
   };
 }
 
@@ -1032,10 +1517,13 @@ export function removeServerFromTargets(name, options = {}) {
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
   const actions = [];
+  const invalidConfigs = new Set();
+  const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of listManagedConfigTargets(registry)) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
+      invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
         type: "sync",
         filePath: target.filePath,
@@ -1047,11 +1535,10 @@ export function syncRegistryTargets(options = {}) {
     }
 
     if (snapshot.stdioServers.length > 0) {
-      const remediation = remediate(
-        target.filePath,
-        snapshot.stdioServers,
-        registry.policies,
-      );
+      const remediation = remediate(target.filePath, snapshot.stdioServers, {
+        ...registry.policies,
+        registry,
+      });
       actions.push({
         type: "remediate",
         filePath: target.filePath,
@@ -1065,13 +1552,49 @@ export function syncRegistryTargets(options = {}) {
   }
 
   for (const target of listPrimaryConfigTargets(registry)) {
-    const updates = Object.entries(registry.servers || {})
-      .filter(([, serverConfig]) =>
-        serverAppliesToClient(serverConfig, target.client),
-      )
-      .map(([name, serverConfig]) =>
+    const snapshot = scanConfig(target.filePath);
+    const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.parseError) {
+      if (!invalidConfigs.has(targetKey)) {
+        actions.push({
+          type: "sync",
+          filePath: target.filePath,
+          label: target.label,
+          status: "invalid-config",
+          message: snapshot.parseError.message,
+        });
+      }
+      continue;
+    }
+
+    const updates = [];
+    for (const [name, serverConfig] of Object.entries(registry.servers || {})) {
+      if (serverConfig?.safe !== true) continue;
+      if (!serverAppliesToClient(serverConfig, target.client)) continue;
+
+      const denyKey = syncDenylistKey(target.client, name);
+      if (denylist.has(denyKey)) {
+        const existing = snapshot.servers.find(
+          (server) => server.name === name,
+        );
+        if (!existing) {
+          actions.push({
+            type: "sync",
+            filePath: target.filePath,
+            label: target.label,
+            status: "policy-skip",
+            server: name,
+            client: target.client,
+            message: `[mcp-guard] policy skip: ${denyKey}`,
+          });
+        }
+        continue;
+      }
+
+      updates.push(
         buildDesiredServerRecord(name, serverConfig, target.filePath),
       );
+    }
 
     if (updates.length === 0) continue;
 
@@ -1090,6 +1613,7 @@ export function syncRegistryTargets(options = {}) {
       label: target.label,
       status: result.modified ? "updated" : "ok",
       serverCount: updates.length,
+      warnings: updates.flatMap((update) => update.warnings || []),
     });
   }
 


### PR DESCRIPTION
## Summary
- root `hub/*`, `scripts/lib/*` 의 v10.18.0 (7c02c19) 상태를 `packages/{core,remote}` 로 동기화
- PR #209 (codex-recovery), PR #218 (trace-recorder + per-CLI label) 머지 시점에 packages/* mirror 가 함께 포함되지 않아 누적된 drift 해소
- 16 files changed (13 modified + 3 new), 2682 insertions, 263 deletions

## Scope
- `packages/core/*` 6 modified + 2 new — 단순 cp (root 와 byte-identical)
- `packages/remote/*` 7 modified + 1 new — import path 변환 적용 (`../foo.mjs` → `@triflux/core/hub/foo.mjs`, `feedback_remote_package_mirror.md` 룰 준수)

## Verification
- IDENTICAL 9개 (`packages/{core,remote}/...` ≡ root) — `diff -q` 결과 빈 출력
- DIFFERENT 4개 (모두 `packages/remote/*`) — import path 변환만 차이, 그 외 byte-identical
- 추가 코드 변경 없음, root 의 검증된 코드 그대로 mirror

## Test plan
- [ ] CI green (lint + test) 확인
- [ ] sanity import smoke 테스트 (`packages/core/hub/account-broker.mjs#isDisabled` getter 등 선택적)
- [ ] merge 후 다음 release 시점에 stash drift 재발 여부 모니터링

## Follow-up
- 별도 PRD 보류: `packages/*` gitignore + `pack.mjs` publish 시점 자동 생성 → drift 원천 차단