### PR TITLE
Fix macOS npm-only hook and recovery sync regressions

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -43,6 +43,12 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "../scripts/claudemd-sync.mjs";
+import {
+  applyPluginRootHookFallbacks,
+  commandExists,
+  findPluginRootHookIssues,
+  inspectMacTimeoutDependency,
+} from "../scripts/lib/doctor-env-checks.mjs";
 import { ensureGeminiProfiles } from "../scripts/lib/gemini-profiles.mjs";
 import { serializeHandoff } from "../scripts/lib/handoff.mjs";
 import {
@@ -2041,6 +2047,60 @@ async function cmdDoctor(options = {}) {
       for (const target of SYNC_MAP) {
         syncFile(target.src, target.dst, target.label);
       }
+      const macTimeoutForFix = inspectMacTimeoutDependency();
+      if (!macTimeoutForFix.ok) {
+        if (commandExists("brew")) {
+          if (process.stdin.isTTY && process.stdout.isTTY) {
+            info("macOS GNU timeout 부재: coreutils 설치 가능");
+            process.stdout.write(
+              "      brew install coreutils 실행할까요? [y/N] ",
+            );
+            let answer = "";
+            try {
+              const buf = Buffer.alloc(128);
+              const n = readSync(0, buf, 0, 128);
+              answer = buf.toString("utf8", 0, n).trim().toLowerCase();
+            } catch {
+              answer = "";
+            }
+            if (answer.startsWith("y")) {
+              try {
+                execFileSync("brew", ["install", "coreutils"], {
+                  stdio: "inherit",
+                  timeout: 600000,
+                  windowsHide: true,
+                });
+                report.actions.push({
+                  type: "install",
+                  name: "coreutils",
+                  status: "ok",
+                });
+                ok("coreutils 설치 완료");
+              } catch (error) {
+                report.actions.push({
+                  type: "install",
+                  name: "coreutils",
+                  status: "failed",
+                  message: error.message,
+                });
+                warn(
+                  `coreutils 설치 실패: ${renderErrorMessage(error.message)}`,
+                );
+              }
+            } else {
+              info("건너뜀: brew install coreutils");
+            }
+          } else {
+            warn(
+              "macOS GNU timeout 부재 — 비대화형 모드에서는 자동 설치하지 않습니다.",
+            );
+            info("수동 설치: brew install coreutils");
+          }
+        } else {
+          warn("macOS GNU timeout 부재 — Homebrew를 찾지 못했습니다.");
+          info("Homebrew 설치 후: brew install coreutils");
+        }
+      }
       {
         const claudeGuide = ensureGlobalClaudeRoutingSection(CLAUDE_DIR);
         if (
@@ -2194,6 +2254,34 @@ async function cmdDoctor(options = {}) {
         fix: "tfx setup",
       });
       fail("미설치 — tfx setup 실행 필요");
+      issues++;
+    }
+
+    // macOS GNU timeout/coreutils
+    section("macOS timeout");
+    const macTimeout = inspectMacTimeoutDependency();
+    if (macTimeout.status === "skipped") {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "skipped",
+        platform: process.platform,
+      });
+      info("macOS 아님 — 건너뜀");
+    } else if (macTimeout.ok) {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "ok",
+        provider: macTimeout.provider,
+      });
+      ok(`timeout provider: ${macTimeout.provider}`);
+    } else {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "missing",
+        fix: macTimeout.fix,
+      });
+      warn("GNU timeout/gtimeout 미설치");
+      info("수정: brew install coreutils");
       issues++;
     }
 
@@ -3813,6 +3901,55 @@ async function cmdDoctor(options = {}) {
         }
 
         if (settings) {
+          let pluginRootHookIssues = findPluginRootHookIssues(settings);
+          if (pluginRootHookIssues.length > 0 && fix) {
+            const fallbackResult = applyPluginRootHookFallbacks(settings, {
+              pluginRoot: PKG_ROOT,
+            });
+            if (fallbackResult.changed) {
+              writeFileSync(
+                settingsPath,
+                JSON.stringify(settings, null, 2) + "\n",
+                "utf8",
+              );
+              ok(
+                `PLUGIN_ROOT fallback ${fallbackResult.count}개 hook command에 적용됨`,
+              );
+              try {
+                settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+                pluginRootHookIssues = findPluginRootHookIssues(settings);
+              } catch (error) {
+                warn(`PLUGIN_ROOT fallback 재검증 실패: ${error.message}`);
+              }
+            }
+          }
+
+          addDoctorCheck(report, {
+            name: "hook-plugin-root",
+            status:
+              pluginRootHookIssues.length === 0 ? "ok" : "missing-fallback",
+            count: pluginRootHookIssues.length,
+            examples: pluginRootHookIssues.slice(0, 3).map((issue) => ({
+              event: issue.event,
+              reason: issue.reason,
+              command: issue.command,
+            })),
+            ...(pluginRootHookIssues.length > 0
+              ? { fix: "tfx doctor --fix 또는 tfx setup" }
+              : {}),
+          });
+          if (pluginRootHookIssues.length === 0) {
+            ok("PLUGIN_ROOT hook fallback 확인됨");
+          } else {
+            warn(
+              `PLUGIN_ROOT fallback 없는 hook ${pluginRootHookIssues.length}개 감지`,
+            );
+            info(
+              "영향: npm 단독 설치에서 /hooks/... 경로로 붕괴할 수 있습니다.",
+            );
+            issues += pluginRootHookIssues.length;
+          }
+
           let coverage = computeHookCoverage(settings, managedHooks);
 
           if (coverage.missing.length > 0 && fix) {

--- a/packages/core/scripts/lib/doctor-env-checks.mjs
+++ b/packages/core/scripts/lib/doctor-env-checks.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+
+export function commandExists(name) {
+  try {
+    execFileSync("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", name], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function inspectMacTimeoutDependency({
+  platform = process.platform,
+  commandExists: exists = commandExists,
+} = {}) {
+  if (platform !== "darwin") {
+    return { ok: true, status: "skipped", platform };
+  }
+
+  if (exists("gtimeout")) {
+    return { ok: true, status: "ok", platform, provider: "gtimeout" };
+  }
+  if (exists("timeout")) {
+    return { ok: true, status: "ok", platform, provider: "timeout" };
+  }
+
+  return {
+    ok: false,
+    status: "missing",
+    platform,
+    fix: "brew install coreutils",
+  };
+}
+
+export function addPluginRootFallbackToCommand(command, pluginRoot) {
+  if (typeof command !== "string") return command;
+  const fallbackRoot = String(pluginRoot || "").replace(/\\/g, "/");
+  if (!fallbackRoot) return command;
+  return command
+    .replaceAll("${PLUGIN_ROOT}", `\${PLUGIN_ROOT:-${fallbackRoot}}`)
+    .replaceAll(
+      "${CLAUDE_PLUGIN_ROOT}",
+      `\${CLAUDE_PLUGIN_ROOT:-${fallbackRoot}}`,
+    )
+    .replace(
+      /(^|[\s"'])\/(hooks|scripts)\//g,
+      `$1\${PLUGIN_ROOT:-${fallbackRoot}}/$2/`,
+    );
+}
+
+function hasBarePluginRootReference(command) {
+  if (typeof command !== "string") return false;
+  return (
+    command.includes("${PLUGIN_ROOT}/") ||
+    command.includes("${CLAUDE_PLUGIN_ROOT}/")
+  );
+}
+
+function hasCollapsedRootHookPath(command) {
+  if (typeof command !== "string") return false;
+  return /(^|[\s"'])\/(?:hooks|scripts)\//.test(command);
+}
+
+export function findPluginRootHookIssues(settings) {
+  const hooksByEvent =
+    settings?.hooks && typeof settings.hooks === "object" ? settings.hooks : {};
+  const issues = [];
+
+  for (const [event, entries] of Object.entries(hooksByEvent)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        const command = hook?.command;
+        if (
+          !hasBarePluginRootReference(command) &&
+          !hasCollapsedRootHookPath(command)
+        ) {
+          continue;
+        }
+        issues.push({
+          event,
+          matcher: entry?.matcher || "*",
+          command,
+          reason: hasCollapsedRootHookPath(command)
+            ? "collapsed-root-path"
+            : "missing-plugin-root-fallback",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function applyPluginRootHookFallbacks(settings, { pluginRoot } = {}) {
+  if (!settings?.hooks || typeof settings.hooks !== "object") {
+    return { changed: false, count: 0, settings };
+  }
+
+  let count = 0;
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        if (typeof hook?.command !== "string") continue;
+        const next = addPluginRootFallbackToCommand(hook.command, pluginRoot);
+        if (next !== hook.command) {
+          hook.command = next;
+          count++;
+        }
+      }
+    }
+  }
+
+  return { changed: count > 0, count, settings };
+}

--- a/packages/remote/scripts/lib/doctor-env-checks.mjs
+++ b/packages/remote/scripts/lib/doctor-env-checks.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+
+export function commandExists(name) {
+  try {
+    execFileSync("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", name], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function inspectMacTimeoutDependency({
+  platform = process.platform,
+  commandExists: exists = commandExists,
+} = {}) {
+  if (platform !== "darwin") {
+    return { ok: true, status: "skipped", platform };
+  }
+
+  if (exists("gtimeout")) {
+    return { ok: true, status: "ok", platform, provider: "gtimeout" };
+  }
+  if (exists("timeout")) {
+    return { ok: true, status: "ok", platform, provider: "timeout" };
+  }
+
+  return {
+    ok: false,
+    status: "missing",
+    platform,
+    fix: "brew install coreutils",
+  };
+}
+
+export function addPluginRootFallbackToCommand(command, pluginRoot) {
+  if (typeof command !== "string") return command;
+  const fallbackRoot = String(pluginRoot || "").replace(/\\/g, "/");
+  if (!fallbackRoot) return command;
+  return command
+    .replaceAll("${PLUGIN_ROOT}", `\${PLUGIN_ROOT:-${fallbackRoot}}`)
+    .replaceAll(
+      "${CLAUDE_PLUGIN_ROOT}",
+      `\${CLAUDE_PLUGIN_ROOT:-${fallbackRoot}}`,
+    )
+    .replace(
+      /(^|[\s"'])\/(hooks|scripts)\//g,
+      `$1\${PLUGIN_ROOT:-${fallbackRoot}}/$2/`,
+    );
+}
+
+function hasBarePluginRootReference(command) {
+  if (typeof command !== "string") return false;
+  return (
+    command.includes("${PLUGIN_ROOT}/") ||
+    command.includes("${CLAUDE_PLUGIN_ROOT}/")
+  );
+}
+
+function hasCollapsedRootHookPath(command) {
+  if (typeof command !== "string") return false;
+  return /(^|[\s"'])\/(?:hooks|scripts)\//.test(command);
+}
+
+export function findPluginRootHookIssues(settings) {
+  const hooksByEvent =
+    settings?.hooks && typeof settings.hooks === "object" ? settings.hooks : {};
+  const issues = [];
+
+  for (const [event, entries] of Object.entries(hooksByEvent)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        const command = hook?.command;
+        if (
+          !hasBarePluginRootReference(command) &&
+          !hasCollapsedRootHookPath(command)
+        ) {
+          continue;
+        }
+        issues.push({
+          event,
+          matcher: entry?.matcher || "*",
+          command,
+          reason: hasCollapsedRootHookPath(command)
+            ? "collapsed-root-path"
+            : "missing-plugin-root-fallback",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function applyPluginRootHookFallbacks(settings, { pluginRoot } = {}) {
+  if (!settings?.hooks || typeof settings.hooks !== "object") {
+    return { changed: false, count: 0, settings };
+  }
+
+  let count = 0;
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        if (typeof hook?.command !== "string") continue;
+        const next = addPluginRootFallbackToCommand(hook.command, pluginRoot);
+        if (next !== hook.command) {
+          hook.command = next;
+          count++;
+        }
+      }
+    }
+  }
+
+  return { changed: count > 0, count, settings };
+}

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -43,6 +43,12 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "../scripts/claudemd-sync.mjs";
+import {
+  applyPluginRootHookFallbacks,
+  commandExists,
+  findPluginRootHookIssues,
+  inspectMacTimeoutDependency,
+} from "../scripts/lib/doctor-env-checks.mjs";
 import { ensureGeminiProfiles } from "../scripts/lib/gemini-profiles.mjs";
 import { serializeHandoff } from "../scripts/lib/handoff.mjs";
 import {
@@ -2041,6 +2047,60 @@ async function cmdDoctor(options = {}) {
       for (const target of SYNC_MAP) {
         syncFile(target.src, target.dst, target.label);
       }
+      const macTimeoutForFix = inspectMacTimeoutDependency();
+      if (!macTimeoutForFix.ok) {
+        if (commandExists("brew")) {
+          if (process.stdin.isTTY && process.stdout.isTTY) {
+            info("macOS GNU timeout 부재: coreutils 설치 가능");
+            process.stdout.write(
+              "      brew install coreutils 실행할까요? [y/N] ",
+            );
+            let answer = "";
+            try {
+              const buf = Buffer.alloc(128);
+              const n = readSync(0, buf, 0, 128);
+              answer = buf.toString("utf8", 0, n).trim().toLowerCase();
+            } catch {
+              answer = "";
+            }
+            if (answer.startsWith("y")) {
+              try {
+                execFileSync("brew", ["install", "coreutils"], {
+                  stdio: "inherit",
+                  timeout: 600000,
+                  windowsHide: true,
+                });
+                report.actions.push({
+                  type: "install",
+                  name: "coreutils",
+                  status: "ok",
+                });
+                ok("coreutils 설치 완료");
+              } catch (error) {
+                report.actions.push({
+                  type: "install",
+                  name: "coreutils",
+                  status: "failed",
+                  message: error.message,
+                });
+                warn(
+                  `coreutils 설치 실패: ${renderErrorMessage(error.message)}`,
+                );
+              }
+            } else {
+              info("건너뜀: brew install coreutils");
+            }
+          } else {
+            warn(
+              "macOS GNU timeout 부재 — 비대화형 모드에서는 자동 설치하지 않습니다.",
+            );
+            info("수동 설치: brew install coreutils");
+          }
+        } else {
+          warn("macOS GNU timeout 부재 — Homebrew를 찾지 못했습니다.");
+          info("Homebrew 설치 후: brew install coreutils");
+        }
+      }
       {
         const claudeGuide = ensureGlobalClaudeRoutingSection(CLAUDE_DIR);
         if (
@@ -2194,6 +2254,34 @@ async function cmdDoctor(options = {}) {
         fix: "tfx setup",
       });
       fail("미설치 — tfx setup 실행 필요");
+      issues++;
+    }
+
+    // macOS GNU timeout/coreutils
+    section("macOS timeout");
+    const macTimeout = inspectMacTimeoutDependency();
+    if (macTimeout.status === "skipped") {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "skipped",
+        platform: process.platform,
+      });
+      info("macOS 아님 — 건너뜀");
+    } else if (macTimeout.ok) {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "ok",
+        provider: macTimeout.provider,
+      });
+      ok(`timeout provider: ${macTimeout.provider}`);
+    } else {
+      addDoctorCheck(report, {
+        name: "macos-timeout",
+        status: "missing",
+        fix: macTimeout.fix,
+      });
+      warn("GNU timeout/gtimeout 미설치");
+      info("수정: brew install coreutils");
       issues++;
     }
 
@@ -3813,6 +3901,55 @@ async function cmdDoctor(options = {}) {
         }
 
         if (settings) {
+          let pluginRootHookIssues = findPluginRootHookIssues(settings);
+          if (pluginRootHookIssues.length > 0 && fix) {
+            const fallbackResult = applyPluginRootHookFallbacks(settings, {
+              pluginRoot: PKG_ROOT,
+            });
+            if (fallbackResult.changed) {
+              writeFileSync(
+                settingsPath,
+                JSON.stringify(settings, null, 2) + "\n",
+                "utf8",
+              );
+              ok(
+                `PLUGIN_ROOT fallback ${fallbackResult.count}개 hook command에 적용됨`,
+              );
+              try {
+                settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+                pluginRootHookIssues = findPluginRootHookIssues(settings);
+              } catch (error) {
+                warn(`PLUGIN_ROOT fallback 재검증 실패: ${error.message}`);
+              }
+            }
+          }
+
+          addDoctorCheck(report, {
+            name: "hook-plugin-root",
+            status:
+              pluginRootHookIssues.length === 0 ? "ok" : "missing-fallback",
+            count: pluginRootHookIssues.length,
+            examples: pluginRootHookIssues.slice(0, 3).map((issue) => ({
+              event: issue.event,
+              reason: issue.reason,
+              command: issue.command,
+            })),
+            ...(pluginRootHookIssues.length > 0
+              ? { fix: "tfx doctor --fix 또는 tfx setup" }
+              : {}),
+          });
+          if (pluginRootHookIssues.length === 0) {
+            ok("PLUGIN_ROOT hook fallback 확인됨");
+          } else {
+            warn(
+              `PLUGIN_ROOT fallback 없는 hook ${pluginRootHookIssues.length}개 감지`,
+            );
+            info(
+              "영향: npm 단독 설치에서 /hooks/... 경로로 붕괴할 수 있습니다.",
+            );
+            issues += pluginRootHookIssues.length;
+          }
+
           let coverage = computeHookCoverage(settings, managedHooks);
 
           if (coverage.missing.length > 0 && fix) {

--- a/packages/triflux/hub/codex-adapter.mjs
+++ b/packages/triflux/hub/codex-adapter.mjs
@@ -184,7 +184,10 @@ function buildLeaseSpawnEnv(lease) {
 
 function dirnameOf(filePath) {
   if (typeof filePath !== "string" || !filePath) return null;
-  const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  const lastSep = Math.max(
+    filePath.lastIndexOf("/"),
+    filePath.lastIndexOf("\\"),
+  );
   if (lastSep < 0) return null;
   return filePath.slice(0, lastSep);
 }

--- a/packages/triflux/scripts/lib/doctor-env-checks.mjs
+++ b/packages/triflux/scripts/lib/doctor-env-checks.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+
+export function commandExists(name) {
+  try {
+    execFileSync("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", name], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function inspectMacTimeoutDependency({
+  platform = process.platform,
+  commandExists: exists = commandExists,
+} = {}) {
+  if (platform !== "darwin") {
+    return { ok: true, status: "skipped", platform };
+  }
+
+  if (exists("gtimeout")) {
+    return { ok: true, status: "ok", platform, provider: "gtimeout" };
+  }
+  if (exists("timeout")) {
+    return { ok: true, status: "ok", platform, provider: "timeout" };
+  }
+
+  return {
+    ok: false,
+    status: "missing",
+    platform,
+    fix: "brew install coreutils",
+  };
+}
+
+export function addPluginRootFallbackToCommand(command, pluginRoot) {
+  if (typeof command !== "string") return command;
+  const fallbackRoot = String(pluginRoot || "").replace(/\\/g, "/");
+  if (!fallbackRoot) return command;
+  return command
+    .replaceAll("${PLUGIN_ROOT}", `\${PLUGIN_ROOT:-${fallbackRoot}}`)
+    .replaceAll(
+      "${CLAUDE_PLUGIN_ROOT}",
+      `\${CLAUDE_PLUGIN_ROOT:-${fallbackRoot}}`,
+    )
+    .replace(
+      /(^|[\s"'])\/(hooks|scripts)\//g,
+      `$1\${PLUGIN_ROOT:-${fallbackRoot}}/$2/`,
+    );
+}
+
+function hasBarePluginRootReference(command) {
+  if (typeof command !== "string") return false;
+  return (
+    command.includes("${PLUGIN_ROOT}/") ||
+    command.includes("${CLAUDE_PLUGIN_ROOT}/")
+  );
+}
+
+function hasCollapsedRootHookPath(command) {
+  if (typeof command !== "string") return false;
+  return /(^|[\s"'])\/(?:hooks|scripts)\//.test(command);
+}
+
+export function findPluginRootHookIssues(settings) {
+  const hooksByEvent =
+    settings?.hooks && typeof settings.hooks === "object" ? settings.hooks : {};
+  const issues = [];
+
+  for (const [event, entries] of Object.entries(hooksByEvent)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        const command = hook?.command;
+        if (
+          !hasBarePluginRootReference(command) &&
+          !hasCollapsedRootHookPath(command)
+        ) {
+          continue;
+        }
+        issues.push({
+          event,
+          matcher: entry?.matcher || "*",
+          command,
+          reason: hasCollapsedRootHookPath(command)
+            ? "collapsed-root-path"
+            : "missing-plugin-root-fallback",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function applyPluginRootHookFallbacks(settings, { pluginRoot } = {}) {
+  if (!settings?.hooks || typeof settings.hooks !== "object") {
+    return { changed: false, count: 0, settings };
+  }
+
+  let count = 0;
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        if (typeof hook?.command !== "string") continue;
+        const next = addPluginRootFallbackToCommand(hook.command, pluginRoot);
+        if (next !== hook.command) {
+          hook.command = next;
+          count++;
+        }
+      }
+    }
+  }
+
+  return { changed: count > 0, count, settings };
+}

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -25,6 +25,7 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "./claudemd-sync.mjs";
+import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -141,7 +142,7 @@ function isSetupUserStateFile(fileName) {
 }
 
 /**
- * scripts/lib/*.mjs 자동 스캔.
+ * scripts/lib/*.mjs 및 *.sh 자동 스캔.
  * 수동 리스트 대신 glob으로 탐색하여 lib 파일 추가 시 sync 누락 방지.
  */
 function scanLibFiles(pluginRoot, claudeDir) {
@@ -149,7 +150,7 @@ function scanLibFiles(pluginRoot, claudeDir) {
   if (!existsSync(libDir)) return [];
   return readdirSync(libDir)
     .sort()
-    .filter((f) => f.endsWith(".mjs"))
+    .filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
     .map((f) => ({
       src: join(libDir, f),
       dst: join(claudeDir, "scripts", "lib", f),
@@ -563,7 +564,13 @@ function ensureHooksInSettings({ settingsPath, registryPath }) {
 
       entries.push({
         matcher: spec.matcher,
-        hooks: [{ type: "command", command: spec.command, timeout: 5 }],
+        hooks: [
+          {
+            type: "command",
+            command: addPluginRootFallbackToCommand(spec.command, PLUGIN_ROOT),
+            timeout: 5,
+          },
+        ],
       });
       added.push(spec.id || spec.fileName);
     }

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1956,8 +1956,12 @@ _codex_config_swap() {
 
 # codex-recovery.sh 의 recover_codex_stdout 헬퍼 사용. STDOUT_LOG/STDERR_LOG env.
 _TFX_ROUTE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/codex-recovery.sh
-source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+if [[ -f "$_TFX_ROUTE_DIR/lib/codex-recovery.sh" ]]; then
+  # shellcheck source=lib/codex-recovery.sh
+  source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+else
+  echo "[tfx-route] WARNING: optional helper missing: $_TFX_ROUTE_DIR/lib/codex-recovery.sh (run: tfx doctor --fix)" >&2
+fi
 
 run_codex_exec() {
   local prompt="$1"

--- a/scripts/lib/doctor-env-checks.mjs
+++ b/scripts/lib/doctor-env-checks.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+
+export function commandExists(name) {
+  try {
+    execFileSync("sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", name], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function inspectMacTimeoutDependency({
+  platform = process.platform,
+  commandExists: exists = commandExists,
+} = {}) {
+  if (platform !== "darwin") {
+    return { ok: true, status: "skipped", platform };
+  }
+
+  if (exists("gtimeout")) {
+    return { ok: true, status: "ok", platform, provider: "gtimeout" };
+  }
+  if (exists("timeout")) {
+    return { ok: true, status: "ok", platform, provider: "timeout" };
+  }
+
+  return {
+    ok: false,
+    status: "missing",
+    platform,
+    fix: "brew install coreutils",
+  };
+}
+
+export function addPluginRootFallbackToCommand(command, pluginRoot) {
+  if (typeof command !== "string") return command;
+  const fallbackRoot = String(pluginRoot || "").replace(/\\/g, "/");
+  if (!fallbackRoot) return command;
+  return command
+    .replaceAll("${PLUGIN_ROOT}", `\${PLUGIN_ROOT:-${fallbackRoot}}`)
+    .replaceAll(
+      "${CLAUDE_PLUGIN_ROOT}",
+      `\${CLAUDE_PLUGIN_ROOT:-${fallbackRoot}}`,
+    )
+    .replace(
+      /(^|[\s"'])\/(hooks|scripts)\//g,
+      `$1\${PLUGIN_ROOT:-${fallbackRoot}}/$2/`,
+    );
+}
+
+function hasBarePluginRootReference(command) {
+  if (typeof command !== "string") return false;
+  return (
+    command.includes("${PLUGIN_ROOT}/") ||
+    command.includes("${CLAUDE_PLUGIN_ROOT}/")
+  );
+}
+
+function hasCollapsedRootHookPath(command) {
+  if (typeof command !== "string") return false;
+  return /(^|[\s"'])\/(?:hooks|scripts)\//.test(command);
+}
+
+export function findPluginRootHookIssues(settings) {
+  const hooksByEvent =
+    settings?.hooks && typeof settings.hooks === "object" ? settings.hooks : {};
+  const issues = [];
+
+  for (const [event, entries] of Object.entries(hooksByEvent)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        const command = hook?.command;
+        if (
+          !hasBarePluginRootReference(command) &&
+          !hasCollapsedRootHookPath(command)
+        ) {
+          continue;
+        }
+        issues.push({
+          event,
+          matcher: entry?.matcher || "*",
+          command,
+          reason: hasCollapsedRootHookPath(command)
+            ? "collapsed-root-path"
+            : "missing-plugin-root-fallback",
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function applyPluginRootHookFallbacks(settings, { pluginRoot } = {}) {
+  if (!settings?.hooks || typeof settings.hooks !== "object") {
+    return { changed: false, count: 0, settings };
+  }
+
+  let count = 0;
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const hook of hooks) {
+        if (typeof hook?.command !== "string") continue;
+        const next = addPluginRootFallbackToCommand(hook.command, pluginRoot);
+        if (next !== hook.command) {
+          hook.command = next;
+          count++;
+        }
+      }
+    }
+  }
+
+  return { changed: count > 0, count, settings };
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -25,6 +25,7 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "./claudemd-sync.mjs";
+import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -141,7 +142,7 @@ function isSetupUserStateFile(fileName) {
 }
 
 /**
- * scripts/lib/*.mjs 자동 스캔.
+ * scripts/lib/*.mjs 및 *.sh 자동 스캔.
  * 수동 리스트 대신 glob으로 탐색하여 lib 파일 추가 시 sync 누락 방지.
  */
 function scanLibFiles(pluginRoot, claudeDir) {
@@ -149,7 +150,7 @@ function scanLibFiles(pluginRoot, claudeDir) {
   if (!existsSync(libDir)) return [];
   return readdirSync(libDir)
     .sort()
-    .filter((f) => f.endsWith(".mjs"))
+    .filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
     .map((f) => ({
       src: join(libDir, f),
       dst: join(claudeDir, "scripts", "lib", f),
@@ -563,7 +564,13 @@ function ensureHooksInSettings({ settingsPath, registryPath }) {
 
       entries.push({
         matcher: spec.matcher,
-        hooks: [{ type: "command", command: spec.command, timeout: 5 }],
+        hooks: [
+          {
+            type: "command",
+            command: addPluginRootFallbackToCommand(spec.command, PLUGIN_ROOT),
+            timeout: 5,
+          },
+        ],
       });
       added.push(spec.id || spec.fileName);
     }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1956,8 +1956,12 @@ _codex_config_swap() {
 
 # codex-recovery.sh 의 recover_codex_stdout 헬퍼 사용. STDOUT_LOG/STDERR_LOG env.
 _TFX_ROUTE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/codex-recovery.sh
-source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+if [[ -f "$_TFX_ROUTE_DIR/lib/codex-recovery.sh" ]]; then
+  # shellcheck source=lib/codex-recovery.sh
+  source "$_TFX_ROUTE_DIR/lib/codex-recovery.sh"
+else
+  echo "[tfx-route] WARNING: optional helper missing: $_TFX_ROUTE_DIR/lib/codex-recovery.sh (run: tfx doctor --fix)" >&2
+fi
 
 run_codex_exec() {
   local prompt="$1"

--- a/tests/unit/doctor-macos-hooks.test.mjs
+++ b/tests/unit/doctor-macos-hooks.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  findPluginRootHookIssues,
+  inspectMacTimeoutDependency,
+} from "../../scripts/lib/doctor-env-checks.mjs";
+
+describe("doctor environment checks", () => {
+  it("flags macOS when neither timeout nor gtimeout is available (#227)", () => {
+    const result = inspectMacTimeoutDependency({
+      platform: "darwin",
+      commandExists: () => false,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, "missing");
+    assert.match(result.fix, /brew install coreutils/);
+  });
+
+  it("accepts gtimeout as the macOS timeout provider (#227)", () => {
+    const result = inspectMacTimeoutDependency({
+      platform: "darwin",
+      commandExists: (name) => name === "gtimeout",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.provider, "gtimeout");
+  });
+
+  it("detects settings hooks that can collapse to /hooks when PLUGIN_ROOT is unset (#228)", () => {
+    const settings = {
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [
+              {
+                type: "command",
+                command: 'node "${PLUGIN_ROOT}/hooks/pipeline-stop.mjs"',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const issues = findPluginRootHookIssues(settings);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].event, "Stop");
+    assert.match(issues[0].command, /\$\{PLUGIN_ROOT\}/);
+  });
+
+  it("does not flag hooks with a PLUGIN_ROOT shell fallback (#228)", () => {
+    const settings = {
+      hooks: {
+        Stop: [
+          {
+            matcher: "*",
+            hooks: [
+              {
+                type: "command",
+                command:
+                  'node "${PLUGIN_ROOT:-/opt/homebrew/lib/node_modules/triflux}/hooks/pipeline-stop.mjs"',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    assert.deepEqual(findPluginRootHookIssues(settings), []);
+  });
+});

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -130,6 +130,21 @@ describe("setup-sync: SYNC_MAP", () => {
     assert.ok(hasFastSh, "SYNC_MAP must include headless-guard-fast.sh");
   });
 
+  it("scripts/lib/*.sh도 SYNC_MAP에 포함한다 (#227)", () => {
+    const entry = SYNC_MAP.find((e) => e.label === "lib/codex-recovery.sh");
+    assert.ok(entry, "SYNC_MAP must include lib/codex-recovery.sh");
+    assert.ok(
+      entry.src.replace(/\\/g, "/").endsWith("/scripts/lib/codex-recovery.sh"),
+      "src path must reference scripts/lib/codex-recovery.sh",
+    );
+    assert.ok(
+      entry.dst
+        .replace(/\\/g, "/")
+        .endsWith("/.claude/scripts/lib/codex-recovery.sh"),
+      "dst path must sync codex-recovery.sh into ~/.claude/scripts/lib",
+    );
+  });
+
   it("agent-map.json이 SYNC_MAP에 포함되어 있다", () => {
     const entry = SYNC_MAP.find((e) => e.label === "hub/team/agent-map.json");
     assert.ok(entry, "SYNC_MAP must include hub/team/agent-map.json");
@@ -257,8 +272,8 @@ describe("setup-sync: managed hook registration", () => {
         "invalid plugin root must not leak into settings",
       );
       assert.ok(
-        stopCommands.some((command) => command.includes("${PLUGIN_ROOT}")),
-        "registered hook must use ${PLUGIN_ROOT} template variable",
+        stopCommands.some((command) => command.includes("${PLUGIN_ROOT:-")),
+        "registered hook must include a ${PLUGIN_ROOT:-...} fallback",
       );
     } finally {
       if (prevPluginRoot === undefined) delete process.env.PLUGIN_ROOT;

--- a/tests/unit/tfx-route-codex-recovery.test.mjs
+++ b/tests/unit/tfx-route-codex-recovery.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const routeSource = readFileSync(
+  join(process.cwd(), "scripts", "tfx-route.sh"),
+  "utf8",
+);
+
+describe("tfx-route codex recovery helper", () => {
+  it("guards the optional codex-recovery.sh source (#227)", () => {
+    assert.match(
+      routeSource,
+      /if\s+\[\[\s+-f\s+"\$_TFX_ROUTE_DIR\/lib\/codex-recovery\.sh"\s+\]\];\s+then[\s\S]+source\s+"\$_TFX_ROUTE_DIR\/lib\/codex-recovery\.sh"[\s\S]+else[\s\S]+codex-recovery\.sh/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Sync `scripts/lib/*.sh` alongside `*.mjs` so `lib/codex-recovery.sh` is installed by `triflux doctor --fix`.
- Guard `scripts/tfx-route.sh` recovery helper sourcing and emit an actionable warning instead of aborting when the optional helper is missing.
- Add macOS doctor coverage for missing `timeout`/`gtimeout`, with `brew install coreutils` guidance and interactive `doctor --fix` installation.
- Add `${PLUGIN_ROOT:-<package-root>}` hook command fallbacks and make `doctor` detect/fix hook commands that would collapse to `/hooks/...` or `/scripts/...`.
- Refresh package mirrors for the changed setup/doctor files.

## Impact
- New npm-only macOS installs should no longer lose the recovery helper during sync.
- npm-only installs that do not receive marketplace `PLUGIN_ROOT` still get executable hook paths.
- `doctor` now surfaces the formerly silent hook-path failure mode instead of leaving only Stop hook stderr as evidence.

## Regression Safety
- Restores PreToolUse guard execution for npm-only installs by preventing `${PLUGIN_ROOT}` from expanding to an empty root path. This closes the security gap where guard hooks silently failed.
- Missing `codex-recovery.sh` is treated as degraded optional behavior with a stderr warning and `doctor --fix` remediation path, not a route-time hard failure.
- macOS timeout handling is diagnostic by default; `doctor --fix` only runs Homebrew installation in an interactive terminal after confirmation.

## Verification
- `env -u TFX_PREFLIGHT_LOADED node --test tests/unit/setup-sync.test.mjs tests/unit/tfx-route-codex-recovery.test.mjs tests/unit/doctor-macos-hooks.test.mjs tests/unit/packages-sync.test.mjs tests/integration/tfx-shape-golden.test.mjs`
- `npm run release:check-mirror`
- `npx biome check bin/triflux.mjs scripts/setup.mjs scripts/lib/doctor-env-checks.mjs tests/unit/setup-sync.test.mjs tests/unit/doctor-macos-hooks.test.mjs tests/unit/tfx-route-codex-recovery.test.mjs packages/triflux/bin/triflux.mjs packages/triflux/scripts/setup.mjs packages/triflux/scripts/lib/doctor-env-checks.mjs packages/core/scripts/lib/doctor-env-checks.mjs packages/remote/scripts/lib/doctor-env-checks.mjs packages/triflux/hub/codex-adapter.mjs`
- `git diff --check`

## Notes
- A full `npm test` run was attempted in the temp clone, but was not used as completion evidence: the first run lacked installed dependencies, and the route smoke path is sensitive to ambient `TFX_PREFLIGHT_LOADED` state in this shell.