### PR TITLE
fix(hud): support Claude OAuth credentials in macOS Keychain

### DIFF
--- a/hud/providers/claude.mjs
+++ b/hud/providers/claude.mjs
@@ -2,7 +2,7 @@
 // Claude Usage API (api.anthropic.com/api/oauth/usage)
 // ============================================================================
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, writeFileSync } from "node:fs";
 import https from "node:https";
 import {
@@ -31,6 +31,7 @@ import {
 
 export const CLAUDE_USAGE_POLL_BASE_MS = 5_000;
 export const CLAUDE_USAGE_POLL_JITTER_RATIO = 0.2;
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
 export const CLAUDE_USAGE_RATE_LIMIT_BACKOFF_MS = [
   CLAUDE_USAGE_POLL_BASE_MS,
   10_000,
@@ -98,8 +99,7 @@ function getSnapshotSchedule(cache) {
   };
 }
 
-export function readClaudeCredentials() {
-  const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
+function normalizeClaudeCredentials(data, source, supportsUsageApi = true) {
   if (!data) return null;
   const creds = data.claudeAiOauth || data;
   if (!creds.accessToken) return null;
@@ -107,7 +107,49 @@ export function readClaudeCredentials() {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
+    source,
+    supportsUsageApi,
   };
+}
+
+function readClaudeKeychainCredentials(execFileSyncFn = execFileSync) {
+  try {
+    const raw = execFileSyncFn(
+      "security",
+      ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
+      { encoding: "utf8" },
+    );
+    return normalizeClaudeCredentials(JSON.parse(raw.trim()), "keychain");
+  } catch {
+    return null;
+  }
+}
+
+export function readClaudeCredentials({
+  readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+  platform = process.platform,
+  execFileSyncFn = execFileSync,
+  env = process.env,
+} = {}) {
+  const fileCreds = normalizeClaudeCredentials(readCredentialFile(), "file");
+  if (fileCreds) return fileCreds;
+
+  if (platform === "darwin") {
+    const keychainCreds = readClaudeKeychainCredentials(execFileSyncFn);
+    if (keychainCreds) return keychainCreds;
+  }
+
+  if (env.ANTHROPIC_API_KEY) {
+    return {
+      accessToken: env.ANTHROPIC_API_KEY,
+      refreshToken: null,
+      expiresAt: null,
+      source: "env",
+      supportsUsageApi: false,
+    };
+  }
+
+  return null;
 }
 
 export function refreshClaudeAccessToken(refreshToken) {
@@ -166,17 +208,67 @@ export function refreshClaudeAccessToken(refreshToken) {
   });
 }
 
-export function writeBackClaudeCredentials(creds) {
+function serializeClaudeCredentials(creds) {
+  const oauth = {
+    accessToken: creds.accessToken,
+  };
+  if (creds.expiresAt != null) oauth.expiresAt = creds.expiresAt;
+  if (creds.refreshToken) oauth.refreshToken = creds.refreshToken;
+  return { claudeAiOauth: oauth };
+}
+
+function writeClaudeKeychainCredentials(creds, execFileSyncFn = execFileSync) {
+  execFileSyncFn(
+    "security",
+    [
+      "add-generic-password",
+      "-s",
+      CLAUDE_KEYCHAIN_SERVICE,
+      "-w",
+      JSON.stringify(serializeClaudeCredentials(creds)),
+      "-U",
+    ],
+    { stdio: "ignore" },
+  );
+}
+
+export function writeBackClaudeCredentials(
+  creds,
+  {
+    readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+    writeCredentialFile = (data) =>
+      writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2)),
+    platform = process.platform,
+    execFileSyncFn = execFileSync,
+  } = {},
+) {
+  if (creds?.source === "env") return;
+
+  let data = null;
   try {
-    const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
-    if (!data) return;
+    data = readCredentialFile();
+  } catch {
+    data = null;
+  }
+
+  if (data) {
     const target = data.claudeAiOauth || data;
     target.accessToken = creds.accessToken;
     if (creds.expiresAt != null) target.expiresAt = creds.expiresAt;
     if (creds.refreshToken) target.refreshToken = creds.refreshToken;
-    writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2));
-  } catch {
-    /* 쓰기 실패 무시 */
+    try {
+      writeCredentialFile(data);
+    } catch {
+      /* 파일 쓰기 실패 무시 */
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      writeClaudeKeychainCredentials(creds, execFileSyncFn);
+    } catch {
+      /* Keychain 쓰기 실패 무시 */
+    }
   }
 }
 
@@ -396,6 +488,10 @@ export async function fetchClaudeUsage(forceRefresh = false) {
     : 0;
   let creds = readClaudeCredentials();
   if (!creds) {
+    writeClaudeUsageCache(null, { type: "auth", status: 0 });
+    return existingSnapshot.data || null;
+  }
+  if (creds.supportsUsageApi === false) {
     writeClaudeUsageCache(null, { type: "auth", status: 0 });
     return existingSnapshot.data || null;
   }

--- a/packages/core/hud/providers/claude.mjs
+++ b/packages/core/hud/providers/claude.mjs
@@ -2,7 +2,7 @@
 // Claude Usage API (api.anthropic.com/api/oauth/usage)
 // ============================================================================
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, writeFileSync } from "node:fs";
 import https from "node:https";
 import {
@@ -31,6 +31,7 @@ import {
 
 export const CLAUDE_USAGE_POLL_BASE_MS = 5_000;
 export const CLAUDE_USAGE_POLL_JITTER_RATIO = 0.2;
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
 export const CLAUDE_USAGE_RATE_LIMIT_BACKOFF_MS = [
   CLAUDE_USAGE_POLL_BASE_MS,
   10_000,
@@ -98,8 +99,7 @@ function getSnapshotSchedule(cache) {
   };
 }
 
-export function readClaudeCredentials() {
-  const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
+function normalizeClaudeCredentials(data, source, supportsUsageApi = true) {
   if (!data) return null;
   const creds = data.claudeAiOauth || data;
   if (!creds.accessToken) return null;
@@ -107,7 +107,49 @@ export function readClaudeCredentials() {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
+    source,
+    supportsUsageApi,
   };
+}
+
+function readClaudeKeychainCredentials(execFileSyncFn = execFileSync) {
+  try {
+    const raw = execFileSyncFn(
+      "security",
+      ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
+      { encoding: "utf8" },
+    );
+    return normalizeClaudeCredentials(JSON.parse(raw.trim()), "keychain");
+  } catch {
+    return null;
+  }
+}
+
+export function readClaudeCredentials({
+  readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+  platform = process.platform,
+  execFileSyncFn = execFileSync,
+  env = process.env,
+} = {}) {
+  const fileCreds = normalizeClaudeCredentials(readCredentialFile(), "file");
+  if (fileCreds) return fileCreds;
+
+  if (platform === "darwin") {
+    const keychainCreds = readClaudeKeychainCredentials(execFileSyncFn);
+    if (keychainCreds) return keychainCreds;
+  }
+
+  if (env.ANTHROPIC_API_KEY) {
+    return {
+      accessToken: env.ANTHROPIC_API_KEY,
+      refreshToken: null,
+      expiresAt: null,
+      source: "env",
+      supportsUsageApi: false,
+    };
+  }
+
+  return null;
 }
 
 export function refreshClaudeAccessToken(refreshToken) {
@@ -166,17 +208,67 @@ export function refreshClaudeAccessToken(refreshToken) {
   });
 }
 
-export function writeBackClaudeCredentials(creds) {
+function serializeClaudeCredentials(creds) {
+  const oauth = {
+    accessToken: creds.accessToken,
+  };
+  if (creds.expiresAt != null) oauth.expiresAt = creds.expiresAt;
+  if (creds.refreshToken) oauth.refreshToken = creds.refreshToken;
+  return { claudeAiOauth: oauth };
+}
+
+function writeClaudeKeychainCredentials(creds, execFileSyncFn = execFileSync) {
+  execFileSyncFn(
+    "security",
+    [
+      "add-generic-password",
+      "-s",
+      CLAUDE_KEYCHAIN_SERVICE,
+      "-w",
+      JSON.stringify(serializeClaudeCredentials(creds)),
+      "-U",
+    ],
+    { stdio: "ignore" },
+  );
+}
+
+export function writeBackClaudeCredentials(
+  creds,
+  {
+    readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+    writeCredentialFile = (data) =>
+      writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2)),
+    platform = process.platform,
+    execFileSyncFn = execFileSync,
+  } = {},
+) {
+  if (creds?.source === "env") return;
+
+  let data = null;
   try {
-    const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
-    if (!data) return;
+    data = readCredentialFile();
+  } catch {
+    data = null;
+  }
+
+  if (data) {
     const target = data.claudeAiOauth || data;
     target.accessToken = creds.accessToken;
     if (creds.expiresAt != null) target.expiresAt = creds.expiresAt;
     if (creds.refreshToken) target.refreshToken = creds.refreshToken;
-    writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2));
-  } catch {
-    /* 쓰기 실패 무시 */
+    try {
+      writeCredentialFile(data);
+    } catch {
+      /* 파일 쓰기 실패 무시 */
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      writeClaudeKeychainCredentials(creds, execFileSyncFn);
+    } catch {
+      /* Keychain 쓰기 실패 무시 */
+    }
   }
 }
 
@@ -396,6 +488,10 @@ export async function fetchClaudeUsage(forceRefresh = false) {
     : 0;
   let creds = readClaudeCredentials();
   if (!creds) {
+    writeClaudeUsageCache(null, { type: "auth", status: 0 });
+    return existingSnapshot.data || null;
+  }
+  if (creds.supportsUsageApi === false) {
     writeClaudeUsageCache(null, { type: "auth", status: 0 });
     return existingSnapshot.data || null;
   }

--- a/packages/triflux/hud/providers/claude.mjs
+++ b/packages/triflux/hud/providers/claude.mjs
@@ -2,7 +2,7 @@
 // Claude Usage API (api.anthropic.com/api/oauth/usage)
 // ============================================================================
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, writeFileSync } from "node:fs";
 import https from "node:https";
 import {
@@ -31,6 +31,7 @@ import {
 
 export const CLAUDE_USAGE_POLL_BASE_MS = 5_000;
 export const CLAUDE_USAGE_POLL_JITTER_RATIO = 0.2;
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
 export const CLAUDE_USAGE_RATE_LIMIT_BACKOFF_MS = [
   CLAUDE_USAGE_POLL_BASE_MS,
   10_000,
@@ -98,8 +99,7 @@ function getSnapshotSchedule(cache) {
   };
 }
 
-export function readClaudeCredentials() {
-  const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
+function normalizeClaudeCredentials(data, source, supportsUsageApi = true) {
   if (!data) return null;
   const creds = data.claudeAiOauth || data;
   if (!creds.accessToken) return null;
@@ -107,7 +107,49 @@ export function readClaudeCredentials() {
     accessToken: creds.accessToken,
     refreshToken: creds.refreshToken,
     expiresAt: creds.expiresAt,
+    source,
+    supportsUsageApi,
   };
+}
+
+function readClaudeKeychainCredentials(execFileSyncFn = execFileSync) {
+  try {
+    const raw = execFileSyncFn(
+      "security",
+      ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
+      { encoding: "utf8" },
+    );
+    return normalizeClaudeCredentials(JSON.parse(raw.trim()), "keychain");
+  } catch {
+    return null;
+  }
+}
+
+export function readClaudeCredentials({
+  readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+  platform = process.platform,
+  execFileSyncFn = execFileSync,
+  env = process.env,
+} = {}) {
+  const fileCreds = normalizeClaudeCredentials(readCredentialFile(), "file");
+  if (fileCreds) return fileCreds;
+
+  if (platform === "darwin") {
+    const keychainCreds = readClaudeKeychainCredentials(execFileSyncFn);
+    if (keychainCreds) return keychainCreds;
+  }
+
+  if (env.ANTHROPIC_API_KEY) {
+    return {
+      accessToken: env.ANTHROPIC_API_KEY,
+      refreshToken: null,
+      expiresAt: null,
+      source: "env",
+      supportsUsageApi: false,
+    };
+  }
+
+  return null;
 }
 
 export function refreshClaudeAccessToken(refreshToken) {
@@ -166,17 +208,67 @@ export function refreshClaudeAccessToken(refreshToken) {
   });
 }
 
-export function writeBackClaudeCredentials(creds) {
+function serializeClaudeCredentials(creds) {
+  const oauth = {
+    accessToken: creds.accessToken,
+  };
+  if (creds.expiresAt != null) oauth.expiresAt = creds.expiresAt;
+  if (creds.refreshToken) oauth.refreshToken = creds.refreshToken;
+  return { claudeAiOauth: oauth };
+}
+
+function writeClaudeKeychainCredentials(creds, execFileSyncFn = execFileSync) {
+  execFileSyncFn(
+    "security",
+    [
+      "add-generic-password",
+      "-s",
+      CLAUDE_KEYCHAIN_SERVICE,
+      "-w",
+      JSON.stringify(serializeClaudeCredentials(creds)),
+      "-U",
+    ],
+    { stdio: "ignore" },
+  );
+}
+
+export function writeBackClaudeCredentials(
+  creds,
+  {
+    readCredentialFile = () => readJson(CLAUDE_CREDENTIALS_PATH, null),
+    writeCredentialFile = (data) =>
+      writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2)),
+    platform = process.platform,
+    execFileSyncFn = execFileSync,
+  } = {},
+) {
+  if (creds?.source === "env") return;
+
+  let data = null;
   try {
-    const data = readJson(CLAUDE_CREDENTIALS_PATH, null);
-    if (!data) return;
+    data = readCredentialFile();
+  } catch {
+    data = null;
+  }
+
+  if (data) {
     const target = data.claudeAiOauth || data;
     target.accessToken = creds.accessToken;
     if (creds.expiresAt != null) target.expiresAt = creds.expiresAt;
     if (creds.refreshToken) target.refreshToken = creds.refreshToken;
-    writeFileSync(CLAUDE_CREDENTIALS_PATH, JSON.stringify(data, null, 2));
-  } catch {
-    /* 쓰기 실패 무시 */
+    try {
+      writeCredentialFile(data);
+    } catch {
+      /* 파일 쓰기 실패 무시 */
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      writeClaudeKeychainCredentials(creds, execFileSyncFn);
+    } catch {
+      /* Keychain 쓰기 실패 무시 */
+    }
   }
 }
 
@@ -396,6 +488,10 @@ export async function fetchClaudeUsage(forceRefresh = false) {
     : 0;
   let creds = readClaudeCredentials();
   if (!creds) {
+    writeClaudeUsageCache(null, { type: "auth", status: 0 });
+    return existingSnapshot.data || null;
+  }
+  if (creds.supportsUsageApi === false) {
     writeClaudeUsageCache(null, { type: "auth", status: 0 });
     return existingSnapshot.data || null;
   }

--- a/tests/unit/hud-claude-credentials.test.mjs
+++ b/tests/unit/hud-claude-credentials.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  readClaudeCredentials,
+  writeBackClaudeCredentials,
+} from "../../hud/providers/claude.mjs";
+
+describe("readClaudeCredentials", () => {
+  it("keeps file credentials as the first priority", () => {
+    const creds = readClaudeCredentials({
+      readCredentialFile: () => ({
+        claudeAiOauth: {
+          accessToken: "file-access",
+          refreshToken: "file-refresh",
+          expiresAt: 123,
+        },
+      }),
+      platform: "darwin",
+      execFileSyncFn: () => {
+        throw new Error(
+          "keychain should not be read when file credentials exist",
+        );
+      },
+      env: {},
+    });
+
+    assert.deepEqual(creds, {
+      accessToken: "file-access",
+      refreshToken: "file-refresh",
+      expiresAt: 123,
+      source: "file",
+      supportsUsageApi: true,
+    });
+  });
+
+  it("falls back to macOS Keychain OAuth credentials", () => {
+    const calls = [];
+    const creds = readClaudeCredentials({
+      readCredentialFile: () => null,
+      platform: "darwin",
+      execFileSyncFn: (command, args, options) => {
+        calls.push({ command, args, options });
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "keychain-access",
+            refreshToken: "keychain-refresh",
+            expiresAt: 456,
+          },
+        });
+      },
+      env: {},
+    });
+
+    assert.deepEqual(calls, [
+      {
+        command: "security",
+        args: ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+        options: { encoding: "utf8" },
+      },
+    ]);
+    assert.deepEqual(creds, {
+      accessToken: "keychain-access",
+      refreshToken: "keychain-refresh",
+      expiresAt: 456,
+      source: "keychain",
+      supportsUsageApi: true,
+    });
+  });
+
+  it("returns null when neither file nor keychain credentials exist", () => {
+    const creds = readClaudeCredentials({
+      readCredentialFile: () => null,
+      platform: "darwin",
+      execFileSyncFn: () => {
+        throw new Error("not found");
+      },
+      env: {},
+    });
+
+    assert.equal(creds, null);
+  });
+});
+
+describe("writeBackClaudeCredentials", () => {
+  it("writes refreshed macOS OAuth credentials to both file and Keychain", () => {
+    const keychainCalls = [];
+    let writtenFile = null;
+    writeBackClaudeCredentials(
+      {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresAt: 789,
+        source: "file",
+        supportsUsageApi: true,
+      },
+      {
+        readCredentialFile: () => ({
+          claudeAiOauth: {
+            accessToken: "old-access",
+            refreshToken: "old-refresh",
+            expiresAt: 123,
+          },
+        }),
+        writeCredentialFile: (data) => {
+          writtenFile = data;
+        },
+        platform: "darwin",
+        execFileSyncFn: (command, args, options) => {
+          keychainCalls.push({ command, args, options });
+        },
+      },
+    );
+
+    assert.deepEqual(writtenFile, {
+      claudeAiOauth: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresAt: 789,
+      },
+    });
+    assert.equal(keychainCalls.length, 1);
+    assert.equal(keychainCalls[0].command, "security");
+    assert.deepEqual(keychainCalls[0].args.slice(0, 4), [
+      "add-generic-password",
+      "-s",
+      "Claude Code-credentials",
+      "-w",
+    ]);
+    assert.deepEqual(JSON.parse(keychainCalls[0].args[4]), writtenFile);
+    assert.equal(keychainCalls[0].args[5], "-U");
+    assert.deepEqual(keychainCalls[0].options, { stdio: "ignore" });
+  });
+});


### PR DESCRIPTION
## Summary
- Keep `~/.claude/.credentials.json` as the first Claude OAuth credential source.
- Add macOS Keychain fallback via `security find-generic-password -s "Claude Code-credentials" -w` and JSON parsing.
- Write refreshed OAuth credentials back to macOS Keychain with `security add-generic-password -U`, while still updating an existing credentials file.
- Mirror the provider change into `packages/core` and `packages/triflux`.

## macOS user impact
macOS users who authenticated Claude Code with `/login` but do not have `~/.claude/.credentials.json` can now use the HUD Claude `c:` usage row from the Keychain-stored OAuth credentials instead of getting a cached `errorType:"auth"` and permanent `--%` / `n/a` output. If a workaround file exists, refresh writes update both the file and Keychain to avoid drift.

`ANTHROPIC_API_KEY` remains a last-resort credential signal, but it is marked as unsupported for the OAuth usage API so the HUD does not try to treat it as an OAuth usage token.

## Verification
- `node --test tests/unit/hud-claude-credentials.test.mjs tests/unit/hud-claude-parse.test.mjs tests/unit/hud-backoff.test.mjs` — 15/15 pass.
- `npx --yes @biomejs/biome@2.0.0 check hud/providers/claude.mjs packages/core/hud/providers/claude.mjs packages/triflux/hud/providers/claude.mjs tests/unit/hud-claude-credentials.test.mjs` — pass.
- `node --check` on the changed provider mirrors and credential test — pass.
- `diff -q hud/providers/claude.mjs packages/core/hud/providers/claude.mjs` and `diff -q hud/providers/claude.mjs packages/triflux/hud/providers/claude.mjs` — pass.

The credential unit test mocks `security` for file-only, macOS Keychain fallback, missing credentials, and Keychain write-back paths. I used targeted `node --test` commands instead of `npm test` because ambient `TFX_PREFLIGHT_LOADED` can affect the full test wrapper.

## Manual macOS verification
1. On a macOS machine logged into Claude Code, temporarily move `~/.claude/.credentials.json` aside if it exists.
2. Confirm `security find-generic-password -s "Claude Code-credentials" -w` prints the Claude Code OAuth JSON.
3. Run the HUD refresh path, for example `node --input-type=module -e 'import { readClaudeCredentials } from "./hud/providers/claude.mjs"; console.log(readClaudeCredentials()?.source)'` and confirm it prints `keychain`.
4. Force or wait for the HUD Claude usage refresh and confirm the `c:` row no longer stays at `--% (n/a)` due to auth-cache failure.

Closes #226
