### PR TITLE
fix(hud): correct Opus 4.7 pricing in token-snapshot ($15/$75 -> $5/$25, #208 scope 1)

### DIFF
--- a/packages/triflux/scripts/token-snapshot.mjs
+++ b/packages/triflux/scripts/token-snapshot.mjs
@@ -30,7 +30,7 @@ const REPORTS_DIR = join(STATE_DIR, "reports");
 // ── 가격 모델 ($/MTok, 비캐시 기준, 보수적 추정) ──
 const PRICING = {
   claude_sonnet: { input: 3, output: 15 },
-  claude_opus: { input: 15, output: 75 },
+  claude_opus: { input: 5, output: 25 },
   codex: { input: 0, output: 0 },
   gemini_flash: { input: 0.1, output: 0.4 },
 };
@@ -38,7 +38,7 @@ const PRICING = {
 // Claude 캐시 가격 ($/MTok) — 오케스트레이션 비용 정밀 계산용
 const CLAUDE_CACHE_PRICING = {
   claude_sonnet: { cache_write: 3.75, cache_read: 0.3 },
-  claude_opus: { cache_write: 18.75, cache_read: 1.5 },
+  claude_opus: { cache_write: 6.25, cache_read: 0.5 },
 };
 
 // 에이전트 → Claude 대체 모델
@@ -628,11 +628,13 @@ function generateReport(sessionId) {
 
 // ── Named exports (파이프라인 벤치마크 훅용) ──
 export {
+  CLAUDE_CACHE_PRICING,
   computeDiff,
   DIFFS_DIR,
   estimateSavings,
   formatCost,
   formatTokenCount,
+  PRICING,
   STATE_DIR,
   takeSnapshot,
 };

--- a/scripts/token-snapshot.mjs
+++ b/scripts/token-snapshot.mjs
@@ -30,7 +30,7 @@ const REPORTS_DIR = join(STATE_DIR, "reports");
 // ── 가격 모델 ($/MTok, 비캐시 기준, 보수적 추정) ──
 const PRICING = {
   claude_sonnet: { input: 3, output: 15 },
-  claude_opus: { input: 15, output: 75 },
+  claude_opus: { input: 5, output: 25 },
   codex: { input: 0, output: 0 },
   gemini_flash: { input: 0.1, output: 0.4 },
 };
@@ -38,7 +38,7 @@ const PRICING = {
 // Claude 캐시 가격 ($/MTok) — 오케스트레이션 비용 정밀 계산용
 const CLAUDE_CACHE_PRICING = {
   claude_sonnet: { cache_write: 3.75, cache_read: 0.3 },
-  claude_opus: { cache_write: 18.75, cache_read: 1.5 },
+  claude_opus: { cache_write: 6.25, cache_read: 0.5 },
 };
 
 // 에이전트 → Claude 대체 모델
@@ -628,11 +628,13 @@ function generateReport(sessionId) {
 
 // ── Named exports (파이프라인 벤치마크 훅용) ──
 export {
+  CLAUDE_CACHE_PRICING,
   computeDiff,
   DIFFS_DIR,
   estimateSavings,
   formatCost,
   formatTokenCount,
+  PRICING,
   STATE_DIR,
   takeSnapshot,
 };

--- a/tests/unit/token-snapshot-pricing.test.mjs
+++ b/tests/unit/token-snapshot-pricing.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  CLAUDE_CACHE_PRICING,
+  PRICING,
+} from "../../scripts/token-snapshot.mjs";
+
+describe("token-snapshot pricing", () => {
+  it("uses current Opus 4.7 pricing for base and cache tokens", () => {
+    // Issue #208: Anthropic public pricing page lists Opus 4.7 at $5/$25 per MTok.
+    assert.equal(PRICING.claude_opus.input, 5);
+    assert.equal(PRICING.claude_opus.output, 25);
+    assert.equal(CLAUDE_CACHE_PRICING.claude_opus.cache_write, 6.25);
+    assert.equal(CLAUDE_CACHE_PRICING.claude_opus.cache_read, 0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Correct Opus-class pricing in token-snapshot from $15/$75 to $5/$25 per MTok.
- Correct Claude Opus cache pricing to $6.25 write and $0.50 read.
- Export pricing tables minimally and add a regression guard for Issue #208 scope 1.

## Context
Anthropic's public pricing page lists Opus 4.7 at $5 per million input tokens and $25 per million output tokens. Prompt cache write is 1.25x base input and cache read is 0.1x base input.

Fixes #208.

## Verification
- `diff -q scripts/token-snapshot.mjs packages/triflux/scripts/token-snapshot.mjs` via Git diff.exe: no output
- `node --test tests/unit/token-snapshot-pricing.test.mjs`
- `node --check scripts/token-snapshot.mjs && node --check packages/triflux/scripts/token-snapshot.mjs`