### PR TITLE
chore(tfx-route): TFX_GEMINI_DEFAULT_PROFILE env 도입 + pro31 → pro25 default

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -940,9 +940,9 @@ resolve_gemini_profile() {
       }
     }
 
-    process.stdout.write(defaults[name] || defaults.pro31);
+    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.pro25);
   " "$profile" "$_GEMINI_PROFILE_CACHE" "$settings_cache" 2>/dev/null)
-  echo "${result:-gemini-3.1-pro-preview}"
+  echo "${result:-gemini-2.5-pro}"
 }
 
 # ── 라우팅 테이블 ──

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -940,9 +940,9 @@ resolve_gemini_profile() {
       }
     }
 
-    process.stdout.write(defaults[name] || defaults.pro31);
+    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.pro25);
   " "$profile" "$_GEMINI_PROFILE_CACHE" "$settings_cache" 2>/dev/null)
-  echo "${result:-gemini-3.1-pro-preview}"
+  echo "${result:-gemini-2.5-pro}"
 }
 
 # ── 라우팅 테이블 ──


### PR DESCRIPTION
## Summary

- `resolve_gemini_profile()` fallback 2곳을 `pro31` → env-or-`pro25` 패턴으로 변경
- 변경 위치: `scripts/tfx-route.sh:943` (Node inline) + `:945` (shell fallback)
- Mirror: `packages/triflux/scripts/tfx-route.sh` byte-identical 동기화

## 변경 사유

`pro31` (gemini-3.1-pro-preview) preview tier 의 quota exhausted 빈도가 높음. 안정 tier (`pro25` = gemini-2.5-pro)로 default fallback 을 변경하여 라우팅 실패 빈도를 줄임. preview 가 필요한 환경은 `TFX_GEMINI_DEFAULT_PROFILE=pro31` 로 명시적 opt-in.

## Behavior

| 환경 | 결과 |
|------|------|
| `TFX_GEMINI_DEFAULT_PROFILE` unset | `gemini-2.5-pro` (pro25) |
| `TFX_GEMINI_DEFAULT_PROFILE=pro31` | `gemini-3.1-pro-preview` |
| `TFX_GEMINI_DEFAULT_PROFILE=flash25` | `gemini-2.5-flash` |
| `TFX_GEMINI_DEFAULT_PROFILE=invalid` | `gemini-2.5-pro` (fallback) |

지원 alias: `pro31`, `flash3`, `pro25`, `flash25`, `lite25` (line 870-876의 defaults 테이블 키).

## Test plan

- [x] `npm run lint` → 597 files clean
- [x] `node --test tests/unit/{routing-qa,gemini-profiles}.test.mjs` → 52/52 pass
- [x] `bash -n scripts/tfx-route.sh && bash -n packages/triflux/scripts/tfx-route.sh` → SYNTAX OK
- [x] `diff -q scripts/tfx-route.sh packages/triflux/scripts/tfx-route.sh` → byte-identical
- [x] env override 4-case sanity (unset / pro31 / flash25 / invalid) 동작 확인

## 관련

- 체크포인트 `20260508-175129-next-work-pr246-pr247-open-followups-pending.md` STEP 4