### PR TITLE
chore: add AI CLI ignore templates (.claudeignore, .codexignore, .geminiignore)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,59 @@
+# Global ignore for AI CLI agents (Claude Code / Codex / Gemini)
+# Same syntax as .gitignore. Per-tool variants live alongside in $HOME.
+# Project-level overrides go in <project>/.{tool}ignore.
+
+# --- Secrets (defense in depth) ---
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+*.key
+*.pem
+*.p12
+*.pfx
+*.crt
+id_rsa
+id_ed25519
+credentials.json
+credentials.yaml
+credentials.yml
+secrets.json
+secrets.yaml
+secrets.yml
+
+# --- Dependencies ---
+node_modules/
+bower_components/
+vendor/
+.venv/
+venv/
+.pnp.*
+__pycache__/
+*.pyc
+*.pyo
+
+# --- Build outputs ---
+dist/
+build/
+out/
+.next/
+.nuxt/
+.svelte-kit/
+.turbo/
+.parcel-cache/
+target/
+*.egg-info/
+*.tsbuildinfo
+
+# --- Caches & local state ---
+.cache/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+coverage/
+.nyc_output/
+
+# --- OS noise ---
+.DS_Store
+Thumbs.db

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,59 @@
+# Global ignore for AI CLI agents (Claude Code / Codex / Gemini)
+# Same syntax as .gitignore. Per-tool variants live alongside in $HOME.
+# Project-level overrides go in <project>/.{tool}ignore.
+
+# --- Secrets (defense in depth) ---
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+*.key
+*.pem
+*.p12
+*.pfx
+*.crt
+id_rsa
+id_ed25519
+credentials.json
+credentials.yaml
+credentials.yml
+secrets.json
+secrets.yaml
+secrets.yml
+
+# --- Dependencies ---
+node_modules/
+bower_components/
+vendor/
+.venv/
+venv/
+.pnp.*
+__pycache__/
+*.pyc
+*.pyo
+
+# --- Build outputs ---
+dist/
+build/
+out/
+.next/
+.nuxt/
+.svelte-kit/
+.turbo/
+.parcel-cache/
+target/
+*.egg-info/
+*.tsbuildinfo
+
+# --- Caches & local state ---
+.cache/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+coverage/
+.nyc_output/
+
+# --- OS noise ---
+.DS_Store
+Thumbs.db

--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,59 @@
+# Global ignore for AI CLI agents (Claude Code / Codex / Gemini)
+# Same syntax as .gitignore. Per-tool variants live alongside in $HOME.
+# Project-level overrides go in <project>/.{tool}ignore.
+
+# --- Secrets (defense in depth) ---
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+*.key
+*.pem
+*.p12
+*.pfx
+*.crt
+id_rsa
+id_ed25519
+credentials.json
+credentials.yaml
+credentials.yml
+secrets.json
+secrets.yaml
+secrets.yml
+
+# --- Dependencies ---
+node_modules/
+bower_components/
+vendor/
+.venv/
+venv/
+.pnp.*
+__pycache__/
+*.pyc
+*.pyo
+
+# --- Build outputs ---
+dist/
+build/
+out/
+.next/
+.nuxt/
+.svelte-kit/
+.turbo/
+.parcel-cache/
+target/
+*.egg-info/
+*.tsbuildinfo
+
+# --- Caches & local state ---
+.cache/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+coverage/
+.nyc_output/
+
+# --- OS noise ---
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary

- Claude Code / Codex / Gemini 3개 CLI 가 read context 에 secrets/deps/build 산출물을 끌어가지 않도록 byte-identical 59-line template 추가
- `.gitignore` 에 누락된 secrets 패턴 (`*.key`, `*.pem`, `id_rsa`, `credentials.*`, `secrets.*`, `.DS_Store`) 을 defense-in-depth 레이어로 보강
- 각 CLI 가 자기 파일명만 인식하므로 3개 모두 유지 (향후 CLI 별 분화 가능성 + 호환성 의도)

## Why 3 files

각 AI CLI 는 자기 이름의 ignore 파일만 인식한다.

| CLI | 인식 파일 |
|-----|----------|
| Claude Code | `.claudeignore` |
| Codex | `.codexignore` |
| Gemini | `.geminiignore` |

현재는 byte-identical 이지만 향후 CLI 별 정책 분화 (예: Codex 만 빌드 산출물 일부 허용) 가능성이 있어 분리 유지.

## Coverage

| 카테고리 | 패턴 | .gitignore 중복 |
|---------|------|---------------|
| Secrets | `.env`, `.env.*`, `*.key`, `*.pem`, `*.p12`, `*.pfx`, `*.crt`, `id_rsa`, `id_ed25519`, `credentials.{json,yaml,yml}`, `secrets.{json,yaml,yml}` | 부분 (`*.key`/`*.pem`/`credentials`/`secrets` 누락) |
| Dependencies | `node_modules/`, `bower_components/`, `vendor/`, `.venv/`, `venv/`, `.pnp.*`, `__pycache__/`, `*.pyc`, `*.pyo` | 일부 |
| Build | `dist/`, `build/`, `out/`, `.next/`, `.nuxt/`, `.svelte-kit/`, `.turbo/`, `.parcel-cache/`, `target/`, `*.egg-info/`, `*.tsbuildinfo` | 일부 |
| Cache | `.cache/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `coverage/`, `.nyc_output/` | 부분 |
| OS noise | `.DS_Store`, `Thumbs.db` | 누락 |

## Test plan

- [x] 3 파일 byte-identical 확인 (`diff -q`)
- [x] `.gitignore` 와 secrets/keys 패턴 비교 — 추가 가치 확인
- [ ] 머지 후 다른 호스트 (m2/ryzen) sync 시 자동 적용 확인

## Notes

- 이전 세션에서 이미 mac local 에 untracked 로 보존되어 있던 파일들. 별도 PR 로 격리.
- mirror policy: 이 파일들은 root 만 적용 (npm files 미포함, packages 도 mirror 불필요).