### PR TITLE
fix(release): F3 — bypass npm wrapper in prepare.mjs npm-test step (#192)

### DIFF
--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -191,8 +191,13 @@ describe("release governance scripts", () => {
       });
       assert.equal(executed.skipTests, false);
 
+      // F3 (issue #192): test step 의 command 가 "npm test" 에서 직접 node
+      // test-lock.mjs 호출로 바뀜. legacy npm test 와 F3 후 node test-lock.mjs
+      // 둘 다 인식.
       const testCall = calls.find(
-        (call) => call.command === "npm" && call.args.join(" ") === "test",
+        (call) =>
+          (call.command === "npm" && call.args.join(" ") === "test") ||
+          (call.args[0] && call.args[0].endsWith("test-lock.mjs")),
       );
       assert.ok(testCall);
       assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);

--- a/packages/triflux/scripts/release/prepare.mjs
+++ b/packages/triflux/scripts/release/prepare.mjs
@@ -64,23 +64,32 @@ export async function prepareRelease({
   const steps = [
     {
       name: "npm-test",
-      command: "npm",
-      args: ["test"],
+      // F3 fix (issue #192 — silent EXIT 0 회귀 우회):
+      // npm wrapper 경유 시 prepare.mjs process 가 native level 에서 hard kill
+      // 됨 (process.on("exit") 핸들러 호출 안 됨, EXIT 0 silent, 후속 lint/pack
+      // step 누락). 2026-04-30 진단 세션에서 5 시나리오 reproduce 결과:
+      //   - npm wrapper 경유 + npm test 실행: silent EXIT 0 재현 (12-24s 비결정)
+      //   - 직접 node 실행 또는 npm test 단독: 정상 진행
+      //   - --skip-tests 우회: 정상 unhandled rejection (lint fail visible)
+      // 따라서 npm wrapper 한 단계 줄여 trigger 약화 (cmd.exe shim → npm-cli.js
+      // → spawn 3 layers 제거). package.json `scripts.test` 와 sync 유지 필수.
+      command: process.execPath,
+      args: [
+        "scripts/test-lock.mjs",
+        "--test",
+        "--test-force-exit",
+        "--test-concurrency=8",
+        "tests/**/*.test.mjs",
+        "scripts/__tests__/**/*.test.mjs",
+      ],
       skip: skipTests,
-      // Windows background execution can stall when `npm test` inherits the
-      // parent's console handles through nested shell/spawn layers. Run the
-      // heavy test step non-interactively and fail fast if it never returns.
-      // maxBuffer raised explicitly: 1 MiB default is too small for piped
-      // npm test --test-concurrency=8 verbose output. This is generic
-      // robustness, NOT a fix for the prepare-only EXIT=1 mismatch — that
-      // root cause is the test-lock.mjs spawn `stdio: "inherit"` cascading
-      // the parent's ignore/pipe/pipe down to grand-child `node --test`,
-      // breaking ConPTY assumptions on Windows. See issue #192 for the
-      // diagnosis and fix candidates (F1 = test-lock stdio split).
+      // maxBuffer: 1 MiB default is too small for piped node --test verbose
+      // output. 128 MiB matches the prior npm-test ceiling.
       options: {
         stdio: ["ignore", "pipe", "pipe"],
         timeoutMs: TEST_TIMEOUT_MS,
         maxBuffer: 128 * 1024 * 1024,
+        shell: false,
       },
     },
     {

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -191,8 +191,13 @@ describe("release governance scripts", () => {
       });
       assert.equal(executed.skipTests, false);
 
+      // F3 (issue #192): test step 의 command 가 "npm test" 에서 직접 node
+      // test-lock.mjs 호출로 바뀜. legacy npm test 와 F3 후 node test-lock.mjs
+      // 둘 다 인식.
       const testCall = calls.find(
-        (call) => call.command === "npm" && call.args.join(" ") === "test",
+        (call) =>
+          (call.command === "npm" && call.args.join(" ") === "test") ||
+          (call.args[0] && call.args[0].endsWith("test-lock.mjs")),
       );
       assert.ok(testCall);
       assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -64,23 +64,32 @@ export async function prepareRelease({
   const steps = [
     {
       name: "npm-test",
-      command: "npm",
-      args: ["test"],
+      // F3 fix (issue #192 — silent EXIT 0 회귀 우회):
+      // npm wrapper 경유 시 prepare.mjs process 가 native level 에서 hard kill
+      // 됨 (process.on("exit") 핸들러 호출 안 됨, EXIT 0 silent, 후속 lint/pack
+      // step 누락). 2026-04-30 진단 세션에서 5 시나리오 reproduce 결과:
+      //   - npm wrapper 경유 + npm test 실행: silent EXIT 0 재현 (12-24s 비결정)
+      //   - 직접 node 실행 또는 npm test 단독: 정상 진행
+      //   - --skip-tests 우회: 정상 unhandled rejection (lint fail visible)
+      // 따라서 npm wrapper 한 단계 줄여 trigger 약화 (cmd.exe shim → npm-cli.js
+      // → spawn 3 layers 제거). package.json `scripts.test` 와 sync 유지 필수.
+      command: process.execPath,
+      args: [
+        "scripts/test-lock.mjs",
+        "--test",
+        "--test-force-exit",
+        "--test-concurrency=8",
+        "tests/**/*.test.mjs",
+        "scripts/__tests__/**/*.test.mjs",
+      ],
       skip: skipTests,
-      // Windows background execution can stall when `npm test` inherits the
-      // parent's console handles through nested shell/spawn layers. Run the
-      // heavy test step non-interactively and fail fast if it never returns.
-      // maxBuffer raised explicitly: 1 MiB default is too small for piped
-      // npm test --test-concurrency=8 verbose output. This is generic
-      // robustness, NOT a fix for the prepare-only EXIT=1 mismatch — that
-      // root cause is the test-lock.mjs spawn `stdio: "inherit"` cascading
-      // the parent's ignore/pipe/pipe down to grand-child `node --test`,
-      // breaking ConPTY assumptions on Windows. See issue #192 for the
-      // diagnosis and fix candidates (F1 = test-lock stdio split).
+      // maxBuffer: 1 MiB default is too small for piped node --test verbose
+      // output. 128 MiB matches the prior npm-test ceiling.
       options: {
         stdio: ["ignore", "pipe", "pipe"],
         timeoutMs: TEST_TIMEOUT_MS,
         maxBuffer: 128 * 1024 * 1024,
+        shell: false,
       },
     },
     {

--- a/tests/regression/release-prepare-completes-all-steps.test.mjs
+++ b/tests/regression/release-prepare-completes-all-steps.test.mjs
@@ -50,15 +50,38 @@ describe("release:prepare regression — step sequence completeness", () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  // overrides: per-command override map { "npm test": (ctx) => string | throw, ... }
+  // F3 fix (PR fix/release-prepare-npm-bypass) 후 npm-test step 의 command 가
+  // "npm" 에서 process.execPath ("node") 로 바뀌고 args 가 ["test"] 에서
+  // ["scripts/test-lock.mjs", "--test", ...] 로 바뀐다. 본 테스트는 step sequence
+  // completeness 보호가 목적이므로 command 종류와 무관하게 step 분류한다.
+  function categorize(call) {
+    const { command, args } = call;
+    const arg0 = args[0] || "";
+    // test step: 둘 다 허용 (legacy npm test 또는 F3 후 node test-lock.mjs)
+    if (
+      (command === "npm" && arg0 === "test") ||
+      arg0.endsWith("test-lock.mjs")
+    ) {
+      return "test";
+    }
+    if (command === "npm" && arg0 === "run" && args[1] === "lint") {
+      return "lint";
+    }
+    if (command === "npm" && arg0 === "pack") return "pack";
+    if (command === "git") return "git";
+    return "other";
+  }
+
+  // overrides: per-step override map { "test": (ctx) => string | throw, ... }
   // calls 는 항상 push 된다 (override 가 throw 하더라도 trace 는 보존)
   function makeMockExec(overrides = {}) {
     const calls = [];
     const fn = (command, args, opts) => {
-      calls.push({ command, args: [...args] });
+      const call = { command, args: [...args] };
+      calls.push(call);
+      const step = categorize(call);
 
-      const key = `${command} ${args[0]}`;
-      if (overrides[key]) return overrides[key]({ command, args, opts });
+      if (overrides[step]) return overrides[step]({ command, args, opts });
 
       // git status --porcelain → clean working tree
       if (command === "git" && args[0] === "status") return "";
@@ -66,11 +89,10 @@ describe("release:prepare regression — step sequence completeness", () => {
       if (command === "git" && args[0] === "describe") return "v10.17.0\n";
       // git log --oneline → some commits
       if (command === "git" && args[0] === "log") return "abc123 feat: test\n";
-      // npm test/lint/pack → success (empty stdout)
-      if (command === "npm") return "";
+      // npm test/lint/pack 또는 node test-lock.mjs → success (empty stdout)
       return "";
     };
-    return { fn, calls };
+    return { fn, calls, categorize };
   }
 
   it("npm-test EXIT 0 (success) 시 후속 step (lint, pack, release-notes) 모두 실행", async () => {
@@ -85,29 +107,26 @@ describe("release:prepare regression — step sequence completeness", () => {
 
     assert.equal(result.ok, true);
 
-    // npm 호출은 정확히 3회: npm test, npm run lint, npm pack --dry-run
-    const npmCalls = calls.filter((c) => c.command === "npm");
-    assert.equal(
-      npmCalls.length,
-      3,
-      `expected 3 npm calls (test/lint/pack), got ${npmCalls.length}: ${JSON.stringify(
-        npmCalls.map((c) => c.args),
+    // 정확히 3개 build step 호출: test, lint, pack
+    const buildSteps = calls.map(categorize).filter((s) => s !== "git");
+    assert.deepEqual(
+      buildSteps,
+      ["test", "lint", "pack"],
+      `expected [test, lint, pack], got ${JSON.stringify(buildSteps)}: ${JSON.stringify(
+        calls.map((c) => ({ command: c.command, args: c.args })),
       )}`,
     );
-    assert.deepEqual(npmCalls[0].args, ["test"]);
-    assert.deepEqual(npmCalls[1].args, ["run", "lint"]);
-    assert.deepEqual(npmCalls[2].args, ["pack", "--dry-run"]);
 
     // release-notes step 실행 검증 (releaseNotesPath 가 결과에 포함됨)
     assert.ok(result.releaseNotesPath, "releaseNotesPath should be set");
     assert.match(result.releaseNotesPath, /release-notes-v10\.18\.0\.md$/);
   });
 
-  it("npm-test 가 빈 stdout 반환해도 (silent EXIT 0 시뮬레이션) 후속 step 호출", async () => {
+  it("test step 이 빈 stdout 반환해도 (silent EXIT 0 시뮬레이션) 후속 step 호출", async () => {
     // 회귀 시나리오: npm test 가 53ms 안에 EXIT 0 + 빈 stdout 반환
     // 이 경우에도 prepare.mjs 의 for-loop 가 다음 step 으로 진행해야 한다.
     const { fn, calls } = makeMockExec({
-      "npm test": () => "", // silent EXIT 0
+      test: () => "", // silent EXIT 0
     });
 
     const result = await prepareRelease({
@@ -119,19 +138,19 @@ describe("release:prepare regression — step sequence completeness", () => {
     });
 
     assert.equal(result.ok, true);
-    const npmCalls = calls.filter((c) => c.command === "npm");
+    const buildSteps = calls.map(categorize).filter((s) => s !== "git");
     // 회귀 가드 핵심: 3개 모두 호출됐는지 (lint/pack 단락 회귀 즉시 catch)
-    assert.equal(
-      npmCalls.length,
-      3,
-      "npm-test silent EXIT 0 후에도 lint/pack 호출되어야 함",
+    assert.deepEqual(
+      buildSteps,
+      ["test", "lint", "pack"],
+      "test step silent EXIT 0 후에도 lint/pack 호출되어야 함",
     );
   });
 
-  it("npm-test 가 throw 시 후속 step 호출 안 됨 (정상 단락 동작)", async () => {
+  it("test step 이 throw 시 후속 step 호출 안 됨 (정상 단락 동작)", async () => {
     const { fn, calls } = makeMockExec({
-      "npm test": () => {
-        const err = new Error("npm test failed");
+      test: () => {
+        const err = new Error("test step failed");
         err.status = 1;
         throw err;
       },
@@ -145,20 +164,19 @@ describe("release:prepare regression — step sequence completeness", () => {
         dryRun: false,
         execFileSyncFn: fn,
       }),
-      /npm test failed/,
+      /test step failed/,
     );
 
-    // 단락 검증: npm test 만 호출됐고, lint/pack 은 호출 안 됨
-    const npmCalls = calls.filter((c) => c.command === "npm");
-    assert.equal(
-      npmCalls.length,
-      1,
-      "npm test fail 시 lint/pack 은 호출되지 않아야 함 (단락)",
+    // 단락 검증: test 만 호출됐고, lint/pack 은 호출 안 됨
+    const buildSteps = calls.map(categorize).filter((s) => s !== "git");
+    assert.deepEqual(
+      buildSteps,
+      ["test"],
+      "test step fail 시 lint/pack 은 호출되지 않아야 함 (단락)",
     );
-    assert.deepEqual(npmCalls[0].args, ["test"]);
   });
 
-  it("skipTests=true 시 npm test 만 skip, lint/pack/release-notes 정상 실행", async () => {
+  it("skipTests=true 시 test step 만 skip, lint/pack/release-notes 정상 실행", async () => {
     const { fn, calls } = makeMockExec();
 
     const result = await prepareRelease({
@@ -171,11 +189,9 @@ describe("release:prepare regression — step sequence completeness", () => {
     });
 
     assert.equal(result.ok, true);
-    const npmCalls = calls.filter((c) => c.command === "npm");
-    // skipTests=true 일 때 npm test 는 skip, npm run lint + npm pack 만 호출
-    assert.equal(npmCalls.length, 2);
-    assert.deepEqual(npmCalls[0].args, ["run", "lint"]);
-    assert.deepEqual(npmCalls[1].args, ["pack", "--dry-run"]);
+    const buildSteps = calls.map(categorize).filter((s) => s !== "git");
+    // skipTests=true 일 때 test 는 skip, lint + pack 만 호출
+    assert.deepEqual(buildSteps, ["lint", "pack"]);
     assert.ok(result.releaseNotesPath);
   });
 });


### PR DESCRIPTION
## Summary

issue #192 silent EXIT 0 회귀 fix. `npm run release:prepare -- --execute` 가 `[prepare] step=npm-test t=N(50~70)ms` 직후 silent exit 0 + lint/pack/release-notes 누락되는 회귀를 우회한다 (체크포인트 20260430 진단 세션).

prepare.mjs 의 npm-test step 에서 npm wrapper 한 단계 줄여 silent kill trigger 를 약화한다.

## Why npm wrapper bypass?

2026-04-30 진단 세션 (5 시나리오 reproduce):

| # | 시나리오 | EXIT | DURATION | 회귀 |
|---|---------|------|----------|------|
| 1 | 직접 node prepare.mjs --execute --version 10.18.0 --allow-dirty | 124 (ext timeout 30s) | 30s | 정상 |
| 2 | npm run release:prepare -- --execute --version 10.18.0 --allow-dirty | **0 silent** | **24s** | **reproduce** |
| 3 | npm test 단독 | 124 (ext timeout 60s) | 60s | 정상 |
| 4 | npm run release:prepare -- ... --skip-tests | 1 (lint fail) | 1.3s | 정상 |
| 5 | 진단 wrapper (no try/catch + import prepareRelease) via npm | **0 silent** | **12s** | **reproduce** |

핵심 메커니즘: prepare.mjs process 가 **native level 에서 hard kill** 됨.
- `process.on('exit')`, `beforeExit`, UR, UE, SIGINT/SIGTERM/SIGHUP/SIGBREAK 핸들러 모두 호출 안 됨
- JavaScript event loop 도달 X
- 결과: `EXIT_CODE=0` (정상 종료처럼 보이나 실제는 hard terminate)

## Changes

- `scripts/release/prepare.mjs`: npm-test step 의 command 를 `"npm"` -> `process.execPath`, args `["test"]` -> `["scripts/test-lock.mjs", "--test", ...]` 로 변경. `shell:false` 명시. cmd.exe shim -> npm-cli.js -> spawn 3 layers 제거.
- `packages/triflux/scripts/release/prepare.mjs`: byte-identical mirror (npm publish files 포함).
- `tests/regression/release-prepare-completes-all-steps.test.mjs`: command 일반화로 `npm test` 와 `node test-lock.mjs` 둘 다 처리. step sequence completeness 보호 유지.

## Verification

- 회귀 가드 (PR #220) 4/4 PASS — command 일반화 후에도 step sequence completeness 보호 유지.
- 시나리오 2 reproduce 재실행: silent EXIT 0 (24s) -> EXIT 124 timeout (30s). 회귀 사라짐.
- 시나리오 1 (직접 node) 재실행: 정상 진행 유지 (EXIT 124, 15s).
- 시나리오 4 (--skip-tests) 재실행: 정상 unhandled rejection 유지 (EXIT 1, 1.2s).

## Root cause status

정확히는 미확정. 가설:
- **K1 (강)**: tests/ 안 어떤 test 가 `hub/lib/process-utils.mjs:589` `killProcessTree()` 호출 시 `protectedPids` 에 부모 PID 누락 -> `taskkill /T /F /PID <pid>` 가 parent tree 포함
- **K2 (중)**: Windows ConPTY race — npm wrapper context 에서 child 종료 시 stdio handle 변환 race 로 부모 abort
- **K3 (약)**: Node 24 + Windows + `execFileSync({shell:true})` + nested npm wrapper 알려진 bug

F3 는 K2/K3 가설에 효과적 (npm wrapper 한 단계 줄여 trigger 약화). K1 가설은 별도 진단 세션에서 검증 필요 (Process Monitor / ETW 로 prepare.mjs PID 추적).

## Test plan

- [x] 회귀 가드 4/4 PASS
- [x] 시나리오 2 (npm wrapper) silent EXIT 사라짐 검증
- [x] 시나리오 1 (직접 node) 정상 진행 유지 검증
- [x] 시나리오 4 (--skip-tests) 정상 unhandled rejection 유지 검증
- [ ] CI 통과 대기
- [ ] reviewer 검토 (root cause K2/K3 가설 검증 — 다른 환경에서도 silent exit 사라지는지)

## Related

- 회귀 가드 PR: #220
- mirror sync PR: #219
- 진단 메모리: feedback_release_prepare_silent_npm_test_return.md
- iron law 메모리: feedback_no_fix_without_root_cause.md — 본 fix 는 메커니즘 우회 (workaround) 이며 정확한 root cause 잡기 (K1 검증) 는 별도 PR 필요.
