### PR TITLE
chore(rules): tfx-mirror-policy.md — packages/ 3-layer mirror 정책 명문화

### DIFF
--- a/.claude/rules/tfx-mirror-policy.md
+++ b/.claude/rules/tfx-mirror-policy.md
@@ -1,0 +1,126 @@
+# packages/ mirror 정책 — 3-layer single source
+
+## 멘탈 모델
+
+triflux 는 root 와 `packages/{core,remote,triflux}/` 3개 published 레이어를 동시에 유지한다. root 가 source of truth 다. mirror 작업은 drift 가 생기지 않도록 레이어별 룰을 다르게 적용한다.
+
+| 레이어 | 역할 | mirror 룰 |
+|--------|------|----------|
+| `packages/core` (`@triflux/core`) | 공용 라이브러리 (hub primitives, scripts/lib helper) | root 와 byte-identical cp |
+| `packages/remote` (`@triflux/remote`) | 원격 entry / store / pipe / server | root subset + `@triflux/core/...` import path 변환 |
+| `packages/triflux` (`triflux` npm) | 사용자 facing CLI / runtime / skills | npm publish files 기준 byte-identical mirror |
+
+## 레이어별 정책
+
+### `packages/core` — byte-identical cp
+
+`packages/core/hub/lib/`, `packages/core/scripts/lib/` 같은 helper 묶음은 root 와 같은 내용이다. import 변환 없음. 단순 cp.
+
+| 행위 | 처리 |
+|------|------|
+| root `hub/lib/foo.mjs` 신규 | `cp hub/lib/foo.mjs packages/core/hub/lib/` |
+| root `hub/lib/foo.mjs` 수정 | 같은 cp 또는 두 곳 동시 Edit |
+| 검증 | `diff -q hub/lib/foo.mjs packages/core/hub/lib/foo.mjs` exit 0 |
+
+### `packages/remote` — import path 변환
+
+`packages/remote/` 는 `packages/core` 를 외부 dep 로 import 한다. 그래서 root 의 상대 경로 import 를 그대로 cp 하면 깨진다.
+
+| 위치 | import 형태 |
+|------|------------|
+| `hub/team/conductor.mjs` | `import { broker } from "../account-broker.mjs"` |
+| `packages/triflux/hub/team/conductor.mjs` | `import { broker } from "../account-broker.mjs"` (root 와 동일) |
+| `packages/remote/hub/team/conductor.mjs` | `import { broker } from "@triflux/core/hub/account-broker.mjs"` |
+
+mirror 변경은 **`Edit` 도구로 개별 수정**한다. `cp` 사용 금지 (덮어쓰면 import path 가 revert 됨).
+
+| 행위 | 처리 |
+|------|------|
+| root 새 파일 | dep 없으면 `cp`, 내부 dep 있으면 `Edit` 3 곳 (root / packages/triflux / packages/remote 각각) |
+| root 수정 | `Edit` 으로 3 곳 동시 수정. import path 만 packages/remote 에서 다름 |
+| 검증 | `git diff` 로 `@triflux/core/...` 경로가 살아있는지 확인. cp 후 import 경로 revert 여부 점검 |
+
+### `packages/triflux` — npm files 기준 byte-identical
+
+`packages/triflux/` 는 사용자가 `npm install -g triflux` 로 받는 패키지다. root `package.json` 의 `files` 필드와 `packages/triflux/package.json` 의 `files` 필드 교집합에 들어가는 것은 byte-identical 로 mirror 한다.
+
+| 행위 | 처리 |
+|------|------|
+| root `bin/triflux.mjs` 수정 | `packages/triflux/bin/triflux.mjs` 도 동일 변경 |
+| root `scripts/__tests__/release-governance.test.mjs` 수정 | mirror 대상 (PR #222 패턴) |
+| root `tests/unit/foo.test.mjs` 수정 | **mirror 제외** (npm files 미포함) |
+| 검증 | `diff -rq` 로 packages/triflux 와 root 의 published 경로 비교 |
+
+## mirror 범위 (in / out)
+
+**mirror 대상** (root → packages 동기 필수):
+- `hub/lib/*` → `packages/core/hub/lib/`, `packages/triflux/hub/lib/`
+- `hub/team/*`, `hub/*.mjs` (entry/runtime) → `packages/triflux/hub/`, `packages/remote/hub/` (해당 모듈만)
+- `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`
+- `scripts/release/*`, `scripts/__tests__/*` → `packages/triflux/scripts/` (publish 포함)
+- `bin/*` → `packages/triflux/bin/`
+- `hooks/*`, `hud/*`, `mesh/*`, `config/*` → `packages/triflux/{hooks,hud,mesh,config}/`
+
+**mirror 제외**:
+- `tests/` (root + `packages/{core,remote}/tests/`) — npm files 에 없음. 만약 packages 쪽에 untracked tests 디렉토리가 만들어졌으면 그건 잘못된 mirror 시도다.
+- `references/codex-snapshots/`, `references/gemini-snapshots/` — packages/triflux files 부정 패턴 (`!references/codex-snapshots`) 으로 명시 제외.
+- `.tfx/`, `.omc/`, `.claude/`, `.gemini/`, `.codex/` — runtime / config 디렉토리.
+- `skills/tfx-workspace` — 사용자별 workspace, packages/triflux files 부정 패턴 (`!skills/tfx-workspace`).
+- `failure-reports/` (any depth) — 진단 산출물.
+
+## 신규 binary 산출물 추가 시
+
+shard 가 `references/{codex,gemini}-snapshots/` 같은 경로에 100MB+ binary 를 쓰는 흐름을 추가하면, `.gitignore` 만으로 부족하다. `packages/triflux/package.json` 의 `files` 필드에 부정 패턴을 동반해야 한다. 안 그러면 npm pack tarball 이 300MB+ 로 폭증해 publish 가 거부된다.
+
+| 추가 위치 | files 부정 패턴 |
+|----------|---------------|
+| `references/<new>-snapshots/` | `"!references/<new>-snapshots"` |
+| `skills/<new>-workspace` | `"!skills/<new>-workspace"` |
+| `**/failure-reports/` | `"!**/failure-reports"` |
+
+검증: ship 전 `cd packages/triflux && npm pack --dry-run` 결과 size 가 ~1MB (아닌 경우 binary 새 path 누수 의심).
+
+## 검증 체크리스트 (PR 단위)
+
+새 PR 이 packages mirror 를 건드리면 머지 전 아래를 통과한다.
+
+| 단계 | 명령 | 기대 결과 |
+|------|------|----------|
+| 1 | `git diff --name-only origin/main..HEAD \| grep -E '^(hub/|scripts/lib/|scripts/__tests__/|scripts/release/|bin/|hooks/|hud/|mesh/|config/)'` | mirror 가 필요한 root 변경 목록 |
+| 2 | 위 목록의 각 파일이 packages/triflux 에 byte-identical 로 존재하는지 `diff -q` | exit 0 |
+| 3 | hub/lib, scripts/lib 변경분이 packages/core 에 cp 됐는지 `diff -q` | exit 0 |
+| 4 | packages/remote/hub/team/ 가 변경됐다면 `grep "@triflux/core/" packages/remote/hub/team/*.mjs` | import 경로 살아있음 |
+| 5 | tests/ 변경이 packages/{core,remote}/tests/ 에 untracked 로 추가됐는지 | **금지 — staging 회수** |
+| 6 | npm publish 영향 시 `cd packages/triflux && npm pack --dry-run` size | ~1MB |
+| 7 | mirror 동기화 PR 이라면 PR body 에 IDENTICAL/DIFFERENT 카운트 (PR #219 패턴 — 13 modified + 3 new = 16 files, 9 IDENTICAL + 4 DIFFERENT) | 명시 |
+
+## 안티패턴
+
+| 패턴 | 문제 | 대체 |
+|------|------|------|
+| `cp hub/team/foo.mjs packages/remote/hub/team/` | import path 가 `../account-broker.mjs` 로 덮어써져 remote 패키지가 자기 모듈을 못 찾음 | `Edit` 으로 packages/remote 만 `@triflux/core/...` 유지 |
+| `cp -r tests/ packages/core/tests/` | npm files 미포함이라 publish 에 안 들어감, untracked 디렉토리만 늘어남 | tests 는 mirror 제외 — 시도 자체 금지 |
+| 신규 binary path 추가 시 `.gitignore` 만 추가 | `packages/triflux/package.json` files 가 root 와 다르므로 npm pack 이 binary 포함, tarball 폭증 → publish 실패 | files 부정 패턴 동반 추가 + `npm pack --dry-run` 검증 |
+| root 만 수정하고 packages 누락한 채 ship | v10.x.x 릴리즈 후 chore PR 로 늦게 sync (PR #219 패턴) | 코드 변경 PR 안에서 동시에 mirror — sync chore PR 은 backfill 용일 때만 |
+| packages/remote 변경 후 import path 검증 생략 | 머지 후 `npm install @triflux/remote` 한 사용자가 `Cannot find module` 으로 깨짐 | `git diff` 로 `@triflux/core/...` 경로 1회 grep 확인 |
+
+## 관련 메모리
+
+- `feedback_packages_mirror_two_layer.md` — 2-layer 룰 (core 단순 cp / remote import 변환)
+- `feedback_packages_mirror_scope_tests_excluded.md` — tests/ 제외 사유 (npm files 미포함)
+- `feedback_remote_package_mirror.md` — packages/remote 는 cp 금지 (import path revert 사고)
+- `feedback_npm_pack_binary_exclusion.md` — files 부정 패턴 (binary 폭증 회피)
+- `feedback_indexof_open_prefix_pattern.md` — assertion boundary marker 패턴 (PR #218)
+
+## 관련 PR
+
+| PR | 사유 |
+|----|------|
+| #219 | packages/{core,remote} mirror sync v10.18.0 hub state — 13 modified + 3 new = 16 files |
+| #222 | packages/triflux/scripts/__tests__/release-governance.test.mjs byte-identical mirror sync (lint optional chain fix 동시 적용) |
+| v10.16.0 ship 1차 publish fail | binary path `references/codex-snapshots/` 추가 후 files 부정 패턴 누락 → 317.5MB → 1MB fix (commit 74a9f2d) |
+
+## 메모
+
+- 이 문서는 정책 추출본이다. 실제 mirror 자동화 (있다면 `scripts/pack.mjs`) 의 구현 세부는 코드 주석 참조.
+- packages 구조가 변경되면 (예: `packages/cli` 신설) 이 문서를 가장 먼저 업데이트한 뒤 코드 작업한다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ background로 실행한 headless 결과는 **반드시 task-notification 완료 
 | `.claude/rules/tfx-autoplan-principles.md` | gstack autoplan의 6 decision principles, phase 우선순위, 충돌 해소 규칙 추출본 |
 | `.claude/rules/tfx-update-logic.md` | triflux / OMC / gstack / Codex / Gemini 업데이트 로직 |
 | `.claude/rules/tfx-stack-coexistence.md` | gstack / superpowers / triflux 공존 원칙, 레이어 분리, 의존 방향, 충돌 해소 |
+| `.claude/rules/tfx-mirror-policy.md` | packages/ 3-layer mirror 정책 (core 단순 cp / remote import 변환 / triflux byte-identical), tests 제외 룰, drift 차단 |
 
 Claude Code는 `.claude/rules/*.md` 를 자동 로드한다. Codex CLI는 `@import` 미지원이므로 필요 시 `AGENTS.md` 를 독립 유지한다.
 


### PR DESCRIPTION
## Summary

`.claude/rules/tfx-mirror-policy.md` 신설. packages/{core,remote,triflux} 3개 published 레이어의 mirror 룰을 root single-source 기준으로 codify. PR #222 직후 자연스러운 follow-up — codex 가 release-governance.test.mjs mirror sync 를 처리한 패턴을 문서로 정착.

## Why

직전 세션 작업 (PR #219 packages/{core,remote} sync, PR #222 packages/triflux mirror) 에서 mirror 룰을 한 번씩 재구성해야 했음. 4개 흩어진 memory (`feedback_packages_mirror_*.md`, `feedback_remote_package_mirror.md`, `feedback_npm_pack_binary_exclusion.md`) 를 단일 정책 문서로 묶어 다음 동기화 사고 (PR #219 류) 사전 차단.

## Changes

### `.claude/rules/tfx-mirror-policy.md` (신설, +127 lines)

- 3-layer mirror 정책표 (core 단순 cp / remote import 변환 / triflux byte-identical)
- mirror 범위 in/out (hub/lib·scripts/lib·bin·hooks·hud·mesh·config 포함, tests·references binary·.tfx·.omc·skills/tfx-workspace 제외)
- 신규 binary path 추가 시 `packages/triflux/package.json` files 부정 패턴 룰 (v10.16.0 ship 1차 publish fail 패턴)
- PR 단위 검증 체크리스트 7단계 (PR #219, #222 패턴 흡수)
- 안티패턴 5종

### `CLAUDE.md`

- 세부 룰 표에 새 룰 파일 1줄 추가

## Test plan

- [x] `npm run lint` → 0 errors (markdown + CLAUDE.md 영향 없음 확인)
- [x] `.claude/rules/` 다른 룰 파일과 형식 일관성 (top heading, 멘탈 모델, 표 위주, 안티패턴, 메모 섹션)
- [ ] CI green