### PR TITLE
chore(lint): baseline cleanup — biome auto-fix + dedup mcp-registry policy_notes

### DIFF
--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -2,9 +2,6 @@
   "$schema": "mcp-registry-schema",
   "version": 1,
   "description": "MCP 서버 중앙 레지스트리 — 진실의 원천",
-  "policy_notes": {
-    "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
-  },
   "defaults": {
     "transport": "hub-url",
     "hub_base": "http://127.0.0.1:27888"
@@ -12,7 +9,8 @@
   "policy_notes": {
     "transport": "Server transport accepts \"hub-url\" for the existing triflux Hub URL flow or \"http\" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.",
     "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
-    "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers."
+    "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
+    "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
   },
   "servers": {
     "tfx-hub": {

--- a/hub/codex-adapter.mjs
+++ b/hub/codex-adapter.mjs
@@ -184,7 +184,10 @@ function buildLeaseSpawnEnv(lease) {
 
 function dirnameOf(filePath) {
   if (typeof filePath !== "string" || !filePath) return null;
-  const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  const lastSep = Math.max(
+    filePath.lastIndexOf("/"),
+    filePath.lastIndexOf("\\"),
+  );
   if (lastSep < 0) return null;
   return filePath.slice(0, lastSep);
 }

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -197,7 +197,7 @@ describe("release governance scripts", () => {
       const testCall = calls.find(
         (call) =>
           (call.command === "npm" && call.args.join(" ") === "test") ||
-          (call.args[0] && call.args[0].endsWith("test-lock.mjs")),
+          call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
       assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -197,7 +197,7 @@ describe("release governance scripts", () => {
       const testCall = calls.find(
         (call) =>
           (call.command === "npm" && call.args.join(" ") === "test") ||
-          (call.args[0] && call.args[0].endsWith("test-lock.mjs")),
+          call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
       assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);

--- a/tests/unit/async-job-status-orphan.test.mjs
+++ b/tests/unit/async-job-status-orphan.test.mjs
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 const SCRIPT = "scripts/tfx-route.sh";
 
@@ -17,7 +23,10 @@ describe("--job-status orphan-running classification", () => {
     // Simulate: wrapper pid dead (PID 99999 unlikely to exist on default pid_max), child sleep alive.
     writeFileSync(join(jobDir, "pid"), "99999");
     writeFileSync(join(jobDir, "agent_type"), "executor");
-    writeFileSync(join(jobDir, "start_time"), String(Math.floor(Date.now() / 1000)));
+    writeFileSync(
+      join(jobDir, "start_time"),
+      String(Math.floor(Date.now() / 1000)),
+    );
 
     // Spawn a real sleep child whose PID we record. sleep 30 is long enough for
     // the assertion below to fire; cleanup kills it directly by PID, not via pkill.
@@ -48,11 +57,11 @@ describe("--job-status orphan-running classification", () => {
       cwd: jobDir,
     });
 
-    const res = spawnSync(
-      "bash",
-      [SCRIPT, "--job-status", jobId],
-      { encoding: "utf-8", env: { ...process.env, TFX_JOBS_DIR: jobsDir }, timeout: 5_000 },
-    );
+    const res = spawnSync("bash", [SCRIPT, "--job-status", jobId], {
+      encoding: "utf-8",
+      env: { ...process.env, TFX_JOBS_DIR: jobsDir },
+      timeout: 5_000,
+    });
 
     const out = (res.stdout || "").trim();
     assert.match(

--- a/tests/unit/async-wrapper-survival.test.mjs
+++ b/tests/unit/async-wrapper-survival.test.mjs
@@ -1,18 +1,18 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 const SCRIPT = "scripts/tfx-route.sh";
 
 function dispatchAsyncJob(jobsDir, target = "wrapper-sleep-3") {
-  const res = spawnSync(
-    "bash",
-    [SCRIPT, "--async-self-test", target],
-    { encoding: "utf-8", env: { ...process.env, TFX_JOBS_DIR: jobsDir }, timeout: 5_000 },
-  );
+  const res = spawnSync("bash", [SCRIPT, "--async-self-test", target], {
+    encoding: "utf-8",
+    env: { ...process.env, TFX_JOBS_DIR: jobsDir },
+    timeout: 5_000,
+  });
   return (res.stdout || "").trim();
 }
 
@@ -41,7 +41,11 @@ describe("async wrapper survives parent shell exit (POSIX)", () => {
       `expected exit_code marker at ${exitCodePath}`,
     );
     const exitCode = readFileSync(exitCodePath, "utf-8").trim();
-    assert.equal(exitCode, "0", `expected exit_code=0, got ${JSON.stringify(exitCode)}`);
+    assert.equal(
+      exitCode,
+      "0",
+      `expected exit_code=0, got ${JSON.stringify(exitCode)}`,
+    );
 
     rmSync(jobsDir, { recursive: true, force: true });
   });
@@ -69,7 +73,11 @@ describe("async wrapper survives parent shell exit (POSIX)", () => {
       `expected exit_code marker at ${exitCodePath}`,
     );
     const exitCode = readFileSync(exitCodePath, "utf-8").trim();
-    assert.equal(exitCode, "0", `expected exit_code=0, got ${JSON.stringify(exitCode)}`);
+    assert.equal(
+      exitCode,
+      "0",
+      `expected exit_code=0, got ${JSON.stringify(exitCode)}`,
+    );
 
     rmSync(jobsDir, { recursive: true, force: true });
   });

--- a/tests/unit/codex-exec-recovery.test.mjs
+++ b/tests/unit/codex-exec-recovery.test.mjs
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 const LIB = "scripts/lib/codex-recovery.sh";
 
@@ -53,7 +53,9 @@ describe("recover_codex_stdout", () => {
   });
 
   it("1차 codex marker: extracts content after last 'codex' line", () => {
-    const { stdout, stderr, exit } = invokeWithFixture("path1-codex-marker.stderr.log");
+    const { stdout, stderr, exit } = invokeWithFixture(
+      "path1-codex-marker.stderr.log",
+    );
     assert.equal(exit, 0);
     assert.match(
       stdout,
@@ -78,7 +80,9 @@ describe("recover_codex_stdout", () => {
   });
 
   it("2차 node parser: filters skip patterns when codex marker absent", () => {
-    const { stdout, stderr, exit } = invokeWithFixture("path2-node-parser.stderr.log");
+    const { stdout, stderr, exit } = invokeWithFixture(
+      "path2-node-parser.stderr.log",
+    );
     assert.equal(exit, 0);
     assert.match(
       stdout,
@@ -87,8 +91,16 @@ describe("recover_codex_stdout", () => {
     );
     assert.match(stdout, /It survives the skip filter/);
     assert.doesNotMatch(stdout, /^mcp:/m, "skip regex must drop mcp: lines");
-    assert.doesNotMatch(stdout, /^workdir:/m, "skip regex must drop workdir: lines");
-    assert.doesNotMatch(stdout, /^tokens used/m, "skip regex must drop tokens used line");
+    assert.doesNotMatch(
+      stdout,
+      /^workdir:/m,
+      "skip regex must drop workdir: lines",
+    );
+    assert.doesNotMatch(
+      stdout,
+      /^tokens used/m,
+      "skip regex must drop tokens used line",
+    );
     assert.doesNotMatch(stdout, /^EXIT:/m, "skip regex must drop EXIT: line");
     assert.ok(
       stderr.includes(RECOVERED_MARKER),
@@ -97,11 +109,21 @@ describe("recover_codex_stdout", () => {
   });
 
   it("3차 stderr tail: dumps everything before 'tokens used' when 1·2차 fail", () => {
-    const { stdout, stderr, exit } = invokeWithFixture("path3-stderr-tail.stderr.log");
+    const { stdout, stderr, exit } = invokeWithFixture(
+      "path3-stderr-tail.stderr.log",
+    );
     assert.equal(exit, 0);
     // 3차 dumps lines that 2차 would have filtered, distinguishing it from 2차.
-    assert.match(stdout, /^mcp: connected/m, "3차 retains mcp: line that 2차 would filter");
-    assert.match(stdout, /^workdir:/m, "3차 retains workdir: line that 2차 would filter");
+    assert.match(
+      stdout,
+      /^mcp: connected/m,
+      "3차 retains mcp: line that 2차 would filter",
+    );
+    assert.match(
+      stdout,
+      /^workdir:/m,
+      "3차 retains workdir: line that 2차 would filter",
+    );
     assert.match(stdout, /^reasoning high/m, "3차 retains reasoning line");
     assert.doesNotMatch(
       stdout,
@@ -115,7 +137,9 @@ describe("recover_codex_stdout", () => {
   });
 
   it("4차 FALLBACK_FAILED: emits marker when all 3 recovery paths fail", () => {
-    const { stdout, stderr, exit } = invokeWithFixture("path4-fallback-failed.stderr.log");
+    const { stdout, stderr, exit } = invokeWithFixture(
+      "path4-fallback-failed.stderr.log",
+    );
     assert.equal(exit, 0, "helper still returns 0 even when recovery fails");
     assert.equal(stdout, "", "stdout must remain empty when all paths fail");
     assert.ok(

--- a/tests/unit/heartbeat-visibility.test.mjs
+++ b/tests/unit/heartbeat-visibility.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
 
 const SCRIPT = "scripts/tfx-route.sh";
 
@@ -16,7 +16,11 @@ describe("heartbeat visibility for non-TTY callers", () => {
       {
         encoding: "utf-8",
         timeout: 15_000,
-        env: { ...process.env, TFX_HEARTBEAT_INTERVAL: "1", TFX_HEARTBEAT: "1" },
+        env: {
+          ...process.env,
+          TFX_HEARTBEAT_INTERVAL: "1",
+          TFX_HEARTBEAT: "1",
+        },
       },
     );
     assert.match(


### PR DESCRIPTION
## Summary

직전 세션 (PR #221 F3 — release:prepare npm wrapper bypass) 머지 후 follow-up. lint baseline 10 errors + 1 warning 정리. mechanical 위주 chore PR.

## Changes

### A. biome safe auto-fix (organizeImports + format)
- `tests/unit/async-job-status-orphan.test.mjs`
- `tests/unit/async-wrapper-survival.test.mjs`
- `tests/unit/codex-exec-recovery.test.mjs`
- `tests/unit/heartbeat-visibility.test.mjs`
- `hub/codex-adapter.mjs`

### B. release-governance.test.mjs useOptionalChain
- `scripts/__tests__/release-governance.test.mjs:200` — `call.args[0] && call.args[0].endsWith(...)` → `call.args[0]?.endsWith(...)`. PR #220/#221 회귀 가드 테스트로 semantic 동일.

### C. mcp-registry.json duplicate key dedup
- `config/mcp-registry.json` — line 5-7 의 `policy_notes.sync_denylist` 노트가 line 12-16 의 `policy_notes` 객체에 의해 silent override 되던 문제. 두 객체를 머지해서 sync_denylist + transport + headers + secret_safety 4개 키 모두 보존.

## Test plan

- [x] `npm run lint` → 0 errors
- [x] 4 affected unit tests + release-governance.test.mjs all pass
- [x] `node -e "JSON.parse(require('fs').readFileSync('config/mcp-registry.json','utf8'))"` JSON validity
- [ ] CI green