### PR TITLE
Keep legacy TFX surfaces behind canonical flags

### DIFF
--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -50,7 +50,7 @@ description에는 해당 스킬을 고르는 데 필요한 좁은 activation phr
 | 수정자 | 신호 | 효과 |
 |--------|------|------|
 | 기본 | (없음), 빠르게, 간단히 | Light 스킬 |
-| 깊이 | 제대로, 꼼꼼히, 철저히 | Deep 스킬 (tfx-deep-*). 예외: tfx-deep-interview는 Gemini 단독 |
+| 깊이 | 제대로, 꼼꼼히, 철저히 | `tfx-auto --mode deep` |
 | 합의 | 3자, 교차, 다각도 | `tfx-auto --mode consensus` |
 | 반복 | 끝까지, 멈추지마, ralph | `--retry ralph` (Phase 3 true state machine, `.claude/rules/tfx-escalation-chain.md` 참조) |
 | 승격 | 알아서 승격, 안 되면 더 강한 모델 | `--retry auto-escalate` (Phase 3 CLI 체인 승격) |
@@ -76,17 +76,18 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 
 **Layer 1 — Light** (tfx-route.sh → 단일 CLI)
 
-| 스킬 | CLI | 용도 |
+| 경로 | CLI | 용도 |
 |------|-----|------|
-| tfx-auto | 자동 | 통합 진입점 |
-| tfx-codex | Codex | Codex 전용 |
-| tfx-gemini | Gemini | Gemini 전용 |
-| tfx-autopilot | Codex→검증 | 단일 파일, 5분 이내 |
-| tfx-autoroute | 자동 승격 | 실패→더 강한 모델 |
+| `tfx-auto` | 자동 | 통합 진입점 |
+| `tfx-auto --cli codex` | Codex | Codex 전용 lane |
+| `tfx-auto --cli gemini` | Gemini | Gemini 전용 lane |
+| `tfx-auto --mode quick` | Codex→검증 | 단일 파일, 5분 이내 |
+| `tfx-auto --retry auto-escalate` | 자동 승격 | 실패→더 강한 모델 |
 
 **Layer 2 — Deep** (headless 3-CLI 합의)
 
-tfx-deep-review, tfx-deep-qa, tfx-deep-plan, tfx-deep-research, tfx-auto (`--mode consensus --shape consensus|debate|panel`), tfx-fullcycle, tfx-persist
+`tfx-auto --mode deep`, `tfx-auto --mode consensus --shape consensus|debate|panel`,
+`tfx-auto --parallel swarm --mode consensus --isolation worktree`, `tfx-auto --retry ralph`
 
 호환 alias:
 - `tfx-consensus` → `tfx-auto --mode consensus`

--- a/.claude/rules/tfx-stack-coexistence.md
+++ b/.claude/rules/tfx-stack-coexistence.md
@@ -42,7 +42,7 @@ triflux  →  superpowers  (금지)
 | 기능 | Owner | 근거 |
 |------|-------|------|
 | **Review** (코드 판정) | superpowers | 입력 diff → 출력 verdict 프리미티브. 가장 단순한 경계 |
-| **Plan** (작업 설계) | triflux (`tfx-plan`, `tfx-deep-plan`) | 멀티모델 합의 + PRD 생성 포함 |
+| **Plan** (작업 설계) | triflux (`tfx-plan`, `tfx-auto --mode deep`) | 멀티모델 합의 + PRD 생성 포함 |
 | **Checkpoint** (진행 상태 스냅샷) | gstack (`/checkpoint`) | 워크플로우 상태 관리는 무대 레이어 책임 |
 | **Worktree** (격리 실행) | triflux (`tfx-swarm`) | PRD별 worktree + auto merge = 오케스트레이션 |
 | **QA / 검증** | gstack (`/qa`) → triflux (`tfx-qa`) 팬아웃 | gstack이 게이트, triflux가 병렬 실행 |
@@ -58,7 +58,7 @@ triflux  →  superpowers  (금지)
 
 라이팅플랜
   → /office-hours  (gstack 게이트: 발표자 영상 전용)
-  → tfx-deep-plan  (triflux: PRD 생성)
+  → tfx-auto --mode deep  (triflux: PRD 생성)
   ← plan.md
 
 워크트리 생성
@@ -80,9 +80,9 @@ triflux  →  superpowers  (금지)
 | 기능 | 1순위 | 2순위 | 3순위 |
 |------|-------|-------|-------|
 | Brainstorm / 아이디어 발산 | `tfx-auto --mode consensus --shape debate` | `sc:brainstorm` | gstack 없음 |
-| Plan / 설계 | `tfx-deep-plan` | `sc:pm` | gstack `/investigate` |
-| Review / 코드 판정 | superpowers `/review` | `tfx-deep-review` | `tfx-auto --mode consensus` |
-| QA / 테스트 검증 | gstack `/qa` → `tfx-qa` | `tfx-deep-qa` | — |
+| Plan / 설계 | `tfx-auto --mode deep` | `sc:pm` | gstack `/investigate` |
+| Review / 코드 판정 | superpowers `/review` | `tfx-auto --mode consensus` | — |
+| QA / 테스트 검증 | gstack `/qa` → `tfx-qa` | `tfx-auto --mode deep` | — |
 | Checkpoint / 스냅샷 | gstack `/checkpoint` | — | — |
 | 문서 작성 | `sc:document` 또는 `/writer` | — | — |
 
@@ -96,5 +96,5 @@ triflux  →  superpowers  (금지)
 | superpowers `/review` 스킬을 triflux 코어에 `import` | sp → tfx 단방향 위반 | triflux는 자체 review primitive 사용 또는 hook으로 sp 결과 수신 |
 | 80+ 스킬 키워드 충돌 시 임의 선택 | 비결정적 라우팅 | 이 문서 §충돌 해소 표에서 1순위를 명확히 따름 |
 | gstack `/ship`이 triflux를 우회하고 codex 직접 호출 | headless-guard 차단 | gstack → triflux → headless 경로 필수 |
-| 발표자 영상 워크플로우에서 tfx-auto만 사용 | /office-hours 게이트 없이 배포 → QA 누락 | gstack /office-hours → tfx-deep-plan → tfx-swarm 순서 준수 |
+| 발표자 영상 워크플로우에서 tfx-auto만 사용 | /office-hours 게이트 없이 배포 → QA 누락 | gstack /office-hours → tfx-auto --mode deep → tfx-swarm 순서 준수 |
 | sp 판정 없이 triflux auto-merge | 미검증 코드 머지 | swarm 완료 후 superpowers review verdict 수신 확인 후 merge |

--- a/docs/codex-conventions.md
+++ b/docs/codex-conventions.md
@@ -1,7 +1,8 @@
 # Codex CLI 실행 컨벤션
 
 > triflux에서 Codex CLI를 사용할 때 반드시 준수해야 하는 규칙.
-> tfx-codex-swarm, tfx-auto-codex, tfx-route.sh 모두 이 규칙을 따른다.
+> `tfx-auto --cli codex`, `tfx-auto --parallel swarm --cli codex`, `tfx-route.sh`
+> 모두 이 규칙을 따른다.
 
 ## 1. 실행 방식
 

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -2045,10 +2045,10 @@ ${B}Shortcuts:${R}
   ${C}tfx-doctor${R}           triflux doctor
 
 ${B}Skills (Claude Code):${R}
-  ${C}/tfx-auto${R}   "작업"   자동 분류 + 병렬 실행
-  ${C}/tfx-auto-codex${R} "작업" Codex 리드 + Gemini 유지
-  ${C}/tfx-codex${R}  "작업"   Codex 전용 모드
-  ${C}/tfx-gemini${R} "작업"   Gemini 전용 모드
+  ${C}/tfx-auto${R} "작업"                 자동 분류 + 병렬 실행
+  ${C}/tfx-auto${R} "작업" --mode deep     계획 + 검증 포함
+  ${C}/tfx-auto${R} "작업" --cli codex     Codex 전용 lane
+  ${C}/tfx-auto${R} "작업" --cli gemini    Gemini 전용 lane
   ${C}/tfx-setup${R}           HUD 설정 + 진단
 
 ${Y}!${R} 세션 재시작 후 스킬이 활성화됩니다

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -77,15 +77,15 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
    - `--retry ralph` → stderr 경고 후 bounded 3회 degrade (Phase 2 미구현)
 
 1. **사용자 명시 키워드** (플래그 없을 때):
-   - "병렬", "swarm", "PRD 돌려" → `Skill("tfx-swarm")` dispatch
-   - "꼼꼼히", "제대로", "deep" → 해당 `tfx-deep-*` dispatch
-   - "끝까지", "멈추지마", "ralph" → `Skill("tfx-persist")` dispatch
-   - "multi", "팀", "협업" → `Skill("tfx-multi")` dispatch
-   - "codex로", "gemini로" → `Skill("tfx-codex")` 또는 `Skill("tfx-gemini")` dispatch
+   - "병렬", "swarm", "PRD 돌려" → `--parallel swarm --mode consensus --isolation worktree`
+   - "꼼꼼히", "제대로", "deep" → `--mode deep`
+   - "끝까지", "멈추지마", "ralph" → `--retry ralph`
+   - "multi", "팀", "협업" → `--parallel N --mode deep`
+   - "codex로", "gemini로" → `--cli codex` 또는 `--cli gemini`
 
 2. **PRD 인자 분석**:
-   - PRD 경로 2개 이상 → `Skill("tfx-swarm")` dispatch
-   - PRD 1개 + XL 규모 → `Skill("tfx-fullcycle")` dispatch
+   - PRD 경로 2개 이상 → `--parallel swarm --mode consensus --isolation worktree`
+   - PRD 1개 + XL 규모 → `--mode deep --parallel 1`
 
 3. **선호도 가중치** (tiebreaker):
    - USER_PREFERRED_MODE가 있고 가중치 > 0.3이면 제안
@@ -94,7 +94,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 
 4. **기본**: 기존 tfx-auto 워크플로우 그대로 실행
 
-dispatch 시 해당 스킬을 Skill 도구로 호출하고 **이 워크플로우를 종료**한다. dispatch하지 않으면 아래 기존 워크플로우 진행.
+정규화된 플래그를 현재 `tfx-auto` 실행 인자로 적용한다. legacy Skill 이름은 compatibility alias 문서에서만 다룬다.
 
 라우팅 결정 후 1줄 표시:
 ```

--- a/packages/triflux/skills/tfx-auto/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-auto/SKILL.md.tmpl
@@ -53,15 +53,15 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 판단 기준 (우선순위 순):
 
 1. **사용자 명시 키워드** (최우선):
-   - "병렬", "swarm", "PRD 돌려" → `Skill("tfx-swarm")` dispatch
-   - "꼼꼼히", "제대로", "deep" → 해당 `tfx-deep-*` dispatch
-   - "끝까지", "멈추지마", "ralph" → `Skill("tfx-persist")` dispatch
-   - "multi", "팀", "협업" → `Skill("tfx-multi")` dispatch
-   - "codex로", "gemini로" → `Skill("tfx-codex")` 또는 `Skill("tfx-gemini")` dispatch
+   - "병렬", "swarm", "PRD 돌려" → `--parallel swarm --mode consensus --isolation worktree`
+   - "꼼꼼히", "제대로", "deep" → `--mode deep`
+   - "끝까지", "멈추지마", "ralph" → `--retry ralph`
+   - "multi", "팀", "협업" → `--parallel N --mode deep`
+   - "codex로", "gemini로" → `--cli codex` 또는 `--cli gemini`
 
 2. **PRD 인자 분석**:
-   - PRD 경로 2개 이상 → `Skill("tfx-swarm")` dispatch
-   - PRD 1개 + XL 규모 → `Skill("tfx-fullcycle")` dispatch
+   - PRD 경로 2개 이상 → `--parallel swarm --mode consensus --isolation worktree`
+   - PRD 1개 + XL 규모 → `--mode deep --parallel 1`
 
 3. **선호도 가중치** (tiebreaker):
    - USER_PREFERRED_MODE가 있고 가중치 > 0.3이면 제안
@@ -70,7 +70,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 
 4. **기본**: 기존 tfx-auto 워크플로우 그대로 실행
 
-dispatch 시 해당 스킬을 Skill 도구로 호출하고 **이 워크플로우를 종료**한다. dispatch하지 않으면 아래 기존 워크플로우 진행.
+정규화된 플래그를 현재 `tfx-auto` 실행 인자로 적용한다. legacy Skill 이름은 compatibility alias 문서에서만 다룬다.
 
 라우팅 결정 후 1줄 표시:
 ```

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -2045,10 +2045,10 @@ ${B}Shortcuts:${R}
   ${C}tfx-doctor${R}           triflux doctor
 
 ${B}Skills (Claude Code):${R}
-  ${C}/tfx-auto${R}   "작업"   자동 분류 + 병렬 실행
-  ${C}/tfx-auto-codex${R} "작업" Codex 리드 + Gemini 유지
-  ${C}/tfx-codex${R}  "작업"   Codex 전용 모드
-  ${C}/tfx-gemini${R} "작업"   Gemini 전용 모드
+  ${C}/tfx-auto${R} "작업"                 자동 분류 + 병렬 실행
+  ${C}/tfx-auto${R} "작업" --mode deep     계획 + 검증 포함
+  ${C}/tfx-auto${R} "작업" --cli codex     Codex 전용 lane
+  ${C}/tfx-auto${R} "작업" --cli gemini    Gemini 전용 lane
   ${C}/tfx-setup${R}           HUD 설정 + 진단
 
 ${Y}!${R} 세션 재시작 후 스킬이 활성화됩니다

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -77,15 +77,15 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
    - `--retry ralph` → stderr 경고 후 bounded 3회 degrade (Phase 2 미구현)
 
 1. **사용자 명시 키워드** (플래그 없을 때):
-   - "병렬", "swarm", "PRD 돌려" → `Skill("tfx-swarm")` dispatch
-   - "꼼꼼히", "제대로", "deep" → 해당 `tfx-deep-*` dispatch
-   - "끝까지", "멈추지마", "ralph" → `Skill("tfx-persist")` dispatch
-   - "multi", "팀", "협업" → `Skill("tfx-multi")` dispatch
-   - "codex로", "gemini로" → `Skill("tfx-codex")` 또는 `Skill("tfx-gemini")` dispatch
+   - "병렬", "swarm", "PRD 돌려" → `--parallel swarm --mode consensus --isolation worktree`
+   - "꼼꼼히", "제대로", "deep" → `--mode deep`
+   - "끝까지", "멈추지마", "ralph" → `--retry ralph`
+   - "multi", "팀", "협업" → `--parallel N --mode deep`
+   - "codex로", "gemini로" → `--cli codex` 또는 `--cli gemini`
 
 2. **PRD 인자 분석**:
-   - PRD 경로 2개 이상 → `Skill("tfx-swarm")` dispatch
-   - PRD 1개 + XL 규모 → `Skill("tfx-fullcycle")` dispatch
+   - PRD 경로 2개 이상 → `--parallel swarm --mode consensus --isolation worktree`
+   - PRD 1개 + XL 규모 → `--mode deep --parallel 1`
 
 3. **선호도 가중치** (tiebreaker):
    - USER_PREFERRED_MODE가 있고 가중치 > 0.3이면 제안
@@ -94,7 +94,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 
 4. **기본**: 기존 tfx-auto 워크플로우 그대로 실행
 
-dispatch 시 해당 스킬을 Skill 도구로 호출하고 **이 워크플로우를 종료**한다. dispatch하지 않으면 아래 기존 워크플로우 진행.
+정규화된 플래그를 현재 `tfx-auto` 실행 인자로 적용한다. legacy Skill 이름은 compatibility alias 문서에서만 다룬다.
 
 라우팅 결정 후 1줄 표시:
 ```

--- a/skills/tfx-auto/SKILL.md.tmpl
+++ b/skills/tfx-auto/SKILL.md.tmpl
@@ -53,15 +53,15 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 판단 기준 (우선순위 순):
 
 1. **사용자 명시 키워드** (최우선):
-   - "병렬", "swarm", "PRD 돌려" → `Skill("tfx-swarm")` dispatch
-   - "꼼꼼히", "제대로", "deep" → 해당 `tfx-deep-*` dispatch
-   - "끝까지", "멈추지마", "ralph" → `Skill("tfx-persist")` dispatch
-   - "multi", "팀", "협업" → `Skill("tfx-multi")` dispatch
-   - "codex로", "gemini로" → `Skill("tfx-codex")` 또는 `Skill("tfx-gemini")` dispatch
+   - "병렬", "swarm", "PRD 돌려" → `--parallel swarm --mode consensus --isolation worktree`
+   - "꼼꼼히", "제대로", "deep" → `--mode deep`
+   - "끝까지", "멈추지마", "ralph" → `--retry ralph`
+   - "multi", "팀", "협업" → `--parallel N --mode deep`
+   - "codex로", "gemini로" → `--cli codex` 또는 `--cli gemini`
 
 2. **PRD 인자 분석**:
-   - PRD 경로 2개 이상 → `Skill("tfx-swarm")` dispatch
-   - PRD 1개 + XL 규모 → `Skill("tfx-fullcycle")` dispatch
+   - PRD 경로 2개 이상 → `--parallel swarm --mode consensus --isolation worktree`
+   - PRD 1개 + XL 규모 → `--mode deep --parallel 1`
 
 3. **선호도 가중치** (tiebreaker):
    - USER_PREFERRED_MODE가 있고 가중치 > 0.3이면 제안
@@ -70,7 +70,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 
 4. **기본**: 기존 tfx-auto 워크플로우 그대로 실행
 
-dispatch 시 해당 스킬을 Skill 도구로 호출하고 **이 워크플로우를 종료**한다. dispatch하지 않으면 아래 기존 워크플로우 진행.
+정규화된 플래그를 현재 `tfx-auto` 실행 인자로 적용한다. legacy Skill 이름은 compatibility alias 문서에서만 다룬다.
 
 라우팅 결정 후 1줄 표시:
 ```

--- a/tests/unit/critical-fixes.test.mjs
+++ b/tests/unit/critical-fixes.test.mjs
@@ -212,10 +212,7 @@ describe("native-supervisor.mjs: child process error handler", () => {
 // 는 cli-adapter-base.mjs:buildExecCommand 가 담당.
 describe("cli-adapter-base.mjs: PowerShell stdin pipe (Windows)", () => {
   it("uses Get-Content -Raw for prompt injection (PowerShell stdin pipe)", () => {
-    const src = readFileSync(
-      join(ROOT, "hub/cli-adapter-base.mjs"),
-      "utf8",
-    );
+    const src = readFileSync(join(ROOT, "hub/cli-adapter-base.mjs"), "utf8");
     assert.ok(
       src.includes("Get-Content -Raw"),
       "cli-adapter-base.mjs should use Get-Content -Raw on Windows for pwsh7-compatible stdin pipe",

--- a/tests/unit/legacy-surface-routing-docs.test.mjs
+++ b/tests/unit/legacy-surface-routing-docs.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+const repoRoot = process.cwd();
+
+function read(relPath) {
+  return readFileSync(resolve(repoRoot, relPath), "utf8");
+}
+
+function setupHelpBlock() {
+  const setup = read("scripts/setup.mjs");
+  const match = setup.match(/\$\{B\}Skills \(Claude Code\):[\s\S]*?\$\{Y\}!/u);
+  assert.ok(match, "scripts/setup.mjs help block not found");
+  return match[0];
+}
+
+const STALE_PRIMARY_SURFACES = [
+  "tfx-auto-codex",
+  "tfx-codex-swarm",
+  "tfx-codex",
+  "tfx-gemini",
+  "tfx-deep-plan",
+  "tfx-deep-review",
+  "tfx-deep-qa",
+  "tfx-deep-research",
+  "tfx-deep-*",
+];
+
+describe("legacy TFX surface routing docs", () => {
+  it("setup help advertises canonical tfx-auto flag forms, not removed primary skills", () => {
+    const help = setupHelpBlock();
+
+    assert.doesNotMatch(help, /\/tfx-auto-codex/u);
+    assert.doesNotMatch(help, /\/tfx-codex\b/u);
+    assert.doesNotMatch(help, /\/tfx-gemini\b/u);
+
+    assert.match(help, /\/tfx-auto.*--cli codex/u);
+    assert.match(help, /\/tfx-auto.*--cli gemini/u);
+    assert.match(help, /\/tfx-auto.*--mode deep/u);
+  });
+
+  it("tfx-auto skill docs route legacy intents through canonical flags", () => {
+    const files = [
+      "skills/tfx-auto/SKILL.md",
+      "skills/tfx-auto/SKILL.md.tmpl",
+      "packages/triflux/skills/tfx-auto/SKILL.md",
+      "packages/triflux/skills/tfx-auto/SKILL.md.tmpl",
+    ];
+
+    for (const file of files) {
+      const content = read(file);
+      assert.doesNotMatch(
+        content,
+        /Skill\("tfx-(?:codex|gemini)"\)/u,
+        `${file} should not dispatch removed CLI-specific skills`,
+      );
+      assert.doesNotMatch(
+        content,
+        /tfx-deep-\*\s+dispatch/u,
+        `${file} should not dispatch tfx-deep-* as a primary route`,
+      );
+      assert.match(
+        content,
+        /--cli codex/u,
+        `${file} should mention --cli codex`,
+      );
+      assert.match(
+        content,
+        /--cli gemini/u,
+        `${file} should mention --cli gemini`,
+      );
+      assert.match(
+        content,
+        /--mode deep/u,
+        `${file} should mention --mode deep`,
+      );
+    }
+  });
+
+  it("routing and convention docs do not present stale legacy surfaces as primary paths", () => {
+    const files = [
+      ".claude/rules/tfx-routing.md",
+      ".claude/rules/tfx-stack-coexistence.md",
+      "docs/codex-conventions.md",
+    ];
+
+    for (const file of files) {
+      const content = read(file);
+      for (const stale of STALE_PRIMARY_SURFACES) {
+        assert.equal(
+          content.includes(stale),
+          false,
+          `${file} still exposes stale primary surface: ${stale}`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replace legacy primary-route copy in setup help with canonical `/tfx-auto` flag examples.
- Make `tfx-auto` Step 0 normalize legacy intents to flags instead of dispatching removed legacy skill names.
- Update routing/convention docs so legacy surfaces appear only as compatibility/deprecation context, not primary routes.
- Add a regression test covering the drift from #254, #255, and #256.
- Include a minimal Biome formatting fix for `tests/unit/critical-fixes.test.mjs` after rebasing onto current `main`, so the branch lint gate stays green.

Closes #254
Closes #255
Closes #256

## Verification

- `node --test tests/unit/legacy-surface-routing-docs.test.mjs`
- `node --test tests/unit/legacy-surface-routing-docs.test.mjs tests/unit/legacy-alias-logging.test.mjs tests/unit/keyword-rules-skill-targets.test.mjs tests/unit/critical-fixes.test.mjs tests/integration/triflux-cli.test.mjs` — 96 pass, 0 fail
- `npm run lint`
- `npm run release:check-sync`
- `npm run release:check-mirror`
- `git diff --check`

## Not tested

- Full `npm test`; targeted routing/alias/CLI coverage was used to avoid unrelated Hub/listener integration noise in this environment.
