### PR TITLE
fix(macos): guard optional hooks and bash 3.2 routing

### DIFF
--- a/hooks/hook-registry.json
+++ b/hooks/hook-registry.json
@@ -206,10 +206,11 @@
       {
         "id": "ext-session-vault-start",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/start_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 10,
         "blocking": false,
         "description": "세션 볼트 로깅 시작"
@@ -230,10 +231,11 @@
       {
         "id": "ext-session-vault-export",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/export_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 30,
         "blocking": false,
         "description": "세션 트랜스크립트 내보내기"

--- a/packages/core/hooks/hook-registry.json
+++ b/packages/core/hooks/hook-registry.json
@@ -206,10 +206,11 @@
       {
         "id": "ext-session-vault-start",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/start_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 10,
         "blocking": false,
         "description": "세션 볼트 로깅 시작"
@@ -230,10 +231,11 @@
       {
         "id": "ext-session-vault-export",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/export_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 30,
         "blocking": false,
         "description": "세션 트랜스크립트 내보내기"

--- a/packages/triflux/hooks/hook-registry.json
+++ b/packages/triflux/hooks/hook-registry.json
@@ -206,10 +206,11 @@
       {
         "id": "ext-session-vault-start",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/start_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 10,
         "blocking": false,
         "description": "세션 볼트 로깅 시작"
@@ -230,10 +231,11 @@
       {
         "id": "ext-session-vault-export",
         "source": "session-vault",
+        "requires": "$HOME/Desktop/Projects/tools/session-vault",
         "matcher": "*",
         "command": "bash \"${HOME}/Desktop/Projects/tools/session-vault/scripts/export_hook.sh\"",
         "priority": 100,
-        "enabled": true,
+        "enabled": false,
         "timeout": 30,
         "blocking": false,
         "description": "세션 트랜스크립트 내보내기"

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -18,7 +18,7 @@ import {
   writeFileSync,
 } from "fs";
 import { homedir } from "os";
-import { dirname, join, relative } from "path";
+import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import {
   ensureGlobalClaudeRoutingSection,
@@ -498,10 +498,22 @@ function extractManagedHookFilename(command) {
   return match ? match[1] : null;
 }
 
+function expandRequiresPath(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  return resolve(
+    value.replace(/\$\{HOME\}/g, _TFX_HOME).replace(/\$HOME\b/g, _TFX_HOME),
+  );
+}
+
+function isRequiredPathAvailable(value) {
+  const expanded = expandRequiresPath(value);
+  return expanded ? existsSync(expanded) : true;
+}
+
 /**
  * hook-registry.json에서 관리 대상 훅 목록을 플랫 배열로 반환한다.
  * @param {string} registryPath - hook-registry.json 경로
- * @returns {Array<{ event: string, id: string, fileName: string, matcher: string, command: string, priority: number, enabled: boolean }>}
+ * @returns {Array<{ event: string, id: string, fileName: string, matcher: string, command: string, priority: number, enabled: boolean, requires?: string }>}
  */
 function getManagedRegistryHooks(registryPath) {
   if (!existsSync(registryPath)) return [];
@@ -513,6 +525,7 @@ function getManagedRegistryHooks(registryPath) {
       if (!Array.isArray(hooks)) continue;
       for (const hook of hooks) {
         if (!hook.enabled) continue;
+        if (!isRequiredPathAvailable(hook.requires)) continue;
         const fileName = extractManagedHookFilename(hook.command);
         result.push({
           event,
@@ -522,6 +535,7 @@ function getManagedRegistryHooks(registryPath) {
           command: hook.command || "",
           priority: hook.priority ?? 100,
           enabled: hook.enabled,
+          requires: hook.requires,
         });
       }
     }

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -365,7 +365,8 @@ mkdir -p "$TFX_PROBE_DIR" 2>/dev/null || true
 
 estimate_expected_duration_sec() {
   local agent="${1:-}" profile="${2:-}" prompt="${3:-}"
-  local text="${prompt,,}"
+  local text
+  text=$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')
   local expected=30
 
   case "$agent" in

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -18,7 +18,7 @@ import {
   writeFileSync,
 } from "fs";
 import { homedir } from "os";
-import { dirname, join, relative } from "path";
+import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import {
   ensureGlobalClaudeRoutingSection,
@@ -498,10 +498,22 @@ function extractManagedHookFilename(command) {
   return match ? match[1] : null;
 }
 
+function expandRequiresPath(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  return resolve(
+    value.replace(/\$\{HOME\}/g, _TFX_HOME).replace(/\$HOME\b/g, _TFX_HOME),
+  );
+}
+
+function isRequiredPathAvailable(value) {
+  const expanded = expandRequiresPath(value);
+  return expanded ? existsSync(expanded) : true;
+}
+
 /**
  * hook-registry.json에서 관리 대상 훅 목록을 플랫 배열로 반환한다.
  * @param {string} registryPath - hook-registry.json 경로
- * @returns {Array<{ event: string, id: string, fileName: string, matcher: string, command: string, priority: number, enabled: boolean }>}
+ * @returns {Array<{ event: string, id: string, fileName: string, matcher: string, command: string, priority: number, enabled: boolean, requires?: string }>}
  */
 function getManagedRegistryHooks(registryPath) {
   if (!existsSync(registryPath)) return [];
@@ -513,6 +525,7 @@ function getManagedRegistryHooks(registryPath) {
       if (!Array.isArray(hooks)) continue;
       for (const hook of hooks) {
         if (!hook.enabled) continue;
+        if (!isRequiredPathAvailable(hook.requires)) continue;
         const fileName = extractManagedHookFilename(hook.command);
         result.push({
           event,
@@ -522,6 +535,7 @@ function getManagedRegistryHooks(registryPath) {
           command: hook.command || "",
           priority: hook.priority ?? 100,
           enabled: hook.enabled,
+          requires: hook.requires,
         });
       }
     }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -365,7 +365,8 @@ mkdir -p "$TFX_PROBE_DIR" 2>/dev/null || true
 
 estimate_expected_duration_sec() {
   local agent="${1:-}" profile="${2:-}" prompt="${3:-}"
-  local text="${prompt,,}"
+  local text
+  text=$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')
   local expected=30
 
   case "$agent" in

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -240,6 +240,94 @@ describe("setup-sync: managed hook registration", () => {
   before(ensureTmpDir);
   after(cleanTmpDir);
 
+  function writeRegistry(registryPath, hooks) {
+    writeFileSync(
+      registryPath,
+      JSON.stringify({ events: { Stop: hooks } }, null, 2) + "\n",
+      "utf8",
+    );
+  }
+
+  function readStopCommands(settingsPath) {
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    return (settings.hooks?.Stop || [])
+      .flatMap((entry) => (Array.isArray(entry?.hooks) ? entry.hooks : []))
+      .map((hook) => String(hook.command || ""));
+  }
+
+  it("requires 경로가 없으면 managed hook 등록을 건너뛴다 (#231)", () => {
+    const settingsPath = join(TMP_DIR, "settings-requires-missing.json");
+    const registryPath = join(TMP_DIR, "registry-requires-missing.json");
+
+    writeRegistry(registryPath, [
+      {
+        id: "external-missing",
+        matcher: "*",
+        command: 'bash "${HOME}/missing-tool/hook.sh"',
+        enabled: true,
+        requires: "$HOME/missing-tool",
+      },
+    ]);
+
+    const result = ensureHooksInSettings({ settingsPath, registryPath });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, false);
+    assert.deepEqual(result.added, []);
+    assert.equal(existsSync(settingsPath), false);
+  });
+
+  it("requires 경로가 있으면 managed hook을 등록한다 (#231)", () => {
+    const settingsPath = join(TMP_DIR, "settings-requires-present.json");
+    const registryPath = join(TMP_DIR, "registry-requires-present.json");
+    const requiredDir = join(TMP_DIR, "present-tool");
+    mkdirSync(requiredDir, { recursive: true });
+
+    writeRegistry(registryPath, [
+      {
+        id: "external-present",
+        matcher: "*",
+        command: 'bash "${HOME}/present-tool/hook.sh"',
+        enabled: true,
+        requires: requiredDir,
+      },
+    ]);
+
+    const result = ensureHooksInSettings({ settingsPath, registryPath });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.added, ["external-present"]);
+    assert.ok(
+      readStopCommands(settingsPath).some((command) =>
+        command.includes("present-tool"),
+      ),
+    );
+  });
+
+  it("requires 없는 managed hook은 기존처럼 등록한다 (#231)", () => {
+    const settingsPath = join(TMP_DIR, "settings-no-requires.json");
+    const registryPath = join(TMP_DIR, "registry-no-requires.json");
+
+    writeRegistry(registryPath, [
+      {
+        id: "internal-hook",
+        matcher: "*",
+        command: 'node "${PLUGIN_ROOT}/hooks/pipeline-stop.mjs"',
+        enabled: true,
+      },
+    ]);
+
+    const result = ensureHooksInSettings({ settingsPath, registryPath });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.added, ["internal-hook"]);
+    assert.ok(
+      readStopCommands(settingsPath).some((command) =>
+        command.includes("pipeline-stop.mjs"),
+      ),
+    );
+  });
+
   it("유효하지 않은 CLAUDE_PLUGIN_ROOT는 무시하고 실제 패키지 루트를 사용한다", () => {
     const settingsPath = join(TMP_DIR, "settings.json");
     const registryPath = join(PROJECT_ROOT, "hooks", "hook-registry.json");

--- a/tests/unit/tfx-route-duration.test.mjs
+++ b/tests/unit/tfx-route-duration.test.mjs
@@ -32,6 +32,20 @@ function estimate(agent, profile, prompt) {
   return parseInt(result.stdout.trim(), 10);
 }
 
+function estimateWithShell(shell, agent, profile, prompt) {
+  const script = `${FUNC}\nestimate_expected_duration_sec "${agent}" "${profile}" "${prompt}"`;
+  const result = spawnSync(shell, ["-c", script], {
+    encoding: "utf8",
+    env: { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8" },
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${shell} failed: ${result.stderr || result.stdout}`,
+  );
+  return parseInt(result.stdout.trim(), 10);
+}
+
 describe("estimate_expected_duration_sec — agent 기본값", () => {
   it("explore = 30", () => {
     assert.equal(estimate("explore", "", ""), 30);
@@ -102,6 +116,15 @@ describe("estimate_expected_duration_sec — 한글 키워드 bump", () => {
 });
 
 describe("estimate_expected_duration_sec — 영어 키워드 bump", () => {
+  it("/bin/bash에서도 uppercase keyword lowercasing이 동작한다 (#232)", {
+    skip: fs.existsSync("/bin/bash") ? false : "/bin/bash is not available",
+  }, () => {
+    assert.equal(
+      estimateWithShell("/bin/bash", "explore", "", "ANALYZE output"),
+      600,
+    );
+  });
+
   it('"deep" → 600', () => {
     assert.equal(estimate("explore", "", "deep investigation"), 600);
   });


### PR DESCRIPTION
## Summary
- Disable the optional `ext-session-vault-*` hooks by default and add a `requires` path for the session-vault integration.
- Teach `doctor --fix` managed hook registration to skip enabled registry entries when their `requires` path is absent, while preserving existing behavior for entries without `requires`.
- Replace Bash 4-only `${var,,}` lowercasing in `scripts/tfx-route.sh` with a Bash 3.2-compatible `tr` pipeline.
- Sync the published package mirrors under `packages/`.

## Impact
- macOS/Linux users without `~/Desktop/Projects/tools/session-vault` no longer get session-vault hooks re-added by `doctor --fix`.
- macOS default `/bin/bash` 3.2 can evaluate `estimate_expected_duration_sec` without `bad substitution`.
- No routing behavior change beyond portable lowercase conversion.

## Verification
- `node --test tests/unit/setup-sync.test.mjs tests/unit/tfx-route-duration.test.mjs tests/unit/packages-mirror.test.mjs`
- `/bin/bash -n scripts/tfx-route.sh && bash -n scripts/tfx-route.sh && /bin/bash -n packages/triflux/scripts/tfx-route.sh && bash -n packages/triflux/scripts/tfx-route.sh`
- `./node_modules/.bin/biome check scripts/setup.mjs tests/unit/setup-sync.test.mjs tests/unit/tfx-route-duration.test.mjs`
- `npm run release:check-mirror -- --json`
- `rg -n "\$\{[^}]+(,,|\^\^)[^}]*\}" scripts hooks hub packages -g "*.sh" -g "*.bash" -g "*.zsh" -g "*.mjs" -g "*.js"` returned no matches.

## Notes
- `npm test` was intentionally not run because ambient `TFX_PREFLIGHT_LOADED` can affect it; targeted `node --test` checks were used as requested.
- Additional non-blocking observation: `tests/unit/tfx-route-preflight-all-dead.test.mjs` currently has unrelated `/bin/bash` 3.2 + `set -u` failures around `new_flags[@]`, so it was not used as completion evidence for this PR.

Closes #231
Closes #232