### PR TITLE
docs(instructions): CODEX.md / GEMINI.md 분리 + swarm-* gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,8 @@ docs/research/*competitor*
 # Codex/Gemini state snapshots (local backup, too large for git)
 references/codex-snapshots/
 references/gemini-snapshots/
+
+# ad-hoc research/eval scratch from earlier projects (diningcode/naver/catchtable/tabling, 2026-04-11)
+# 다른 프로젝트 잔재가 다른 브랜치 체크아웃 시 따라다니지 않도록 ignore
+swarm-logs/
+swarm-prompts/

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,45 @@
+# triflux — Codex 프로젝트 지시
+
+triflux 워크스페이스에서 Codex CLI의 역할과 운영 규칙. Claude/Gemini와 함께 3-CLI 합의·교차 검증·헤드리스 병렬 실행의 한 축으로 사용된다.
+
+전체 프로젝트 컨텍스트는 `CLAUDE.md`를 참조한다 (이 파일은 Codex 관점만 다룸).
+
+## Codex의 역할
+- 교차 검증: Claude가 작성한 코드의 독립 리뷰 (동일 모델 self-approve 금지)
+- 단일 파일 오토파일럿: tfx-autopilot, tfx-codex
+- 3-CLI 합의(consensus/debate/panel)에서 Codex 시점 제공
+- swarm/multi headless 병렬 실행의 워커
+
+## psmux에서 Codex 실행
+- interactive `codex` 불가 (TTY 못 잡음)
+- `codex < prompt.md` 불가 ("stdin is not a terminal")
+- 사용 가능 패턴: `codex exec "$(cat prompt.md)" -s danger-full-access --dangerously-bypass-approvals-and-sandbox`
+- `codex exec`는 config.toml의 approval_mode를 무시 → bypass 플래그 필수
+- `-s` 유효값: read-only / workspace-write / danger-full-access
+
+## config.toml 사용 규칙
+- 이미 설정된 값은 CLI 플래그로 중복 지정 금지
+  - `approval_mode = "auto"` 있으면 `-a` / `--full-auto` 생략
+  - `sandbox = "workspace-write"` 있으면 `-s` / `--full-auto` 생략
+- 안전 패턴: config.toml에 기본값 + CLI는 `--profile` 선택만
+
+## headless-guard
+- `codex exec` / `gemini -y -p` 직접 호출은 차단됨
+- 반드시 tfx 스킬 경유: tfx-auto, tfx-codex, tfx-multi, tfx-swarm 등
+
+## Headless 결과 회수
+- task-notification 완료 **후** output 파일 읽기 (그 전에는 시작 메시지만)
+- 완료 마커: `=== HEADLESS_COMPLETE succeeded=N failed=N total=N ===`
+- 워커 상세: `$TMPDIR/tfx-headless/{sessionName}-worker-N.txt`
+
+## SSH 패턴
+- `hosts.json`의 `os` 필드로 셸 판단 (windows=PowerShell, darwin=zsh, linux=bash)
+- SSH 너머로 codex 직접 실행 금지 (config.toml 충돌 + TTY 문제)
+- 원격에서 codex가 필요하면: tfx-remote-spawn → Claude Code → Claude가 내부에서 codex 호출
+
+## Working agreements
+- 한국어 우선, 기술 용어 원어 유지
+- 커밋: `Type: 한국어 설명 (50자 이내)`. Co-Authored-By / AI trailer 금지
+- 변경 후 lint/typecheck/test 실행
+- 시크릿(API 키, 토큰, 세션) 하드코딩 금지
+- 새 차단 규칙을 safety-guard에 추가할 때는 항상 대안 API를 같이 만들 것 (차단만 추가하면 데드락)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,43 @@
-# triflux
+# triflux — Gemini 프로젝트 지시
 
-@CLAUDE.md
+triflux 워크스페이스에서 Gemini CLI의 역할과 운영 규칙. 1M context 활용·웹 검색·헤드리스 합의의 한 축으로 사용된다.
 
-<!-- Gemini 전용 지시사항은 이 아래에 추가. CLAUDE.md가 공용 베이스. -->
+전체 프로젝트 컨텍스트는 `CLAUDE.md`를 참조한다 (이 파일은 Gemini 관점만 다룸).
+
+## 행동 규칙 (파일 상단 우선 적용)
+- 한국어 우선, 기술 용어 원어 유지
+- 응답은 결정론적·구조적으로 — 마크다운 헤더 또는 XML 태그 일관 사용 (혼용 금지)
+- 부정 지시도 효과적 (긍정과 동등한 adherence — A/B 검증)
+- 커밋: `Type: 한국어 설명 (50자 이내)`. Co-Authored-By / AI trailer 금지
+- 시크릿(API 키, 토큰, 세션) 하드코딩 금지
+
+## Gemini의 역할
+- 빠른 웹 검색 (Google Search 통합) — `tfx-research --quick`
+- 3-CLI 합의(consensus/debate/panel)에서 Gemini 시점 제공
+- 1M context 활용 — 큰 코드베이스 분석 / `tfx-deep-interview`는 Gemini 단독
+- swarm/multi headless 병렬 실행의 워커
+
+## headless-guard
+- `gemini -y -p` 직접 호출은 차단됨
+- 반드시 tfx 스킬 경유: tfx-auto, tfx-gemini, tfx-multi, tfx-swarm 등
+- 일반 호출: `tfx-route.sh --cli gemini ...`
+
+## 디렉터리 import 금지 (EISDIR)
+- `@./path/` 처럼 디렉터리 import하면 Gemini ImportProcessor가 fs.readFile을 호출해 EISDIR로 크래시 (gemini-cli #6450, #4760)
+- 디렉터리 경로를 문서에 남겨야 한다면 백틱(`)으로 감싸 import 스캔에서 제외
+
+## 핵심 운영 컨텍스트 (요약 — 상세는 CLAUDE.md)
+- psmux/WT 규칙: `tfx-psmux-rules` 스킬 / WT 프리징 방지 (exit → sleep 2 → kill)
+- AccountBroker 싱글턴: 계정별 CircuitBreaker, busy 플래그, 이벤트 기반 HUD 연동
+- 원격 실행: tfx-remote-spawn (SSH → Claude Code → 내부 tfx 라우팅)
+- Headless 결과 회수: task-notification 완료 후 output 파일 읽기
+  - 완료 마커: `=== HEADLESS_COMPLETE succeeded=N failed=N total=N ===`
+
+## 교차 검증
+- Claude 작성 코드 → Gemini/Codex 리뷰 가능
+- Gemini 작성 코드 → Claude 또는 Codex 리뷰
+- 동일 모델 self-approve 금지
+
+## 검증
+- 변경 후 lint/typecheck/test 실행
+- 새 차단 규칙은 항상 대안 API와 함께 추가 (차단만 추가하면 데드락)


### PR DESCRIPTION
## Summary

m2 host 에서 cherry-pick 된 두 commit. 3-way consensus (Claude+Codex+Gemini, 92/100) 검증 후 진행.

### Commit 1 — `docs(instructions): CODEX.md / GEMINI.md 분리`

- `CODEX.md` 신규 (45 lines): Codex CLI 운영 규칙 (psmux 실행 패턴, config.toml, headless-guard, 3-CLI 합의 역할)
- `GEMINI.md` 풍부화 (5 → 43 lines): Gemini CLI 운영 규칙 (역할/headless-guard/디렉터리 import 금지/EISDIR/핵심 운영 컨텍스트 요약)
- CLAUDE.md 는 origin/main 그대로 (mac 세션의 prompt-hygiene 마커 정리 의도 존중, m2 의 line_limit 변경은 drop)

원본 m2 commit: `a395322` (cherry-pick 후 `ef62937` 로 재생성)

### Commit 2 — `chore(gitignore): swarm-logs/ swarm-prompts/ ignore 추가`

- 4월 11일 다른 프로젝트 (diningcode/naver/catchtable/tabling) 작업 잔재가 m2 working tree 에서 untracked 로 약 4주 잔존
- 다른 브랜치 체크아웃 시 따라다니지 않도록 ignore
- Gemini 합의: **Workspace hygiene P0 (Phase 1-0)** — `git add .` 사고 시 오염 위험

## Context

이 PR 은 m2 host 정리 5-Phase 의 **Phase 1-0 + Phase 1** 통합 실행:
- Phase 1-0: workspace hygiene (Gemini 추가)
- Phase 1: a395322 docs PR (low risk, 다른 9 commits 는 mac main 에 의도 흡수 확인됨)
- Phase 2: feat/macos-compat-deep archive + delete (Phase 1 머지 후)
- Phase 3: m2 main 처리 (`git diff main origin/main` 검증 후 결정)

관련 메모: `~/.gstack/projects/tellang-triflux/checkpoints/20260507-170643-3-way-consensus-m2-direction-5phase-plan.md`

## Test plan

- [ ] CODEX.md / GEMINI.md 내용 검토 (운영 규칙 정확성)
- [ ] CLAUDE.md 변경 없음 확인 (origin/main 그대로)
- [ ] .gitignore 추가 항목이 다른 ignore 패턴과 충돌하지 않음 확인