### PR TITLE
chore(pr236-followup): lake-bundle cleanup (A1 dead code + F2/S1/T2/M1/M2/A2)

### DIFF
--- a/hub/account-broker.mjs
+++ b/hub/account-broker.mjs
@@ -250,6 +250,19 @@ function withLockFile(lockPath, opts, task) {
 
 // ── AccountBroker ────────────────────────────────────────────────
 
+/**
+ * AccountBroker는 codex/gemini 계정 풀 + lease/cooldown/circuit breaker 를 관리한다.
+ *
+ * **Resolved-at-construction 정책 (lazy/eager mix 주의)**
+ *
+ * `getAuthBasePath()` / `getCodexAuthSourcePath()` 는 호출 시점에 `homedir()` 를
+ * 다시 평가하는 lazy getter 다. 그러나 default 파라미터 (`_authBasePath = getAuthBasePath()`)
+ * 는 생성자 호출 시점에 한 번만 평가되고 결과가 `#authBasePath` 등 private field 에 박힌다.
+ *
+ * 결과: 생성자 이후 process.env.HOME 변경은 broker 가 보는 경로에 전파되지 않는다.
+ * 테스트에서 HOME 을 갈아끼우려면 `new AccountBroker(config, { _authBasePath, _codexAuthSourcePath })`
+ * 로 오버라이드를 직접 주입하거나, broker 자체를 재생성해야 한다.
+ */
 class AccountBroker extends EventEmitter {
   #config;
   #state; // Map<accountId, accountState>

--- a/hub/team/dashboard-open.mjs
+++ b/hub/team/dashboard-open.mjs
@@ -13,14 +13,6 @@ export function parseWorkerNumber(value) {
   return null;
 }
 
-export function decideDashboardOpenMode({
-  openAll = false,
-  hasWtSession = !!process.env.WT_SESSION,
-} = {}) {
-  if (openAll) return hasWtSession ? "tab" : "window";
-  return hasWtSession ? "split" : "window";
-}
-
 function ignoreAsyncFailure(value) {
   if (value && typeof value.then === "function") void value.catch(() => {});
 }

--- a/hub/team/runtime-strategy.mjs
+++ b/hub/team/runtime-strategy.mjs
@@ -60,9 +60,25 @@ export function createPsmuxRuntime(adapter = defaultPsmuxAdapter) {
 // tmux 어댑터
 // ---------------------------------------------------------------------------
 
+// tmux 세션 이름은 tmuxExec 명령 문자열에 직접 보간되므로 shell 메타문자가 들어오면 위험.
+// 현 호출처는 모두 safe identifier (slug/uuid 류) 이지만 어댑터 export 가 contract 를
+// 강제하지 않아 외부 호출자가 임의 문자열을 주입할 수 있다 → 보수적으로 검증.
+const TMUX_SAFE_SESSION_NAME = /^[A-Za-z0-9_.:-]+$/;
+
+function assertSafeTmuxSessionName(sessionName) {
+  const value = String(sessionName ?? "");
+  if (!TMUX_SAFE_SESSION_NAME.test(value)) {
+    throw new Error(
+      `Unsafe tmux session name: ${JSON.stringify(value)} (allowed: A-Za-z0-9_.:-)`,
+    );
+  }
+  return value;
+}
+
 function tmuxSessionExists(sessionName) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   try {
-    tmuxExec(`has-session -t ${sessionName}`);
+    tmuxExec(`has-session -t ${safe}`);
     return true;
   } catch {
     return false;
@@ -70,17 +86,25 @@ function tmuxSessionExists(sessionName) {
 }
 
 function createTmuxSession(sessionName, opts = {}) {
-  tmuxExec(`new-session -d -s ${sessionName} -x 220 -y 55`);
+  const safe = assertSafeTmuxSessionName(sessionName);
+  tmuxExec(`new-session -d -s ${safe} -x 220 -y 55`);
 }
 
 function sendPromptToTmuxSession(sessionName, prompt) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   const quotedPrompt = String(prompt).replace(/'/g, "'\\''");
-  tmuxExec(`send-keys -t ${sessionName}:0.0 '${quotedPrompt}' Enter`);
+  tmuxExec(`send-keys -t ${safe}:0.0 '${quotedPrompt}' Enter`);
 }
 
 function killTmuxSessionByName(sessionName) {
+  let safe;
   try {
-    tmuxExec(`kill-session -t ${sessionName}`);
+    safe = assertSafeTmuxSessionName(sessionName);
+  } catch {
+    return;
+  }
+  try {
+    tmuxExec(`kill-session -t ${safe}`);
   } catch {
     // 이미 종료된 세션 — 무시
   }
@@ -120,11 +144,16 @@ export function createTmuxRuntime(opts = {}) {
     name: "tmux",
     kind: "tmux",
     sessionName,
-    createSession(opts = {}) {
-      return adapter.createSession(sessionName, opts);
+    // start() 와 동일하게 첫 인자로 sessionName override 를 받는다.
+    // 첫 인자가 string 이 아니면 (옵션 객체 등) closure sessionName 을 사용하는 legacy 형태로 폴백.
+    createSession(sessionNameArg, opts) {
+      if (typeof sessionNameArg === "string") {
+        return adapter.createSession(sessionNameArg, opts ?? {});
+      }
+      return adapter.createSession(sessionName, sessionNameArg ?? {});
     },
-    sendPrompt(prompt) {
-      return adapter.sendPrompt(sessionName, prompt);
+    sendPrompt(prompt, sessionNameArg = sessionName) {
+      return adapter.sendPrompt(sessionNameArg, prompt);
     },
     start(sessionNameArg = sessionName, opts = {}) {
       return adapter.createSession(sessionNameArg, opts);

--- a/hub/team/terminal-opener.mjs
+++ b/hub/team/terminal-opener.mjs
@@ -56,6 +56,9 @@ function execOpenTerminal(execFn) {
   });
 }
 
+// psmux는 Windows에서 wt-manager 경유 (createTab/splitPane 등) — tmux 호환 unix 명령군과 다른 표면.
+// 비-Windows(macOS/Linux) 환경에서는 psmux가 tmux-compatible new-window/select-pane 명령을 받아주므로
+// tmux 어댑터와 동일하게 취급한다.
 function isTmuxLikeMux(mux, platform) {
   return TMUX_LIKE_MUXES.has(mux) || (platform !== "win32" && mux === "psmux");
 }
@@ -72,6 +75,8 @@ function buildAttachCommand(mux, sessionName) {
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
 
+// wt-manager.createTab은 (a) undefined/void 반환 — legacy success 의미 (b) {success:true|false, ...} 객체 반환의 두 형태가 공존.
+// `result?.success !== false`는 undefined/null/{}을 모두 success로 취급하고 명시적 {success:false}만 실패로 본다.
 function wtResultSucceeded(result) {
   return result?.success !== false;
 }

--- a/packages/remote/hub/team/dashboard-open.mjs
+++ b/packages/remote/hub/team/dashboard-open.mjs
@@ -13,14 +13,6 @@ export function parseWorkerNumber(value) {
   return null;
 }
 
-export function decideDashboardOpenMode({
-  openAll = false,
-  hasWtSession = !!process.env.WT_SESSION,
-} = {}) {
-  if (openAll) return hasWtSession ? "tab" : "window";
-  return hasWtSession ? "split" : "window";
-}
-
 function ignoreAsyncFailure(value) {
   if (value && typeof value.then === "function") void value.catch(() => {});
 }

--- a/packages/remote/hub/team/runtime-strategy.mjs
+++ b/packages/remote/hub/team/runtime-strategy.mjs
@@ -60,9 +60,25 @@ export function createPsmuxRuntime(adapter = defaultPsmuxAdapter) {
 // tmux 어댑터
 // ---------------------------------------------------------------------------
 
+// tmux 세션 이름은 tmuxExec 명령 문자열에 직접 보간되므로 shell 메타문자가 들어오면 위험.
+// 현 호출처는 모두 safe identifier (slug/uuid 류) 이지만 어댑터 export 가 contract 를
+// 강제하지 않아 외부 호출자가 임의 문자열을 주입할 수 있다 → 보수적으로 검증.
+const TMUX_SAFE_SESSION_NAME = /^[A-Za-z0-9_.:-]+$/;
+
+function assertSafeTmuxSessionName(sessionName) {
+  const value = String(sessionName ?? "");
+  if (!TMUX_SAFE_SESSION_NAME.test(value)) {
+    throw new Error(
+      `Unsafe tmux session name: ${JSON.stringify(value)} (allowed: A-Za-z0-9_.:-)`,
+    );
+  }
+  return value;
+}
+
 function tmuxSessionExists(sessionName) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   try {
-    tmuxExec(`has-session -t ${sessionName}`);
+    tmuxExec(`has-session -t ${safe}`);
     return true;
   } catch {
     return false;
@@ -70,17 +86,25 @@ function tmuxSessionExists(sessionName) {
 }
 
 function createTmuxSession(sessionName, opts = {}) {
-  tmuxExec(`new-session -d -s ${sessionName} -x 220 -y 55`);
+  const safe = assertSafeTmuxSessionName(sessionName);
+  tmuxExec(`new-session -d -s ${safe} -x 220 -y 55`);
 }
 
 function sendPromptToTmuxSession(sessionName, prompt) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   const quotedPrompt = String(prompt).replace(/'/g, "'\\''");
-  tmuxExec(`send-keys -t ${sessionName}:0.0 '${quotedPrompt}' Enter`);
+  tmuxExec(`send-keys -t ${safe}:0.0 '${quotedPrompt}' Enter`);
 }
 
 function killTmuxSessionByName(sessionName) {
+  let safe;
   try {
-    tmuxExec(`kill-session -t ${sessionName}`);
+    safe = assertSafeTmuxSessionName(sessionName);
+  } catch {
+    return;
+  }
+  try {
+    tmuxExec(`kill-session -t ${safe}`);
   } catch {
     // 이미 종료된 세션 — 무시
   }
@@ -120,11 +144,16 @@ export function createTmuxRuntime(opts = {}) {
     name: "tmux",
     kind: "tmux",
     sessionName,
-    createSession(opts = {}) {
-      return adapter.createSession(sessionName, opts);
+    // start() 와 동일하게 첫 인자로 sessionName override 를 받는다.
+    // 첫 인자가 string 이 아니면 (옵션 객체 등) closure sessionName 을 사용하는 legacy 형태로 폴백.
+    createSession(sessionNameArg, opts) {
+      if (typeof sessionNameArg === "string") {
+        return adapter.createSession(sessionNameArg, opts ?? {});
+      }
+      return adapter.createSession(sessionName, sessionNameArg ?? {});
     },
-    sendPrompt(prompt) {
-      return adapter.sendPrompt(sessionName, prompt);
+    sendPrompt(prompt, sessionNameArg = sessionName) {
+      return adapter.sendPrompt(sessionNameArg, prompt);
     },
     start(sessionNameArg = sessionName, opts = {}) {
       return adapter.createSession(sessionNameArg, opts);

--- a/packages/remote/hub/team/terminal-opener.mjs
+++ b/packages/remote/hub/team/terminal-opener.mjs
@@ -56,6 +56,9 @@ function execOpenTerminal(execFn) {
   });
 }
 
+// psmux는 Windows에서 wt-manager 경유 (createTab/splitPane 등) — tmux 호환 unix 명령군과 다른 표면.
+// 비-Windows(macOS/Linux) 환경에서는 psmux가 tmux-compatible new-window/select-pane 명령을 받아주므로
+// tmux 어댑터와 동일하게 취급한다.
 function isTmuxLikeMux(mux, platform) {
   return TMUX_LIKE_MUXES.has(mux) || (platform !== "win32" && mux === "psmux");
 }
@@ -72,6 +75,8 @@ function buildAttachCommand(mux, sessionName) {
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
 
+// wt-manager.createTab은 (a) undefined/void 반환 — legacy success 의미 (b) {success:true|false, ...} 객체 반환의 두 형태가 공존.
+// `result?.success !== false`는 undefined/null/{}을 모두 success로 취급하고 명시적 {success:false}만 실패로 본다.
 function wtResultSucceeded(result) {
   return result?.success !== false;
 }

--- a/packages/triflux/hub/account-broker.mjs
+++ b/packages/triflux/hub/account-broker.mjs
@@ -250,6 +250,19 @@ function withLockFile(lockPath, opts, task) {
 
 // ── AccountBroker ────────────────────────────────────────────────
 
+/**
+ * AccountBroker는 codex/gemini 계정 풀 + lease/cooldown/circuit breaker 를 관리한다.
+ *
+ * **Resolved-at-construction 정책 (lazy/eager mix 주의)**
+ *
+ * `getAuthBasePath()` / `getCodexAuthSourcePath()` 는 호출 시점에 `homedir()` 를
+ * 다시 평가하는 lazy getter 다. 그러나 default 파라미터 (`_authBasePath = getAuthBasePath()`)
+ * 는 생성자 호출 시점에 한 번만 평가되고 결과가 `#authBasePath` 등 private field 에 박힌다.
+ *
+ * 결과: 생성자 이후 process.env.HOME 변경은 broker 가 보는 경로에 전파되지 않는다.
+ * 테스트에서 HOME 을 갈아끼우려면 `new AccountBroker(config, { _authBasePath, _codexAuthSourcePath })`
+ * 로 오버라이드를 직접 주입하거나, broker 자체를 재생성해야 한다.
+ */
 class AccountBroker extends EventEmitter {
   #config;
   #state; // Map<accountId, accountState>

--- a/packages/triflux/hub/team/dashboard-open.mjs
+++ b/packages/triflux/hub/team/dashboard-open.mjs
@@ -13,14 +13,6 @@ export function parseWorkerNumber(value) {
   return null;
 }
 
-export function decideDashboardOpenMode({
-  openAll = false,
-  hasWtSession = !!process.env.WT_SESSION,
-} = {}) {
-  if (openAll) return hasWtSession ? "tab" : "window";
-  return hasWtSession ? "split" : "window";
-}
-
 function ignoreAsyncFailure(value) {
   if (value && typeof value.then === "function") void value.catch(() => {});
 }

--- a/packages/triflux/hub/team/runtime-strategy.mjs
+++ b/packages/triflux/hub/team/runtime-strategy.mjs
@@ -60,9 +60,25 @@ export function createPsmuxRuntime(adapter = defaultPsmuxAdapter) {
 // tmux 어댑터
 // ---------------------------------------------------------------------------
 
+// tmux 세션 이름은 tmuxExec 명령 문자열에 직접 보간되므로 shell 메타문자가 들어오면 위험.
+// 현 호출처는 모두 safe identifier (slug/uuid 류) 이지만 어댑터 export 가 contract 를
+// 강제하지 않아 외부 호출자가 임의 문자열을 주입할 수 있다 → 보수적으로 검증.
+const TMUX_SAFE_SESSION_NAME = /^[A-Za-z0-9_.:-]+$/;
+
+function assertSafeTmuxSessionName(sessionName) {
+  const value = String(sessionName ?? "");
+  if (!TMUX_SAFE_SESSION_NAME.test(value)) {
+    throw new Error(
+      `Unsafe tmux session name: ${JSON.stringify(value)} (allowed: A-Za-z0-9_.:-)`,
+    );
+  }
+  return value;
+}
+
 function tmuxSessionExists(sessionName) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   try {
-    tmuxExec(`has-session -t ${sessionName}`);
+    tmuxExec(`has-session -t ${safe}`);
     return true;
   } catch {
     return false;
@@ -70,17 +86,25 @@ function tmuxSessionExists(sessionName) {
 }
 
 function createTmuxSession(sessionName, opts = {}) {
-  tmuxExec(`new-session -d -s ${sessionName} -x 220 -y 55`);
+  const safe = assertSafeTmuxSessionName(sessionName);
+  tmuxExec(`new-session -d -s ${safe} -x 220 -y 55`);
 }
 
 function sendPromptToTmuxSession(sessionName, prompt) {
+  const safe = assertSafeTmuxSessionName(sessionName);
   const quotedPrompt = String(prompt).replace(/'/g, "'\\''");
-  tmuxExec(`send-keys -t ${sessionName}:0.0 '${quotedPrompt}' Enter`);
+  tmuxExec(`send-keys -t ${safe}:0.0 '${quotedPrompt}' Enter`);
 }
 
 function killTmuxSessionByName(sessionName) {
+  let safe;
   try {
-    tmuxExec(`kill-session -t ${sessionName}`);
+    safe = assertSafeTmuxSessionName(sessionName);
+  } catch {
+    return;
+  }
+  try {
+    tmuxExec(`kill-session -t ${safe}`);
   } catch {
     // 이미 종료된 세션 — 무시
   }
@@ -120,11 +144,16 @@ export function createTmuxRuntime(opts = {}) {
     name: "tmux",
     kind: "tmux",
     sessionName,
-    createSession(opts = {}) {
-      return adapter.createSession(sessionName, opts);
+    // start() 와 동일하게 첫 인자로 sessionName override 를 받는다.
+    // 첫 인자가 string 이 아니면 (옵션 객체 등) closure sessionName 을 사용하는 legacy 형태로 폴백.
+    createSession(sessionNameArg, opts) {
+      if (typeof sessionNameArg === "string") {
+        return adapter.createSession(sessionNameArg, opts ?? {});
+      }
+      return adapter.createSession(sessionName, sessionNameArg ?? {});
     },
-    sendPrompt(prompt) {
-      return adapter.sendPrompt(sessionName, prompt);
+    sendPrompt(prompt, sessionNameArg = sessionName) {
+      return adapter.sendPrompt(sessionNameArg, prompt);
     },
     start(sessionNameArg = sessionName, opts = {}) {
       return adapter.createSession(sessionNameArg, opts);

--- a/packages/triflux/hub/team/terminal-opener.mjs
+++ b/packages/triflux/hub/team/terminal-opener.mjs
@@ -56,6 +56,9 @@ function execOpenTerminal(execFn) {
   });
 }
 
+// psmux는 Windows에서 wt-manager 경유 (createTab/splitPane 등) — tmux 호환 unix 명령군과 다른 표면.
+// 비-Windows(macOS/Linux) 환경에서는 psmux가 tmux-compatible new-window/select-pane 명령을 받아주므로
+// tmux 어댑터와 동일하게 취급한다.
 function isTmuxLikeMux(mux, platform) {
   return TMUX_LIKE_MUXES.has(mux) || (platform !== "win32" && mux === "psmux");
 }
@@ -72,6 +75,8 @@ function buildAttachCommand(mux, sessionName) {
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
 
+// wt-manager.createTab은 (a) undefined/void 반환 — legacy success 의미 (b) {success:true|false, ...} 객체 반환의 두 형태가 공존.
+// `result?.success !== false`는 undefined/null/{}을 모두 success로 취급하고 명시적 {success:false}만 실패로 본다.
 function wtResultSucceeded(result) {
   return result?.success !== false;
 }

--- a/tests/unit/dashboard-open.test.mjs
+++ b/tests/unit/dashboard-open.test.mjs
@@ -2,37 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
-  decideDashboardOpenMode,
   openHeadlessDashboardTarget,
   parseWorkerNumber,
 } from "../../hub/team/dashboard-open.mjs";
 
 describe("dashboard-open", () => {
-  it("selected worker는 WT 세션에서 split 우선", () => {
-    assert.equal(
-      decideDashboardOpenMode({ openAll: false, hasWtSession: true }),
-      "split",
-    );
-  });
-
-  it("openAll은 WT 세션에서 tab 우선", () => {
-    assert.equal(
-      decideDashboardOpenMode({ openAll: true, hasWtSession: true }),
-      "tab",
-    );
-  });
-
-  it("WT 세션이 없으면 window fallback", () => {
-    assert.equal(
-      decideDashboardOpenMode({ openAll: false, hasWtSession: false }),
-      "window",
-    );
-    assert.equal(
-      decideDashboardOpenMode({ openAll: true, hasWtSession: false }),
-      "window",
-    );
-  });
-
   it("worker/pane 표기에서 워커 번호를 추출한다", () => {
     assert.equal(parseWorkerNumber("worker-3"), 3);
     assert.equal(parseWorkerNumber("wt:2"), 2);

--- a/tests/unit/terminal-opener.test.mjs
+++ b/tests/unit/terminal-opener.test.mjs
@@ -243,4 +243,50 @@ describe("terminal-opener adapter", () => {
     );
     assert.deepEqual(calls, [["select-pane", "-t", "demo:0.1"]]);
   });
+
+  it("Linux without mux returns false from openCommand", async () => {
+    const opener = createTerminalOpener({
+      platform: "linux",
+      mux: null,
+    });
+    assert.equal(await opener.openCommand({ command: "echo hi" }), false);
+  });
+
+  it("Linux without mux returns false from openSession", async () => {
+    const opener = createTerminalOpener({
+      platform: "linux",
+      mux: null,
+    });
+    assert.equal(await opener.openSession("demo"), false);
+  });
+
+  it("Windows wt-manager undefined return is treated as success", async () => {
+    const opener = createTerminalOpener({
+      platform: "win32",
+      createWtManager: () => ({
+        createTab: async () => undefined,
+      }),
+    });
+    assert.equal(await opener.openCommand({ command: "echo hi" }), true);
+  });
+
+  it("Windows wt-manager null return is treated as success", async () => {
+    const opener = createTerminalOpener({
+      platform: "win32",
+      createWtManager: () => ({
+        createTab: async () => null,
+      }),
+    });
+    assert.equal(await opener.openSession("demo"), true);
+  });
+
+  it("Windows wt-manager empty object return is treated as success (no explicit success:false)", async () => {
+    const opener = createTerminalOpener({
+      platform: "win32",
+      createWtManager: () => ({
+        createTab: async () => ({}),
+      }),
+    });
+    assert.equal(await opener.openCommand({ command: "echo hi" }), true);
+  });
 });


### PR DESCRIPTION
## Summary

PR #236 머지 후 3-CLI consensus (Codex+Gemini+Claude, score 92/100, blocker 0) 가 식별한 **P3 follow-up cleanup** 6개 항목 (A1, F2, S1, T2, M1, M2, A2) 을 lake-boil 단위로 묶음. T1 platform smoke 는 별도 PR.

artifact 출처: `.omc/artifacts/consensus/pr236-3way-review-20260508-123034/consensus.md`

## Changes

| # | code | 항목 | 파일 |
|---|------|------|------|
| 1 | **A1** | `decideDashboardOpenMode` dead code drop (production path 미사용) | `dashboard-open.mjs`, `dashboard-open.test.mjs` |
| 2 | **F2** | `createTmuxRuntime.createSession()` 가 sessionName override 받도록 정합 (start/sendPrompt 와 동일) | `runtime-strategy.mjs` |
| 3 | **S1** | tmux sessionName shell-quote contract — `assertSafeTmuxSessionName` 검증 (4 함수) | `runtime-strategy.mjs` |
| 4 | **T2** | `terminal-opener.test.mjs` Linux no-mux + `wtResultSucceeded` edge cases 5 tests 추가 | `terminal-opener.test.mjs` |
| 5 | **M1** | `wtResultSucceeded` legacy/object 반환 contract 2-line 주석 | `terminal-opener.mjs` |
| 6 | **M2** | `isTmuxLikeMux` psmux+non-Windows 의미 3-line 주석 | `terminal-opener.mjs` |
| 7 | **A2** | `AccountBroker` resolved-at-construction lazy/eager mix 8-line JSDoc | `account-broker.mjs` |

## Why these 6 (not 7)

**T1 (platform smoke)** 는 lake 가 아닌 ocean 가능성 있는 인프라 작업 (Windows WT/psmux + macOS tmux 실제 binaries 환경 필요). 별도 PR 로 분리.

CLAUDE.md `tfx-autoplan-principles.md` 의 **lake-boil 원칙** 에 따라 blast radius 안에서 끝낼 수 있는 mechanical/small-refactor 항목 6개만 묶음.

## Mirror policy

| 파일 | root | packages/triflux | packages/remote |
|------|------|-----------------|-----------------|
| `terminal-opener.mjs` | YES | YES byte-identical | YES byte-identical |
| `dashboard-open.mjs` | YES | YES byte-identical | YES byte-identical |
| `runtime-strategy.mjs` | YES | YES byte-identical | YES byte-identical |
| `account-broker.mjs` | YES | YES byte-identical | (drift 기존, 본 PR 범위 외) |
| `tests/unit/*` | YES | (mirror 제외, npm files 미포함) | (제외) |

`diff -q` 로 packages 미러 byte-identical 검증 완료.

## Test plan

- [x] `npm run lint` → 597 files clean (Biome)
- [x] `node --test tests/unit/{terminal-opener,dashboard-open,runtime-strategy,account-broker,account-broker-auth-sync}.test.mjs` → **70/70 pass**
- [x] decideDashboardOpenMode grep → production 사용처 0개 (test 만 있음, 함께 제거)
- [x] mirror byte-identical (`diff -q`)
- [ ] CI 전체 스위트 통과 (PR open 시 자동)

## Out of scope

- **T1 platform smoke** — Windows WT/psmux + macOS tmux 실제 binaries smoke. 별도 PR (또는 opt-in flag).
- **packages/core/hub/account-broker.mjs drift** — 기존 drift, 본 PR 에서 다루지 않음.

## Security Note (S1)

현재 호출처는 모두 safe identifier (slug/uuid 류) 사용 중이라 실제 injection vector 는 없으나, export 된 어댑터 surface 가 contract 강제하지 않음 → 보수적으로 검증 추가. 새 검증으로 인해 기존 호출 동작 변화 없음 (안전 문자만 통과시키므로).