### PR TITLE
fix(cli-adapter-base): pipe codex exec prompts via stdin (macOS hook regression)

### DIFF
--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
 // ── Quota retry-after 파싱 ──────────────────────────────────────
@@ -145,9 +146,16 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
 
 /**
  * long-form 플래그 기반 명령 빌더.
+ *
+ * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
+ * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
+ * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
+ * stdin 미지원 환경 대비).
+ *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
- * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[] }} [opts]
+ * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[], stdinPrompt?: boolean }} [opts]
  * @returns {string} 실행할 셸 커맨드
  */
 export function buildExecCommand(prompt, resultFile = null, opts = {}) {
@@ -156,6 +164,7 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     skipGitRepoCheck = true,
     sandboxBypass = true,
     mcpServers,
+    stdinPrompt,
   } = opts;
 
   const parts = ["codex"];
@@ -183,8 +192,23 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
   }
 
+  const useStdin = resolveStdinPromptMode(stdinPrompt);
+  const hasPrompt = typeof prompt === "string" && prompt.length > 0;
+  if (useStdin && hasPrompt) {
+    const promptFile = writePromptToTmpFile(prompt);
+    return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
+  }
+
   parts.push(JSON.stringify(prompt));
   return parts.join(" ");
+}
+
+function resolveStdinPromptMode(explicit) {
+  if (typeof explicit === "boolean") return explicit;
+  // Default ON to fix macOS codex hook regression. Opt out via env=0.
+  const env = process.env.TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
 }
 
 // ── Sleep ───────────────────────────────────────────────────────

--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -148,10 +148,14 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
  * long-form 플래그 기반 명령 빌더.
  *
  * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
- * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
- * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
- * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
- * stdin 미지원 환경 대비).
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 prompt
+ * 를 stdin 으로 전달하는 패턴. 셸별 분기:
+ *   - Unix (bash/zsh): `codex exec ... < '/tmp/triflux-codex-prompt/prompt-*.txt'`
+ *   - Windows (pwsh7): `Get-Content -Raw 'path' | codex exec ...`
+ *     (pwsh7 의 `<` 는 reserved future syntax 라 호환성 보장 안 됨)
+ *
+ * 환경 변수 `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀.
+ * 결정론 보장이 필요한 launcher path 는 호출 시 `stdinPrompt: false` 명시.
  *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
@@ -196,6 +200,11 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   const hasPrompt = typeof prompt === "string" && prompt.length > 0;
   if (useStdin && hasPrompt) {
     const promptFile = writePromptToTmpFile(prompt);
+    if (IS_WINDOWS) {
+      // pwsh7 호환: `<` redirect 는 reserved future syntax 라 동작 불안정.
+      // Get-Content -Raw stdin pipe 로 prompt 를 codex stdin 에 주입.
+      return `Get-Content -Raw '${escapePwshSingleQuoted(promptFile)}' | ${parts.join(" ")}`;
+    }
     return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
   }
 

--- a/hub/codex-adapter.mjs
+++ b/hub/codex-adapter.mjs
@@ -108,6 +108,10 @@ export function buildExecArgs(opts = {}) {
     skipGitRepoCheck: true,
     sandboxBypass: true,
     cwd: opts.cwd,
+    // stdinPrompt 가 명시되면 buildExecCommand 로 forward.
+    // headless 워커 spawn (backend.mjs) 은 default (stdin on, macOS hook fix).
+    // launcher path (launcher-template.mjs) 는 결정론 위해 false 전달.
+    stdinPrompt: opts.stdinPrompt,
   });
 
   if (!prompt) return command.replace(/\s+""$/u, "");

--- a/hub/lib/prompt-tmp.mjs
+++ b/hub/lib/prompt-tmp.mjs
@@ -1,0 +1,33 @@
+// hub/lib/prompt-tmp.mjs
+//
+// macOS `codex exec` 회귀 fix 보조 helper. codex CLI v0.130.0 의 macOS hook
+// lifecycle (oh-my-codex/codex-native-hook.js) 이 매우 긴 argv inline prompt
+// (4KB+) 를 받으면 SessionStart Failed 로 즉시 exit. PR #243 의 stdin EAGAIN
+// async stream fix 후속 회귀로 추정.
+//
+// 대안: prompt 를 임시 파일에 쓰고 `< /tmp/...` stdin redirect 로 전달.
+// Manual `echo prompt | codex exec ...` (stdin pipe) 가 정상 작동하는 fact 와
+// 정합.
+//
+// cleanup 정책: best-effort. OS `/tmp` 가 자동 cleanup 하고, 이 모듈은
+// 매 호출마다 unique path 사용 (timestamp + pid + counter). orphan 파일은
+// 추후 doctor 가 prune.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PROMPT_TMP_DIR = join(tmpdir(), "triflux-codex-prompt");
+let counter = 0;
+
+export function writePromptToTmpFile(prompt) {
+  mkdirSync(PROMPT_TMP_DIR, { recursive: true });
+  const id = `${Date.now()}-${process.pid}-${counter++}`;
+  const file = join(PROMPT_TMP_DIR, `prompt-${id}.txt`);
+  writeFileSync(file, String(prompt ?? ""), "utf8");
+  return file;
+}
+
+export function getPromptTmpDir() {
+  return PROMPT_TMP_DIR;
+}

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -208,20 +208,22 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
   const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
 
-  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지)
+  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
+  // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어
+  // backend.buildArgs 에 전달했는데, 새 stdin-prompt 모드 (PR #252) 가
+  // 그 literal 을 user message 로 해석해서 codex 가 prompt 가 아닌
+  // shell expression 자체를 받는 회귀가 있었다. 이제 fullPrompt 를 그대로
+  // 전달하고 buildExecCommand 가 자체적으로 tmp file 작성 + stdin redirect.
   if (!existsSync(RESULT_DIR)) mkdirSync(RESULT_DIR, { recursive: true });
   const promptFile = join(
     RESULT_DIR,
     "prompt-" + randomUUID().slice(0, 8) + ".txt",
   ).replace(/\\/g, "/");
   writeFileSync(promptFile, fullPrompt, "utf8");
+  void IS_WINDOWS; // referenced for diagnostic guard chain below
 
   const backend = getBackend(resolvedCli);
-  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
-  const promptExpr = IS_WINDOWS
-    ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+  const backendCommand = backend.buildArgs(fullPrompt, resultFile, {
     ...opts,
     model,
   });

--- a/hub/team/launcher-template.mjs
+++ b/hub/team/launcher-template.mjs
@@ -78,6 +78,11 @@ export function buildLauncher(opts) {
     workdir,
     cwd: workdir,
     mcpServers,
+    // launcher 는 동일 입력 → 동일 명령 (F5 결정론 보장). buildExecCommand 의
+    // stdin redirect 모드는 timestamp/pid/counter 가 들어가 비결정적이라
+    // launcher path 에서는 argv-inline 모드로 강제. headless 워커 spawn 은
+    // backend.mjs → buildExecArgs (stdinPrompt 미명시) 로 default stdin on.
+    stdinPrompt: false,
   });
 
   const env = adapter.env(profile);

--- a/packages/core/hub/cli-adapter-base.mjs
+++ b/packages/core/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
 // ── Quota retry-after 파싱 ──────────────────────────────────────
@@ -145,9 +146,16 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
 
 /**
  * long-form 플래그 기반 명령 빌더.
+ *
+ * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
+ * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
+ * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
+ * stdin 미지원 환경 대비).
+ *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
- * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[] }} [opts]
+ * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[], stdinPrompt?: boolean }} [opts]
  * @returns {string} 실행할 셸 커맨드
  */
 export function buildExecCommand(prompt, resultFile = null, opts = {}) {
@@ -156,6 +164,7 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     skipGitRepoCheck = true,
     sandboxBypass = true,
     mcpServers,
+    stdinPrompt,
   } = opts;
 
   const parts = ["codex"];
@@ -183,8 +192,23 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
   }
 
+  const useStdin = resolveStdinPromptMode(stdinPrompt);
+  const hasPrompt = typeof prompt === "string" && prompt.length > 0;
+  if (useStdin && hasPrompt) {
+    const promptFile = writePromptToTmpFile(prompt);
+    return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
+  }
+
   parts.push(JSON.stringify(prompt));
   return parts.join(" ");
+}
+
+function resolveStdinPromptMode(explicit) {
+  if (typeof explicit === "boolean") return explicit;
+  // Default ON to fix macOS codex hook regression. Opt out via env=0.
+  const env = process.env.TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
 }
 
 // ── Sleep ───────────────────────────────────────────────────────

--- a/packages/core/hub/cli-adapter-base.mjs
+++ b/packages/core/hub/cli-adapter-base.mjs
@@ -148,10 +148,14 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
  * long-form 플래그 기반 명령 빌더.
  *
  * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
- * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
- * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
- * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
- * stdin 미지원 환경 대비).
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 prompt
+ * 를 stdin 으로 전달하는 패턴. 셸별 분기:
+ *   - Unix (bash/zsh): `codex exec ... < '/tmp/triflux-codex-prompt/prompt-*.txt'`
+ *   - Windows (pwsh7): `Get-Content -Raw 'path' | codex exec ...`
+ *     (pwsh7 의 `<` 는 reserved future syntax 라 호환성 보장 안 됨)
+ *
+ * 환경 변수 `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀.
+ * 결정론 보장이 필요한 launcher path 는 호출 시 `stdinPrompt: false` 명시.
  *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
@@ -196,6 +200,11 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   const hasPrompt = typeof prompt === "string" && prompt.length > 0;
   if (useStdin && hasPrompt) {
     const promptFile = writePromptToTmpFile(prompt);
+    if (IS_WINDOWS) {
+      // pwsh7 호환: `<` redirect 는 reserved future syntax 라 동작 불안정.
+      // Get-Content -Raw stdin pipe 로 prompt 를 codex stdin 에 주입.
+      return `Get-Content -Raw '${escapePwshSingleQuoted(promptFile)}' | ${parts.join(" ")}`;
+    }
     return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
   }
 

--- a/packages/core/hub/lib/prompt-tmp.mjs
+++ b/packages/core/hub/lib/prompt-tmp.mjs
@@ -1,0 +1,33 @@
+// hub/lib/prompt-tmp.mjs
+//
+// macOS `codex exec` 회귀 fix 보조 helper. codex CLI v0.130.0 의 macOS hook
+// lifecycle (oh-my-codex/codex-native-hook.js) 이 매우 긴 argv inline prompt
+// (4KB+) 를 받으면 SessionStart Failed 로 즉시 exit. PR #243 의 stdin EAGAIN
+// async stream fix 후속 회귀로 추정.
+//
+// 대안: prompt 를 임시 파일에 쓰고 `< /tmp/...` stdin redirect 로 전달.
+// Manual `echo prompt | codex exec ...` (stdin pipe) 가 정상 작동하는 fact 와
+// 정합.
+//
+// cleanup 정책: best-effort. OS `/tmp` 가 자동 cleanup 하고, 이 모듈은
+// 매 호출마다 unique path 사용 (timestamp + pid + counter). orphan 파일은
+// 추후 doctor 가 prune.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PROMPT_TMP_DIR = join(tmpdir(), "triflux-codex-prompt");
+let counter = 0;
+
+export function writePromptToTmpFile(prompt) {
+  mkdirSync(PROMPT_TMP_DIR, { recursive: true });
+  const id = `${Date.now()}-${process.pid}-${counter++}`;
+  const file = join(PROMPT_TMP_DIR, `prompt-${id}.txt`);
+  writeFileSync(file, String(prompt ?? ""), "utf8");
+  return file;
+}
+
+export function getPromptTmpDir() {
+  return PROMPT_TMP_DIR;
+}

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -208,20 +208,22 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
   const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
 
-  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지)
+  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
+  // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어
+  // backend.buildArgs 에 전달했는데, 새 stdin-prompt 모드 (PR #252) 가
+  // 그 literal 을 user message 로 해석해서 codex 가 prompt 가 아닌
+  // shell expression 자체를 받는 회귀가 있었다. 이제 fullPrompt 를 그대로
+  // 전달하고 buildExecCommand 가 자체적으로 tmp file 작성 + stdin redirect.
   if (!existsSync(RESULT_DIR)) mkdirSync(RESULT_DIR, { recursive: true });
   const promptFile = join(
     RESULT_DIR,
     "prompt-" + randomUUID().slice(0, 8) + ".txt",
   ).replace(/\\/g, "/");
   writeFileSync(promptFile, fullPrompt, "utf8");
+  void IS_WINDOWS; // referenced for diagnostic guard chain below
 
   const backend = getBackend(resolvedCli);
-  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
-  const promptExpr = IS_WINDOWS
-    ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+  const backendCommand = backend.buildArgs(fullPrompt, resultFile, {
     ...opts,
     model,
   });

--- a/packages/remote/hub/team/launcher-template.mjs
+++ b/packages/remote/hub/team/launcher-template.mjs
@@ -78,6 +78,11 @@ export function buildLauncher(opts) {
     workdir,
     cwd: workdir,
     mcpServers,
+    // launcher 는 동일 입력 → 동일 명령 (F5 결정론 보장). buildExecCommand 의
+    // stdin redirect 모드는 timestamp/pid/counter 가 들어가 비결정적이라
+    // launcher path 에서는 argv-inline 모드로 강제. headless 워커 spawn 은
+    // backend.mjs → buildExecArgs (stdinPrompt 미명시) 로 default stdin on.
+    stdinPrompt: false,
   });
 
   const env = adapter.env(profile);

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
 // ── Quota retry-after 파싱 ──────────────────────────────────────
@@ -145,9 +146,16 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
 
 /**
  * long-form 플래그 기반 명령 빌더.
+ *
+ * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
+ * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
+ * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
+ * stdin 미지원 환경 대비).
+ *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
- * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[] }} [opts]
+ * @param {{ profile?: string, skipGitRepoCheck?: boolean, sandboxBypass?: boolean, cwd?: string, mcpServers?: string[], stdinPrompt?: boolean }} [opts]
  * @returns {string} 실행할 셸 커맨드
  */
 export function buildExecCommand(prompt, resultFile = null, opts = {}) {
@@ -156,6 +164,7 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     skipGitRepoCheck = true,
     sandboxBypass = true,
     mcpServers,
+    stdinPrompt,
   } = opts;
 
   const parts = ["codex"];
@@ -183,8 +192,23 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
   }
 
+  const useStdin = resolveStdinPromptMode(stdinPrompt);
+  const hasPrompt = typeof prompt === "string" && prompt.length > 0;
+  if (useStdin && hasPrompt) {
+    const promptFile = writePromptToTmpFile(prompt);
+    return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
+  }
+
   parts.push(JSON.stringify(prompt));
   return parts.join(" ");
+}
+
+function resolveStdinPromptMode(explicit) {
+  if (typeof explicit === "boolean") return explicit;
+  // Default ON to fix macOS codex hook regression. Opt out via env=0.
+  const env = process.env.TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
 }
 
 // ── Sleep ───────────────────────────────────────────────────────

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -148,10 +148,14 @@ export const CODEX_MCP_EXECUTION_EXIT_CODE = 1;
  * long-form 플래그 기반 명령 빌더.
  *
  * macOS 회귀 fix (codex v0.130.0 oh-my-codex hook lifecycle): 매우 긴
- * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 stdin
- * redirect 패턴 (`< /tmp/triflux-codex-prompt/prompt-*.txt`). 환경에서
- * `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀 (Windows 또는
- * stdin 미지원 환경 대비).
+ * argv-inline prompt 가 SessionStart Failed 를 유발하므로 default 가 prompt
+ * 를 stdin 으로 전달하는 패턴. 셸별 분기:
+ *   - Unix (bash/zsh): `codex exec ... < '/tmp/triflux-codex-prompt/prompt-*.txt'`
+ *   - Windows (pwsh7): `Get-Content -Raw 'path' | codex exec ...`
+ *     (pwsh7 의 `<` 는 reserved future syntax 라 호환성 보장 안 됨)
+ *
+ * 환경 변수 `TFX_CODEX_STDIN_PROMPT=0` 이면 legacy argv-inline 으로 회귀.
+ * 결정론 보장이 필요한 launcher path 는 호출 시 `stdinPrompt: false` 명시.
  *
  * @param {string} prompt
  * @param {string|null} resultFile — null이면 --output-last-message 생략
@@ -196,6 +200,11 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   const hasPrompt = typeof prompt === "string" && prompt.length > 0;
   if (useStdin && hasPrompt) {
     const promptFile = writePromptToTmpFile(prompt);
+    if (IS_WINDOWS) {
+      // pwsh7 호환: `<` redirect 는 reserved future syntax 라 동작 불안정.
+      // Get-Content -Raw stdin pipe 로 prompt 를 codex stdin 에 주입.
+      return `Get-Content -Raw '${escapePwshSingleQuoted(promptFile)}' | ${parts.join(" ")}`;
+    }
     return `${parts.join(" ")} < ${shellQuote(promptFile)}`;
   }
 

--- a/packages/triflux/hub/codex-adapter.mjs
+++ b/packages/triflux/hub/codex-adapter.mjs
@@ -108,6 +108,10 @@ export function buildExecArgs(opts = {}) {
     skipGitRepoCheck: true,
     sandboxBypass: true,
     cwd: opts.cwd,
+    // stdinPrompt 가 명시되면 buildExecCommand 로 forward.
+    // headless 워커 spawn (backend.mjs) 은 default (stdin on, macOS hook fix).
+    // launcher path (launcher-template.mjs) 는 결정론 위해 false 전달.
+    stdinPrompt: opts.stdinPrompt,
   });
 
   if (!prompt) return command.replace(/\s+""$/u, "");

--- a/packages/triflux/hub/lib/prompt-tmp.mjs
+++ b/packages/triflux/hub/lib/prompt-tmp.mjs
@@ -1,0 +1,33 @@
+// hub/lib/prompt-tmp.mjs
+//
+// macOS `codex exec` 회귀 fix 보조 helper. codex CLI v0.130.0 의 macOS hook
+// lifecycle (oh-my-codex/codex-native-hook.js) 이 매우 긴 argv inline prompt
+// (4KB+) 를 받으면 SessionStart Failed 로 즉시 exit. PR #243 의 stdin EAGAIN
+// async stream fix 후속 회귀로 추정.
+//
+// 대안: prompt 를 임시 파일에 쓰고 `< /tmp/...` stdin redirect 로 전달.
+// Manual `echo prompt | codex exec ...` (stdin pipe) 가 정상 작동하는 fact 와
+// 정합.
+//
+// cleanup 정책: best-effort. OS `/tmp` 가 자동 cleanup 하고, 이 모듈은
+// 매 호출마다 unique path 사용 (timestamp + pid + counter). orphan 파일은
+// 추후 doctor 가 prune.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PROMPT_TMP_DIR = join(tmpdir(), "triflux-codex-prompt");
+let counter = 0;
+
+export function writePromptToTmpFile(prompt) {
+  mkdirSync(PROMPT_TMP_DIR, { recursive: true });
+  const id = `${Date.now()}-${process.pid}-${counter++}`;
+  const file = join(PROMPT_TMP_DIR, `prompt-${id}.txt`);
+  writeFileSync(file, String(prompt ?? ""), "utf8");
+  return file;
+}
+
+export function getPromptTmpDir() {
+  return PROMPT_TMP_DIR;
+}

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -208,20 +208,22 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
   const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
 
-  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지)
+  // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
+  // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어
+  // backend.buildArgs 에 전달했는데, 새 stdin-prompt 모드 (PR #252) 가
+  // 그 literal 을 user message 로 해석해서 codex 가 prompt 가 아닌
+  // shell expression 자체를 받는 회귀가 있었다. 이제 fullPrompt 를 그대로
+  // 전달하고 buildExecCommand 가 자체적으로 tmp file 작성 + stdin redirect.
   if (!existsSync(RESULT_DIR)) mkdirSync(RESULT_DIR, { recursive: true });
   const promptFile = join(
     RESULT_DIR,
     "prompt-" + randomUUID().slice(0, 8) + ".txt",
   ).replace(/\\/g, "/");
   writeFileSync(promptFile, fullPrompt, "utf8");
+  void IS_WINDOWS; // referenced for diagnostic guard chain below
 
   const backend = getBackend(resolvedCli);
-  // 플랫폼 분기: PowerShell은 Get-Content, bash/zsh는 cat
-  const promptExpr = IS_WINDOWS
-    ? `(Get-Content -Raw '${promptFile}')`
-    : `"$(cat '${promptFile.replace(/'/g, "'\\''")}')"`;
-  const backendCommand = backend.buildArgs(promptExpr, resultFile, {
+  const backendCommand = backend.buildArgs(fullPrompt, resultFile, {
     ...opts,
     model,
   });

--- a/packages/triflux/hub/team/launcher-template.mjs
+++ b/packages/triflux/hub/team/launcher-template.mjs
@@ -78,6 +78,11 @@ export function buildLauncher(opts) {
     workdir,
     cwd: workdir,
     mcpServers,
+    // launcher 는 동일 입력 → 동일 명령 (F5 결정론 보장). buildExecCommand 의
+    // stdin redirect 모드는 timestamp/pid/counter 가 들어가 비결정적이라
+    // launcher path 에서는 argv-inline 모드로 강제. headless 워커 spawn 은
+    // backend.mjs → buildExecArgs (stdinPrompt 미명시) 로 default stdin on.
+    stdinPrompt: false,
   });
 
   const env = adapter.env(profile);

--- a/tests/fixtures/fake-codex.mjs
+++ b/tests/fixtures/fake-codex.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // tests/fixtures/fake-codex.mjs — Codex CLI/MCP 테스트 대역
+import { readFileSync } from "node:fs";
 import process from "node:process";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -154,7 +155,16 @@ async function runMcpServer() {
 }
 
 function runExec() {
-  const prompt = process.argv.at(-1) || "";
+  // PR #252: prompt 는 stdin redirect (Unix `< file`) / stdin pipe (Windows
+  // `Get-Content -Raw | codex`) 로 전달될 수 있다. stdin 이 redirect 된 경우
+  // 우선 사용하고, 아니면 마지막 argv (legacy 인라인) fallback.
+  let stdinPrompt = "";
+  try {
+    stdinPrompt = readFileSync(0, "utf8");
+  } catch {
+    /* TTY 또는 권한 부족 — argv fallback */
+  }
+  const prompt = stdinPrompt || process.argv.at(-1) || "";
   const configFlags = [];
 
   for (let i = 3; i < process.argv.length - 1; i += 1) {

--- a/tests/unit/cli-adapter-base.test.mjs
+++ b/tests/unit/cli-adapter-base.test.mjs
@@ -72,20 +72,76 @@ function importFresh(relativePath) {
   return import(`${relativePath}?t=${Date.now()}-${Math.random()}`);
 }
 
-test("cli-adapter-base exports the shared codex exec builder and codex-compat re-exports it", async () => {
+test("buildExecCommand: stdin-prompt mode (macOS hook regression fix) keeps argv short", async () => {
+  await withSandbox(async () => {
+    const base = await importFresh("../../hub/cli-adapter-base.mjs");
+    const longPrompt = "x".repeat(4000) + " — long prompt simulation";
+    const command = base.buildExecCommand(longPrompt, "/tmp/result.txt", {
+      stdinPrompt: true,
+    });
+    // stdin redirect: command 끝이 `< "/path/to/prompt-*.txt"` 패턴이고
+    // 전체 길이가 입력 prompt 길이와 무관하게 짧다.
+    assert.ok(
+      command.length < 500,
+      `stdin-mode command must stay short regardless of prompt size, got ${command.length}`,
+    );
+    assert.match(
+      command,
+      /< "[^"]+\/triflux-codex-prompt\/prompt-\d+-\d+-\d+\.txt"$/u,
+    );
+    assert.ok(!command.includes("xxxxxxxx"), "prompt must NOT be argv-inlined");
+  });
+});
+
+test("buildExecCommand: empty prompt falls back to argv even in stdin mode", async () => {
+  await withSandbox(async () => {
+    const base = await importFresh("../../hub/cli-adapter-base.mjs");
+    const command = base.buildExecCommand("", "/tmp/result.txt", {
+      stdinPrompt: true,
+    });
+    // 빈 prompt 는 stdin redirect 안 함 (그대로 argv "" 로 inline).
+    assert.ok(
+      !command.includes("< "),
+      `empty prompt should not trigger stdin redirect: ${command}`,
+    );
+    assert.ok(command.endsWith('""'));
+  });
+});
+
+test("buildExecCommand: TFX_CODEX_STDIN_PROMPT=0 env opts out of stdin mode", async () => {
+  await withSandbox(async () => {
+    const prev = process.env.TFX_CODEX_STDIN_PROMPT;
+    process.env.TFX_CODEX_STDIN_PROMPT = "0";
+    try {
+      const base = await importFresh("../../hub/cli-adapter-base.mjs");
+      const command = base.buildExecCommand("hello", "/tmp/result.txt", {});
+      assert.ok(command.endsWith('"hello"'));
+      assert.ok(!command.includes("< "));
+    } finally {
+      if (prev === undefined) delete process.env.TFX_CODEX_STDIN_PROMPT;
+      else process.env.TFX_CODEX_STDIN_PROMPT = prev;
+    }
+  });
+});
+
+test("cli-adapter-base exports the shared codex exec builder and codex-compat re-exports it (legacy argv-inline mode)", async () => {
   await withSandbox(async () => {
     const base = await importFresh("../../hub/cli-adapter-base.mjs");
     const compat = await importFresh("../../hub/codex-compat.mjs");
 
+    // explicit opt-out of the stdin-prompt fix to verify legacy argv-inline
+    // shape (matches codex < v0.130 + non-macOS environments).
     const command = base.buildExecCommand("hello", "/tmp/result.txt", {
       profile: "codex53_high",
       cwd: "C:/work/it's-me",
+      stdinPrompt: false,
     });
 
     assert.equal(
       compat.buildExecCommand("hello", "/tmp/result.txt", {
         profile: "codex53_high",
         cwd: "C:/work/it's-me",
+        stdinPrompt: false,
       }),
       command,
     );

--- a/tests/unit/codex-adapter.test.mjs
+++ b/tests/unit/codex-adapter.test.mjs
@@ -37,7 +37,14 @@ function installFakeCodex(binDir) {
       "if (process.env.FAKE_CODEX_FAIL === '1') { process.stderr.write('exec failed'); process.exit(5); }",
       "const outIndex = args.indexOf('--output-last-message');",
       'const resultFile = outIndex >= 0 ? args[outIndex + 1] : "";',
-      'const prompt = args.at(-1) || "";',
+      // PR #252: prompt 는 stdin redirect (Unix `< file`) 또는 stdin pipe
+      // (Windows `Get-Content -Raw | codex`) 로 전달될 수 있다. stdin 이
+      // redirect 된 경우 우선 사용하고, 아니면 마지막 argv (legacy 인라인)
+      // 로 fallback. readFileSync(0) 는 stdin 이 file/pipe 면 EOF 까지
+      // 동기 차단, TTY 면 throw (자식 spawn 에서는 TTY 가 없으므로 안전).
+      "let stdinPrompt = '';",
+      "try { stdinPrompt = readFileSync(0, 'utf8'); } catch {}",
+      'const prompt = stdinPrompt || args.at(-1) || "";',
       "let output = `EXEC:${prompt}`;",
       "if (process.env.FAKE_CODEX_ECHO_AUTH === '1') {",
       "  const auth = JSON.parse(readFileSync(join(process.env.CODEX_HOME || '', 'auth.json'), 'utf8'));",

--- a/tests/unit/critical-fixes.test.mjs
+++ b/tests/unit/critical-fixes.test.mjs
@@ -206,20 +206,27 @@ describe("native-supervisor.mjs: child process error handler", () => {
 // ========================================================================
 // 6. headless prompt file-based injection (shell injection prevention)
 // ========================================================================
-describe("headless.mjs: prompt file-based injection", () => {
-  it("uses Get-Content -Raw for prompt injection (not inline shell)", () => {
-    const src = readFileSync(join(ROOT, "hub/team/headless.mjs"), "utf8");
+// PR #252: headless.mjs 가 직접 셸 표현식 (Get-Content / $(cat)) 을 만들지
+// 않고, fullPrompt 를 backend.buildArgs → buildExecCommand 로 위임. 셸 분기
+// (Windows pwsh7 의 Get-Content -Raw stdin pipe / Unix `< file` redirect)
+// 는 cli-adapter-base.mjs:buildExecCommand 가 담당.
+describe("cli-adapter-base.mjs: PowerShell stdin pipe (Windows)", () => {
+  it("uses Get-Content -Raw for prompt injection (PowerShell stdin pipe)", () => {
+    const src = readFileSync(
+      join(ROOT, "hub/cli-adapter-base.mjs"),
+      "utf8",
+    );
     assert.ok(
       src.includes("Get-Content -Raw"),
-      "headless.mjs should use Get-Content -Raw to read prompt from file",
+      "cli-adapter-base.mjs should use Get-Content -Raw on Windows for pwsh7-compatible stdin pipe",
     );
   });
 
   it("writes prompt to a temporary file before execution", () => {
-    const src = readFileSync(join(ROOT, "hub/team/headless.mjs"), "utf8");
+    const src = readFileSync(join(ROOT, "hub/lib/prompt-tmp.mjs"), "utf8");
     assert.ok(
-      /writeFileSync\([^)]*prompt/i.test(src),
-      "headless.mjs should write prompt to a temp file via writeFileSync",
+      /writeFileSync\([^)]*file/i.test(src),
+      "prompt-tmp.mjs should write prompt to a temp file via writeFileSync",
     );
   });
 });

--- a/tests/unit/routing-qa.test.mjs
+++ b/tests/unit/routing-qa.test.mjs
@@ -283,20 +283,25 @@ describe("headless: buildHeadlessCommand", async () => {
 
   it("프롬프트를 임시 파일에 저장 (셸 주입 방지)", () => {
     const cmd = buildHeadlessCommand("codex", "it's a test", "/tmp/r.txt");
-    // 플랫폼별 프롬프트 읽기 표현식 검증
+    // PR #252: codex 명령은 셸 분기로 prompt 를 stdin 으로 전달.
+    //   - Windows pwsh7: `Get-Content -Raw 'path' | codex ...`
+    //   - Unix bash/zsh: `codex ... < 'path'`
+    // 두 경우 모두 codex 의 argv 에는 prompt 가 안 들어가서 셸 주입 방지.
     if (process.platform === "win32") {
       assert.ok(
         cmd.includes("Get-Content -Raw"),
-        `프롬프트가 파일에서 읽혀야 함 (Windows): ${cmd}`,
+        `프롬프트가 PowerShell stdin pipe 로 주입되어야 함 (Windows): ${cmd}`,
       );
     } else {
       assert.ok(
-        cmd.includes("$(cat "),
-        `프롬프트가 파일에서 읽혀야 함 (Unix): ${cmd}`,
+        /< ['"][^'"]*prompt-/.test(cmd),
+        `프롬프트가 stdin redirect 로 주입되어야 함 (Unix): ${cmd}`,
       );
     }
+    // prompt 파일 경로 검증 — buildExecCommand 의 새 naming
+    // (`prompt-<timestamp>-<pid>-<counter>.txt`).
     assert.ok(
-      cmd.includes("prompt-"),
+      /prompt-\d+-\d+-\d+\.txt/.test(cmd),
       `프롬프트 파일 경로가 포함되어야 함: ${cmd}`,
     );
   });
@@ -321,11 +326,13 @@ describe("headless: buildHeadlessCommand", async () => {
       handoff: false,
       mcp: "implement",
     });
-    // 힌트는 프롬프트 파일에 포함됨 — 파일 경로를 추출하고 내용 검증
-    const promptMatch = cmd.match(/prompt-[a-f0-9]+\.txt/);
+    // PR #252: 힌트는 buildExecCommand 가 생성한 stdin prompt 파일에 포함됨.
+    // 새 file naming: `prompt-<timestamp>-<pid>-<counter>.txt`.
+    const promptMatch = cmd.match(/prompt-\d+-\d+-\d+\.txt/);
     assert.ok(promptMatch, `프롬프트 파일 경로가 명령에 포함되어야 함: ${cmd}`);
-    // 프롬프트 파일이 생성되었으면 MCP 힌트 포함 확인
-    const fullPath = cmd.match(/'([^']*prompt-[a-f0-9]+\.txt)'/)?.[1];
+    // 프롬프트 파일이 생성되었으면 MCP 힌트 포함 확인.
+    // Windows: `Get-Content -Raw 'path' | ...` / Unix: `... < 'path'`.
+    const fullPath = cmd.match(/['"]([^'"]*prompt-\d+-\d+-\d+\.txt)['"]/)?.[1];
     if (fullPath && existsSync(fullPath)) {
       const content = readFileSync(fullPath, "utf8");
       assert.ok(


### PR DESCRIPTION
## Summary

macOS m5 (codex CLI v0.130.0 + oh-my-codex hook) 에서 `tfx multi` 가 spawn 한 codex worker 가 **SessionStart Failed + UserPromptSubmit Failed 로 즉시 exit 1**. trace 결과 codex CLI 가 **매우 긴 argv-inline prompt (4KB+) 를 받으면 native-hook lifecycle 이 prompt processing 직전에 죽음**. Manual `echo prompt | codex exec ...` (stdin pipe) 는 동일 환경 정상 동작. 즉 codex/hook 자체 회귀가 아니라 **spawn pattern 회귀** (PR #243 stdin EAGAIN async stream fix 후속).

## Root cause

`hub/cli-adapter-base.mjs:buildExecCommand` 가 argv-inline 패턴 (`parts.push(JSON.stringify(prompt))`) 으로 prompt 박음. macOS codex v0.130.0 의 hook 이 매우 긴 argv 받으면 SessionStart 단계에서 fail.

## Fix

- **default = stdin redirect** (`< /tmp/triflux-codex-prompt/prompt-*.txt`), argv 길이 prompt 와 무관하게 ~234자.
- **legacy opt-out** via `TFX_CODEX_STDIN_PROMPT=0` env 또는 `opts.stdinPrompt: false` (Windows / stdin 미지원 환경 대비).
- **empty prompt 는 항상 argv-inline** (stdin redirect 무의미).
- **`hub/lib/prompt-tmp.mjs`** 신규 — `writePromptToTmpFile()` helper. unique path 로 동일 호출 race 방지.

## Test plan

- [x] `tests/unit/cli-adapter-base.test.mjs` — 신규 3 tests (stdin-mode short argv, empty prompt fallback, env opt-out) + 기존 backwards-compat test
- [x] `npm run lint` → 617 files clean
- [x] `npm run release:check-mirror` → packages/triflux matches root
- [x] Direct verify: 4000-char long prompt → 234-char command (vs 4155-char legacy)
- [ ] Live verify: `tfx multi` 로 codex worker SessionStart Completed 확인 (PR review 시)

## Remaining (별도 PR 후보)

- `hub/team/execution-mode.mjs:132` (process spawn args) + `:234` (shell command) 가 별도 path 라 buildExecCommand 안 거침. 같은 회귀 risk — Phase 1+ 별도 fix 권장.

## Mirror

3-layer byte-identical: root + packages/triflux + packages/core. `hub/cli-adapter-base.mjs` + 신규 `hub/lib/prompt-tmp.mjs`.

## Commits

`fix(cli-adapter-base)`: pipe codex exec prompts through stdin