### PR TITLE
fix(conductor): codex headless prompt를 stdin transport로 분리 (#116-C)

### DIFF
--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -621,9 +621,24 @@ export function createConductor(opts = {}) {
     session.errPath = errPath;
     session.descendantSnapshot = [];
 
-    // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
-    // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
-    if (child.stdin) child.stdin.end();
+    // #116-C: spawnSpec.stdinPrompt 가 true 면 codex 의 oh-my-codex hook
+    // (macOS) 가 매우 긴 argv-inline prompt 에서 SessionStart Failed → exit 1
+    // 회귀를 유발하므로 prompt 를 stdin write 로 분리해서 전달한다.
+    // stdinPrompt 없으면 기존 흐름 — codex "Reading additional input..." 대기
+    // 방지를 위해 stdin 즉시 닫기.
+    if (child.stdin) {
+      if (spawnSpec.stdinPrompt && typeof spawnSpec.prompt === "string") {
+        try {
+          child.stdin.write(spawnSpec.prompt);
+        } catch (err) {
+          eventLog.append("spawn_stdin_write_error", {
+            session: session.id,
+            error: err.message,
+          });
+        }
+      }
+      child.stdin.end();
+    }
 
     eventLog.append("spawn", {
       session: session.id,

--- a/hub/team/execution-mode.mjs
+++ b/hub/team/execution-mode.mjs
@@ -42,6 +42,19 @@ function pushFlag(args, flag, value) {
   }
 }
 
+// #116-C: codex headless 의 argv-inline prompt 가 macOS oh-my-codex hook
+// SessionStart Failed 회귀를 유발 (codex CLI v0.130.0). cli-adapter-base 의
+// buildExecCommand 가 shell command 형태에서 동일 fix 를 적용했고
+// (TFX_CODEX_STDIN_PROMPT=0 opt-out), 본 함수의 spawn-args 형태에서도 같은
+// 정신으로 prompt 를 stdin transport 로 분리한다. 동일 env var 를 재사용해
+// 사용자가 한 곳만 끄면 양쪽 path 모두 비활성.
+export function resolveStdinPromptMode(explicit, envSource) {
+  if (typeof explicit === "boolean") return explicit;
+  const env = (envSource || process.env).TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
+}
+
 export function resolveCliExecutable(cli, opts = {}) {
   const name = String(cli || "codex");
   const resolveCommand = opts.resolveCommand || whichCommand;
@@ -134,6 +147,22 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }
+
+  // #116-C: codex headless 의 argv-inline prompt → macOS oh-my-codex hook
+  // SessionStart Failed 회귀 (codex v0.130.0). default 가 stdin transport.
+  // conductor.respawnSession 이 spec.prompt 를 child.stdin.write 로 주입한다.
+  const useStdin =
+    resolveStdinPromptMode(opts.stdinPrompt, opts.env) && prompt.length > 0;
+  if (useStdin) {
+    return {
+      ...wrap(args),
+      useExec: true,
+      shell: false,
+      stdinPrompt: true,
+      prompt,
+    };
+  }
+
   args.push(prompt);
   return { ...wrap(args), useExec: true, shell: false };
 }

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -601,9 +601,24 @@ export function createConductor(opts = {}) {
     session.errPath = errPath;
     session.descendantSnapshot = [];
 
-    // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
-    // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
-    if (child.stdin) child.stdin.end();
+    // #116-C: spawnSpec.stdinPrompt 가 true 면 codex 의 oh-my-codex hook
+    // (macOS) 가 매우 긴 argv-inline prompt 에서 SessionStart Failed → exit 1
+    // 회귀를 유발하므로 prompt 를 stdin write 로 분리해서 전달한다.
+    // stdinPrompt 없으면 기존 흐름 — codex "Reading additional input..." 대기
+    // 방지를 위해 stdin 즉시 닫기.
+    if (child.stdin) {
+      if (spawnSpec.stdinPrompt && typeof spawnSpec.prompt === "string") {
+        try {
+          child.stdin.write(spawnSpec.prompt);
+        } catch (err) {
+          eventLog.append("spawn_stdin_write_error", {
+            session: session.id,
+            error: err.message,
+          });
+        }
+      }
+      child.stdin.end();
+    }
 
     eventLog.append("spawn", {
       session: session.id,

--- a/packages/remote/hub/team/execution-mode.mjs
+++ b/packages/remote/hub/team/execution-mode.mjs
@@ -42,6 +42,19 @@ function pushFlag(args, flag, value) {
   }
 }
 
+// #116-C: codex headless 의 argv-inline prompt 가 macOS oh-my-codex hook
+// SessionStart Failed 회귀를 유발 (codex CLI v0.130.0). cli-adapter-base 의
+// buildExecCommand 가 shell command 형태에서 동일 fix 를 적용했고
+// (TFX_CODEX_STDIN_PROMPT=0 opt-out), 본 함수의 spawn-args 형태에서도 같은
+// 정신으로 prompt 를 stdin transport 로 분리한다. 동일 env var 를 재사용해
+// 사용자가 한 곳만 끄면 양쪽 path 모두 비활성.
+export function resolveStdinPromptMode(explicit, envSource) {
+  if (typeof explicit === "boolean") return explicit;
+  const env = (envSource || process.env).TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
+}
+
 export function resolveCliExecutable(cli, opts = {}) {
   const name = String(cli || "codex");
   const resolveCommand = opts.resolveCommand || whichCommand;
@@ -134,6 +147,22 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }
+
+  // #116-C: codex headless 의 argv-inline prompt → macOS oh-my-codex hook
+  // SessionStart Failed 회귀 (codex v0.130.0). default 가 stdin transport.
+  // conductor.respawnSession 이 spec.prompt 를 child.stdin.write 로 주입한다.
+  const useStdin =
+    resolveStdinPromptMode(opts.stdinPrompt, opts.env) && prompt.length > 0;
+  if (useStdin) {
+    return {
+      ...wrap(args),
+      useExec: true,
+      shell: false,
+      stdinPrompt: true,
+      prompt,
+    };
+  }
+
   args.push(prompt);
   return { ...wrap(args), useExec: true, shell: false };
 }

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -621,9 +621,24 @@ export function createConductor(opts = {}) {
     session.errPath = errPath;
     session.descendantSnapshot = [];
 
-    // 로컬 세션: 프롬프트는 CLI args로 전달되므로 stdin 즉시 닫기
-    // (codex가 stdin pipe 감지 시 "Reading additional input..." 대기 방지)
-    if (child.stdin) child.stdin.end();
+    // #116-C: spawnSpec.stdinPrompt 가 true 면 codex 의 oh-my-codex hook
+    // (macOS) 가 매우 긴 argv-inline prompt 에서 SessionStart Failed → exit 1
+    // 회귀를 유발하므로 prompt 를 stdin write 로 분리해서 전달한다.
+    // stdinPrompt 없으면 기존 흐름 — codex "Reading additional input..." 대기
+    // 방지를 위해 stdin 즉시 닫기.
+    if (child.stdin) {
+      if (spawnSpec.stdinPrompt && typeof spawnSpec.prompt === "string") {
+        try {
+          child.stdin.write(spawnSpec.prompt);
+        } catch (err) {
+          eventLog.append("spawn_stdin_write_error", {
+            session: session.id,
+            error: err.message,
+          });
+        }
+      }
+      child.stdin.end();
+    }
 
     eventLog.append("spawn", {
       session: session.id,

--- a/packages/triflux/hub/team/execution-mode.mjs
+++ b/packages/triflux/hub/team/execution-mode.mjs
@@ -42,6 +42,19 @@ function pushFlag(args, flag, value) {
   }
 }
 
+// #116-C: codex headless 의 argv-inline prompt 가 macOS oh-my-codex hook
+// SessionStart Failed 회귀를 유발 (codex CLI v0.130.0). cli-adapter-base 의
+// buildExecCommand 가 shell command 형태에서 동일 fix 를 적용했고
+// (TFX_CODEX_STDIN_PROMPT=0 opt-out), 본 함수의 spawn-args 형태에서도 같은
+// 정신으로 prompt 를 stdin transport 로 분리한다. 동일 env var 를 재사용해
+// 사용자가 한 곳만 끄면 양쪽 path 모두 비활성.
+export function resolveStdinPromptMode(explicit, envSource) {
+  if (typeof explicit === "boolean") return explicit;
+  const env = (envSource || process.env).TFX_CODEX_STDIN_PROMPT;
+  if (env === "0" || env === "false") return false;
+  return true;
+}
+
 export function resolveCliExecutable(cli, opts = {}) {
   const name = String(cli || "codex");
   const resolveCommand = opts.resolveCommand || whichCommand;
@@ -134,6 +147,22 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }
+
+  // #116-C: codex headless 의 argv-inline prompt → macOS oh-my-codex hook
+  // SessionStart Failed 회귀 (codex v0.130.0). default 가 stdin transport.
+  // conductor.respawnSession 이 spec.prompt 를 child.stdin.write 로 주입한다.
+  const useStdin =
+    resolveStdinPromptMode(opts.stdinPrompt, opts.env) && prompt.length > 0;
+  if (useStdin) {
+    return {
+      ...wrap(args),
+      useExec: true,
+      shell: false,
+      stdinPrompt: true,
+      prompt,
+    };
+  }
+
   args.push(prompt);
   return { ...wrap(args), useExec: true, shell: false };
 }

--- a/tests/unit/conductor-windows-quote-regression.test.mjs
+++ b/tests/unit/conductor-windows-quote-regression.test.mjs
@@ -80,7 +80,7 @@ afterEach(async () => {
   rmSync(logsDir, { recursive: true, force: true });
 });
 
-test("conductor launches quoted prompts through argv without shell quoting on Windows-sensitive paths", async () => {
+test("conductor launches quoted prompts through stdin without shell quoting or argv injection on Windows-sensitive paths", async () => {
   const spawnCalls = [];
   conductor = createConductor({
     logsDir,
@@ -139,11 +139,21 @@ test("conductor launches quoted prompts through argv without shell quoting on Wi
   }
   assert.equal(spawnCalls[0].options.shell, false);
   assert.notEqual(spawnCalls[0].exitCode, 255);
-  assert.equal(spawnCalls[0].args.at(-1), prompt);
+
+  // #116-C (v10.21+): default stdinPrompt=true 이므로 prompt 가 args 에서
+  // 빠지고 conductor.respawnSession 이 child.stdin.write 로 분리해서 전달.
+  // 마지막 args 는 --color flag 의 value ("never"). 이는 PR #128 BUG-A 의
+  // 가드보다 더 강력한 가드 — prompt 가 argv 어디에도 없으므로 cmd batch %*
+  // 파싱 / shell quoting / quote escaping 회귀 가능성이 원천 차단된다.
+  assert.equal(spawnCalls[0].args.at(-1), "never");
+  assert.ok(
+    !spawnCalls[0].args.includes(prompt),
+    `prompt must not appear in args under default stdinPrompt=true: ${JSON.stringify(spawnCalls[0].args)}`,
+  );
   assert.ok(
     !spawnCalls[0].args.some((arg) =>
       String(arg).includes('\\"hello world\\"'),
     ),
-    `prompt should be passed as a raw argv item: ${JSON.stringify(spawnCalls[0].args)}`,
+    `no shell-quoted prompt fragment in args: ${JSON.stringify(spawnCalls[0].args)}`,
   );
 });

--- a/tests/unit/execution-mode.test.mjs
+++ b/tests/unit/execution-mode.test.mjs
@@ -5,6 +5,7 @@ import {
   buildSpawnSpecForMode,
   MODES,
   resolveCliExecutable,
+  resolveStdinPromptMode,
   selectExecutionMode,
   unwrapCmdToJsScript,
 } from "../../hub/team/execution-mode.mjs";
@@ -227,8 +228,9 @@ test("unwrapCmdToJsScript: returns null when .js does not exist on disk", () => 
   assert.equal(result, null);
 });
 
-test("buildSpawnSpecForMode: win32 + .cmd uses node + .js (cmd /c bypass)", () => {
-  // 회귀 방지 #128 BUG-A: cmd /c wrap 경로가 prompt truncation 의 원인이었음
+test("buildSpawnSpecForMode: win32 + .cmd uses node + .js (cmd /c bypass, legacy stdinPrompt=false)", () => {
+  // 회귀 방지 #128 BUG-A: cmd /c wrap 경로가 prompt truncation 의 원인이었음.
+  // stdinPrompt=false 강제 (legacy argv-inline) 회귀 가드.
   const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
     cli: "codex",
     prompt: "no-op probe.\n\n```bash\necho ok\n```\n",
@@ -238,6 +240,7 @@ test("buildSpawnSpecForMode: win32 + .cmd uses node + .js (cmd /c bypass)", () =
     unwrapCmdFn: () =>
       String.raw`C:\npm\node_modules\@openai\codex\bin\codex.js`,
     nodeExecPath: String.raw`C:\nodejs\node.exe`,
+    stdinPrompt: false,
   });
   assert.equal(spec.command, String.raw`C:\nodejs\node.exe`);
   assert.equal(
@@ -248,9 +251,10 @@ test("buildSpawnSpecForMode: win32 + .cmd uses node + .js (cmd /c bypass)", () =
   const lastArg = spec.args[spec.args.length - 1];
   assert.ok(lastArg.includes("```bash"), "fenced bash block must survive");
   assert.ok(lastArg.includes("\n"), "newline must survive in args");
+  assert.notEqual(spec.stdinPrompt, true);
 });
 
-test("buildSpawnSpecForMode: win32 + .cmd falls back to cmd /c when unwrap fails", () => {
+test("buildSpawnSpecForMode: win32 + .cmd falls back to cmd /c when unwrap fails (legacy stdinPrompt=false)", () => {
   const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
     cli: "codex",
     prompt: "test",
@@ -258,8 +262,109 @@ test("buildSpawnSpecForMode: win32 + .cmd falls back to cmd /c when unwrap fails
     resolveCommand: () => String.raw`C:\npm\codex.cmd`,
     existsSyncFn: () => true,
     unwrapCmdFn: () => null,
+    stdinPrompt: false,
   });
   assert.equal(spec.command, "cmd");
   assert.equal(spec.args[0], "/c");
   assert.equal(spec.args[1], String.raw`C:\npm\codex.cmd`);
+});
+
+// ── #116-C: stdin transport for codex headless prompt ────────────────────
+
+test("resolveStdinPromptMode: explicit boolean wins", () => {
+  assert.equal(resolveStdinPromptMode(true, {}), true);
+  assert.equal(resolveStdinPromptMode(false, {}), false);
+  assert.equal(
+    resolveStdinPromptMode(false, { TFX_CODEX_STDIN_PROMPT: "1" }),
+    false,
+  );
+});
+
+test("resolveStdinPromptMode: default true; env=0|false opts out", () => {
+  assert.equal(resolveStdinPromptMode(undefined, {}), true);
+  assert.equal(
+    resolveStdinPromptMode(undefined, { TFX_CODEX_STDIN_PROMPT: "0" }),
+    false,
+  );
+  assert.equal(
+    resolveStdinPromptMode(undefined, { TFX_CODEX_STDIN_PROMPT: "false" }),
+    false,
+  );
+  assert.equal(
+    resolveStdinPromptMode(undefined, { TFX_CODEX_STDIN_PROMPT: "1" }),
+    true,
+  );
+});
+
+test("buildSpawnSpecForMode: codex headless default uses stdinPrompt (prompt out of args)", () => {
+  const prompt = "Please respond ACK.\n\n```bash\necho ok\n```\n";
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "codex",
+    prompt,
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/codex",
+    env: {},
+  });
+  assert.equal(spec.stdinPrompt, true);
+  assert.equal(spec.prompt, prompt);
+  assert.equal(spec.command, "/usr/local/bin/codex");
+  assert.ok(spec.args.includes("exec"), "exec arg must be present");
+  for (const a of spec.args) {
+    assert.notEqual(
+      a,
+      prompt,
+      "prompt must not appear in args when stdinPrompt=true",
+    );
+  }
+});
+
+test("buildSpawnSpecForMode: codex headless TFX_CODEX_STDIN_PROMPT=0 falls back to argv-inline", () => {
+  const prompt = "argv-inline legacy";
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "codex",
+    prompt,
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/codex",
+    env: { TFX_CODEX_STDIN_PROMPT: "0" },
+  });
+  assert.notEqual(spec.stdinPrompt, true);
+  assert.equal(spec.args[spec.args.length - 1], prompt);
+});
+
+test("buildSpawnSpecForMode: codex headless empty prompt falls back to argv-inline (avoid empty stdin EOF)", () => {
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "codex",
+    prompt: "",
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/codex",
+    env: {},
+  });
+  assert.notEqual(spec.stdinPrompt, true);
+  assert.equal(spec.args[spec.args.length - 1], "");
+});
+
+test("buildSpawnSpecForMode: gemini headless ignores stdinPrompt (keeps --prompt flag)", () => {
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "gemini",
+    prompt: "ACK",
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/gemini",
+    env: {},
+  });
+  assert.notEqual(spec.stdinPrompt, true);
+  assert.ok(spec.args.includes("--prompt"));
+  assert.equal(spec.args[spec.args.indexOf("--prompt") + 1], "ACK");
+});
+
+test("buildSpawnSpecForMode: claude headless ignores stdinPrompt (keeps -p flag)", () => {
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "claude",
+    prompt: "ACK",
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/claude",
+    env: {},
+  });
+  assert.notEqual(spec.stdinPrompt, true);
+  assert.ok(spec.args.includes("-p"));
+  assert.equal(spec.args[spec.args.indexOf("-p") + 1], "ACK");
 });


### PR DESCRIPTION
PR #252가 shell command 경로(cli-adapter-base.buildExecCommand)는 stdin
redirect로 fix했지만 spawn-args 경로(execution-mode.buildSpawnSpecForMode)는
여전히 argv-inline. conductor가 spawn하는 codex headless worker가 non-TTY
환경에서 oh-my-codex hook SessionStart Failed → F1_crash exit 1.

- buildSpawnSpecForMode codex headless 분기에서 stdinPrompt default ON
- conductor.respawnSession spec.stdinPrompt → child.stdin.write(prompt) + end()
- TFX_CODEX_STDIN_PROMPT env를 cli-adapter-base와 공유 (opt-out 한 곳 일괄)
- 3-layer mirror (root + packages/triflux + packages/remote, @triflux/core import 보존)
- execution-mode.test.mjs 28/28 (stdinPrompt 신규 7) + conductor-windows-quote
  가드 강화 — prompt가 args에 아예 없음 검증 (PR #128 BUG-A 가드보다 강력)
