### PR TITLE
refactor(multiplexer): OS-primary 명시 분기 + dead code 제거

### DIFF
--- a/hub/lib/spawn-trace.mjs
+++ b/hub/lib/spawn-trace.mjs
@@ -7,9 +7,13 @@ import { join } from "node:path";
 const LOG_DIR = join(homedir(), ".triflux", "logs");
 const DEDUPE_WINDOW_MS = 5_000;
 const RATE_WINDOW_MS = 1_000;
+// multi-worker headless dispatch 가 1 초 안에 ~25-30+ psmux/tmux 명령을 호출한다.
+// 2-worker dispatchBatch 가 default 30 limit 을 초과해 `rate_limit` throw 로 mac
+// 호환성 회귀 (smoke test 발견, 2026-05-15). 100 으로 상향 — 폭주 안전망은
+// 여전히 (default 100/sec) 유지, env override 로 보수 설정 가능.
 export let MAX_SPAWN_PER_SEC = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_SPAWN_RATE,
-  30,
+  100,
 );
 export const MAX_TOTAL_DESCENDANTS = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_DESCENDANTS,

--- a/hub/team/execution-mode.mjs
+++ b/hub/team/execution-mode.mjs
@@ -32,10 +32,6 @@ export const MODES = Object.freeze({
   AUTO: "auto",
 });
 
-function quotePrompt(prompt) {
-  return JSON.stringify(typeof prompt === "string" ? prompt : "");
-}
-
 function asPrompt(prompt) {
   return typeof prompt === "string" ? prompt : "";
 }
@@ -209,29 +205,8 @@ export function selectExecutionMode(opts = {}) {
   };
 }
 
-/**
- * @param {string} mode
- * @param {{ cli?: "codex"|"gemini"|"claude", prompt?: string }} opts
- * @returns {{ command: string, useExec: boolean }}
- */
-export function buildCommandForMode(mode, opts = {}) {
-  const cli = opts.cli || "codex";
-  const prompt = quotePrompt(opts.prompt);
-
-  if (cli === "gemini") {
-    return { command: `gemini -p ${prompt}`, useExec: true };
-  }
-
-  if (mode === MODES.INTERACTIVE || mode === MODES.AUTO) {
-    return { command: cli === "claude" ? "claude" : "codex", useExec: false };
-  }
-
-  if (cli === "claude") {
-    return { command: `claude --print ${prompt}`, useExec: true };
-  }
-
-  return {
-    command: `codex exec ${prompt} -s danger-full-access --dangerously-bypass-approvals-and-sandbox`,
-    useExec: true,
-  };
-}
+// buildCommandForMode 는 caller 가 없어 제거됨 (v10.20.x). argv-inline 프롬프트와
+// `-s danger-full-access` flag 가 PR #252 의 stdin redirect 패턴과 정합하지
+// 않아 회귀 위험이 있었다. 실제 헤드리스 spawn 은 buildSpawnSpecForMode
+// (conductor.mjs:544) 가 담당하며, 셸 명령 형태가 필요한 경우는
+// hub/cli-adapter-base.mjs:buildExecCommand 를 사용한다.

--- a/hub/team/psmux.mjs
+++ b/hub/team/psmux.mjs
@@ -1,4 +1,15 @@
-// hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
+// hub/team/psmux.mjs — terminal multiplexer 세션/키바인딩/캡처/steering 관리
+//
+// 역사: psmux 는 Windows pwsh7 환경용 tmux 호환 클론 (Windows 에서 tmux 가
+// 깔리지 않거나 ConPTY 호환이 부족할 때 대안). triflux 는 원래 Windows 첫
+// 운영 환경이었고 그래서 변수 명에 `PSMUX_` prefix 가 남아있다. 실제 의미는
+// "OS 별 primary multiplexer" 다:
+//   - mac/Linux: tmux 가 primary (POSIX 표준)
+//   - Windows: psmux 가 primary (Windows pwsh7 전용)
+// 이전 코드는 mac 에서 psmux 를 시도하고 tmux 로 silent fallback 했는데,
+// 운영 fact 는 mac 표준이 tmux 라 fallback 이 아닌 정식 primary 다.
+// (PSMUX_BIN 변수 명은 backward-compat 위해 유지)
+//
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
 import {
@@ -15,21 +26,26 @@ import { resolveGitBashExecutable } from "../lib/bash-path.mjs";
 import childProcess from "../lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 
+// OS 별 primary multiplexer 를 명시적으로 결정한다.
+//   - PSMUX_BIN env 가 있으면 user override (가장 우선)
+//   - Windows: psmux 가 primary. PATH + 기본 설치 경로에서 탐색.
+//   - mac/Linux: tmux 가 primary. PATH 에서만 찾는다 (HomeBrew, apt 등 표준 위치).
+// silent fallback 은 두지 않는다 — primary 가 없으면 의도된 fail.
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 psmux 찾기
-  try {
-    childProcess.execFileSync("psmux", ["-V"], {
-      stdio: "ignore",
-      timeout: 2000,
-      windowsHide: true,
-    });
-    return "psmux";
-  } catch {
-    /* not in PATH */
-  }
-  // Windows 기본 설치 경로 탐색
+
   if (IS_WINDOWS) {
+    // Windows primary: psmux
+    try {
+      childProcess.execFileSync("psmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+        windowsHide: true,
+      });
+      return "psmux";
+    } catch {
+      /* not in PATH */
+    }
     const candidates = [
       join(process.env.LOCALAPPDATA || "", "psmux", "psmux.exe"),
       join(process.env.APPDATA || "", "npm", "psmux.cmd"),
@@ -39,20 +55,20 @@ const PSMUX_BIN = (() => {
     for (const p of candidates) {
       if (existsSync(p)) return p;
     }
+    return "psmux"; // 최종 — hasPsmux/hasMultiplexer 가 검증
   }
-  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
-  if (!IS_WINDOWS) {
-    try {
-      childProcess.execFileSync("tmux", ["-V"], {
-        stdio: "ignore",
-        timeout: 2000,
-      });
-      return "tmux";
-    } catch {
-      /* tmux도 없음 */
-    }
+
+  // mac/Linux primary: tmux (POSIX 표준). silent fallback 아님 — 정식 primary.
+  try {
+    childProcess.execFileSync("tmux", ["-V"], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return "tmux";
+  } catch {
+    /* tmux not in PATH — hasMultiplexer 가 false 반환할 것 */
   }
-  return "psmux"; // 최종 fallback — 원래대로
+  return "tmux";
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
@@ -582,8 +598,8 @@ function psmux(args, opts = {}) {
   }
 }
 
-/** psmux 실행 가능 여부 확인 */
-export function hasPsmux() {
+/** primary terminal multiplexer (Windows=psmux, mac/Linux=tmux) 실행 가능 여부 */
+export function hasMultiplexer() {
   try {
     childProcess.execFileSync(PSMUX_BIN, ["-V"], {
       stdio: "ignore",
@@ -596,9 +612,20 @@ export function hasPsmux() {
   }
 }
 
-/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
-export function isTmuxFallback() {
-  return PSMUX_BIN === "tmux";
+/**
+ * backward-compat alias — historical 이름 `hasPsmux` 는 OS 별 primary 의 의미를
+ * 가린다. 외부 caller (scripts/remote-spawn.mjs, scripts/session-spawn-helper.mjs,
+ * tests) 호환을 위해 alias 로 보존. 신규 코드는 hasMultiplexer 사용.
+ */
+export const hasPsmux = hasMultiplexer;
+
+/**
+ * 현재 resolved multiplexer 종류 — "psmux" | "tmux" | <user override path>.
+ * isTmuxFallback() 의 후속 — mac/Linux 에서 tmux 는 fallback 이 아닌 primary 라
+ * "fallback" 표현이 부정확해서 type 으로 정정.
+ */
+export function getMultiplexerType() {
+  return PSMUX_BIN;
 }
 
 /**

--- a/packages/core/hub/lib/spawn-trace.mjs
+++ b/packages/core/hub/lib/spawn-trace.mjs
@@ -7,9 +7,13 @@ import { join } from "node:path";
 const LOG_DIR = join(homedir(), ".triflux", "logs");
 const DEDUPE_WINDOW_MS = 5_000;
 const RATE_WINDOW_MS = 1_000;
+// multi-worker headless dispatch 가 1 초 안에 ~25-30+ psmux/tmux 명령을 호출한다.
+// 2-worker dispatchBatch 가 default 30 limit 을 초과해 `rate_limit` throw 로 mac
+// 호환성 회귀 (smoke test 발견, 2026-05-15). 100 으로 상향 — 폭주 안전망은
+// 여전히 (default 100/sec) 유지, env override 로 보수 설정 가능.
 export let MAX_SPAWN_PER_SEC = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_SPAWN_RATE,
-  30,
+  100,
 );
 export const MAX_TOTAL_DESCENDANTS = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_DESCENDANTS,

--- a/packages/remote/hub/team/execution-mode.mjs
+++ b/packages/remote/hub/team/execution-mode.mjs
@@ -32,10 +32,6 @@ export const MODES = Object.freeze({
   AUTO: "auto",
 });
 
-function quotePrompt(prompt) {
-  return JSON.stringify(typeof prompt === "string" ? prompt : "");
-}
-
 function asPrompt(prompt) {
   return typeof prompt === "string" ? prompt : "";
 }
@@ -209,29 +205,8 @@ export function selectExecutionMode(opts = {}) {
   };
 }
 
-/**
- * @param {string} mode
- * @param {{ cli?: "codex"|"gemini"|"claude", prompt?: string }} opts
- * @returns {{ command: string, useExec: boolean }}
- */
-export function buildCommandForMode(mode, opts = {}) {
-  const cli = opts.cli || "codex";
-  const prompt = quotePrompt(opts.prompt);
-
-  if (cli === "gemini") {
-    return { command: `gemini -p ${prompt}`, useExec: true };
-  }
-
-  if (mode === MODES.INTERACTIVE || mode === MODES.AUTO) {
-    return { command: cli === "claude" ? "claude" : "codex", useExec: false };
-  }
-
-  if (cli === "claude") {
-    return { command: `claude --print ${prompt}`, useExec: true };
-  }
-
-  return {
-    command: `codex exec ${prompt} -s danger-full-access --dangerously-bypass-approvals-and-sandbox`,
-    useExec: true,
-  };
-}
+// buildCommandForMode 는 caller 가 없어 제거됨 (v10.20.x). argv-inline 프롬프트와
+// `-s danger-full-access` flag 가 PR #252 의 stdin redirect 패턴과 정합하지
+// 않아 회귀 위험이 있었다. 실제 헤드리스 spawn 은 buildSpawnSpecForMode
+// (conductor.mjs:544) 가 담당하며, 셸 명령 형태가 필요한 경우는
+// hub/cli-adapter-base.mjs:buildExecCommand 를 사용한다.

--- a/packages/remote/hub/team/psmux.mjs
+++ b/packages/remote/hub/team/psmux.mjs
@@ -1,4 +1,15 @@
-// hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
+// hub/team/psmux.mjs — terminal multiplexer 세션/키바인딩/캡처/steering 관리
+//
+// 역사: psmux 는 Windows pwsh7 환경용 tmux 호환 클론 (Windows 에서 tmux 가
+// 깔리지 않거나 ConPTY 호환이 부족할 때 대안). triflux 는 원래 Windows 첫
+// 운영 환경이었고 그래서 변수 명에 `PSMUX_` prefix 가 남아있다. 실제 의미는
+// "OS 별 primary multiplexer" 다:
+//   - mac/Linux: tmux 가 primary (POSIX 표준)
+//   - Windows: psmux 가 primary (Windows pwsh7 전용)
+// 이전 코드는 mac 에서 psmux 를 시도하고 tmux 로 silent fallback 했는데,
+// 운영 fact 는 mac 표준이 tmux 라 fallback 이 아닌 정식 primary 다.
+// (PSMUX_BIN 변수 명은 backward-compat 위해 유지)
+//
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
 import {
@@ -15,21 +26,26 @@ import { resolveGitBashExecutable } from "@triflux/core/hub/lib/bash-path.mjs";
 import childProcess from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 
+// OS 별 primary multiplexer 를 명시적으로 결정한다.
+//   - PSMUX_BIN env 가 있으면 user override (가장 우선)
+//   - Windows: psmux 가 primary. PATH + 기본 설치 경로에서 탐색.
+//   - mac/Linux: tmux 가 primary. PATH 에서만 찾는다 (HomeBrew, apt 등 표준 위치).
+// silent fallback 은 두지 않는다 — primary 가 없으면 의도된 fail.
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 psmux 찾기
-  try {
-    childProcess.execFileSync("psmux", ["-V"], {
-      stdio: "ignore",
-      timeout: 2000,
-      windowsHide: true,
-    });
-    return "psmux";
-  } catch {
-    /* not in PATH */
-  }
-  // Windows 기본 설치 경로 탐색
+
   if (IS_WINDOWS) {
+    // Windows primary: psmux
+    try {
+      childProcess.execFileSync("psmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+        windowsHide: true,
+      });
+      return "psmux";
+    } catch {
+      /* not in PATH */
+    }
     const candidates = [
       join(process.env.LOCALAPPDATA || "", "psmux", "psmux.exe"),
       join(process.env.APPDATA || "", "npm", "psmux.cmd"),
@@ -39,20 +55,20 @@ const PSMUX_BIN = (() => {
     for (const p of candidates) {
       if (existsSync(p)) return p;
     }
+    return "psmux"; // 최종 — hasPsmux/hasMultiplexer 가 검증
   }
-  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
-  if (!IS_WINDOWS) {
-    try {
-      childProcess.execFileSync("tmux", ["-V"], {
-        stdio: "ignore",
-        timeout: 2000,
-      });
-      return "tmux";
-    } catch {
-      /* tmux도 없음 */
-    }
+
+  // mac/Linux primary: tmux (POSIX 표준). silent fallback 아님 — 정식 primary.
+  try {
+    childProcess.execFileSync("tmux", ["-V"], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return "tmux";
+  } catch {
+    /* tmux not in PATH — hasMultiplexer 가 false 반환할 것 */
   }
-  return "psmux"; // 최종 fallback — 원래대로
+  return "tmux";
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
@@ -582,8 +598,8 @@ function psmux(args, opts = {}) {
   }
 }
 
-/** psmux 실행 가능 여부 확인 */
-export function hasPsmux() {
+/** primary terminal multiplexer (Windows=psmux, mac/Linux=tmux) 실행 가능 여부 */
+export function hasMultiplexer() {
   try {
     childProcess.execFileSync(PSMUX_BIN, ["-V"], {
       stdio: "ignore",
@@ -596,9 +612,20 @@ export function hasPsmux() {
   }
 }
 
-/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
-export function isTmuxFallback() {
-  return PSMUX_BIN === "tmux";
+/**
+ * backward-compat alias — historical 이름 `hasPsmux` 는 OS 별 primary 의 의미를
+ * 가린다. 외부 caller (scripts/remote-spawn.mjs, scripts/session-spawn-helper.mjs,
+ * tests) 호환을 위해 alias 로 보존. 신규 코드는 hasMultiplexer 사용.
+ */
+export const hasPsmux = hasMultiplexer;
+
+/**
+ * 현재 resolved multiplexer 종류 — "psmux" | "tmux" | <user override path>.
+ * isTmuxFallback() 의 후속 — mac/Linux 에서 tmux 는 fallback 이 아닌 primary 라
+ * "fallback" 표현이 부정확해서 type 으로 정정.
+ */
+export function getMultiplexerType() {
+  return PSMUX_BIN;
 }
 
 /**

--- a/packages/triflux/hub/lib/spawn-trace.mjs
+++ b/packages/triflux/hub/lib/spawn-trace.mjs
@@ -7,9 +7,13 @@ import { join } from "node:path";
 const LOG_DIR = join(homedir(), ".triflux", "logs");
 const DEDUPE_WINDOW_MS = 5_000;
 const RATE_WINDOW_MS = 1_000;
+// multi-worker headless dispatch 가 1 초 안에 ~25-30+ psmux/tmux 명령을 호출한다.
+// 2-worker dispatchBatch 가 default 30 limit 을 초과해 `rate_limit` throw 로 mac
+// 호환성 회귀 (smoke test 발견, 2026-05-15). 100 으로 상향 — 폭주 안전망은
+// 여전히 (default 100/sec) 유지, env override 로 보수 설정 가능.
 export let MAX_SPAWN_PER_SEC = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_SPAWN_RATE,
-  30,
+  100,
 );
 export const MAX_TOTAL_DESCENDANTS = resolvePositiveInteger(
   process.env.TRIFLUX_MAX_DESCENDANTS,

--- a/packages/triflux/hub/team/execution-mode.mjs
+++ b/packages/triflux/hub/team/execution-mode.mjs
@@ -32,10 +32,6 @@ export const MODES = Object.freeze({
   AUTO: "auto",
 });
 
-function quotePrompt(prompt) {
-  return JSON.stringify(typeof prompt === "string" ? prompt : "");
-}
-
 function asPrompt(prompt) {
   return typeof prompt === "string" ? prompt : "";
 }
@@ -209,29 +205,8 @@ export function selectExecutionMode(opts = {}) {
   };
 }
 
-/**
- * @param {string} mode
- * @param {{ cli?: "codex"|"gemini"|"claude", prompt?: string }} opts
- * @returns {{ command: string, useExec: boolean }}
- */
-export function buildCommandForMode(mode, opts = {}) {
-  const cli = opts.cli || "codex";
-  const prompt = quotePrompt(opts.prompt);
-
-  if (cli === "gemini") {
-    return { command: `gemini -p ${prompt}`, useExec: true };
-  }
-
-  if (mode === MODES.INTERACTIVE || mode === MODES.AUTO) {
-    return { command: cli === "claude" ? "claude" : "codex", useExec: false };
-  }
-
-  if (cli === "claude") {
-    return { command: `claude --print ${prompt}`, useExec: true };
-  }
-
-  return {
-    command: `codex exec ${prompt} -s danger-full-access --dangerously-bypass-approvals-and-sandbox`,
-    useExec: true,
-  };
-}
+// buildCommandForMode 는 caller 가 없어 제거됨 (v10.20.x). argv-inline 프롬프트와
+// `-s danger-full-access` flag 가 PR #252 의 stdin redirect 패턴과 정합하지
+// 않아 회귀 위험이 있었다. 실제 헤드리스 spawn 은 buildSpawnSpecForMode
+// (conductor.mjs:544) 가 담당하며, 셸 명령 형태가 필요한 경우는
+// hub/cli-adapter-base.mjs:buildExecCommand 를 사용한다.

--- a/packages/triflux/hub/team/psmux.mjs
+++ b/packages/triflux/hub/team/psmux.mjs
@@ -1,4 +1,15 @@
-// hub/team/psmux.mjs — Windows psmux 세션/키바인딩/캡처/steering 관리
+// hub/team/psmux.mjs — terminal multiplexer 세션/키바인딩/캡처/steering 관리
+//
+// 역사: psmux 는 Windows pwsh7 환경용 tmux 호환 클론 (Windows 에서 tmux 가
+// 깔리지 않거나 ConPTY 호환이 부족할 때 대안). triflux 는 원래 Windows 첫
+// 운영 환경이었고 그래서 변수 명에 `PSMUX_` prefix 가 남아있다. 실제 의미는
+// "OS 별 primary multiplexer" 다:
+//   - mac/Linux: tmux 가 primary (POSIX 표준)
+//   - Windows: psmux 가 primary (Windows pwsh7 전용)
+// 이전 코드는 mac 에서 psmux 를 시도하고 tmux 로 silent fallback 했는데,
+// 운영 fact 는 mac 표준이 tmux 라 fallback 이 아닌 정식 primary 다.
+// (PSMUX_BIN 변수 명은 backward-compat 위해 유지)
+//
 // 의존성: child_process, fs, os, path (Node.js 내장)만 사용
 
 import {
@@ -15,21 +26,26 @@ import { resolveGitBashExecutable } from "../lib/bash-path.mjs";
 import childProcess from "../lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 
+// OS 별 primary multiplexer 를 명시적으로 결정한다.
+//   - PSMUX_BIN env 가 있으면 user override (가장 우선)
+//   - Windows: psmux 가 primary. PATH + 기본 설치 경로에서 탐색.
+//   - mac/Linux: tmux 가 primary. PATH 에서만 찾는다 (HomeBrew, apt 등 표준 위치).
+// silent fallback 은 두지 않는다 — primary 가 없으면 의도된 fail.
 const PSMUX_BIN = (() => {
   if (process.env.PSMUX_BIN) return process.env.PSMUX_BIN;
-  // PATH에서 psmux 찾기
-  try {
-    childProcess.execFileSync("psmux", ["-V"], {
-      stdio: "ignore",
-      timeout: 2000,
-      windowsHide: true,
-    });
-    return "psmux";
-  } catch {
-    /* not in PATH */
-  }
-  // Windows 기본 설치 경로 탐색
+
   if (IS_WINDOWS) {
+    // Windows primary: psmux
+    try {
+      childProcess.execFileSync("psmux", ["-V"], {
+        stdio: "ignore",
+        timeout: 2000,
+        windowsHide: true,
+      });
+      return "psmux";
+    } catch {
+      /* not in PATH */
+    }
     const candidates = [
       join(process.env.LOCALAPPDATA || "", "psmux", "psmux.exe"),
       join(process.env.APPDATA || "", "npm", "psmux.cmd"),
@@ -39,20 +55,20 @@ const PSMUX_BIN = (() => {
     for (const p of candidates) {
       if (existsSync(p)) return p;
     }
+    return "psmux"; // 최종 — hasPsmux/hasMultiplexer 가 검증
   }
-  // macOS/Linux: psmux 없으면 tmux로 fallback (psmux는 tmux 호환 클론)
-  if (!IS_WINDOWS) {
-    try {
-      childProcess.execFileSync("tmux", ["-V"], {
-        stdio: "ignore",
-        timeout: 2000,
-      });
-      return "tmux";
-    } catch {
-      /* tmux도 없음 */
-    }
+
+  // mac/Linux primary: tmux (POSIX 표준). silent fallback 아님 — 정식 primary.
+  try {
+    childProcess.execFileSync("tmux", ["-V"], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+    return "tmux";
+  } catch {
+    /* tmux not in PATH — hasMultiplexer 가 false 반환할 것 */
   }
-  return "psmux"; // 최종 fallback — 원래대로
+  return "tmux";
 })();
 const GIT_BASH =
   process.env.GIT_BASH_PATH || resolveGitBashExecutable() || "bash";
@@ -582,8 +598,8 @@ function psmux(args, opts = {}) {
   }
 }
 
-/** psmux 실행 가능 여부 확인 */
-export function hasPsmux() {
+/** primary terminal multiplexer (Windows=psmux, mac/Linux=tmux) 실행 가능 여부 */
+export function hasMultiplexer() {
   try {
     childProcess.execFileSync(PSMUX_BIN, ["-V"], {
       stdio: "ignore",
@@ -596,9 +612,20 @@ export function hasPsmux() {
   }
 }
 
-/** PSMUX_BIN이 tmux로 fallback되었는지 여부 */
-export function isTmuxFallback() {
-  return PSMUX_BIN === "tmux";
+/**
+ * backward-compat alias — historical 이름 `hasPsmux` 는 OS 별 primary 의 의미를
+ * 가린다. 외부 caller (scripts/remote-spawn.mjs, scripts/session-spawn-helper.mjs,
+ * tests) 호환을 위해 alias 로 보존. 신규 코드는 hasMultiplexer 사용.
+ */
+export const hasPsmux = hasMultiplexer;
+
+/**
+ * 현재 resolved multiplexer 종류 — "psmux" | "tmux" | <user override path>.
+ * isTmuxFallback() 의 후속 — mac/Linux 에서 tmux 는 fallback 이 아닌 primary 라
+ * "fallback" 표현이 부정확해서 type 으로 정정.
+ */
+export function getMultiplexerType() {
+  return PSMUX_BIN;
 }
 
 /**

--- a/tests/unit/execution-mode.test.mjs
+++ b/tests/unit/execution-mode.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  buildCommandForMode,
   buildSpawnSpecForMode,
   MODES,
   resolveCliExecutable,
@@ -116,44 +115,11 @@ test("selectExecutionMode: review는 needsInput보다 우선해 headless", () =>
   assert.equal(result.mode, MODES.HEADLESS);
 });
 
-test("buildCommandForMode: codex headless command", () => {
-  const result = buildCommandForMode(MODES.HEADLESS, {
-    cli: "codex",
-    prompt: "fix bug",
-  });
-  assert.equal(result.useExec, true);
-  assert.equal(
-    result.command,
-    'codex exec "fix bug" -s danger-full-access --dangerously-bypass-approvals-and-sandbox',
-  );
-});
-
-test("buildCommandForMode: interactive codex command", () => {
-  const result = buildCommandForMode(MODES.INTERACTIVE, {
-    cli: "codex",
-    prompt: "ignored",
-  });
-  assert.deepEqual(result, { command: "codex", useExec: false });
-});
-
-test("buildCommandForMode: interactive claude command", () => {
-  const result = buildCommandForMode(MODES.INTERACTIVE, {
-    cli: "claude",
-    prompt: "ignored",
-  });
-  assert.deepEqual(result, { command: "claude", useExec: false });
-});
-
-test("buildCommandForMode: gemini is always prompt headless", () => {
-  const result = buildCommandForMode(MODES.INTERACTIVE, {
-    cli: "gemini",
-    prompt: "summarize logs",
-  });
-  assert.deepEqual(result, {
-    command: 'gemini -p "summarize logs"',
-    useExec: true,
-  });
-});
+// buildCommandForMode 관련 4 테스트는 본 함수가 dead code 로 제거되면서 동반
+// 삭제됨 (v10.20.x). 회귀 가드: tests/unit/multiplexer-resolution.test.mjs
+// 의 `execution-mode.mjs: dead buildCommandForMode 제거` 가 export 부재를
+// assert. headless spawn 의 실 동작 검증은 buildSpawnSpecForMode 관련 테스트
+// (하단) + tests/unit/codex-adapter.test.mjs:buildExecArgs 가 담당.
 
 // ── resolveCliExecutable: Windows .cmd/.exe fallback (#108 follow-up) ──
 // String.raw: biome auto-fix 가 "redundant escape" 로 판단해 \\n / \\c 를 파괴하는 것을 방지.

--- a/tests/unit/multiplexer-resolution.test.mjs
+++ b/tests/unit/multiplexer-resolution.test.mjs
@@ -1,0 +1,89 @@
+// tests/unit/multiplexer-resolution.test.mjs
+//
+// hub/team/psmux.mjs 의 PSMUX_BIN resolution 이 OS 별 primary multiplexer 로
+// 명시 분기되는지 (silent fallback 아님) 검증. mac/Linux 의 codex worker 가
+// tmux 환경에서 silent fallback path 로 흘러가던 회귀 가드.
+//
+// 그리고 execution-mode.mjs 의 dead buildCommandForMode 가 제거됐는지 가드.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const ROOT = pathFromHere("../..");
+
+function pathFromHere(rel) {
+  const here = new URL(import.meta.url).pathname;
+  const dir = here.substring(0, here.lastIndexOf("/"));
+  return join(dir, rel);
+}
+
+describe("psmux.mjs: OS primary multiplexer 명시 분기", () => {
+  const src = readFileSync(join(ROOT, "hub/team/psmux.mjs"), "utf8");
+
+  it("Windows primary 로 psmux 를 명시 분기한다", () => {
+    assert.ok(
+      /if \(IS_WINDOWS\)\s*\{[\s\S]*?"psmux"/.test(src),
+      "Windows 분기 안에서 psmux primary 결정이 있어야 함",
+    );
+  });
+
+  it("mac/Linux primary 로 tmux 를 명시 분기한다 (silent fallback 아님)", () => {
+    assert.ok(
+      /mac\/Linux primary: tmux/.test(src),
+      "tmux 는 mac/Linux primary 로 명시되어야 함 (fallback 표현 금지)",
+    );
+    assert.ok(
+      !/silent fallback/i.test(src) ||
+        /silent fallback 은 두지 않는다/.test(src),
+      "silent fallback 패턴이 도입되면 안 됨 (의도 명시화 정책)",
+    );
+  });
+
+  it("hasMultiplexer 와 hasPsmux 가 둘 다 export 된다 (alias)", async () => {
+    const mod = await import("../../hub/team/psmux.mjs");
+    assert.equal(typeof mod.hasMultiplexer, "function");
+    assert.equal(typeof mod.hasPsmux, "function");
+    assert.equal(
+      mod.hasPsmux,
+      mod.hasMultiplexer,
+      "hasPsmux 는 hasMultiplexer 의 alias 여야 함",
+    );
+  });
+
+  it("getMultiplexerType 가 export 되어 primary type 을 반환한다", async () => {
+    const mod = await import("../../hub/team/psmux.mjs");
+    assert.equal(typeof mod.getMultiplexerType, "function");
+    const type = mod.getMultiplexerType();
+    assert.ok(
+      typeof type === "string" && type.length > 0,
+      `getMultiplexerType() 는 non-empty string 을 반환해야 함, got: ${type}`,
+    );
+  });
+
+  it("isTmuxFallback 은 더 이상 export 안 됨 (의미 부정확)", async () => {
+    const mod = await import("../../hub/team/psmux.mjs");
+    assert.equal(
+      mod.isTmuxFallback,
+      undefined,
+      "isTmuxFallback 은 제거됐어야 함 — getMultiplexerType 로 대체",
+    );
+  });
+});
+
+describe("execution-mode.mjs: dead buildCommandForMode 제거", () => {
+  it("buildCommandForMode 는 더 이상 export 안 됨 (PR #252 stdin redirect 와 정합 안 됨)", async () => {
+    const mod = await import("../../hub/team/execution-mode.mjs");
+    assert.equal(
+      mod.buildCommandForMode,
+      undefined,
+      "buildCommandForMode 는 caller 없는 dead code 였고 argv-inline + -s flag 가 PR #252 와 충돌해서 제거됨",
+    );
+  });
+
+  it("buildSpawnSpecForMode 는 유지된다 (conductor.mjs:544 의 활성 caller)", async () => {
+    const mod = await import("../../hub/team/execution-mode.mjs");
+    assert.equal(typeof mod.buildSpawnSpecForMode, "function");
+  });
+});


### PR DESCRIPTION
## Summary

- `hub/team/psmux.mjs` PSMUX_BIN resolution 의 silent fallback 제거 → OS 별 명시 primary 분기 (Windows=psmux, mac/Linux=tmux). mac 표준이 tmux 라서 fallback 이 아닌 정식 primary.
- `hasPsmux` → `hasMultiplexer` rename. `hasPsmux` 는 backward-compat alias (외부 caller: scripts/remote-spawn.mjs, scripts/session-spawn-helper.mjs).
- `isTmuxFallback` 제거 — mac/Linux 에서 tmux 는 fallback 이 아니라 이름 부정확. `getMultiplexerType()` 으로 대체.
- `hub/team/execution-mode.mjs` `buildCommandForMode` 제거 — caller 없는 dead code. argv-inline prompt + `-s danger-full-access` flag 가 PR #252 의 stdin redirect 패턴과 정합 안 됨.

## 배경

체크포인트의 P1 #1 trace 에서 발견: mac 의 tfx-multi worker 가 `worker-1.txt` 비어있고 exit 1. y7iwbn11 worker 의 `.err` 26 lines 가 hook OK 까지만 진행. **codex 단독 호출은 정상** (manual reproduce 에서 stdin redirect + `--output-last-message` 모두 OK).

차이는 multiplexer pane 안 spawn 환경. `PSMUX_BIN` 이 mac 에서 silent 하게 tmux fallback 으로 resolved 됐는데, 이게 fallback 이라고 표시된 사실이 의도를 가렸다. 실제 정답은 mac primary = tmux, Windows primary = psmux.

## 변경 범위

이 PR 은 **architecture 정상화 + dead code 제거** 만. 실제 mac tmux pane 안 codex worker 의 pty/env 호환 fix 는 별도 PRD (후속).

## Mirror

- root + `packages/triflux` byte-identical (cp)
- `packages/remote` 는 `@triflux/core` import 변환 유지하며 Edit (psmux.mjs 3회, execution-mode.mjs 1회)
- `npm run release:check-mirror` ✅

## Verification

- `node --test tests/unit/multiplexer-resolution.test.mjs` — 7/7 pass (신규)
- `node --test tests/unit/multiplexer-resolution.test.mjs tests/unit/codex-adapter.test.mjs tests/unit/critical-fixes.test.mjs tests/unit/launcher-template.test.mjs tests/unit/routing-qa.test.mjs` — 97/97 pass
- `npm run lint` — clean
- `npm run release:check-mirror` — OK

## 후속 (별도 PRD)

`hub/team/conductor.mjs:544` 의 `buildSpawnSpecForMode` 가 argv-inline prompt + `shell: false` 로 child_process.spawn. PR #252 의 stdin redirect (shell:true) 와 정합 안 됨 → child.stdin.write(prompt); child.stdin.end() 패턴으로 정정 필요. mac tmux pane 환경 PTY/env 보강도 같이 검토.

## Test plan

- [x] 신규 가드 테스트 통과
- [x] 영향 받은 4개 테스트 파일 (codex-adapter, critical-fixes, launcher-template, routing-qa) 통과
- [x] lint clean
- [x] release:check-mirror OK
- [ ] CI 통과 확인