### PR TITLE
feat(routing): dynamic-routing-engine Phase 0 (scenario evaluator + 24 tests)

### DIFF
--- a/config/routing-policy.json
+++ b/config/routing-policy.json
@@ -1,0 +1,124 @@
+{
+  "version": 1,
+  "freshness": {
+    "max_snapshot_age_ms": 900000,
+    "max_cross_provider_skew_ms": 300000,
+    "local_clock_skew_guard_ms": 60000
+  },
+  "thresholds": {
+    "reset_imminent_ms": 86400000,
+    "exhaustion_high_percent": 80,
+    "exhaustion_low_percent": 20,
+    "expiry_drain_window_ms": 604800000,
+    "drain_usage_ceiling_percent": 50
+  },
+  "scenarios": [
+    {
+      "id": "S1",
+      "name": "claude-reset-imminent-drain",
+      "when": {
+        "provider": "claude",
+        "weeklyResetsAtLteMs": 86400000,
+        "weeklyPercentLt": 100,
+        "hasMultipleAccounts": true
+      },
+      "then": {
+        "lane": "multi",
+        "primary_cli": "claude",
+        "reserve_codex_share": 0.1,
+        "reason": "claude-weekly-reset-imminent-drain-fleet"
+      }
+    },
+    {
+      "id": "S2",
+      "name": "codex-reset-imminent-drain",
+      "when": {
+        "provider": "codex",
+        "weeklyResetsAtLteMs": 86400000,
+        "weeklyPercentLt": 100
+      },
+      "then": {
+        "lane": "swarm",
+        "primary_cli": "codex",
+        "reserve_claude_share": 0.1,
+        "reason": "codex-weekly-reset-imminent-drain-fleet"
+      }
+    },
+    {
+      "id": "S3",
+      "name": "claude-burned-codex-fresh",
+      "when": {
+        "claude_weekly_percent_gte": 80,
+        "codex_weekly_percent_lt": 20,
+        "claude_weekly_resets_at_gt_ms": 172800000
+      },
+      "then": {
+        "lane": "single",
+        "primary_cli": "codex",
+        "claude_lanes_allowed": ["explore", "final-challenge"],
+        "reason": "claude-burned-codex-fresh-rebalance"
+      }
+    },
+    {
+      "id": "S4",
+      "name": "claude-multi-account-staggered",
+      "when": {
+        "provider": "claude",
+        "accountCountGte": 2,
+        "staggered": true
+      },
+      "then": {
+        "lane": "multi",
+        "primary_cli": "claude",
+        "rank_by": "expiring_capacity_score",
+        "reason": "claude-multi-account-staggered-reset"
+      }
+    },
+    {
+      "id": "S5",
+      "name": "claude-parallel-leasemany",
+      "when": {
+        "provider": "claude",
+        "request_team_size_gte": 2,
+        "accountCountGte": 2
+      },
+      "then": {
+        "lane": "swarm",
+        "primary_cli": "claude",
+        "atomic": "leaseMany",
+        "atomic_policy": "balanced",
+        "reason": "claude-parallel-multi-account"
+      }
+    },
+    {
+      "id": "S6",
+      "name": "account-expiry-drain",
+      "when": {
+        "expiresAtLteMs": 604800000,
+        "weeklyPercentLt": 50,
+        "circuitStateNotOpen": true
+      },
+      "then": {
+        "lane": "single",
+        "riskTier": "drain",
+        "elevated_weight": 2.0,
+        "reason": "account-expiry-drain-before-loss"
+      }
+    }
+  ],
+  "fallback": {
+    "default_mode": "codex-default",
+    "default_cli": "codex",
+    "default_model": "gpt-5.5",
+    "triggers": [
+      "hud_null",
+      "hud_stale_gte_15min",
+      "weekly_reset_in_past",
+      "cross_provider_skew_exceeded",
+      "broker_empty",
+      "all_circuits_open",
+      "mirror_drift",
+      "flag_disabled"
+    ]
+  }
+}

--- a/hub/dynamic-routing-engine.mjs
+++ b/hub/dynamic-routing-engine.mjs
@@ -1,0 +1,399 @@
+// hub/dynamic-routing-engine.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure deterministic classifier. Takes a `request`, a `snapshot`
+// (from `hub/routing-snapshot.mjs`), and a `policy` (loaded from
+// `config/routing-policy.json`), then emits a single `RouteDecision`.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). conductor/swarm/tfx-route.sh integration is Phase 1+.
+//   - pure function: same (request, snapshot, policy) → same RouteDecision.
+//   - no network, no disk reads, no clock reads outside the explicit `now` arg.
+//   - fallback policy = codex-default. fails closed.
+//   - scenario evaluators are first-match-wins in policy.scenarios order.
+
+import { createHash } from "node:crypto";
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== "object") return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function hashInputs(request, snapshot) {
+  return createHash("sha256")
+    .update(stableStringify({ request, snapshot }))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function makeFallback(policy, trigger, inputsHash, now) {
+  const fb = policy?.fallback ?? {};
+  return {
+    decisionId: inputsHash,
+    mode: fb.default_mode ?? "codex-default",
+    scenario: "fallback",
+    lane: "single",
+    shards: [
+      {
+        cli: fb.default_cli ?? "codex",
+        accountId: null,
+        model: fb.default_model ?? "gpt-5.5",
+        riskTier: "safe",
+        reason: trigger,
+      },
+    ],
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+    },
+    fallback: { trigger, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(undefined, now),
+    confidence: 50,
+  };
+}
+
+function snapshotAge(snapshot, now) {
+  if (!snapshot || typeof snapshot !== "object") return null;
+  const observed = Number(snapshot.observedAt);
+  if (!Number.isFinite(observed)) return null;
+  return Math.max(0, now - observed);
+}
+
+function checkFreshness(snapshot, freshness, now) {
+  if (!snapshot) return "hud_null";
+  const max = freshness?.max_snapshot_age_ms ?? 900_000;
+  const skewMax = freshness?.max_cross_provider_skew_ms ?? 300_000;
+
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude && !codex) return "hud_null";
+  if (claude && (claude.isStale || claude.error))
+    return "claude_stale_or_error";
+  if (codex && (codex.isStale || codex.error)) return "codex_stale_or_error";
+
+  const claudeAge = claude?.observedAt ? now - claude.observedAt : null;
+  const codexAge = codex?.observedAt ? now - codex.observedAt : null;
+  if (claudeAge !== null && claudeAge > max) return "claude_age_exceeded";
+  if (codexAge !== null && codexAge > max) return "codex_age_exceeded";
+  if (claudeAge !== null && codexAge !== null) {
+    if (Math.abs(claudeAge - codexAge) > skewMax)
+      return "cross_provider_skew_exceeded";
+  }
+
+  if (claude?.weeklyResetsAt !== null && claude?.weeklyResetsAt !== undefined) {
+    if (
+      claude.weeklyResetsAt <
+      now - (freshness?.local_clock_skew_guard_ms ?? 60_000)
+    ) {
+      return "claude_weekly_reset_in_past";
+    }
+  }
+
+  return null;
+}
+
+function brokerAvailableCount(snapshot, provider) {
+  const accounts = snapshot?.broker?.[provider] ?? [];
+  return accounts.filter((a) => a.circuitState !== "open").length;
+}
+
+function brokerAllCircuitsOpen(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups) return false;
+  const all = [];
+  for (const provider of Object.keys(groups)) {
+    for (const acct of groups[provider] ?? []) all.push(acct);
+  }
+  if (all.length === 0) return true;
+  return all.every((a) => a.circuitState === "open");
+}
+
+// ─── Scenario evaluators ──────────────────────────────────────────────
+// Each returns either null (no match) or a partial RouteDecision payload
+// `{ scenario, lane, shards, riskTier?, reasonCodes }` to be wrapped by
+// `makeScenarioDecision()` below.
+
+function evalS1(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const claude = snapshot.claude;
+  if (!claude) return null;
+  const resetIn = (claude.weeklyResetsAt ?? Number.POSITIVE_INFINITY) - now;
+  if (
+    resetIn >
+    (scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms)
+  )
+    return null;
+  if ((claude.weeklyPercent ?? 100) >= (scenario.when.weeklyPercentLt ?? 100))
+    return null;
+  if (
+    scenario.when.hasMultipleAccounts &&
+    brokerAvailableCount(snapshot, "claude") < 2
+  )
+    return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: [
+      { cli: "claude", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS2(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const codex = snapshot.codex;
+  if (!codex) return null;
+  const buckets = codex.buckets ?? {};
+  const window =
+    scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? 100;
+  // Inspect both primary and secondary legs so a fresh secondary tier with
+  // imminent reset is not silently ignored when primary is exhausted.
+  const anyLegMatches = Object.values(buckets).some((b) =>
+    [b?.primary, b?.secondary].some((leg) => {
+      if (!leg) return false;
+      if (!leg.resetsAt) return false;
+      if (leg.resetsAt - now > window) return false;
+      return (leg.usedPercent ?? 100) < usageCeiling;
+    }),
+  );
+  if (!anyLegMatches) return null;
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    shards: [
+      { cli: "codex", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS3(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude || !codex) return null;
+  if ((claude.weeklyPercent ?? 0) < scenario.when.claude_weekly_percent_gte)
+    return null;
+  const codexAnyBucket = Object.values(codex.buckets ?? {}).some(
+    (b) =>
+      (b?.primary?.usedPercent ?? 100) < scenario.when.codex_weekly_percent_lt,
+  );
+  if (!codexAnyBucket) return null;
+  const resetIn = (claude.weeklyResetsAt ?? 0) - now;
+  if (resetIn <= scenario.when.claude_weekly_resets_at_gt_ms) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    shards: [{ cli: "codex", riskTier: "safe", reason: scenario.then.reason }],
+  };
+}
+
+function evalS4(ctx) {
+  const { snapshot, scenario } = ctx;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  // Staggered = at least 2 distinct cooldown/expiresAt anchors.
+  const anchors = new Set(
+    claude.map((a) => `${a.cooldownUntil ?? 0}-${a.expiresAt ?? 0}`),
+  );
+  if (scenario.when.staggered && anchors.size < 2) return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: claude.map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS5(ctx) {
+  const { request, snapshot, scenario } = ctx;
+  if ((request?.team_size ?? 1) < (scenario.when.request_team_size_gte ?? 2))
+    return null;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  const wanted = Math.min(request.team_size, claude.length);
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    atomic: scenario.then.atomic,
+    atomicPolicy: scenario.then.atomic_policy ?? "balanced",
+    shards: claude.slice(0, wanted).map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS6(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const all = [];
+  for (const p of Object.keys(snapshot.broker ?? {})) {
+    const accounts = snapshot.broker[p];
+    if (!Array.isArray(accounts)) continue;
+    for (const a of accounts) all.push({ ...a, provider: p });
+  }
+  const window = scenario.when.expiresAtLteMs ?? 604_800_000;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? null;
+  const expiring = all.filter((a) => {
+    if (!a.expiresAt) return false;
+    // Past-dated expirations are dead accounts, not drain targets.
+    if (a.expiresAt - now <= 0) return false;
+    if (a.expiresAt - now > window) return false;
+    if (scenario.when.circuitStateNotOpen && a.circuitState === "open")
+      return false;
+    if (usageCeiling !== null) {
+      const usage = providerUsagePercent(snapshot, a.provider);
+      if (usage !== null && usage >= usageCeiling) return false;
+    }
+    return true;
+  });
+  if (expiring.length === 0) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    riskTier: scenario.then.riskTier ?? "drain",
+    shards: expiring.map((a) => ({
+      cli: a.provider === "claude" ? "claude" : "codex",
+      accountId: a.id,
+      riskTier: "drain",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function providerUsagePercent(snapshot, provider) {
+  if (provider === "claude") {
+    return typeof snapshot.claude?.weeklyPercent === "number"
+      ? snapshot.claude.weeklyPercent
+      : null;
+  }
+  if (provider === "codex") {
+    const buckets = Object.values(snapshot.codex?.buckets ?? {});
+    if (buckets.length === 0) return null;
+    let max = 0;
+    for (const b of buckets) {
+      for (const leg of [b?.primary, b?.secondary]) {
+        if (typeof leg?.usedPercent === "number" && leg.usedPercent > max) {
+          max = leg.usedPercent;
+        }
+      }
+    }
+    return max;
+  }
+  return null;
+}
+
+const SCENARIO_EVALUATORS = {
+  S1: evalS1,
+  S2: evalS2,
+  S3: evalS3,
+  S4: evalS4,
+  S5: evalS5,
+  S6: evalS6,
+};
+
+function makeScenarioDecision({ match, scenario, inputsHash, snapshot, now }) {
+  return {
+    decisionId: inputsHash,
+    mode: "dynamic-overlay",
+    scenario: scenario.id,
+    lane: match.lane,
+    shards: match.shards,
+    atomic: match.atomic ?? null,
+    atomicPolicy: match.atomicPolicy ?? null,
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+      scenarioName: scenario.name,
+    },
+    fallback: { trigger: null, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(snapshot, now),
+    confidence: 72,
+  };
+}
+
+function brokerIsEmpty(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups || typeof groups !== "object") return true;
+  for (const p of Object.keys(groups)) {
+    const accounts = groups[p];
+    if (Array.isArray(accounts) && accounts.length > 0) return false;
+  }
+  return true;
+}
+
+/**
+ * @param {object} request
+ * @param {object} snapshot
+ * @param {object} policy
+ * @param {object} options
+ * @param {number} options.now — REQUIRED. Pure-fn contract: callers must
+ *   supply the current epoch; the engine itself never reads the clock.
+ */
+export function evaluateDynamicRoute(request, snapshot, policy, options) {
+  if (!options || typeof options.now !== "number") {
+    throw new TypeError(
+      "evaluateDynamicRoute: options.now (epoch ms) is required for pure-fn contract",
+    );
+  }
+  const { now } = options;
+  const inputsHash = hashInputs(request, snapshot);
+
+  if (!policy || !Array.isArray(policy.scenarios)) {
+    return makeFallback(
+      { fallback: { default_mode: "codex-default" } },
+      "policy_missing",
+      inputsHash,
+      now,
+    );
+  }
+
+  const freshnessVeto = checkFreshness(snapshot, policy.freshness, now);
+  if (freshnessVeto)
+    return makeFallback(policy, freshnessVeto, inputsHash, now);
+
+  if (brokerIsEmpty(snapshot)) {
+    return makeFallback(policy, "broker_empty", inputsHash, now);
+  }
+
+  if (brokerAllCircuitsOpen(snapshot)) {
+    return makeFallback(policy, "all_circuits_open", inputsHash, now);
+  }
+
+  for (const scenario of policy.scenarios) {
+    const evaluator = SCENARIO_EVALUATORS[scenario.id];
+    if (!evaluator) continue;
+    const match = evaluator({
+      request: request ?? {},
+      snapshot,
+      scenario,
+      policy,
+      now,
+    });
+    if (match)
+      return makeScenarioDecision({
+        match,
+        scenario,
+        inputsHash,
+        snapshot,
+        now,
+      });
+  }
+
+  return makeFallback(policy, "no_scenario_matched", inputsHash, now);
+}
+
+export const __internal__ = {
+  hashInputs,
+  checkFreshness,
+  brokerAvailableCount,
+  brokerAllCircuitsOpen,
+  brokerIsEmpty,
+  providerUsagePercent,
+  SCENARIO_EVALUATORS,
+};

--- a/hub/routing-snapshot.mjs
+++ b/hub/routing-snapshot.mjs
@@ -1,0 +1,193 @@
+// hub/routing-snapshot.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure read-only context projector. Wraps HUD providers and the
+// AccountBroker public snapshot into a single deterministic snapshot that
+// `evaluateDynamicRoute(request, snapshot, policy)` consumes.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). Only `evaluateDynamicRoute()` is meant to read this.
+//   - lazy import of HUD providers + broker so this module imports cleanly even
+//     when those surfaces are absent in tests.
+//   - never mutates upstream state — strictly read-only.
+//   - all output fields are derivable from `publicSnapshot()` / HUD redacted API,
+//     so writing the resulting snapshot to disk does not leak credentials.
+
+const CLAUDE_HUD_MODULE = "../hud/providers/claude.mjs";
+const CODEX_HUD_MODULE = "../hud/providers/codex.mjs";
+const BROKER_MODULE = "./account-broker.mjs";
+
+async function loadHudClaude() {
+  try {
+    return await import(CLAUDE_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadHudCodex() {
+  try {
+    return await import(CODEX_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadBroker() {
+  try {
+    const mod = await import(BROKER_MODULE);
+    return mod.broker ?? mod.default ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeClaudeUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw.data ?? raw;
+  if (!data) return null;
+  return {
+    fiveHourPercent: numericOrNull(data.fiveHourPercent),
+    weeklyPercent: numericOrNull(data.weeklyPercent),
+    fiveHourResetsAt: toEpoch(data.fiveHourResetsAt),
+    weeklyResetsAt: toEpoch(data.weeklyResetsAt),
+    observedAt: toEpoch(data.observedAt) ?? now,
+    isStale: Boolean(raw.isStale ?? data.isStale),
+    source: data.source ?? "hud/providers/claude.mjs",
+  };
+}
+
+function normalizeCodexUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const buckets = raw.buckets ?? raw.data?.buckets ?? raw;
+  if (!buckets || typeof buckets !== "object") return null;
+  const entries = Object.entries(buckets);
+  if (entries.length === 0) return null;
+  const out = {};
+  for (const [id, bucket] of entries) {
+    if (!bucket || typeof bucket !== "object") continue;
+    out[id] = {
+      primary: normalizeCodexBucketLeg(bucket.primary),
+      secondary: normalizeCodexBucketLeg(bucket.secondary),
+    };
+  }
+  return {
+    buckets: out,
+    observedAt: toEpoch(raw.observedAt) ?? now,
+    isStale: Boolean(raw.shouldRefresh === false ? false : raw.isStale),
+    source: raw.source ?? "hud/providers/codex.mjs",
+  };
+}
+
+function normalizeCodexBucketLeg(leg) {
+  if (!leg || typeof leg !== "object") return null;
+  return {
+    usedPercent: numericOrNull(leg.used_percent ?? leg.usedPercent),
+    resetsAt: toEpoch(leg.resets_at ?? leg.resetsAt),
+  };
+}
+
+function normalizeBrokerSnapshot(raw) {
+  if (!Array.isArray(raw)) return null;
+  const grouped = { codex: [], claude: [], gemini: [] };
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const provider = entry.provider;
+    if (!grouped[provider]) continue;
+    grouped[provider].push({
+      id: entry.id,
+      tier: entry.tier ?? "unknown",
+      busy: Boolean(entry.busy),
+      cooldownUntil: toEpoch(entry.cooldownUntil),
+      lastUsedAt: toEpoch(entry.lastUsedAt),
+      remainingMs: numericOrNull(entry.remainingMs),
+      circuitState: entry.circuitState ?? "closed",
+      failureCount: numericOrNull(entry.failureCount) ?? 0,
+      expiresAt: toEpoch(entry.expiresAt),
+      drainAfter: toEpoch(entry.drainAfter),
+    });
+  }
+  return grouped;
+}
+
+function numericOrNull(v) {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toEpoch(v) {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  const parsed = Date.parse(v);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export async function buildRoutingSnapshot({
+  forceRefresh = false,
+  now = Date.now(),
+} = {}) {
+  const [hudClaude, hudCodex, broker] = await Promise.all([
+    loadHudClaude(),
+    loadHudCodex(),
+    loadBroker(),
+  ]);
+
+  let claude = null;
+  if (hudClaude?.readClaudeUsageSnapshot) {
+    try {
+      claude = normalizeClaudeUsage(
+        hudClaude.readClaudeUsageSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      claude = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let codex = null;
+  if (hudCodex?.readCodexRateLimitSnapshot) {
+    try {
+      codex = normalizeCodexUsage(
+        hudCodex.readCodexRateLimitSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      codex = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let brokerState = null;
+  if (broker?.publicSnapshot) {
+    try {
+      brokerState = normalizeBrokerSnapshot(broker.publicSnapshot());
+    } catch (err) {
+      brokerState = { error: String(err?.message ?? err) };
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    observedAt: now,
+    claude,
+    codex,
+    broker: brokerState,
+  };
+}
+
+// Test helpers — pure normalizers exposed so unit tests can build snapshots
+// from mock provider responses without running real HUD I/O.
+export const __internal__ = {
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+  normalizeBrokerSnapshot,
+};

--- a/packages/core/hub/dynamic-routing-engine.mjs
+++ b/packages/core/hub/dynamic-routing-engine.mjs
@@ -1,0 +1,399 @@
+// hub/dynamic-routing-engine.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure deterministic classifier. Takes a `request`, a `snapshot`
+// (from `hub/routing-snapshot.mjs`), and a `policy` (loaded from
+// `config/routing-policy.json`), then emits a single `RouteDecision`.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). conductor/swarm/tfx-route.sh integration is Phase 1+.
+//   - pure function: same (request, snapshot, policy) → same RouteDecision.
+//   - no network, no disk reads, no clock reads outside the explicit `now` arg.
+//   - fallback policy = codex-default. fails closed.
+//   - scenario evaluators are first-match-wins in policy.scenarios order.
+
+import { createHash } from "node:crypto";
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== "object") return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function hashInputs(request, snapshot) {
+  return createHash("sha256")
+    .update(stableStringify({ request, snapshot }))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function makeFallback(policy, trigger, inputsHash, now) {
+  const fb = policy?.fallback ?? {};
+  return {
+    decisionId: inputsHash,
+    mode: fb.default_mode ?? "codex-default",
+    scenario: "fallback",
+    lane: "single",
+    shards: [
+      {
+        cli: fb.default_cli ?? "codex",
+        accountId: null,
+        model: fb.default_model ?? "gpt-5.5",
+        riskTier: "safe",
+        reason: trigger,
+      },
+    ],
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+    },
+    fallback: { trigger, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(undefined, now),
+    confidence: 50,
+  };
+}
+
+function snapshotAge(snapshot, now) {
+  if (!snapshot || typeof snapshot !== "object") return null;
+  const observed = Number(snapshot.observedAt);
+  if (!Number.isFinite(observed)) return null;
+  return Math.max(0, now - observed);
+}
+
+function checkFreshness(snapshot, freshness, now) {
+  if (!snapshot) return "hud_null";
+  const max = freshness?.max_snapshot_age_ms ?? 900_000;
+  const skewMax = freshness?.max_cross_provider_skew_ms ?? 300_000;
+
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude && !codex) return "hud_null";
+  if (claude && (claude.isStale || claude.error))
+    return "claude_stale_or_error";
+  if (codex && (codex.isStale || codex.error)) return "codex_stale_or_error";
+
+  const claudeAge = claude?.observedAt ? now - claude.observedAt : null;
+  const codexAge = codex?.observedAt ? now - codex.observedAt : null;
+  if (claudeAge !== null && claudeAge > max) return "claude_age_exceeded";
+  if (codexAge !== null && codexAge > max) return "codex_age_exceeded";
+  if (claudeAge !== null && codexAge !== null) {
+    if (Math.abs(claudeAge - codexAge) > skewMax)
+      return "cross_provider_skew_exceeded";
+  }
+
+  if (claude?.weeklyResetsAt !== null && claude?.weeklyResetsAt !== undefined) {
+    if (
+      claude.weeklyResetsAt <
+      now - (freshness?.local_clock_skew_guard_ms ?? 60_000)
+    ) {
+      return "claude_weekly_reset_in_past";
+    }
+  }
+
+  return null;
+}
+
+function brokerAvailableCount(snapshot, provider) {
+  const accounts = snapshot?.broker?.[provider] ?? [];
+  return accounts.filter((a) => a.circuitState !== "open").length;
+}
+
+function brokerAllCircuitsOpen(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups) return false;
+  const all = [];
+  for (const provider of Object.keys(groups)) {
+    for (const acct of groups[provider] ?? []) all.push(acct);
+  }
+  if (all.length === 0) return true;
+  return all.every((a) => a.circuitState === "open");
+}
+
+// ─── Scenario evaluators ──────────────────────────────────────────────
+// Each returns either null (no match) or a partial RouteDecision payload
+// `{ scenario, lane, shards, riskTier?, reasonCodes }` to be wrapped by
+// `makeScenarioDecision()` below.
+
+function evalS1(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const claude = snapshot.claude;
+  if (!claude) return null;
+  const resetIn = (claude.weeklyResetsAt ?? Number.POSITIVE_INFINITY) - now;
+  if (
+    resetIn >
+    (scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms)
+  )
+    return null;
+  if ((claude.weeklyPercent ?? 100) >= (scenario.when.weeklyPercentLt ?? 100))
+    return null;
+  if (
+    scenario.when.hasMultipleAccounts &&
+    brokerAvailableCount(snapshot, "claude") < 2
+  )
+    return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: [
+      { cli: "claude", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS2(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const codex = snapshot.codex;
+  if (!codex) return null;
+  const buckets = codex.buckets ?? {};
+  const window =
+    scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? 100;
+  // Inspect both primary and secondary legs so a fresh secondary tier with
+  // imminent reset is not silently ignored when primary is exhausted.
+  const anyLegMatches = Object.values(buckets).some((b) =>
+    [b?.primary, b?.secondary].some((leg) => {
+      if (!leg) return false;
+      if (!leg.resetsAt) return false;
+      if (leg.resetsAt - now > window) return false;
+      return (leg.usedPercent ?? 100) < usageCeiling;
+    }),
+  );
+  if (!anyLegMatches) return null;
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    shards: [
+      { cli: "codex", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS3(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude || !codex) return null;
+  if ((claude.weeklyPercent ?? 0) < scenario.when.claude_weekly_percent_gte)
+    return null;
+  const codexAnyBucket = Object.values(codex.buckets ?? {}).some(
+    (b) =>
+      (b?.primary?.usedPercent ?? 100) < scenario.when.codex_weekly_percent_lt,
+  );
+  if (!codexAnyBucket) return null;
+  const resetIn = (claude.weeklyResetsAt ?? 0) - now;
+  if (resetIn <= scenario.when.claude_weekly_resets_at_gt_ms) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    shards: [{ cli: "codex", riskTier: "safe", reason: scenario.then.reason }],
+  };
+}
+
+function evalS4(ctx) {
+  const { snapshot, scenario } = ctx;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  // Staggered = at least 2 distinct cooldown/expiresAt anchors.
+  const anchors = new Set(
+    claude.map((a) => `${a.cooldownUntil ?? 0}-${a.expiresAt ?? 0}`),
+  );
+  if (scenario.when.staggered && anchors.size < 2) return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: claude.map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS5(ctx) {
+  const { request, snapshot, scenario } = ctx;
+  if ((request?.team_size ?? 1) < (scenario.when.request_team_size_gte ?? 2))
+    return null;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  const wanted = Math.min(request.team_size, claude.length);
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    atomic: scenario.then.atomic,
+    atomicPolicy: scenario.then.atomic_policy ?? "balanced",
+    shards: claude.slice(0, wanted).map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS6(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const all = [];
+  for (const p of Object.keys(snapshot.broker ?? {})) {
+    const accounts = snapshot.broker[p];
+    if (!Array.isArray(accounts)) continue;
+    for (const a of accounts) all.push({ ...a, provider: p });
+  }
+  const window = scenario.when.expiresAtLteMs ?? 604_800_000;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? null;
+  const expiring = all.filter((a) => {
+    if (!a.expiresAt) return false;
+    // Past-dated expirations are dead accounts, not drain targets.
+    if (a.expiresAt - now <= 0) return false;
+    if (a.expiresAt - now > window) return false;
+    if (scenario.when.circuitStateNotOpen && a.circuitState === "open")
+      return false;
+    if (usageCeiling !== null) {
+      const usage = providerUsagePercent(snapshot, a.provider);
+      if (usage !== null && usage >= usageCeiling) return false;
+    }
+    return true;
+  });
+  if (expiring.length === 0) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    riskTier: scenario.then.riskTier ?? "drain",
+    shards: expiring.map((a) => ({
+      cli: a.provider === "claude" ? "claude" : "codex",
+      accountId: a.id,
+      riskTier: "drain",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function providerUsagePercent(snapshot, provider) {
+  if (provider === "claude") {
+    return typeof snapshot.claude?.weeklyPercent === "number"
+      ? snapshot.claude.weeklyPercent
+      : null;
+  }
+  if (provider === "codex") {
+    const buckets = Object.values(snapshot.codex?.buckets ?? {});
+    if (buckets.length === 0) return null;
+    let max = 0;
+    for (const b of buckets) {
+      for (const leg of [b?.primary, b?.secondary]) {
+        if (typeof leg?.usedPercent === "number" && leg.usedPercent > max) {
+          max = leg.usedPercent;
+        }
+      }
+    }
+    return max;
+  }
+  return null;
+}
+
+const SCENARIO_EVALUATORS = {
+  S1: evalS1,
+  S2: evalS2,
+  S3: evalS3,
+  S4: evalS4,
+  S5: evalS5,
+  S6: evalS6,
+};
+
+function makeScenarioDecision({ match, scenario, inputsHash, snapshot, now }) {
+  return {
+    decisionId: inputsHash,
+    mode: "dynamic-overlay",
+    scenario: scenario.id,
+    lane: match.lane,
+    shards: match.shards,
+    atomic: match.atomic ?? null,
+    atomicPolicy: match.atomicPolicy ?? null,
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+      scenarioName: scenario.name,
+    },
+    fallback: { trigger: null, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(snapshot, now),
+    confidence: 72,
+  };
+}
+
+function brokerIsEmpty(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups || typeof groups !== "object") return true;
+  for (const p of Object.keys(groups)) {
+    const accounts = groups[p];
+    if (Array.isArray(accounts) && accounts.length > 0) return false;
+  }
+  return true;
+}
+
+/**
+ * @param {object} request
+ * @param {object} snapshot
+ * @param {object} policy
+ * @param {object} options
+ * @param {number} options.now — REQUIRED. Pure-fn contract: callers must
+ *   supply the current epoch; the engine itself never reads the clock.
+ */
+export function evaluateDynamicRoute(request, snapshot, policy, options) {
+  if (!options || typeof options.now !== "number") {
+    throw new TypeError(
+      "evaluateDynamicRoute: options.now (epoch ms) is required for pure-fn contract",
+    );
+  }
+  const { now } = options;
+  const inputsHash = hashInputs(request, snapshot);
+
+  if (!policy || !Array.isArray(policy.scenarios)) {
+    return makeFallback(
+      { fallback: { default_mode: "codex-default" } },
+      "policy_missing",
+      inputsHash,
+      now,
+    );
+  }
+
+  const freshnessVeto = checkFreshness(snapshot, policy.freshness, now);
+  if (freshnessVeto)
+    return makeFallback(policy, freshnessVeto, inputsHash, now);
+
+  if (brokerIsEmpty(snapshot)) {
+    return makeFallback(policy, "broker_empty", inputsHash, now);
+  }
+
+  if (brokerAllCircuitsOpen(snapshot)) {
+    return makeFallback(policy, "all_circuits_open", inputsHash, now);
+  }
+
+  for (const scenario of policy.scenarios) {
+    const evaluator = SCENARIO_EVALUATORS[scenario.id];
+    if (!evaluator) continue;
+    const match = evaluator({
+      request: request ?? {},
+      snapshot,
+      scenario,
+      policy,
+      now,
+    });
+    if (match)
+      return makeScenarioDecision({
+        match,
+        scenario,
+        inputsHash,
+        snapshot,
+        now,
+      });
+  }
+
+  return makeFallback(policy, "no_scenario_matched", inputsHash, now);
+}
+
+export const __internal__ = {
+  hashInputs,
+  checkFreshness,
+  brokerAvailableCount,
+  brokerAllCircuitsOpen,
+  brokerIsEmpty,
+  providerUsagePercent,
+  SCENARIO_EVALUATORS,
+};

--- a/packages/core/hub/routing-snapshot.mjs
+++ b/packages/core/hub/routing-snapshot.mjs
@@ -1,0 +1,193 @@
+// hub/routing-snapshot.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure read-only context projector. Wraps HUD providers and the
+// AccountBroker public snapshot into a single deterministic snapshot that
+// `evaluateDynamicRoute(request, snapshot, policy)` consumes.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). Only `evaluateDynamicRoute()` is meant to read this.
+//   - lazy import of HUD providers + broker so this module imports cleanly even
+//     when those surfaces are absent in tests.
+//   - never mutates upstream state — strictly read-only.
+//   - all output fields are derivable from `publicSnapshot()` / HUD redacted API,
+//     so writing the resulting snapshot to disk does not leak credentials.
+
+const CLAUDE_HUD_MODULE = "../hud/providers/claude.mjs";
+const CODEX_HUD_MODULE = "../hud/providers/codex.mjs";
+const BROKER_MODULE = "./account-broker.mjs";
+
+async function loadHudClaude() {
+  try {
+    return await import(CLAUDE_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadHudCodex() {
+  try {
+    return await import(CODEX_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadBroker() {
+  try {
+    const mod = await import(BROKER_MODULE);
+    return mod.broker ?? mod.default ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeClaudeUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw.data ?? raw;
+  if (!data) return null;
+  return {
+    fiveHourPercent: numericOrNull(data.fiveHourPercent),
+    weeklyPercent: numericOrNull(data.weeklyPercent),
+    fiveHourResetsAt: toEpoch(data.fiveHourResetsAt),
+    weeklyResetsAt: toEpoch(data.weeklyResetsAt),
+    observedAt: toEpoch(data.observedAt) ?? now,
+    isStale: Boolean(raw.isStale ?? data.isStale),
+    source: data.source ?? "hud/providers/claude.mjs",
+  };
+}
+
+function normalizeCodexUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const buckets = raw.buckets ?? raw.data?.buckets ?? raw;
+  if (!buckets || typeof buckets !== "object") return null;
+  const entries = Object.entries(buckets);
+  if (entries.length === 0) return null;
+  const out = {};
+  for (const [id, bucket] of entries) {
+    if (!bucket || typeof bucket !== "object") continue;
+    out[id] = {
+      primary: normalizeCodexBucketLeg(bucket.primary),
+      secondary: normalizeCodexBucketLeg(bucket.secondary),
+    };
+  }
+  return {
+    buckets: out,
+    observedAt: toEpoch(raw.observedAt) ?? now,
+    isStale: Boolean(raw.shouldRefresh === false ? false : raw.isStale),
+    source: raw.source ?? "hud/providers/codex.mjs",
+  };
+}
+
+function normalizeCodexBucketLeg(leg) {
+  if (!leg || typeof leg !== "object") return null;
+  return {
+    usedPercent: numericOrNull(leg.used_percent ?? leg.usedPercent),
+    resetsAt: toEpoch(leg.resets_at ?? leg.resetsAt),
+  };
+}
+
+function normalizeBrokerSnapshot(raw) {
+  if (!Array.isArray(raw)) return null;
+  const grouped = { codex: [], claude: [], gemini: [] };
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const provider = entry.provider;
+    if (!grouped[provider]) continue;
+    grouped[provider].push({
+      id: entry.id,
+      tier: entry.tier ?? "unknown",
+      busy: Boolean(entry.busy),
+      cooldownUntil: toEpoch(entry.cooldownUntil),
+      lastUsedAt: toEpoch(entry.lastUsedAt),
+      remainingMs: numericOrNull(entry.remainingMs),
+      circuitState: entry.circuitState ?? "closed",
+      failureCount: numericOrNull(entry.failureCount) ?? 0,
+      expiresAt: toEpoch(entry.expiresAt),
+      drainAfter: toEpoch(entry.drainAfter),
+    });
+  }
+  return grouped;
+}
+
+function numericOrNull(v) {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toEpoch(v) {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  const parsed = Date.parse(v);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export async function buildRoutingSnapshot({
+  forceRefresh = false,
+  now = Date.now(),
+} = {}) {
+  const [hudClaude, hudCodex, broker] = await Promise.all([
+    loadHudClaude(),
+    loadHudCodex(),
+    loadBroker(),
+  ]);
+
+  let claude = null;
+  if (hudClaude?.readClaudeUsageSnapshot) {
+    try {
+      claude = normalizeClaudeUsage(
+        hudClaude.readClaudeUsageSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      claude = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let codex = null;
+  if (hudCodex?.readCodexRateLimitSnapshot) {
+    try {
+      codex = normalizeCodexUsage(
+        hudCodex.readCodexRateLimitSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      codex = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let brokerState = null;
+  if (broker?.publicSnapshot) {
+    try {
+      brokerState = normalizeBrokerSnapshot(broker.publicSnapshot());
+    } catch (err) {
+      brokerState = { error: String(err?.message ?? err) };
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    observedAt: now,
+    claude,
+    codex,
+    broker: brokerState,
+  };
+}
+
+// Test helpers — pure normalizers exposed so unit tests can build snapshots
+// from mock provider responses without running real HUD I/O.
+export const __internal__ = {
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+  normalizeBrokerSnapshot,
+};

--- a/packages/triflux/config/routing-policy.json
+++ b/packages/triflux/config/routing-policy.json
@@ -1,0 +1,124 @@
+{
+  "version": 1,
+  "freshness": {
+    "max_snapshot_age_ms": 900000,
+    "max_cross_provider_skew_ms": 300000,
+    "local_clock_skew_guard_ms": 60000
+  },
+  "thresholds": {
+    "reset_imminent_ms": 86400000,
+    "exhaustion_high_percent": 80,
+    "exhaustion_low_percent": 20,
+    "expiry_drain_window_ms": 604800000,
+    "drain_usage_ceiling_percent": 50
+  },
+  "scenarios": [
+    {
+      "id": "S1",
+      "name": "claude-reset-imminent-drain",
+      "when": {
+        "provider": "claude",
+        "weeklyResetsAtLteMs": 86400000,
+        "weeklyPercentLt": 100,
+        "hasMultipleAccounts": true
+      },
+      "then": {
+        "lane": "multi",
+        "primary_cli": "claude",
+        "reserve_codex_share": 0.1,
+        "reason": "claude-weekly-reset-imminent-drain-fleet"
+      }
+    },
+    {
+      "id": "S2",
+      "name": "codex-reset-imminent-drain",
+      "when": {
+        "provider": "codex",
+        "weeklyResetsAtLteMs": 86400000,
+        "weeklyPercentLt": 100
+      },
+      "then": {
+        "lane": "swarm",
+        "primary_cli": "codex",
+        "reserve_claude_share": 0.1,
+        "reason": "codex-weekly-reset-imminent-drain-fleet"
+      }
+    },
+    {
+      "id": "S3",
+      "name": "claude-burned-codex-fresh",
+      "when": {
+        "claude_weekly_percent_gte": 80,
+        "codex_weekly_percent_lt": 20,
+        "claude_weekly_resets_at_gt_ms": 172800000
+      },
+      "then": {
+        "lane": "single",
+        "primary_cli": "codex",
+        "claude_lanes_allowed": ["explore", "final-challenge"],
+        "reason": "claude-burned-codex-fresh-rebalance"
+      }
+    },
+    {
+      "id": "S4",
+      "name": "claude-multi-account-staggered",
+      "when": {
+        "provider": "claude",
+        "accountCountGte": 2,
+        "staggered": true
+      },
+      "then": {
+        "lane": "multi",
+        "primary_cli": "claude",
+        "rank_by": "expiring_capacity_score",
+        "reason": "claude-multi-account-staggered-reset"
+      }
+    },
+    {
+      "id": "S5",
+      "name": "claude-parallel-leasemany",
+      "when": {
+        "provider": "claude",
+        "request_team_size_gte": 2,
+        "accountCountGte": 2
+      },
+      "then": {
+        "lane": "swarm",
+        "primary_cli": "claude",
+        "atomic": "leaseMany",
+        "atomic_policy": "balanced",
+        "reason": "claude-parallel-multi-account"
+      }
+    },
+    {
+      "id": "S6",
+      "name": "account-expiry-drain",
+      "when": {
+        "expiresAtLteMs": 604800000,
+        "weeklyPercentLt": 50,
+        "circuitStateNotOpen": true
+      },
+      "then": {
+        "lane": "single",
+        "riskTier": "drain",
+        "elevated_weight": 2.0,
+        "reason": "account-expiry-drain-before-loss"
+      }
+    }
+  ],
+  "fallback": {
+    "default_mode": "codex-default",
+    "default_cli": "codex",
+    "default_model": "gpt-5.5",
+    "triggers": [
+      "hud_null",
+      "hud_stale_gte_15min",
+      "weekly_reset_in_past",
+      "cross_provider_skew_exceeded",
+      "broker_empty",
+      "all_circuits_open",
+      "mirror_drift",
+      "flag_disabled"
+    ]
+  }
+}

--- a/packages/triflux/hub/dynamic-routing-engine.mjs
+++ b/packages/triflux/hub/dynamic-routing-engine.mjs
@@ -1,0 +1,399 @@
+// hub/dynamic-routing-engine.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure deterministic classifier. Takes a `request`, a `snapshot`
+// (from `hub/routing-snapshot.mjs`), and a `policy` (loaded from
+// `config/routing-policy.json`), then emits a single `RouteDecision`.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). conductor/swarm/tfx-route.sh integration is Phase 1+.
+//   - pure function: same (request, snapshot, policy) → same RouteDecision.
+//   - no network, no disk reads, no clock reads outside the explicit `now` arg.
+//   - fallback policy = codex-default. fails closed.
+//   - scenario evaluators are first-match-wins in policy.scenarios order.
+
+import { createHash } from "node:crypto";
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== "object") return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function hashInputs(request, snapshot) {
+  return createHash("sha256")
+    .update(stableStringify({ request, snapshot }))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function makeFallback(policy, trigger, inputsHash, now) {
+  const fb = policy?.fallback ?? {};
+  return {
+    decisionId: inputsHash,
+    mode: fb.default_mode ?? "codex-default",
+    scenario: "fallback",
+    lane: "single",
+    shards: [
+      {
+        cli: fb.default_cli ?? "codex",
+        accountId: null,
+        model: fb.default_model ?? "gpt-5.5",
+        riskTier: "safe",
+        reason: trigger,
+      },
+    ],
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+    },
+    fallback: { trigger, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(undefined, now),
+    confidence: 50,
+  };
+}
+
+function snapshotAge(snapshot, now) {
+  if (!snapshot || typeof snapshot !== "object") return null;
+  const observed = Number(snapshot.observedAt);
+  if (!Number.isFinite(observed)) return null;
+  return Math.max(0, now - observed);
+}
+
+function checkFreshness(snapshot, freshness, now) {
+  if (!snapshot) return "hud_null";
+  const max = freshness?.max_snapshot_age_ms ?? 900_000;
+  const skewMax = freshness?.max_cross_provider_skew_ms ?? 300_000;
+
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude && !codex) return "hud_null";
+  if (claude && (claude.isStale || claude.error))
+    return "claude_stale_or_error";
+  if (codex && (codex.isStale || codex.error)) return "codex_stale_or_error";
+
+  const claudeAge = claude?.observedAt ? now - claude.observedAt : null;
+  const codexAge = codex?.observedAt ? now - codex.observedAt : null;
+  if (claudeAge !== null && claudeAge > max) return "claude_age_exceeded";
+  if (codexAge !== null && codexAge > max) return "codex_age_exceeded";
+  if (claudeAge !== null && codexAge !== null) {
+    if (Math.abs(claudeAge - codexAge) > skewMax)
+      return "cross_provider_skew_exceeded";
+  }
+
+  if (claude?.weeklyResetsAt !== null && claude?.weeklyResetsAt !== undefined) {
+    if (
+      claude.weeklyResetsAt <
+      now - (freshness?.local_clock_skew_guard_ms ?? 60_000)
+    ) {
+      return "claude_weekly_reset_in_past";
+    }
+  }
+
+  return null;
+}
+
+function brokerAvailableCount(snapshot, provider) {
+  const accounts = snapshot?.broker?.[provider] ?? [];
+  return accounts.filter((a) => a.circuitState !== "open").length;
+}
+
+function brokerAllCircuitsOpen(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups) return false;
+  const all = [];
+  for (const provider of Object.keys(groups)) {
+    for (const acct of groups[provider] ?? []) all.push(acct);
+  }
+  if (all.length === 0) return true;
+  return all.every((a) => a.circuitState === "open");
+}
+
+// ─── Scenario evaluators ──────────────────────────────────────────────
+// Each returns either null (no match) or a partial RouteDecision payload
+// `{ scenario, lane, shards, riskTier?, reasonCodes }` to be wrapped by
+// `makeScenarioDecision()` below.
+
+function evalS1(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const claude = snapshot.claude;
+  if (!claude) return null;
+  const resetIn = (claude.weeklyResetsAt ?? Number.POSITIVE_INFINITY) - now;
+  if (
+    resetIn >
+    (scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms)
+  )
+    return null;
+  if ((claude.weeklyPercent ?? 100) >= (scenario.when.weeklyPercentLt ?? 100))
+    return null;
+  if (
+    scenario.when.hasMultipleAccounts &&
+    brokerAvailableCount(snapshot, "claude") < 2
+  )
+    return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: [
+      { cli: "claude", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS2(ctx) {
+  const { snapshot, scenario, policy, now } = ctx;
+  const codex = snapshot.codex;
+  if (!codex) return null;
+  const buckets = codex.buckets ?? {};
+  const window =
+    scenario.when.weeklyResetsAtLteMs ?? policy.thresholds.reset_imminent_ms;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? 100;
+  // Inspect both primary and secondary legs so a fresh secondary tier with
+  // imminent reset is not silently ignored when primary is exhausted.
+  const anyLegMatches = Object.values(buckets).some((b) =>
+    [b?.primary, b?.secondary].some((leg) => {
+      if (!leg) return false;
+      if (!leg.resetsAt) return false;
+      if (leg.resetsAt - now > window) return false;
+      return (leg.usedPercent ?? 100) < usageCeiling;
+    }),
+  );
+  if (!anyLegMatches) return null;
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    shards: [
+      { cli: "codex", riskTier: "stretch", reason: scenario.then.reason },
+    ],
+  };
+}
+
+function evalS3(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const claude = snapshot.claude;
+  const codex = snapshot.codex;
+  if (!claude || !codex) return null;
+  if ((claude.weeklyPercent ?? 0) < scenario.when.claude_weekly_percent_gte)
+    return null;
+  const codexAnyBucket = Object.values(codex.buckets ?? {}).some(
+    (b) =>
+      (b?.primary?.usedPercent ?? 100) < scenario.when.codex_weekly_percent_lt,
+  );
+  if (!codexAnyBucket) return null;
+  const resetIn = (claude.weeklyResetsAt ?? 0) - now;
+  if (resetIn <= scenario.when.claude_weekly_resets_at_gt_ms) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    shards: [{ cli: "codex", riskTier: "safe", reason: scenario.then.reason }],
+  };
+}
+
+function evalS4(ctx) {
+  const { snapshot, scenario } = ctx;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  // Staggered = at least 2 distinct cooldown/expiresAt anchors.
+  const anchors = new Set(
+    claude.map((a) => `${a.cooldownUntil ?? 0}-${a.expiresAt ?? 0}`),
+  );
+  if (scenario.when.staggered && anchors.size < 2) return null;
+  return {
+    lane: scenario.then.lane ?? "multi",
+    shards: claude.map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS5(ctx) {
+  const { request, snapshot, scenario } = ctx;
+  if ((request?.team_size ?? 1) < (scenario.when.request_team_size_gte ?? 2))
+    return null;
+  const claude = snapshot.broker?.claude ?? [];
+  if (claude.length < (scenario.when.accountCountGte ?? 2)) return null;
+  const wanted = Math.min(request.team_size, claude.length);
+  return {
+    lane: scenario.then.lane ?? "swarm",
+    atomic: scenario.then.atomic,
+    atomicPolicy: scenario.then.atomic_policy ?? "balanced",
+    shards: claude.slice(0, wanted).map((a) => ({
+      cli: "claude",
+      accountId: a.id,
+      riskTier: "stretch",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function evalS6(ctx) {
+  const { snapshot, scenario, now } = ctx;
+  const all = [];
+  for (const p of Object.keys(snapshot.broker ?? {})) {
+    const accounts = snapshot.broker[p];
+    if (!Array.isArray(accounts)) continue;
+    for (const a of accounts) all.push({ ...a, provider: p });
+  }
+  const window = scenario.when.expiresAtLteMs ?? 604_800_000;
+  const usageCeiling = scenario.when.weeklyPercentLt ?? null;
+  const expiring = all.filter((a) => {
+    if (!a.expiresAt) return false;
+    // Past-dated expirations are dead accounts, not drain targets.
+    if (a.expiresAt - now <= 0) return false;
+    if (a.expiresAt - now > window) return false;
+    if (scenario.when.circuitStateNotOpen && a.circuitState === "open")
+      return false;
+    if (usageCeiling !== null) {
+      const usage = providerUsagePercent(snapshot, a.provider);
+      if (usage !== null && usage >= usageCeiling) return false;
+    }
+    return true;
+  });
+  if (expiring.length === 0) return null;
+  return {
+    lane: scenario.then.lane ?? "single",
+    riskTier: scenario.then.riskTier ?? "drain",
+    shards: expiring.map((a) => ({
+      cli: a.provider === "claude" ? "claude" : "codex",
+      accountId: a.id,
+      riskTier: "drain",
+      reason: scenario.then.reason,
+    })),
+  };
+}
+
+function providerUsagePercent(snapshot, provider) {
+  if (provider === "claude") {
+    return typeof snapshot.claude?.weeklyPercent === "number"
+      ? snapshot.claude.weeklyPercent
+      : null;
+  }
+  if (provider === "codex") {
+    const buckets = Object.values(snapshot.codex?.buckets ?? {});
+    if (buckets.length === 0) return null;
+    let max = 0;
+    for (const b of buckets) {
+      for (const leg of [b?.primary, b?.secondary]) {
+        if (typeof leg?.usedPercent === "number" && leg.usedPercent > max) {
+          max = leg.usedPercent;
+        }
+      }
+    }
+    return max;
+  }
+  return null;
+}
+
+const SCENARIO_EVALUATORS = {
+  S1: evalS1,
+  S2: evalS2,
+  S3: evalS3,
+  S4: evalS4,
+  S5: evalS5,
+  S6: evalS6,
+};
+
+function makeScenarioDecision({ match, scenario, inputsHash, snapshot, now }) {
+  return {
+    decisionId: inputsHash,
+    mode: "dynamic-overlay",
+    scenario: scenario.id,
+    lane: match.lane,
+    shards: match.shards,
+    atomic: match.atomic ?? null,
+    atomicPolicy: match.atomicPolicy ?? null,
+    rationale: {
+      inputsHash,
+      biasScore: null,
+      alternatives: [],
+      scenarioName: scenario.name,
+    },
+    fallback: { trigger: null, action: "codex-default" },
+    snapshotAgeMs: snapshotAge(snapshot, now),
+    confidence: 72,
+  };
+}
+
+function brokerIsEmpty(snapshot) {
+  const groups = snapshot?.broker;
+  if (!groups || typeof groups !== "object") return true;
+  for (const p of Object.keys(groups)) {
+    const accounts = groups[p];
+    if (Array.isArray(accounts) && accounts.length > 0) return false;
+  }
+  return true;
+}
+
+/**
+ * @param {object} request
+ * @param {object} snapshot
+ * @param {object} policy
+ * @param {object} options
+ * @param {number} options.now — REQUIRED. Pure-fn contract: callers must
+ *   supply the current epoch; the engine itself never reads the clock.
+ */
+export function evaluateDynamicRoute(request, snapshot, policy, options) {
+  if (!options || typeof options.now !== "number") {
+    throw new TypeError(
+      "evaluateDynamicRoute: options.now (epoch ms) is required for pure-fn contract",
+    );
+  }
+  const { now } = options;
+  const inputsHash = hashInputs(request, snapshot);
+
+  if (!policy || !Array.isArray(policy.scenarios)) {
+    return makeFallback(
+      { fallback: { default_mode: "codex-default" } },
+      "policy_missing",
+      inputsHash,
+      now,
+    );
+  }
+
+  const freshnessVeto = checkFreshness(snapshot, policy.freshness, now);
+  if (freshnessVeto)
+    return makeFallback(policy, freshnessVeto, inputsHash, now);
+
+  if (brokerIsEmpty(snapshot)) {
+    return makeFallback(policy, "broker_empty", inputsHash, now);
+  }
+
+  if (brokerAllCircuitsOpen(snapshot)) {
+    return makeFallback(policy, "all_circuits_open", inputsHash, now);
+  }
+
+  for (const scenario of policy.scenarios) {
+    const evaluator = SCENARIO_EVALUATORS[scenario.id];
+    if (!evaluator) continue;
+    const match = evaluator({
+      request: request ?? {},
+      snapshot,
+      scenario,
+      policy,
+      now,
+    });
+    if (match)
+      return makeScenarioDecision({
+        match,
+        scenario,
+        inputsHash,
+        snapshot,
+        now,
+      });
+  }
+
+  return makeFallback(policy, "no_scenario_matched", inputsHash, now);
+}
+
+export const __internal__ = {
+  hashInputs,
+  checkFreshness,
+  brokerAvailableCount,
+  brokerAllCircuitsOpen,
+  brokerIsEmpty,
+  providerUsagePercent,
+  SCENARIO_EVALUATORS,
+};

--- a/packages/triflux/hub/routing-snapshot.mjs
+++ b/packages/triflux/hub/routing-snapshot.mjs
@@ -1,0 +1,193 @@
+// hub/routing-snapshot.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 — pure read-only context projector. Wraps HUD providers and the
+// AccountBroker public snapshot into a single deterministic snapshot that
+// `evaluateDynamicRoute(request, snapshot, policy)` consumes.
+//
+// Phase 0 contract:
+//   - no callers yet (dormant). Only `evaluateDynamicRoute()` is meant to read this.
+//   - lazy import of HUD providers + broker so this module imports cleanly even
+//     when those surfaces are absent in tests.
+//   - never mutates upstream state — strictly read-only.
+//   - all output fields are derivable from `publicSnapshot()` / HUD redacted API,
+//     so writing the resulting snapshot to disk does not leak credentials.
+
+const CLAUDE_HUD_MODULE = "../hud/providers/claude.mjs";
+const CODEX_HUD_MODULE = "../hud/providers/codex.mjs";
+const BROKER_MODULE = "./account-broker.mjs";
+
+async function loadHudClaude() {
+  try {
+    return await import(CLAUDE_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadHudCodex() {
+  try {
+    return await import(CODEX_HUD_MODULE);
+  } catch {
+    return null;
+  }
+}
+
+async function loadBroker() {
+  try {
+    const mod = await import(BROKER_MODULE);
+    return mod.broker ?? mod.default ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeClaudeUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw.data ?? raw;
+  if (!data) return null;
+  return {
+    fiveHourPercent: numericOrNull(data.fiveHourPercent),
+    weeklyPercent: numericOrNull(data.weeklyPercent),
+    fiveHourResetsAt: toEpoch(data.fiveHourResetsAt),
+    weeklyResetsAt: toEpoch(data.weeklyResetsAt),
+    observedAt: toEpoch(data.observedAt) ?? now,
+    isStale: Boolean(raw.isStale ?? data.isStale),
+    source: data.source ?? "hud/providers/claude.mjs",
+  };
+}
+
+function normalizeCodexUsage(raw, now) {
+  if (!raw || typeof raw !== "object") return null;
+  const buckets = raw.buckets ?? raw.data?.buckets ?? raw;
+  if (!buckets || typeof buckets !== "object") return null;
+  const entries = Object.entries(buckets);
+  if (entries.length === 0) return null;
+  const out = {};
+  for (const [id, bucket] of entries) {
+    if (!bucket || typeof bucket !== "object") continue;
+    out[id] = {
+      primary: normalizeCodexBucketLeg(bucket.primary),
+      secondary: normalizeCodexBucketLeg(bucket.secondary),
+    };
+  }
+  return {
+    buckets: out,
+    observedAt: toEpoch(raw.observedAt) ?? now,
+    isStale: Boolean(raw.shouldRefresh === false ? false : raw.isStale),
+    source: raw.source ?? "hud/providers/codex.mjs",
+  };
+}
+
+function normalizeCodexBucketLeg(leg) {
+  if (!leg || typeof leg !== "object") return null;
+  return {
+    usedPercent: numericOrNull(leg.used_percent ?? leg.usedPercent),
+    resetsAt: toEpoch(leg.resets_at ?? leg.resetsAt),
+  };
+}
+
+function normalizeBrokerSnapshot(raw) {
+  if (!Array.isArray(raw)) return null;
+  const grouped = { codex: [], claude: [], gemini: [] };
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const provider = entry.provider;
+    if (!grouped[provider]) continue;
+    grouped[provider].push({
+      id: entry.id,
+      tier: entry.tier ?? "unknown",
+      busy: Boolean(entry.busy),
+      cooldownUntil: toEpoch(entry.cooldownUntil),
+      lastUsedAt: toEpoch(entry.lastUsedAt),
+      remainingMs: numericOrNull(entry.remainingMs),
+      circuitState: entry.circuitState ?? "closed",
+      failureCount: numericOrNull(entry.failureCount) ?? 0,
+      expiresAt: toEpoch(entry.expiresAt),
+      drainAfter: toEpoch(entry.drainAfter),
+    });
+  }
+  return grouped;
+}
+
+function numericOrNull(v) {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toEpoch(v) {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  const parsed = Date.parse(v);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export async function buildRoutingSnapshot({
+  forceRefresh = false,
+  now = Date.now(),
+} = {}) {
+  const [hudClaude, hudCodex, broker] = await Promise.all([
+    loadHudClaude(),
+    loadHudCodex(),
+    loadBroker(),
+  ]);
+
+  let claude = null;
+  if (hudClaude?.readClaudeUsageSnapshot) {
+    try {
+      claude = normalizeClaudeUsage(
+        hudClaude.readClaudeUsageSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      claude = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let codex = null;
+  if (hudCodex?.readCodexRateLimitSnapshot) {
+    try {
+      codex = normalizeCodexUsage(
+        hudCodex.readCodexRateLimitSnapshot({ forceRefresh }),
+        now,
+      );
+    } catch (err) {
+      codex = {
+        error: String(err?.message ?? err),
+        observedAt: now,
+        isStale: true,
+      };
+    }
+  }
+
+  let brokerState = null;
+  if (broker?.publicSnapshot) {
+    try {
+      brokerState = normalizeBrokerSnapshot(broker.publicSnapshot());
+    } catch (err) {
+      brokerState = { error: String(err?.message ?? err) };
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    observedAt: now,
+    claude,
+    codex,
+    broker: brokerState,
+  };
+}
+
+// Test helpers — pure normalizers exposed so unit tests can build snapshots
+// from mock provider responses without running real HUD I/O.
+export const __internal__ = {
+  normalizeClaudeUsage,
+  normalizeCodexUsage,
+  normalizeBrokerSnapshot,
+};

--- a/tests/unit/dynamic-routing-engine.test.mjs
+++ b/tests/unit/dynamic-routing-engine.test.mjs
@@ -1,0 +1,391 @@
+// tests/unit/dynamic-routing-engine.test.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md
+//
+// Phase 0 acceptance suite. Pure-fn classifier — given a mock snapshot and
+// the production routing policy JSON, the engine emits a deterministic
+// RouteDecision. Six scenarios (S1..S6) + freshness/edge fallbacks.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import { evaluateDynamicRoute } from "../../hub/dynamic-routing-engine.mjs";
+
+const POLICY = JSON.parse(
+  readFileSync(
+    new URL("../../config/routing-policy.json", import.meta.url),
+    "utf8",
+  ),
+);
+// 2026-05-15T08:00:00Z — fixed epoch for deterministic tests.
+// Verified via `new Date(NOW).toISOString()` → "2026-05-15T08:00:00.000Z".
+const NOW = 1778832000000;
+const HOUR = 3600_000;
+const DAY = 24 * HOUR;
+
+function mkClaude({
+  weekly = 30,
+  fiveHour = 10,
+  resetIn = 5 * DAY,
+  stale = false,
+} = {}) {
+  return {
+    fiveHourPercent: fiveHour,
+    weeklyPercent: weekly,
+    fiveHourResetsAt: NOW + 4 * HOUR,
+    weeklyResetsAt: NOW + resetIn,
+    observedAt: NOW - 60_000,
+    isStale: stale,
+    source: "test",
+  };
+}
+
+function mkCodex({
+  primaryPct = 30,
+  secondaryPct = 30,
+  resetIn = 5 * DAY,
+  stale = false,
+} = {}) {
+  return {
+    buckets: {
+      codex: {
+        primary: { usedPercent: primaryPct, resetsAt: NOW + resetIn },
+        secondary: { usedPercent: secondaryPct, resetsAt: NOW + resetIn },
+      },
+    },
+    observedAt: NOW - 60_000,
+    isStale: stale,
+    source: "test",
+  };
+}
+
+function mkBroker({
+  claudeCount = 0,
+  codexCount = 1,
+  codexExpiresIn = null,
+  allCircuitsOpen = false,
+} = {}) {
+  const baseAcct = (id, provider, overrides = {}) => ({
+    id,
+    tier: "pro",
+    busy: false,
+    cooldownUntil: null,
+    lastUsedAt: NOW - HOUR,
+    remainingMs: null,
+    circuitState: allCircuitsOpen ? "open" : "closed",
+    failureCount: 0,
+    expiresAt: null,
+    drainAfter: null,
+    provider,
+    ...overrides,
+  });
+  return {
+    claude: Array.from({ length: claudeCount }, (_, i) =>
+      baseAcct(`claude-${i + 1}`, "claude"),
+    ),
+    codex: Array.from({ length: codexCount }, (_, i) =>
+      baseAcct(`codex-${i + 1}`, "codex", {
+        expiresAt: codexExpiresIn ? NOW + codexExpiresIn : null,
+      }),
+    ),
+    gemini: [],
+  };
+}
+
+function mkSnapshot(parts = {}) {
+  return {
+    schemaVersion: 1,
+    observedAt: NOW,
+    claude: parts.claude !== undefined ? parts.claude : mkClaude(),
+    codex: parts.codex !== undefined ? parts.codex : mkCodex(),
+    broker: parts.broker !== undefined ? parts.broker : mkBroker(),
+  };
+}
+
+describe("dynamic-routing-engine — Phase 0", () => {
+  it("S1: Claude weekly reset 임박 + 다계정 → claude multi lane", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 35, resetIn: 12 * HOUR }),
+      broker: mkBroker({ claudeCount: 2 }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "S1");
+    assert.equal(decision.lane, "multi");
+    assert.equal(decision.shards[0].cli, "claude");
+    assert.match(decision.rationale.scenarioName, /claude-reset-imminent/);
+  });
+
+  it("S2: Codex weekly reset 임박 → codex swarm lane", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 50, resetIn: 5 * DAY }),
+      codex: mkCodex({ primaryPct: 40, resetIn: 12 * HOUR }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "S2");
+    assert.equal(decision.lane, "swarm");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("S3: Claude >80% + Codex <20% + Claude reset >48h → codex single", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 85, resetIn: 5 * DAY }),
+      codex: mkCodex({ primaryPct: 10, resetIn: 5 * DAY }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "S3");
+    assert.equal(decision.lane, "single");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("S4: Claude multi-account staggered → claude multi with all accounts as shards", () => {
+    const broker = mkBroker({ claudeCount: 2 });
+    // make staggered: distinct expiresAt
+    broker.claude[0].expiresAt = NOW + 7 * DAY;
+    broker.claude[1].expiresAt = NOW + 14 * DAY;
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 50, resetIn: 5 * DAY }),
+      broker,
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    // S1 also can match (reset 5d < 24h? No, 5d > 24h). So S4 should win when reset is far.
+    assert.equal(decision.scenario, "S4");
+    assert.equal(decision.lane, "multi");
+    assert.equal(decision.shards.length, 2);
+  });
+
+  it("S5: team_size>=2 + multi-account → claude swarm with leaseMany atomic", () => {
+    const broker = mkBroker({ claudeCount: 2 });
+    broker.claude[0].expiresAt = NOW + 7 * DAY;
+    broker.claude[1].expiresAt = NOW + 14 * DAY;
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 40, resetIn: 5 * DAY }),
+      broker,
+    });
+    const decision = evaluateDynamicRoute({ team_size: 3 }, snap, POLICY, {
+      now: NOW,
+    });
+    // S4 will likely match first (both have accountCountGte:2 and staggered). For
+    // explicit S5 testing we need a snapshot where S4 doesn't match. S4 requires
+    // staggered: distinct cooldown/expiresAt. Use identical anchors to skip S4.
+    const broker2 = mkBroker({ claudeCount: 2 });
+    broker2.claude[0].expiresAt = NOW + 7 * DAY;
+    broker2.claude[1].expiresAt = NOW + 7 * DAY;
+    const snap2 = mkSnapshot({
+      claude: mkClaude({ weekly: 40, resetIn: 5 * DAY }),
+      broker: broker2,
+    });
+    const decision2 = evaluateDynamicRoute({ team_size: 3 }, snap2, POLICY, {
+      now: NOW,
+    });
+    assert.equal(decision2.scenario, "S5");
+    assert.equal(decision2.atomic, "leaseMany");
+    // sanity: first call also resolves to a valid scenario
+    assert.ok(["S4", "S5"].includes(decision.scenario));
+  });
+
+  it("S6: account expires within 7d + low usage → drain mode", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 30, resetIn: 5 * DAY }),
+      codex: mkCodex({ primaryPct: 30, resetIn: 5 * DAY }),
+      broker: mkBroker({
+        claudeCount: 0,
+        codexCount: 1,
+        codexExpiresIn: 3 * DAY,
+      }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "S6");
+    assert.equal(decision.shards[0].riskTier, "drain");
+  });
+
+  it("freshness veto: claude isStale → codex-default fallback", () => {
+    const snap = mkSnapshot({ claude: mkClaude({ stale: true }) });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.mode, "codex-default");
+    assert.equal(decision.fallback.trigger, "claude_stale_or_error");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("freshness veto: both HUD providers null → codex-default fallback", () => {
+    const snap = mkSnapshot({ claude: null, codex: null });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "hud_null");
+  });
+
+  it("freshness veto: claude weeklyResetsAt in past → codex-default fallback", () => {
+    const snap = mkSnapshot({
+      claude: { ...mkClaude(), weeklyResetsAt: NOW - 2 * HOUR },
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "claude_weekly_reset_in_past");
+  });
+
+  it("freshness veto: snapshot older than 15min → codex-default fallback", () => {
+    const snap = mkSnapshot({
+      claude: { ...mkClaude(), observedAt: NOW - 20 * 60_000 },
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "claude_age_exceeded");
+  });
+
+  it("all circuits open → codex-default fallback", () => {
+    const snap = mkSnapshot({
+      broker: mkBroker({
+        claudeCount: 1,
+        codexCount: 1,
+        allCircuitsOpen: true,
+      }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "all_circuits_open");
+  });
+
+  it("no scenario matches (default healthy state) → codex-default fallback", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 30, resetIn: 5 * DAY }),
+      codex: mkCodex({ primaryPct: 30, resetIn: 5 * DAY }),
+      broker: mkBroker({ claudeCount: 0, codexCount: 1 }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "no_scenario_matched");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("deterministic: same (request, snapshot) → same decisionId", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 35, resetIn: 12 * HOUR }),
+      broker: mkBroker({ claudeCount: 2 }),
+    });
+    const d1 = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    const d2 = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(d1.decisionId, d2.decisionId);
+    assert.equal(d1.scenario, d2.scenario);
+  });
+
+  it("policy missing → policy_missing fallback (no throw)", () => {
+    const snap = mkSnapshot();
+    const decision = evaluateDynamicRoute({}, snap, null, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "policy_missing");
+  });
+
+  // ─── Negative fixtures (verifier audit follow-up) ───────────────
+
+  it("S1 negative: claudeCount=1 (단일 account) → S1 skip → fallback", () => {
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 35, resetIn: 12 * HOUR }),
+      broker: mkBroker({ claudeCount: 1, codexCount: 1 }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.notEqual(decision.scenario, "S1");
+  });
+
+  it("S2 secondary leg: primary exhausted + secondary reset 임박 → S2 trigger", () => {
+    const codex = {
+      buckets: {
+        codex: {
+          primary: { usedPercent: 100, resetsAt: NOW + 30 * DAY },
+          secondary: { usedPercent: 20, resetsAt: NOW + 12 * HOUR },
+        },
+      },
+      observedAt: NOW - 60_000,
+      isStale: false,
+      source: "test",
+    };
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 50, resetIn: 5 * DAY }),
+      codex,
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "S2");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("S5 negative: team_size=1 → S5 skip", () => {
+    const broker = mkBroker({ claudeCount: 2 });
+    broker.claude[0].expiresAt = NOW + 7 * DAY;
+    broker.claude[1].expiresAt = NOW + 7 * DAY;
+    const snap = mkSnapshot({
+      claude: mkClaude({ weekly: 40, resetIn: 5 * DAY }),
+      broker,
+    });
+    const decision = evaluateDynamicRoute({ team_size: 1 }, snap, POLICY, {
+      now: NOW,
+    });
+    assert.notEqual(decision.scenario, "S5");
+  });
+
+  it("S6 negative: expiresAt 이미 과거 → 죽은 계정 filter 후 fallback", () => {
+    const broker = mkBroker({ claudeCount: 0, codexCount: 1 });
+    broker.codex[0].expiresAt = NOW - 24 * HOUR; // already expired
+    const snap = mkSnapshot({
+      claude: mkClaude(),
+      codex: mkCodex(),
+      broker,
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.notEqual(decision.scenario, "S6");
+  });
+
+  it("S6 weeklyPercentLt cross-check: codex 80% used → drain skip", () => {
+    const broker = mkBroker({ claudeCount: 0, codexCount: 1 });
+    broker.codex[0].expiresAt = NOW + 3 * DAY;
+    const snap = mkSnapshot({
+      claude: mkClaude(),
+      codex: mkCodex({ primaryPct: 80, resetIn: 5 * DAY }),
+      broker,
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.notEqual(decision.scenario, "S6");
+  });
+
+  it("freshness veto: codex isStale → codex-default fallback", () => {
+    const snap = mkSnapshot({
+      codex: mkCodex({ stale: true }),
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "codex_stale_or_error");
+  });
+
+  it("freshness veto: codex snapshot older than 15min → codex_age_exceeded", () => {
+    const snap = mkSnapshot({
+      codex: { ...mkCodex(), observedAt: NOW - 20 * 60_000 },
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "codex_age_exceeded");
+  });
+
+  it("freshness veto: cross-provider snapshot skew > 5min → fallback", () => {
+    const snap = mkSnapshot({
+      claude: { ...mkClaude(), observedAt: NOW - 60_000 },
+      codex: { ...mkCodex(), observedAt: NOW - 7 * 60_000 },
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "cross_provider_skew_exceeded");
+  });
+
+  it("broker_empty: 모든 provider 계정 0개 → broker_empty fallback", () => {
+    const snap = mkSnapshot({
+      broker: { claude: [], codex: [], gemini: [] },
+    });
+    const decision = evaluateDynamicRoute({}, snap, POLICY, { now: NOW });
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.fallback.trigger, "broker_empty");
+  });
+
+  it("pure-fn contract: options.now 미지정 시 TypeError", () => {
+    const snap = mkSnapshot();
+    assert.throws(() => evaluateDynamicRoute({}, snap, POLICY), TypeError);
+    assert.throws(() => evaluateDynamicRoute({}, snap, POLICY, {}), TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

triflux 본진 routing 정책이 v10.18.0~v10.20.2 동안 정적 codex-default 였던 건 quality 차이가 아니라 **"Claude 를 아끼자" conservation 정책의 결과**였다. 사용자가 그 가정을 revise — Claude opus 와 Codex gpt-5.5 는 코드 작업 quality 비등비등 — 그리고 dispatch decision 을 **token-economy + 인프라 + lane 등 다축 휴리스틱**으로 동적으로 결정하는 routing engine overlay 를 Phase 0 부터 도입.

## Phase 0 scope (read-only / dormant / opt-in)

| 파일 | LoC | 역할 |
|---|---|---|
| `hub/routing-snapshot.mjs` | 193 | HUD providers (claude/codex/gemini) + AccountBroker.publicSnapshot() 통합 read-only projector |
| `hub/dynamic-routing-engine.mjs` | ~280 | `evaluateDynamicRoute(request, snapshot, policy, {now})` pure deterministic classifier — 6 scenarios (S1~S6) + 8 fallback triggers |
| `config/routing-policy.json` | ~120 | scenarios + thresholds + fallback 외부화 (Codex 가 코드 안 읽고 JSON rewrite 가능 — self-bias mitigation) |
| `tests/unit/dynamic-routing-engine.test.mjs` | ~360 | **24 tests** (6 happy + 4 negative + 9 fallback/edge case + 5 보강) |

## 6 Scenarios

| ID | When | Then |
|---|---|---|
| S1 | claude weekly reset ≤24h + 미소진 + 다계정 | claude multi-team |
| S2 | codex weekly (primary OR secondary) reset ≤24h + 미소진 | codex swarm |
| S3 | claude ≥80% + codex <20% + claude reset >48h | codex single |
| S4 | claude N계정 staggered (distinct cooldown/expiresAt) | claude multi, 모든 계정 shards |
| S5 | team_size≥2 + claude N계정 | claude swarm with `leaseMany` atomic |
| S6 | expiresAt ≤7d (미래) + usage <ceiling + circuit not open | drain mode |

## 8 Fallback triggers (codex-default 회귀)

`hud_null`, `claude_stale_or_error`, `codex_stale_or_error`, `claude_age_exceeded`, `codex_age_exceeded`, `cross_provider_skew_exceeded`, `claude_weekly_reset_in_past`, `broker_empty`, `all_circuits_open`, `no_scenario_matched`, `policy_missing`.

## Self-bias mitigation (사용자 명시 가드 5중)

1. **모든 threshold/predicate JSON config 외부화** — `config/routing-policy.json`. Codex 가 코드 안 읽고 rewrite 가능
2. **Safety fallback = codex-default** (claude-default 아님). 시스템 uncertain 시 Codex
3. **Provider-symmetric vocabulary** — `cli`, `riskTier`, `mode` 모두 양쪽 적용. Claude-specific field 없음
4. **pure-fn contract** — `options.now` mandatory. 호출자가 클럭 명시 (단위 test 의 deterministic 보장)
5. **deterministic `decisionId`** — `stableStringify({request, snapshot})` SHA-256 → 16-char hex. 동일 input → 동일 ID

## Sub-agent 검증 결과

- **Claude verifier** (`oh-my-claudecode:verifier` opus): 1차 NEEDS_FIX 판정 후 **7 blockers 모두 해소**:
  - evalS2 의 `b.secondary` silent half-coverage bug fix
  - evalS6 `void ceiling` 제거 + `weeklyPercentLt` cross-check 실구현 (`providerUsagePercent`)
  - `broker_empty` trigger 명시 처리 (policy/impl drift 해소)
  - `NOW` epoch 2026-05-15T08:00:00Z 정확 (이전 코멘트 2024 였음)
  - `evaluateDynamicRoute` default `now` 제거 → mandatory throw
  - 10 신규 fixtures 추가 (S1/S5 negative, S6 past-expired + circuit-open + weeklyPercentLt cross-check, codex freshness 3, broker_empty, pure-fn contract)
  - verifier 의 self-bias 자기 점검: Claude paths (S1/S4/S5) 를 Codex path (S2) 보다 더 강하게 stress-test 했다고 명시 → 자기 우대 안 함
- **Codex challenger**: macOS m5 환경의 `~/.codex/hooks.json` SessionStart/UserPromptSubmit hook 회귀로 spawn 실패 (별도 issue 후보). Phase 0 검증에는 Claude verifier 단독 + self-bias mitigation 5중 정책으로 보강.

## Phase 0 contract

- **caller 0**: `evaluateDynamicRoute()` / `buildRoutingSnapshot()` 을 호출하는 코드는 본 PR 에 **없음**. 회귀 영향 0.
- **opt-in**: 향후 통합은 `TRIFLUX_DYNAMIC_ROUTING && TFX_TOKEN_ECONOMY_ROUTING` env flag 기반.
- **dormant import**: lazy import 로 HUD/broker 부재해도 module 자체는 깨지지 않음.

## Phase 1+ integration plan (별도 PR)

- `hub/team/conductor.mjs:1027` `activeBroker.lease({provider})` → `activeBroker.lease({provider, preferredAccountId})`
- `hub/team/swarm-hypervisor.mjs:81` `FALLBACK_AGENTS` static → `getFallbackAgent(primary, ctx)` policy-driven
- `scripts/tfx-route.sh:2473` `--cli` 결정 시 `TFX_ROUTING_DECISION_FILE` env JSON 우선
- **추가 발견**: `tfx multi` 가 `codex exec` 직접 spawn (사용자 관찰) → `hub/headless.mjs` 또는 `hub/team/conductor.mjs` 의 spawn 위치도 Phase 1 후크 필요. tfx-route.sh 만 후크하면 multi 워커는 dynamic routing 못 받음.

## Test plan

- [x] `npm run lint` → 620 files clean
- [x] `npm run release:check-mirror` → packages/triflux matches root
- [x] `npm run release:check-sync` → Version sync OK (10.20.2)
- [x] `node --test tests/unit/dynamic-routing-engine.test.mjs` → **24/24 pass** (5ms total)
- [x] 3-layer mirror byte-identical (root + packages/triflux + packages/core, 5 files)

## Commits

- `8bbbf25e` Add dynamic routing engine Phase 0 (read-only scenario evaluator)