### PR TITLE
fix(wt-manager): macOS/Linux stub manager + autoAttachTerminal OS guard (v10.18.2 회귀)

### DIFF
--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -1370,6 +1370,7 @@ export async function autoAttachTerminal(
   opts = {},
   workerCount = 2,
 ) {
+  if (process.platform !== "win32") return false;
   if (!process.env.WT_SESSION) return false;
 
   const wt = createWtManager();

--- a/hub/team/wt-manager.mjs
+++ b/hub/team/wt-manager.mjs
@@ -170,12 +170,34 @@ function atomicWriteSync(filePath, data) {
  * @param {number} [opts.tabCreateDelayMs=500]
  * @param {object} [opts.deps] — 테스트용 의존성 주입
  */
+function createNonWindowsStubManager() {
+  const asyncFalse = async () => false;
+  return Object.freeze({
+    ensureWtProfile: () => {},
+    createTab: asyncFalse,
+    renameTab: asyncFalse,
+    closeTab: asyncFalse,
+    listTabs: async () => [],
+    closeStale: async () => 0,
+    createSession: asyncFalse,
+    splitPane: asyncFalse,
+    applySplitLayout: asyncFalse,
+    getEnvironmentInfo: () => ({
+      platform: process.platform,
+      hasWindowsTerminal: false,
+      hasWt: false,
+      isWindowsTerminalSession: false,
+    }),
+    getTabCount: () => 0,
+  });
+}
+
 export function createWtManager(opts = {}) {
   const deps = opts.deps || {};
   const platform = deps.platform || osPlatform;
 
   if (platform() !== "win32") {
-    throw new Error("wt-manager.mjs is Windows-only");
+    return createNonWindowsStubManager();
   }
 
   const now = deps.now || Date.now;

--- a/packages/remote/hub/team/wt-manager.mjs
+++ b/packages/remote/hub/team/wt-manager.mjs
@@ -170,12 +170,34 @@ function atomicWriteSync(filePath, data) {
  * @param {number} [opts.tabCreateDelayMs=500]
  * @param {object} [opts.deps] — 테스트용 의존성 주입
  */
+function createNonWindowsStubManager() {
+  const asyncFalse = async () => false;
+  return Object.freeze({
+    ensureWtProfile: () => {},
+    createTab: asyncFalse,
+    renameTab: asyncFalse,
+    closeTab: asyncFalse,
+    listTabs: async () => [],
+    closeStale: async () => 0,
+    createSession: asyncFalse,
+    splitPane: asyncFalse,
+    applySplitLayout: asyncFalse,
+    getEnvironmentInfo: () => ({
+      platform: process.platform,
+      hasWindowsTerminal: false,
+      hasWt: false,
+      isWindowsTerminalSession: false,
+    }),
+    getTabCount: () => 0,
+  });
+}
+
 export function createWtManager(opts = {}) {
   const deps = opts.deps || {};
   const platform = deps.platform || osPlatform;
 
   if (platform() !== "win32") {
-    throw new Error("wt-manager.mjs is Windows-only");
+    return createNonWindowsStubManager();
   }
 
   const now = deps.now || Date.now;

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -1370,6 +1370,7 @@ export async function autoAttachTerminal(
   opts = {},
   workerCount = 2,
 ) {
+  if (process.platform !== "win32") return false;
   if (!process.env.WT_SESSION) return false;
 
   const wt = createWtManager();

--- a/packages/triflux/hub/team/wt-manager.mjs
+++ b/packages/triflux/hub/team/wt-manager.mjs
@@ -170,12 +170,34 @@ function atomicWriteSync(filePath, data) {
  * @param {number} [opts.tabCreateDelayMs=500]
  * @param {object} [opts.deps] — 테스트용 의존성 주입
  */
+function createNonWindowsStubManager() {
+  const asyncFalse = async () => false;
+  return Object.freeze({
+    ensureWtProfile: () => {},
+    createTab: asyncFalse,
+    renameTab: asyncFalse,
+    closeTab: asyncFalse,
+    listTabs: async () => [],
+    closeStale: async () => 0,
+    createSession: asyncFalse,
+    splitPane: asyncFalse,
+    applySplitLayout: asyncFalse,
+    getEnvironmentInfo: () => ({
+      platform: process.platform,
+      hasWindowsTerminal: false,
+      hasWt: false,
+      isWindowsTerminalSession: false,
+    }),
+    getTabCount: () => 0,
+  });
+}
+
 export function createWtManager(opts = {}) {
   const deps = opts.deps || {};
   const platform = deps.platform || osPlatform;
 
   if (platform() !== "win32") {
-    throw new Error("wt-manager.mjs is Windows-only");
+    return createNonWindowsStubManager();
   }
 
   const now = deps.now || Date.now;

--- a/tests/unit/wt-manager-os-stub.test.mjs
+++ b/tests/unit/wt-manager-os-stub.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createWtManager } from "../../hub/team/wt-manager.mjs";
+
+describe("wt-manager non-Windows stub", () => {
+  it("createWtManager는 darwin에서 throw 하지 않고 stub manager 를 반환한다", () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    assert.ok(wt, "stub manager 반환되어야 함");
+    assert.equal(typeof wt.createTab, "function");
+    assert.equal(typeof wt.ensureWtProfile, "function");
+    assert.equal(typeof wt.getEnvironmentInfo, "function");
+  });
+
+  it("createWtManager는 linux에서도 stub manager 반환한다", () => {
+    const wt = createWtManager({ deps: { platform: () => "linux" } });
+    assert.ok(wt);
+  });
+
+  it("stub getEnvironmentInfo는 hasWindowsTerminal=false 를 반환한다", () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    const env = wt.getEnvironmentInfo();
+    assert.equal(env.hasWindowsTerminal, false);
+    assert.equal(env.hasWt, false);
+    assert.equal(env.isWindowsTerminalSession, false);
+  });
+
+  it("stub createTab 은 false 를 비동기 반환한다", async () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    const result = await wt.createTab({ title: "x", command: "echo" });
+    assert.equal(result, false);
+  });
+
+  it("stub applySplitLayout 도 false 를 비동기 반환한다", async () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    const result = await wt.applySplitLayout([]);
+    assert.equal(result, false);
+  });
+
+  it("stub ensureWtProfile 은 throw 하지 않는 noop 이다", () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    assert.doesNotThrow(() => wt.ensureWtProfile(2));
+  });
+
+  it("stub listTabs 는 빈 배열을 반환한다", async () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    const tabs = await wt.listTabs();
+    assert.deepEqual(tabs, []);
+  });
+
+  it("stub closeStale 은 0 을 반환한다", async () => {
+    const wt = createWtManager({ deps: { platform: () => "darwin" } });
+    const count = await wt.closeStale({ olderThanMs: 1000 });
+    assert.equal(count, 0);
+  });
+});

--- a/tests/unit/wt-manager.test.mjs
+++ b/tests/unit/wt-manager.test.mjs
@@ -109,11 +109,12 @@ afterEach(() => {
 });
 
 describe("wt-manager: createWtManager", () => {
-  it("Windows가 아니면 즉시 에러를 던진다", () => {
-    assert.throws(
-      () => createWtManager({ deps: { platform: () => "linux" } }),
-      /Windows-only/,
-    );
+  it("Windows가 아니면 stub manager 를 반환한다 (no throw)", () => {
+    const stub = createWtManager({ deps: { platform: () => "linux" } });
+    assert.ok(stub, "stub manager 반환되어야 함");
+    assert.equal(typeof stub.createTab, "function");
+    assert.equal(typeof stub.getEnvironmentInfo, "function");
+    assert.equal(stub.getEnvironmentInfo().hasWindowsTerminal, false);
   });
 
   it("Object.freeze된 공개 API를 반환한다", () => {


### PR DESCRIPTION
## Summary

사용자 보고된 v10.18.2 회귀 수정 — `tfx multi --teammate-mode headless` 가 macOS 에서 dispatch 직후 `wt-manager.mjs is Windows-only` 로 크래시. dashboard/wt-manager 옵션 없는 호출에서도 동일.

## Root cause

- `hub/team/wt-manager.mjs:177-179`: `createWtManager()` 가 non-Windows 에서 `throw new Error("wt-manager.mjs is Windows-only")`
- `createWtManager` 호출 사이트 **8 곳** (전체 코드베이스 grep):
  - `hub/team/wt-manager.mjs` 내부
  - `hub/team/headless.mjs:1375` (autoAttachTerminal)
  - `hub/team/headless.mjs:1450` (attachDashboardTab)
  - `hub/team/dashboard-open.mjs:43`
  - `hub/team/session.mjs:247`
  - `hub/team/tui.mjs:982`
  - `scripts/wt-cli.mjs:16`
  - `scripts/remote-spawn.mjs:620/713/1009` (3 instances)
  - `scripts/session-spawn-helper.mjs:110`
- 일부 호출자 (예: `attachDashboardTab` line 1450) 는 `createWtManager()` 호출이 try-catch 밖이라 throw 가 unhandled crash 로 전파

## Fix

### 1. `hub/team/wt-manager.mjs` — `createWtManager` non-Windows stub 반환

```diff
+ function createNonWindowsStubManager() {
+   const asyncFalse = async () => false;
+   return Object.freeze({
+     ensureWtProfile: () => {},
+     createTab: asyncFalse,
+     ...
+     getEnvironmentInfo: () => ({
+       platform: process.platform,
+       hasWindowsTerminal: false,
+       hasWt: false,
+       isWindowsTerminalSession: false,
+     }),
+     getTabCount: () => 0,
+   });
+ }
+
  export function createWtManager(opts = {}) {
    ...
    if (platform() !== "win32") {
-     throw new Error("wt-manager.mjs is Windows-only");
+     return createNonWindowsStubManager();
    }
```

**효과**: 호출자 변경 없이 8 곳 모두 OS-aware 동작.
- `attachDashboardTab` 의 `wt.getEnvironmentInfo()?.hasWindowsTerminal` 가드 (line 1453) 가 stub 의 `false` 로 정상 early return
- 다른 호출자도 stub 의 method 가 noop/false 반환 → silent success-but-no-attach (사용자 visible behavior 변화 없음)

### 2. `hub/team/headless.mjs:1373` — `autoAttachTerminal` OS guard 강화 (defensive)

```diff
  export async function autoAttachTerminal(...) {
+   if (process.platform !== "win32") return false;
    if (!process.env.WT_SESSION) return false;
    const wt = createWtManager();
    ...
  }
```

**효과**: stale `WT_SESSION` env 시나리오 (사용자가 WT 세션 후 macOS shell 진입 시 env 잔류) 에서 stub success 가 silent return true 로 호출자에게 "attached" 신호 보내는 edge case 차단.

## Mirror

- `hub/team/wt-manager.mjs` → `packages/triflux/hub/team/wt-manager.mjs` byte-identical
- `hub/team/headless.mjs` → `packages/triflux/hub/team/headless.mjs` byte-identical
- `packages/core/hub/team/` 디렉토리 부재 (packages/core 는 `hub/lib`, `hub/middleware`, `hub/pipeline`, `hub/quality`, `hub/workers`, `hub/routing`, `hub/delegator` 만 sync). hub/team mirror 정책 외.

`node scripts/release/check-packages-mirror.mjs --json`:

```json
{ "ok": true, "issues": [], "fixed": [] }
```

## Test

`tests/unit/wt-manager-os-stub.test.mjs` (8 cases):

- ✅ darwin/linux 에서 createWtManager throw 안 함
- ✅ stub getEnvironmentInfo 가 hasWindowsTerminal=false 반환
- ✅ stub createTab/applySplitLayout 가 false async 반환
- ✅ stub ensureWtProfile noop (throw 없음)
- ✅ stub listTabs `[]`, closeStale `0` 반환

기존 `tests/unit/headless-wt-attach.test.mjs` 6 cases 모두 회귀 없음.

## 영향 범위 (추적)

| 진입점 | 경로 | macOS 영향 |
|---|---|---|
| `tfx team start --headless` | `start-headless.mjs` → `runHeadlessInteractive` → autoAttachTerminal/attachDashboardTab | ✅ Fix |
| `tfx multi/auto/swarm/fullcycle` | `delegator-mcp.mjs` → `runHeadlessWithCleanup` → `runHeadless` | ✅ Fix (stub 으로 모든 wt-manager 호출 사이트 안전) |
| `tfx remote-spawn` | `scripts/remote-spawn.mjs` | ✅ Fix |
| `tfx wt-cli` | `scripts/wt-cli.mjs` | ✅ Fix (silent no-op 동작) |

사용자 노트 ("multi 뿐만이 아니라 tfx auto 면 되는거 아닌가") 반영 — multi/auto/swarm 모두 동일 코어 거치므로 한 곳 fix 로 해결.

## Cross-review

CLAUDE.md `## 교차 검증` 룰: Claude 작성 → Codex 리뷰. 본 PR 은 Claude 작성 fix 이므로 Codex review 권장.

## Test plan

- [ ] `node --test tests/unit/wt-manager-os-stub.test.mjs` 8 pass
- [ ] `node --test tests/unit/headless-wt-attach.test.mjs` 회귀 없음
- [ ] m2 (macOS) 에서 `tfx multi --teammate-mode headless --assign 'codex:echo:role'` 실행 → 크래시 없이 dispatch
- [ ] ryzen (Windows) 에서 기존 동작 회귀 없음 (createTab/attachDashboardTab 정상)
- [ ] `node scripts/release/check-packages-mirror.mjs --json` ok=true