### PR TITLE
fix(codex-mcp): bounded worker.stop with closeWithin (#234 P1 root fix)

### DIFF
--- a/hub/workers/codex-mcp.mjs
+++ b/hub/workers/codex-mcp.mjs
@@ -48,7 +48,6 @@ async function closeWithin(label, closeFn, timeoutMs) {
       timer = setTimeout(() => {
         resolve({ timedOut: true });
       }, timeoutMs);
-      timer.unref?.();
     });
     const closed = Promise.resolve()
       .then(closeFn)

--- a/hub/workers/codex-mcp.mjs
+++ b/hub/workers/codex-mcp.mjs
@@ -16,6 +16,7 @@ const REQUIRED_TOOLS = ["codex", "codex-reply"];
 export { CODEX_MCP_EXECUTION_EXIT_CODE, CODEX_MCP_TRANSPORT_EXIT_CODE };
 export const DEFAULT_CODEX_MCP_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_CODEX_MCP_BOOTSTRAP_TIMEOUT_MS = 120 * 1000;
+export const DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 /**
  * Codex MCP transport/bootstrap 계층 오류
@@ -38,6 +39,35 @@ function cloneEnv(env = process.env) {
   return Object.fromEntries(
     Object.entries(env).filter(([, value]) => typeof value === "string"),
   );
+}
+
+async function closeWithin(label, closeFn, timeoutMs) {
+  let timer = null;
+  try {
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(() => {
+        resolve({ timedOut: true });
+      }, timeoutMs);
+      timer.unref?.();
+    });
+    const closed = Promise.resolve()
+      .then(closeFn)
+      .then(() => ({ timedOut: false }));
+    const result = await Promise.race([closed, timeout]);
+    if (result.timedOut) {
+      console.error(
+        `[codex-mcp] WARNING: ${label} did not close within ${timeoutMs}ms; continuing shutdown.`,
+      );
+    }
+    return result;
+  } catch (error) {
+    console.error(
+      `[codex-mcp] WARNING: ${label} close failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { timedOut: false };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function collectTextContent(content = []) {
@@ -388,7 +418,7 @@ export class CodexMcpWorker {
     this.ready = true;
   }
 
-  async stop() {
+  async stop(options = {}) {
     this.ready = false;
     this.availableTools.clear();
 
@@ -397,10 +427,26 @@ export class CodexMcpWorker {
     this.transport = null;
     this.client = null;
 
+    const shutdownTimeoutMs = Number.isFinite(options.shutdownTimeoutMs)
+      ? options.shutdownTimeoutMs
+      : DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS;
+
+    let clientCloseTimedOut = false;
     if (client) {
-      await client.close().catch(() => {});
-    } else if (transport) {
-      await transport.close().catch(() => {});
+      const result = await closeWithin(
+        "client.close",
+        () => client.close(),
+        shutdownTimeoutMs,
+      );
+      clientCloseTimedOut = Boolean(result.timedOut);
+    }
+
+    if (transport && (!client || clientCloseTimedOut)) {
+      await closeWithin(
+        "transport.close",
+        () => transport.close(),
+        shutdownTimeoutMs,
+      );
     }
 
     transport?.stderr?.destroy?.();

--- a/packages/remote/hub/workers/codex-mcp.mjs
+++ b/packages/remote/hub/workers/codex-mcp.mjs
@@ -48,7 +48,6 @@ async function closeWithin(label, closeFn, timeoutMs) {
       timer = setTimeout(() => {
         resolve({ timedOut: true });
       }, timeoutMs);
-      timer.unref?.();
     });
     const closed = Promise.resolve()
       .then(closeFn)

--- a/packages/remote/hub/workers/codex-mcp.mjs
+++ b/packages/remote/hub/workers/codex-mcp.mjs
@@ -16,6 +16,7 @@ const REQUIRED_TOOLS = ["codex", "codex-reply"];
 export { CODEX_MCP_EXECUTION_EXIT_CODE, CODEX_MCP_TRANSPORT_EXIT_CODE };
 export const DEFAULT_CODEX_MCP_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_CODEX_MCP_BOOTSTRAP_TIMEOUT_MS = 120 * 1000;
+export const DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 /**
  * Codex MCP transport/bootstrap 계층 오류
@@ -38,6 +39,35 @@ function cloneEnv(env = process.env) {
   return Object.fromEntries(
     Object.entries(env).filter(([, value]) => typeof value === "string"),
   );
+}
+
+async function closeWithin(label, closeFn, timeoutMs) {
+  let timer = null;
+  try {
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(() => {
+        resolve({ timedOut: true });
+      }, timeoutMs);
+      timer.unref?.();
+    });
+    const closed = Promise.resolve()
+      .then(closeFn)
+      .then(() => ({ timedOut: false }));
+    const result = await Promise.race([closed, timeout]);
+    if (result.timedOut) {
+      console.error(
+        `[codex-mcp] WARNING: ${label} did not close within ${timeoutMs}ms; continuing shutdown.`,
+      );
+    }
+    return result;
+  } catch (error) {
+    console.error(
+      `[codex-mcp] WARNING: ${label} close failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { timedOut: false };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function collectTextContent(content = []) {
@@ -388,7 +418,7 @@ export class CodexMcpWorker {
     this.ready = true;
   }
 
-  async stop() {
+  async stop(options = {}) {
     this.ready = false;
     this.availableTools.clear();
 
@@ -397,10 +427,26 @@ export class CodexMcpWorker {
     this.transport = null;
     this.client = null;
 
+    const shutdownTimeoutMs = Number.isFinite(options.shutdownTimeoutMs)
+      ? options.shutdownTimeoutMs
+      : DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS;
+
+    let clientCloseTimedOut = false;
     if (client) {
-      await client.close().catch(() => {});
-    } else if (transport) {
-      await transport.close().catch(() => {});
+      const result = await closeWithin(
+        "client.close",
+        () => client.close(),
+        shutdownTimeoutMs,
+      );
+      clientCloseTimedOut = Boolean(result.timedOut);
+    }
+
+    if (transport && (!client || clientCloseTimedOut)) {
+      await closeWithin(
+        "transport.close",
+        () => transport.close(),
+        shutdownTimeoutMs,
+      );
     }
 
     transport?.stderr?.destroy?.();

--- a/packages/triflux/hub/workers/codex-mcp.mjs
+++ b/packages/triflux/hub/workers/codex-mcp.mjs
@@ -48,7 +48,6 @@ async function closeWithin(label, closeFn, timeoutMs) {
       timer = setTimeout(() => {
         resolve({ timedOut: true });
       }, timeoutMs);
-      timer.unref?.();
     });
     const closed = Promise.resolve()
       .then(closeFn)

--- a/packages/triflux/hub/workers/codex-mcp.mjs
+++ b/packages/triflux/hub/workers/codex-mcp.mjs
@@ -16,6 +16,7 @@ const REQUIRED_TOOLS = ["codex", "codex-reply"];
 export { CODEX_MCP_EXECUTION_EXIT_CODE, CODEX_MCP_TRANSPORT_EXIT_CODE };
 export const DEFAULT_CODEX_MCP_TIMEOUT_MS = 10 * 60 * 1000;
 export const DEFAULT_CODEX_MCP_BOOTSTRAP_TIMEOUT_MS = 120 * 1000;
+export const DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 /**
  * Codex MCP transport/bootstrap 계층 오류
@@ -38,6 +39,35 @@ function cloneEnv(env = process.env) {
   return Object.fromEntries(
     Object.entries(env).filter(([, value]) => typeof value === "string"),
   );
+}
+
+async function closeWithin(label, closeFn, timeoutMs) {
+  let timer = null;
+  try {
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(() => {
+        resolve({ timedOut: true });
+      }, timeoutMs);
+      timer.unref?.();
+    });
+    const closed = Promise.resolve()
+      .then(closeFn)
+      .then(() => ({ timedOut: false }));
+    const result = await Promise.race([closed, timeout]);
+    if (result.timedOut) {
+      console.error(
+        `[codex-mcp] WARNING: ${label} did not close within ${timeoutMs}ms; continuing shutdown.`,
+      );
+    }
+    return result;
+  } catch (error) {
+    console.error(
+      `[codex-mcp] WARNING: ${label} close failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { timedOut: false };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function collectTextContent(content = []) {
@@ -388,7 +418,7 @@ export class CodexMcpWorker {
     this.ready = true;
   }
 
-  async stop() {
+  async stop(options = {}) {
     this.ready = false;
     this.availableTools.clear();
 
@@ -397,10 +427,26 @@ export class CodexMcpWorker {
     this.transport = null;
     this.client = null;
 
+    const shutdownTimeoutMs = Number.isFinite(options.shutdownTimeoutMs)
+      ? options.shutdownTimeoutMs
+      : DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS;
+
+    let clientCloseTimedOut = false;
     if (client) {
-      await client.close().catch(() => {});
-    } else if (transport) {
-      await transport.close().catch(() => {});
+      const result = await closeWithin(
+        "client.close",
+        () => client.close(),
+        shutdownTimeoutMs,
+      );
+      clientCloseTimedOut = Boolean(result.timedOut);
+    }
+
+    if (transport && (!client || clientCloseTimedOut)) {
+      await closeWithin(
+        "transport.close",
+        () => transport.close(),
+        shutdownTimeoutMs,
+      );
     }
 
     transport?.stderr?.destroy?.();

--- a/tests/unit/codex-mcp-worker.test.mjs
+++ b/tests/unit/codex-mcp-worker.test.mjs
@@ -144,4 +144,52 @@ describe("CodexMcpWorker", () => {
       await worker.stop();
     }
   });
+
+  it("all packaged codex-mcp worker entrypoints import successfully", async () => {
+    const root = await import("../../hub/workers/codex-mcp.mjs");
+    const triflux = await import(
+      "../../packages/triflux/hub/workers/codex-mcp.mjs"
+    );
+    const remote = await import(
+      "../../packages/remote/hub/workers/codex-mcp.mjs"
+    );
+
+    assert.equal(typeof root.CodexMcpWorker, "function");
+    assert.equal(typeof triflux.CodexMcpWorker, "function");
+    assert.equal(typeof remote.CodexMcpWorker, "function");
+  });
+
+  it("stop returns when client.close never settles and then attempts transport.close", async () => {
+    const worker = createWorker({ FAKE_CODEX_MODE: "mcp-ok" });
+    let transportClosed = false;
+    let stderrDestroyed = false;
+
+    worker.ready = true;
+    worker.availableTools.add("codex");
+    worker.client = {
+      close: () => new Promise(() => {}),
+    };
+    worker.transport = {
+      close: async () => {
+        transportClosed = true;
+      },
+      stderr: {
+        destroy: () => {
+          stderrDestroyed = true;
+        },
+      },
+    };
+
+    const started = Date.now();
+    await worker.stop({ shutdownTimeoutMs: 25 });
+    const elapsed = Date.now() - started;
+
+    assert.equal(worker.ready, false);
+    assert.equal(worker.client, null);
+    assert.equal(worker.transport, null);
+    assert.equal(worker.availableTools.size, 0);
+    assert.equal(transportClosed, true);
+    assert.equal(stderrDestroyed, true);
+    assert.ok(elapsed < 500, `stop took ${elapsed}ms`);
+  });
 });


### PR DESCRIPTION
Fixes #234 (P1 #1 root fix).

## Background

Issue #234는 `hub/workers/codex-mcp.mjs:672`의 `worker.stop()`이 unbounded 대기로 stall 가능성을 안고 있다는 P1 결함을 보고했다. ROADMAP 세션 17 carry-over 항목.

## Fix

`closeWithin()` helper 추가 + `DEFAULT_CODEX_MCP_SHUTDOWN_TIMEOUT_MS = 2_000` 도입:

- `client.close()` + `transport.close()`를 `Promise.race(close, timeout)` 으로 bound
- 2초 timeout 후에도 종료 안 되면 강제 진행
- 회귀 가드 테스트 (`tests/unit/codex-mcp-worker.test.mjs` +48줄) 동반

## Mirror

3-layer mirror 모두 동일 변경:
- `hub/workers/codex-mcp.mjs` (root, source of truth)
- `packages/remote/hub/workers/codex-mcp.mjs` (import path: `@triflux/core/hub/cli-adapter-base.mjs`)
- `packages/triflux/hub/workers/codex-mcp.mjs` (byte-identical mirror)

\`scripts/release/check-packages-mirror.mjs --json\` → ok.

## Provenance

- 원작자: Codex (pte1024@gmail.com), 5/01 작성
- 5/01 ryzen worktree \`fix/stall-prevention-patch-train\` (a59256a, 미push 상태로 4주 잔존)에서 cherry-pick
- PR #239 close 후 대체 PR로 별도 생성 (#239는 macOS bash 3.2 회귀 + codex-recovery.sh hard fail로 close)

## Cross-review

triflux 정책에 따라 Codex 작성 → Claude 리뷰 진행 (cross-review).

## Test

- \`tests/unit/codex-mcp-worker.test.mjs\` 회귀 가드 추가