### PR TITLE
fix(tfx-route-worker): async stream stdin read to avoid EAGAIN race on Node v25

### DIFF
--- a/packages/triflux/scripts/tfx-route-worker.mjs
+++ b/packages/triflux/scripts/tfx-route-worker.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // tfx-route-worker.mjs — tfx-route.sh용 subprocess worker 러너
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -133,8 +133,18 @@ function parseJsonArray(raw, label) {
   }
 }
 
-function readPromptFromStdin() {
-  return readFileSync(0, "utf8");
+async function readPromptFromStdin() {
+  // Stream-based async read avoids EAGAIN race on Node v25 + background pipe stdin.
+  // readFileSync(0, "utf8") raised EAGAIN when stdin pipe was non-blocking and
+  // data hadn't fully arrived (Node v25 timing change vs v22), causing the
+  // tfx-route.sh wrapper to fall back to claude-native silently.
+  if (process.stdin.isTTY) return "";
+  process.stdin.setEncoding("utf8");
+  let data = "";
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
 }
 
 function resolveDefaultMcpConfig(cwd) {
@@ -197,7 +207,7 @@ async function runWorker(worker, type, prompt) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const prompt = readPromptFromStdin();
+const prompt = await readPromptFromStdin();
 
 const worker = await createWorker(args.type, {
   command: args.command,

--- a/scripts/tfx-route-worker.mjs
+++ b/scripts/tfx-route-worker.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // tfx-route-worker.mjs — tfx-route.sh용 subprocess worker 러너
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -133,8 +133,18 @@ function parseJsonArray(raw, label) {
   }
 }
 
-function readPromptFromStdin() {
-  return readFileSync(0, "utf8");
+async function readPromptFromStdin() {
+  // Stream-based async read avoids EAGAIN race on Node v25 + background pipe stdin.
+  // readFileSync(0, "utf8") raised EAGAIN when stdin pipe was non-blocking and
+  // data hadn't fully arrived (Node v25 timing change vs v22), causing the
+  // tfx-route.sh wrapper to fall back to claude-native silently.
+  if (process.stdin.isTTY) return "";
+  process.stdin.setEncoding("utf8");
+  let data = "";
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
 }
 
 function resolveDefaultMcpConfig(cwd) {
@@ -197,7 +207,7 @@ async function runWorker(worker, type, prompt) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const prompt = readPromptFromStdin();
+const prompt = await readPromptFromStdin();
 
 const worker = await createWorker(args.type, {
   command: args.command,


### PR DESCRIPTION
## Background

`tfx-route-worker.mjs:137 readPromptFromStdin` used `readFileSync(0, "utf8")` which raises `EAGAIN: resource temporarily unavailable, read` when stdin pipe is non-blocking and data hasn't fully arrived. Node v25 timing changed this behavior compared to v22 — the worker fails immediately on background dispatch.

## Observed symptom

Calling \`bash ~/.claude/scripts/tfx-route.sh gemini "..." review\` in background mode silently fell back to \`claude-native\` (Sonnet) instead of running Gemini:

```
[tfx-route] Gemini stream wrapper 실패(exit=1, stderr=432B). claude-native fallback.
Error: EAGAIN: resource temporarily unavailable, read
    at readFileSync (node:fs:436:20)
    at readPromptFromStdin (file:///.../tfx-route-worker.mjs:137:10)
```

The user observed this during a 3-CLI consensus review on PR #236 — Gemini agent dispatch returned a Sonnet response instead of Gemini, with `cli: claude-native` in the result header.

## Root cause

`readFileSync(0, ...)` is synchronous and assumes blocking-mode stdin. Node v25 sets non-blocking flags on inherited stdin pipes earlier in the process lifecycle, so when `tfx-route.sh` pipes the prompt via `<<<` heredoc to a background subprocess, `readFileSync` may execute before kernel signals data is ready, raising `EAGAIN`.

## Fix

Convert `readPromptFromStdin` to async stream read using `for await (const chunk of process.stdin)`. The caller is already in a top-level await context (ESM), so adding `await` at the single call site is straightforward.

```js
// Before:
function readPromptFromStdin() {
  return readFileSync(0, "utf8");
}
const prompt = readPromptFromStdin();

// After:
async function readPromptFromStdin() {
  if (process.stdin.isTTY) return "";
  process.stdin.setEncoding("utf8");
  let data = "";
  for await (const chunk of process.stdin) {
    data += chunk;
  }
  return data;
}
const prompt = await readPromptFromStdin();
```

Removed unused \`readFileSync\` import (only line 137 used it).

## Verification

Reproduced v1 failure scenario before fix and verified after:

| | Before | After |
|---|---|---|
| cli | \`claude-native\` (fallback) | **\`gemini\`** ✓ |
| EAGAIN 발생 | YES | **0회** |
| elapsed | 0s (instant fail) | 433s (real Gemini call) |
| exit_code | (fallback path) | **0** |
| stderr stream wrapper | exit=1, EAGAIN | clean |

Test prompt: \`bash ~/.claude/scripts/tfx-route.sh gemini "<small review prompt>" review\`

Result header after fix:
```
=== TFX-ROUTE RESULT ===
agent: gemini
cli: gemini (/opt/homebrew/bin/gemini)
effort: pro31
exit_code: 0
elapsed: 433s
status: success
```

## Mirror

- root: \`scripts/tfx-route-worker.mjs\`
- mirror: \`packages/triflux/scripts/tfx-route-worker.mjs\` (byte-identical)
- deployed: \`~/.claude/scripts/tfx-route-worker.mjs\` (sync 시 갱신)

\`diff -q scripts/tfx-route-worker.mjs packages/triflux/scripts/tfx-route-worker.mjs\` → exit 0.

## Cross-review

Claude authored. Codex review pending per triflux policy.

## Related

- 3-CLI consensus review on PR #236 surfaced this — Gemini agent silently dispatched as claude-native, distorting the consensus result.