### PR TITLE
fix(cli-adapter-base): runProcess resultFile size/mtime을 progress signal로 인정 (Codex Tier 1)

### DIFF
--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -2,7 +2,7 @@
 // Phase 2: codex-adapter.mjs에서 추출한 재사용 가능 유틸리티
 
 import { execSync, spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -391,7 +391,18 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
     });
   }
 
+  const resultFileSignature = () => {
+    if (!resultFile) return "";
+    try {
+      const info = statSync(resultFile);
+      return `${info.size}:${info.mtimeMs}`;
+    } catch {
+      return "";
+    }
+  };
+
   let lastBytes = 0;
+  let lastResultFileSignature = resultFileSignature();
   let lastChange = Date.now();
   const touch = () => {
     lastChange = Date.now();
@@ -420,8 +431,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   }, timeout);
   const stallTimer = setInterval(() => {
     const size = Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
-    if (size !== lastBytes) {
+    const currentResultFileSignature = resultFileSignature();
+    if (
+      size !== lastBytes ||
+      currentResultFileSignature !== lastResultFileSignature
+    ) {
       lastBytes = size;
+      lastResultFileSignature = currentResultFileSignature;
+      touch();
       return;
     }
     if (Date.now() - lastChange >= stallThresholdMs)

--- a/packages/core/hub/cli-adapter-base.mjs
+++ b/packages/core/hub/cli-adapter-base.mjs
@@ -2,7 +2,7 @@
 // Phase 2: codex-adapter.mjs에서 추출한 재사용 가능 유틸리티
 
 import { execSync, spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -391,7 +391,18 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
     });
   }
 
+  const resultFileSignature = () => {
+    if (!resultFile) return "";
+    try {
+      const info = statSync(resultFile);
+      return `${info.size}:${info.mtimeMs}`;
+    } catch {
+      return "";
+    }
+  };
+
   let lastBytes = 0;
+  let lastResultFileSignature = resultFileSignature();
   let lastChange = Date.now();
   const touch = () => {
     lastChange = Date.now();
@@ -420,8 +431,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   }, timeout);
   const stallTimer = setInterval(() => {
     const size = Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
-    if (size !== lastBytes) {
+    const currentResultFileSignature = resultFileSignature();
+    if (
+      size !== lastBytes ||
+      currentResultFileSignature !== lastResultFileSignature
+    ) {
       lastBytes = size;
+      lastResultFileSignature = currentResultFileSignature;
+      touch();
       return;
     }
     if (Date.now() - lastChange >= stallThresholdMs)

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -2,7 +2,7 @@
 // Phase 2: codex-adapter.mjs에서 추출한 재사용 가능 유틸리티
 
 import { execSync, spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -391,7 +391,18 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
     });
   }
 
+  const resultFileSignature = () => {
+    if (!resultFile) return "";
+    try {
+      const info = statSync(resultFile);
+      return `${info.size}:${info.mtimeMs}`;
+    } catch {
+      return "";
+    }
+  };
+
   let lastBytes = 0;
+  let lastResultFileSignature = resultFileSignature();
   let lastChange = Date.now();
   const touch = () => {
     lastChange = Date.now();
@@ -420,8 +431,14 @@ export async function runProcess(command, workdir, timeout, opts = {}) {
   }, timeout);
   const stallTimer = setInterval(() => {
     const size = Buffer.byteLength(stdout) + Buffer.byteLength(stderr);
-    if (size !== lastBytes) {
+    const currentResultFileSignature = resultFileSignature();
+    if (
+      size !== lastBytes ||
+      currentResultFileSignature !== lastResultFileSignature
+    ) {
       lastBytes = size;
+      lastResultFileSignature = currentResultFileSignature;
+      touch();
       return;
     }
     if (Date.now() - lastChange >= stallThresholdMs)

--- a/tests/unit/cli-adapter-base.test.mjs
+++ b/tests/unit/cli-adapter-base.test.mjs
@@ -113,19 +113,26 @@ test("runProcess treats resultFile updates as progress during quiet CLI executio
   await withSandbox(async ({ root }) => {
     const { runProcess } = await importFresh("../../hub/cli-adapter-base.mjs");
     const resultFile = join(root, "result.txt");
-    const script = [
-      "const { writeFileSync } = require('node:fs');",
-      "const file = process.env.RESULT_FILE;",
-      "let n = 0;",
-      "const timer = setInterval(() => {",
-      "  n += 1;",
-      "  writeFileSync(file, `tick-${n}`, 'utf8');",
-      "  if (n >= 6) { clearInterval(timer); process.exit(0); }",
-      "}, 75);",
-    ].join(" ");
+    // Write the script to a file to avoid shell-quoting hazards (backticks /
+    // ${...} get expanded by the shell when passed via `node -e "..."`).
+    const scriptPath = join(root, "tick.cjs");
+    writeFileSync(
+      scriptPath,
+      [
+        "const { writeFileSync } = require('node:fs');",
+        "const file = process.env.RESULT_FILE;",
+        "let n = 0;",
+        "const timer = setInterval(() => {",
+        "  n += 1;",
+        "  writeFileSync(file, 'tick-' + n, 'utf8');",
+        "  if (n >= 6) { clearInterval(timer); process.exit(0); }",
+        "}, 75);",
+      ].join("\n"),
+      "utf8",
+    );
 
     const result = await runProcess(
-      `node -e ${JSON.stringify(script)}`,
+      `node ${JSON.stringify(scriptPath)}`,
       root,
       3_000,
       {

--- a/tests/unit/cli-adapter-base.test.mjs
+++ b/tests/unit/cli-adapter-base.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -105,5 +106,41 @@ test("cli-adapter-base exports the shared codex exec builder and codex-compat re
     assert.equal(base.CODEX_MCP_EXECUTION_EXIT_CODE, 1);
     assert.equal(compat.CODEX_MCP_TRANSPORT_EXIT_CODE, 70);
     assert.equal(compat.CODEX_MCP_EXECUTION_EXIT_CODE, 1);
+  });
+});
+
+test("runProcess treats resultFile updates as progress during quiet CLI execution", async () => {
+  await withSandbox(async ({ root }) => {
+    const { runProcess } = await importFresh("../../hub/cli-adapter-base.mjs");
+    const resultFile = join(root, "result.txt");
+    const script = [
+      "const { writeFileSync } = require('node:fs');",
+      "const file = process.env.RESULT_FILE;",
+      "let n = 0;",
+      "const timer = setInterval(() => {",
+      "  n += 1;",
+      "  writeFileSync(file, `tick-${n}`, 'utf8');",
+      "  if (n >= 6) { clearInterval(timer); process.exit(0); }",
+      "}, 75);",
+    ].join(" ");
+
+    const result = await runProcess(
+      `node -e ${JSON.stringify(script)}`,
+      root,
+      3_000,
+      {
+        resultFile,
+        stallCheckIntervalMs: 50,
+        stallThresholdMs: 150,
+        inferStallMode: () => "stall",
+        spawnEnv: { ...process.env, RESULT_FILE: resultFile },
+      },
+    );
+
+    assert.equal(existsSync(resultFile), true);
+    assert.equal(result.ok, true);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.failureMode, null);
+    assert.equal(result.output, "tick-6");
   });
 });


### PR DESCRIPTION
## Summary

ROADMAP 세션 17 carry-over (B Tier visibility hardening 트랙). codex 가 `resultFile` (output JSON) 에 직접 쓰는 경우 wrapper 가 stdout pipe 신호 부재로 stuck 으로 오인하는 회귀 방지.

## 문제

- `hub/cli-adapter-base.mjs` `runProcess` 가 progress 신호로 stdout pipe 만 모니터
- codex/gemini 가 결과를 stdout 이 아닌 `resultFile` 로 쓰는 경우 wrapper 가 진행 중인지 stuck 인지 구분 불가
- 진짜 root cause: `codex-mcp.mjs:672` `await worker.stop()` 무제한 대기 (별도 PR P1 #1)

## 변경

- `runProcess` 가 `resultFile` 의 size 또는 mtime 변화도 progress signal 로 인정
- size 가 증가하거나 mtime 이 갱신되면 worker 가 살아있는 것으로 판정 → stuck 오판 방지
- 회귀 가드: `tests/unit/cli-adapter-base.test.mjs` (+37 lines)

## Mirror

- `hub/cli-adapter-base.mjs`
- `packages/triflux/hub/cli-adapter-base.mjs`
- `packages/core/hub/cli-adapter-base.mjs`

세 위치 byte-identical 검증. `node scripts/release/check-packages-mirror.mjs --json`:

```json
{ "ok": true, "issues": [], "fixed": [] }
```

`packages/remote/hub/cli-adapter-base.mjs` 는 부재이므로 변환 mirror 불필요.

## 위치 (Tier 1 vs P1 root fix)

| 작업 | 의미 | 진행 |
|---|---|---|
| **이 PR (Codex Tier 1)** | runProcess resultFile signal 인정 | ✅ 본 PR |
| **P1 #1 root fix** | `codex-mcp.mjs:672` `worker.stop()` Promise.race + 1-2s timeout | 미적용 (별도) |
| **B Tier 2 EXIT trap** | wrapper-stuck 시 emergency dump | PR #239 |
| **ROADMAP carry-over** | 세션 17 요약 + plan | PR #238 |

## Cross-review

CLAUDE.md 룰: Codex 작성 코드 → Claude 리뷰. 본 PR 의 변경은 Codex Tier 1 후보이므로 Claude 리뷰 권장.

## Test plan

- [ ] `bun test tests/unit/cli-adapter-base.test.mjs` 통과
- [ ] 기존 cli-adapter-base 회귀 없음
- [ ] mirror byte-identical (`check-packages-mirror.mjs`)