### PR TITLE
fix(check-codex-config): [hooks.state.*] section whitelist 추가 (#193)

### DIFF
--- a/packages/triflux/scripts/check-codex-config-stable.mjs
+++ b/packages/triflux/scripts/check-codex-config-stable.mjs
@@ -8,9 +8,19 @@
 // 되면 즉시 fail 하고 진단 정보를 출력한다. CI 또는 로컬 npm script 에서
 // `npm run test:guard-codex-config` 처럼 호출한다.
 //
+// Issue #193 follow-up — `[hooks.state.*]` section whitelist:
+//   oh-my-codex 는 codex CLI hooks 가 발화될 때마다 ~/.codex/config.toml 의
+//   `[hooks.state."<hook-key>"]` section 의 trusted_hash 를 자동 갱신한다.
+//   사용자가 npm test 도중 다른 터미널에서 codex 를 활성 사용 중이면 이
+//   외부 mutation 이 false positive 로 잡힌다. 따라서 hooks.state-only
+//   churn 은 informational warning 으로 분류하고 exit 0 으로 통과시킨다.
+//   triflux 자체 mutation (e.g. tfx-hub URL drift) 은 기존대로 exit 2.
+//
 // Exit codes:
-//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0)
-//   2  = mutation 감지. wrap 한 명령의 exit code 와 무관하게 강제 fail.
+//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0).
+//        hooks.state-only churn 도 여기 포함 (informational warning 만 출력).
+//   2  = triflux 가드가 잡아야 할 mutation 감지. wrap 한 명령의 exit code
+//        와 무관하게 강제 fail.
 //   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
 
 import { spawnSync } from "node:child_process";
@@ -21,6 +31,7 @@ import { join } from "node:path";
 
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const EXPECTED_TFX_HUB_URL = "http://127.0.0.1:27888/mcp";
+const HOOKS_STATE_PREFIX = "hooks.state.";
 
 function readTfxHubUrl(raw) {
   const headerMatch =
@@ -42,6 +53,65 @@ function readTfxHubUrl(raw) {
   return urlMatch?.[1] ?? urlMatch?.[2] ?? "";
 }
 
+// Split a TOML payload into section blocks. Pre-header content (top-level
+// keys, comments) becomes a single anonymous section with header "".
+// Each returned section has `{ header, body }` — body is the raw text
+// between this header and the next section header, used for byte-level
+// equality comparison.
+export function splitTomlSections(raw) {
+  if (typeof raw !== "string") return [];
+  const sections = [];
+  const headerRegex = /^[ \t]*\[[ \t]*([^\]\n]+?)[ \t]*\][ \t]*\r?$/gm;
+  let lastIndex = 0;
+  let currentHeader = "";
+  let match;
+  while ((match = headerRegex.exec(raw)) !== null) {
+    const body = raw.slice(lastIndex, match.index);
+    sections.push({ header: currentHeader, body });
+    currentHeader = match[1].trim();
+    // skip past header line + trailing newline (if present)
+    lastIndex = match.index + match[0].length;
+    if (raw[lastIndex] === "\n") lastIndex += 1;
+  }
+  sections.push({ header: currentHeader, body: raw.slice(lastIndex) });
+  return sections;
+}
+
+// Classify which sections drifted between before / after payloads.
+// Returns:
+//   { hooksStateOnly: bool, changedSections: string[] }
+//
+// hooksStateOnly = true means every changed section header starts with
+// "hooks.state." (the oh-my-codex managed area). Empty diff returns
+// hooksStateOnly=false so callers don't accidentally whitelist "no change".
+export function classifySectionDiff(beforeRaw, afterRaw) {
+  const beforeSections = splitTomlSections(beforeRaw);
+  const afterSections = splitTomlSections(afterRaw);
+  const beforeMap = new Map();
+  for (const s of beforeSections) {
+    beforeMap.set(s.header, s.body);
+  }
+  const afterMap = new Map();
+  for (const s of afterSections) {
+    afterMap.set(s.header, s.body);
+  }
+  const changed = new Set();
+  for (const [header, body] of afterMap) {
+    if (header === "") continue; // preamble drift is rare and noisy — ignore
+    const prev = beforeMap.get(header);
+    if (prev === undefined || prev !== body) changed.add(header);
+  }
+  for (const header of beforeMap.keys()) {
+    if (header === "") continue;
+    if (!afterMap.has(header)) changed.add(header);
+  }
+  const changedSections = Array.from(changed);
+  const hooksStateOnly =
+    changedSections.length > 0 &&
+    changedSections.every((h) => h.startsWith(HOOKS_STATE_PREFIX));
+  return { hooksStateOnly, changedSections };
+}
+
 function snapshotConfig() {
   try {
     const stat = statSync(CODEX_CONFIG);
@@ -53,6 +123,7 @@ function snapshotConfig() {
       size: stat.size,
       mtimeMs: stat.mtimeMs,
       sha,
+      raw,
       tfxHubUrl: readTfxHubUrl(raw),
     };
   } catch {
@@ -60,16 +131,36 @@ function snapshotConfig() {
   }
 }
 
-function describeChange(before, after) {
+// describeChange — kind + (sha-changed 시) hooksStateOnly 라벨 + message.
+// 호출 측에서 hooksStateOnly 면 informational 처리, 아니면 mutation 으로
+// 처리한다. 반환 null = 차이 없음.
+export function describeChange(before, after) {
   if (!before.exists && !after.exists) return null;
   if (before.exists !== after.exists) {
-    return before.exists ? "file deleted" : "file created";
+    return {
+      kind: before.exists ? "file-deleted" : "file-created",
+      message: before.exists ? "file deleted" : "file created",
+    };
   }
   if (before.sha !== after.sha) {
-    return `sha256 differs (size: ${before.size} → ${after.size})`;
+    const beforeRaw = typeof before.raw === "string" ? before.raw : "";
+    const afterRaw = typeof after.raw === "string" ? after.raw : "";
+    const { hooksStateOnly, changedSections } = classifySectionDiff(
+      beforeRaw,
+      afterRaw,
+    );
+    return {
+      kind: "sha-changed",
+      hooksStateOnly,
+      changedSections,
+      message: `sha256 differs (size: ${before.size} → ${after.size})`,
+    };
   }
   if (before.mtimeMs !== after.mtimeMs) {
-    return `mtime differs (${before.mtimeMs} → ${after.mtimeMs})`;
+    return {
+      kind: "mtime-only",
+      message: `mtime differs (${before.mtimeMs} → ${after.mtimeMs})`,
+    };
   }
   return null;
 }
@@ -81,42 +172,79 @@ function describePortDrift(snapshot) {
   return `tfx-hub url is ${JSON.stringify(snapshot.tfxHubUrl)}; expected ${JSON.stringify(EXPECTED_TFX_HUB_URL)}`;
 }
 
-const argv = process.argv.slice(2);
-const command = argv.length > 0 ? argv : ["npm", "test"];
+// CLI entry only when this script is the main module — keeps unit tests
+// import-safe.
+const isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
 
-const before = snapshotConfig();
-process.stderr.write(
-  `[check-codex-config-stable] before: ${JSON.stringify(before)}\n`,
-);
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const command = argv.length > 0 ? argv : ["npm", "test"];
 
-const result = spawnSync(command[0], command.slice(1), {
-  stdio: "inherit",
-  shell: process.platform === "win32",
-});
-
-const after = snapshotConfig();
-process.stderr.write(
-  `[check-codex-config-stable] after: ${JSON.stringify(after)}\n`,
-);
-
-const change = describeChange(before, after);
-const portDrift = describePortDrift(after);
-if (change || portDrift) {
+  const before = snapshotConfig();
   process.stderr.write(
-    [
-      "",
-      "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
-      `Path:    ${CODEX_CONFIG}`,
-      `Change:  ${change || "none"}`,
-      portDrift ? `Port:    ${portDrift}` : null,
-      "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
-      "Context: https://github.com/tellang/triflux/issues/193",
-      "",
-    ]
-      .filter(Boolean)
-      .join("\n"),
+    `[check-codex-config-stable] before: ${JSON.stringify({ ...before, raw: undefined })}\n`,
   );
-  process.exit(2);
-}
 
-process.exit(result.status ?? 0);
+  const result = spawnSync(command[0], command.slice(1), {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  const after = snapshotConfig();
+  process.stderr.write(
+    `[check-codex-config-stable] after: ${JSON.stringify({ ...after, raw: undefined })}\n`,
+  );
+
+  const change = describeChange(before, after);
+  const portDrift = describePortDrift(after);
+  const hooksStateOnly =
+    change?.kind === "sha-changed" && change.hooksStateOnly === true;
+
+  // hooksStateOnly + port drift 없음 = informational warning + pass.
+  // port drift 가 같이 잡혔으면 그건 triflux-owned section mutation 이라
+  // 기존 fail path 를 탄다.
+  if (hooksStateOnly && !portDrift) {
+    process.stderr.write(
+      [
+        "",
+        "[check-codex-config-stable] hooks.state-only churn (whitelist)",
+        `Path:     ${CODEX_CONFIG}`,
+        `Sections: ${(change.changedSections || []).join(", ") || "(none)"}`,
+        "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신.",
+        "          triflux 외부 mutation 이므로 #193 가드의 false positive 다.",
+        "Action:   informational only — pass-through.",
+        "",
+      ].join("\n"),
+    );
+    process.exit(result.status ?? 0);
+  }
+
+  if (change || portDrift) {
+    process.stderr.write(
+      [
+        "",
+        "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
+        `Path:    ${CODEX_CONFIG}`,
+        `Change:  ${change?.message || "none"}`,
+        change?.changedSections?.length
+          ? `Sections: ${change.changedSections.join(", ")}`
+          : null,
+        portDrift ? `Port:    ${portDrift}` : null,
+        "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
+        "Context: https://github.com/tellang/triflux/issues/193",
+        "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+    process.exit(2);
+  }
+
+  process.exit(result.status ?? 0);
+}

--- a/scripts/check-codex-config-stable.mjs
+++ b/scripts/check-codex-config-stable.mjs
@@ -8,9 +8,19 @@
 // 되면 즉시 fail 하고 진단 정보를 출력한다. CI 또는 로컬 npm script 에서
 // `npm run test:guard-codex-config` 처럼 호출한다.
 //
+// Issue #193 follow-up — `[hooks.state.*]` section whitelist:
+//   oh-my-codex 는 codex CLI hooks 가 발화될 때마다 ~/.codex/config.toml 의
+//   `[hooks.state."<hook-key>"]` section 의 trusted_hash 를 자동 갱신한다.
+//   사용자가 npm test 도중 다른 터미널에서 codex 를 활성 사용 중이면 이
+//   외부 mutation 이 false positive 로 잡힌다. 따라서 hooks.state-only
+//   churn 은 informational warning 으로 분류하고 exit 0 으로 통과시킨다.
+//   triflux 자체 mutation (e.g. tfx-hub URL drift) 은 기존대로 exit 2.
+//
 // Exit codes:
-//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0)
-//   2  = mutation 감지. wrap 한 명령의 exit code 와 무관하게 강제 fail.
+//   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0).
+//        hooks.state-only churn 도 여기 포함 (informational warning 만 출력).
+//   2  = triflux 가드가 잡아야 할 mutation 감지. wrap 한 명령의 exit code
+//        와 무관하게 강제 fail.
 //   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
 
 import { spawnSync } from "node:child_process";
@@ -21,6 +31,7 @@ import { join } from "node:path";
 
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const EXPECTED_TFX_HUB_URL = "http://127.0.0.1:27888/mcp";
+const HOOKS_STATE_PREFIX = "hooks.state.";
 
 function readTfxHubUrl(raw) {
   const headerMatch =
@@ -42,6 +53,65 @@ function readTfxHubUrl(raw) {
   return urlMatch?.[1] ?? urlMatch?.[2] ?? "";
 }
 
+// Split a TOML payload into section blocks. Pre-header content (top-level
+// keys, comments) becomes a single anonymous section with header "".
+// Each returned section has `{ header, body }` — body is the raw text
+// between this header and the next section header, used for byte-level
+// equality comparison.
+export function splitTomlSections(raw) {
+  if (typeof raw !== "string") return [];
+  const sections = [];
+  const headerRegex = /^[ \t]*\[[ \t]*([^\]\n]+?)[ \t]*\][ \t]*\r?$/gm;
+  let lastIndex = 0;
+  let currentHeader = "";
+  let match;
+  while ((match = headerRegex.exec(raw)) !== null) {
+    const body = raw.slice(lastIndex, match.index);
+    sections.push({ header: currentHeader, body });
+    currentHeader = match[1].trim();
+    // skip past header line + trailing newline (if present)
+    lastIndex = match.index + match[0].length;
+    if (raw[lastIndex] === "\n") lastIndex += 1;
+  }
+  sections.push({ header: currentHeader, body: raw.slice(lastIndex) });
+  return sections;
+}
+
+// Classify which sections drifted between before / after payloads.
+// Returns:
+//   { hooksStateOnly: bool, changedSections: string[] }
+//
+// hooksStateOnly = true means every changed section header starts with
+// "hooks.state." (the oh-my-codex managed area). Empty diff returns
+// hooksStateOnly=false so callers don't accidentally whitelist "no change".
+export function classifySectionDiff(beforeRaw, afterRaw) {
+  const beforeSections = splitTomlSections(beforeRaw);
+  const afterSections = splitTomlSections(afterRaw);
+  const beforeMap = new Map();
+  for (const s of beforeSections) {
+    beforeMap.set(s.header, s.body);
+  }
+  const afterMap = new Map();
+  for (const s of afterSections) {
+    afterMap.set(s.header, s.body);
+  }
+  const changed = new Set();
+  for (const [header, body] of afterMap) {
+    if (header === "") continue; // preamble drift is rare and noisy — ignore
+    const prev = beforeMap.get(header);
+    if (prev === undefined || prev !== body) changed.add(header);
+  }
+  for (const header of beforeMap.keys()) {
+    if (header === "") continue;
+    if (!afterMap.has(header)) changed.add(header);
+  }
+  const changedSections = Array.from(changed);
+  const hooksStateOnly =
+    changedSections.length > 0 &&
+    changedSections.every((h) => h.startsWith(HOOKS_STATE_PREFIX));
+  return { hooksStateOnly, changedSections };
+}
+
 function snapshotConfig() {
   try {
     const stat = statSync(CODEX_CONFIG);
@@ -53,6 +123,7 @@ function snapshotConfig() {
       size: stat.size,
       mtimeMs: stat.mtimeMs,
       sha,
+      raw,
       tfxHubUrl: readTfxHubUrl(raw),
     };
   } catch {
@@ -60,16 +131,36 @@ function snapshotConfig() {
   }
 }
 
-function describeChange(before, after) {
+// describeChange — kind + (sha-changed 시) hooksStateOnly 라벨 + message.
+// 호출 측에서 hooksStateOnly 면 informational 처리, 아니면 mutation 으로
+// 처리한다. 반환 null = 차이 없음.
+export function describeChange(before, after) {
   if (!before.exists && !after.exists) return null;
   if (before.exists !== after.exists) {
-    return before.exists ? "file deleted" : "file created";
+    return {
+      kind: before.exists ? "file-deleted" : "file-created",
+      message: before.exists ? "file deleted" : "file created",
+    };
   }
   if (before.sha !== after.sha) {
-    return `sha256 differs (size: ${before.size} → ${after.size})`;
+    const beforeRaw = typeof before.raw === "string" ? before.raw : "";
+    const afterRaw = typeof after.raw === "string" ? after.raw : "";
+    const { hooksStateOnly, changedSections } = classifySectionDiff(
+      beforeRaw,
+      afterRaw,
+    );
+    return {
+      kind: "sha-changed",
+      hooksStateOnly,
+      changedSections,
+      message: `sha256 differs (size: ${before.size} → ${after.size})`,
+    };
   }
   if (before.mtimeMs !== after.mtimeMs) {
-    return `mtime differs (${before.mtimeMs} → ${after.mtimeMs})`;
+    return {
+      kind: "mtime-only",
+      message: `mtime differs (${before.mtimeMs} → ${after.mtimeMs})`,
+    };
   }
   return null;
 }
@@ -81,42 +172,79 @@ function describePortDrift(snapshot) {
   return `tfx-hub url is ${JSON.stringify(snapshot.tfxHubUrl)}; expected ${JSON.stringify(EXPECTED_TFX_HUB_URL)}`;
 }
 
-const argv = process.argv.slice(2);
-const command = argv.length > 0 ? argv : ["npm", "test"];
+// CLI entry only when this script is the main module — keeps unit tests
+// import-safe.
+const isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
 
-const before = snapshotConfig();
-process.stderr.write(
-  `[check-codex-config-stable] before: ${JSON.stringify(before)}\n`,
-);
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const command = argv.length > 0 ? argv : ["npm", "test"];
 
-const result = spawnSync(command[0], command.slice(1), {
-  stdio: "inherit",
-  shell: process.platform === "win32",
-});
-
-const after = snapshotConfig();
-process.stderr.write(
-  `[check-codex-config-stable] after: ${JSON.stringify(after)}\n`,
-);
-
-const change = describeChange(before, after);
-const portDrift = describePortDrift(after);
-if (change || portDrift) {
+  const before = snapshotConfig();
   process.stderr.write(
-    [
-      "",
-      "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
-      `Path:    ${CODEX_CONFIG}`,
-      `Change:  ${change || "none"}`,
-      portDrift ? `Port:    ${portDrift}` : null,
-      "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
-      "Context: https://github.com/tellang/triflux/issues/193",
-      "",
-    ]
-      .filter(Boolean)
-      .join("\n"),
+    `[check-codex-config-stable] before: ${JSON.stringify({ ...before, raw: undefined })}\n`,
   );
-  process.exit(2);
-}
 
-process.exit(result.status ?? 0);
+  const result = spawnSync(command[0], command.slice(1), {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  const after = snapshotConfig();
+  process.stderr.write(
+    `[check-codex-config-stable] after: ${JSON.stringify({ ...after, raw: undefined })}\n`,
+  );
+
+  const change = describeChange(before, after);
+  const portDrift = describePortDrift(after);
+  const hooksStateOnly =
+    change?.kind === "sha-changed" && change.hooksStateOnly === true;
+
+  // hooksStateOnly + port drift 없음 = informational warning + pass.
+  // port drift 가 같이 잡혔으면 그건 triflux-owned section mutation 이라
+  // 기존 fail path 를 탄다.
+  if (hooksStateOnly && !portDrift) {
+    process.stderr.write(
+      [
+        "",
+        "[check-codex-config-stable] hooks.state-only churn (whitelist)",
+        `Path:     ${CODEX_CONFIG}`,
+        `Sections: ${(change.changedSections || []).join(", ") || "(none)"}`,
+        "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신.",
+        "          triflux 외부 mutation 이므로 #193 가드의 false positive 다.",
+        "Action:   informational only — pass-through.",
+        "",
+      ].join("\n"),
+    );
+    process.exit(result.status ?? 0);
+  }
+
+  if (change || portDrift) {
+    process.stderr.write(
+      [
+        "",
+        "=== CONFIG MUTATION DETECTED (#193 회귀) ===",
+        `Path:    ${CODEX_CONFIG}`,
+        `Change:  ${change?.message || "none"}`,
+        change?.changedSections?.length
+          ? `Sections: ${change.changedSections.join(", ")}`
+          : null,
+        portDrift ? `Port:    ${portDrift}` : null,
+        "Action:  즉시 backup 으로 복원 + mutation source 추적 필요.",
+        "Context: https://github.com/tellang/triflux/issues/193",
+        "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+    process.exit(2);
+  }
+
+  process.exit(result.status ?? 0);
+}

--- a/tests/unit/check-codex-config-stable.test.mjs
+++ b/tests/unit/check-codex-config-stable.test.mjs
@@ -1,0 +1,164 @@
+// tests/unit/check-codex-config-stable.test.mjs
+// Issue #193 follow-up — `[hooks.state.*]` whitelist 가드 단위 테스트.
+//
+// describeChange 가 sha 변경을 hooks.state-only / 다른 section 변경으로
+// 정확히 분류해야 npm test 도중 일어나는 oh-my-codex trust_hash 갱신을
+// false positive 로 잡지 않는다.
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, it } from "node:test";
+
+import {
+  classifySectionDiff,
+  describeChange,
+  splitTomlSections,
+} from "../../scripts/check-codex-config-stable.mjs";
+
+const HOOKS_STATE_BLOCK_BEFORE = `[hooks.state."/Users/tellang/.codex/hooks.json:stop:0:0"]
+trusted_hash = "sha256:0585a6"
+
+[hooks.state."/Users/tellang/.codex/hooks.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:624a4a"
+`;
+
+const HOOKS_STATE_BLOCK_AFTER = `[hooks.state."/Users/tellang/.codex/hooks.json:stop:0:0"]
+trusted_hash = "sha256:NEWHASH1"
+
+[hooks.state."/Users/tellang/.codex/hooks.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:NEWHASH2"
+`;
+
+const TFX_HUB_BLOCK = `[mcp_servers.tfx-hub]
+url = "http://127.0.0.1:27888/mcp"
+`;
+
+const TFX_HUB_BLOCK_DRIFTED = `[mcp_servers.tfx-hub]
+url = "http://127.0.0.1:27999/mcp"
+`;
+
+const PROFILE_BLOCK = `[profiles.codex53_low]
+model = "gpt-5.3-codex"
+`;
+
+function snapshot(raw) {
+  return {
+    exists: true,
+    size: Buffer.byteLength(raw, "utf8"),
+    mtimeMs: 0,
+    sha: createHash("sha256").update(raw).digest("hex"),
+    raw,
+    tfxHubUrl: null,
+  };
+}
+
+describe("#193 splitTomlSections", () => {
+  it("captures preamble before first header as empty-key section", () => {
+    const raw = `# top comment\nkey = "value"\n\n[a]\nx = 1\n`;
+    const sections = splitTomlSections(raw);
+    assert.equal(sections.length, 2);
+    assert.equal(sections[0].header, "");
+    assert.match(sections[0].body, /key = "value"/);
+    assert.equal(sections[1].header, "a");
+    assert.match(sections[1].body, /x = 1/);
+  });
+
+  it("trims spaces inside header brackets", () => {
+    const raw = `[ hooks.state."abc" ]\nv = 1\n`;
+    const sections = splitTomlSections(raw);
+    assert.equal(sections[1].header, `hooks.state."abc"`);
+  });
+});
+
+describe("#193 classifySectionDiff", () => {
+  it("returns hooksStateOnly=false when payloads are identical", () => {
+    const raw = HOOKS_STATE_BLOCK_BEFORE + TFX_HUB_BLOCK;
+    const result = classifySectionDiff(raw, raw);
+    assert.equal(result.hooksStateOnly, false);
+    assert.deepEqual(result.changedSections, []);
+  });
+
+  it("flags hooks.state-only churn as whitelisted", () => {
+    const before = `${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_BEFORE}`;
+    const after = `${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_AFTER}`;
+    const result = classifySectionDiff(before, after);
+    assert.equal(result.hooksStateOnly, true);
+    assert.equal(result.changedSections.length, 2);
+    for (const header of result.changedSections) {
+      assert.match(header, /^hooks\.state\./);
+    }
+  });
+
+  it("rejects whitelist when tfx-hub also drifts", () => {
+    const before = `${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_BEFORE}`;
+    const after = `${TFX_HUB_BLOCK_DRIFTED}\n${HOOKS_STATE_BLOCK_AFTER}`;
+    const result = classifySectionDiff(before, after);
+    assert.equal(result.hooksStateOnly, false);
+    assert.ok(
+      result.changedSections.some((h) => h === "mcp_servers.tfx-hub"),
+      `expected mcp_servers.tfx-hub in ${JSON.stringify(result.changedSections)}`,
+    );
+  });
+
+  it("rejects whitelist when an unrelated section is added", () => {
+    const before = HOOKS_STATE_BLOCK_BEFORE;
+    const after = `${HOOKS_STATE_BLOCK_AFTER}\n${PROFILE_BLOCK}`;
+    const result = classifySectionDiff(before, after);
+    assert.equal(result.hooksStateOnly, false);
+    assert.ok(result.changedSections.includes("profiles.codex53_low"));
+  });
+});
+
+describe("#193 describeChange", () => {
+  it("returns null when before and after are identical", () => {
+    const raw = `${TFX_HUB_BLOCK}${HOOKS_STATE_BLOCK_BEFORE}`;
+    const before = snapshot(raw);
+    const after = snapshot(raw);
+    assert.equal(describeChange(before, after), null);
+  });
+
+  it("classifies hooks.state-only churn as sha-changed + hooksStateOnly=true", () => {
+    const before = snapshot(`${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_BEFORE}`);
+    const after = snapshot(`${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_AFTER}`);
+    const change = describeChange(before, after);
+    assert.ok(change !== null, "expected change");
+    assert.equal(change.kind, "sha-changed");
+    assert.equal(change.hooksStateOnly, true);
+    assert.ok(change.message.startsWith("sha256 differs"));
+  });
+
+  it("classifies tfx-hub mutation as sha-changed + hooksStateOnly=false", () => {
+    const before = snapshot(`${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_BEFORE}`);
+    const after = snapshot(
+      `${TFX_HUB_BLOCK_DRIFTED}\n${HOOKS_STATE_BLOCK_BEFORE}`,
+    );
+    const change = describeChange(before, after);
+    assert.ok(change !== null, "expected change");
+    assert.equal(change.kind, "sha-changed");
+    assert.equal(change.hooksStateOnly, false);
+  });
+
+  it("rejects whitelist when hooks.state churn is mixed with other section drift", () => {
+    const before = snapshot(`${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_BEFORE}`);
+    const after = snapshot(
+      `${TFX_HUB_BLOCK_DRIFTED}\n${HOOKS_STATE_BLOCK_AFTER}`,
+    );
+    const change = describeChange(before, after);
+    assert.ok(change !== null, "expected change");
+    assert.equal(change.kind, "sha-changed");
+    assert.equal(change.hooksStateOnly, false);
+    assert.ok(
+      change.changedSections.includes("mcp_servers.tfx-hub"),
+      `expected mcp_servers.tfx-hub in ${JSON.stringify(change.changedSections)}`,
+    );
+  });
+
+  it("flags mtime-only drift even when sha matches", () => {
+    const raw = `${TFX_HUB_BLOCK}${HOOKS_STATE_BLOCK_BEFORE}`;
+    const before = snapshot(raw);
+    const after = { ...snapshot(raw), mtimeMs: before.mtimeMs + 1000 };
+    const change = describeChange(before, after);
+    assert.ok(change !== null, "expected change");
+    assert.equal(change.kind, "mtime-only");
+  });
+});


### PR DESCRIPTION
oh-my-codex 가 codex CLI hook 발화 시마다 ~/.codex/config.toml 의
[hooks.state."<key>"] section 의 trusted_hash 를 자동 갱신한다. 사용자가
npm test 도중 다른 터미널에서 codex 활성 사용 중이면 이 외부 mutation 이
#193 가드의 false positive 로 잡혀 exit 2 fail.

- splitTomlSections: TOML payload 를 section 블록 단위로 split (header + body)
- classifySectionDiff: changed section 헤더 모두가 "hooks.state." prefix 면
  hooksStateOnly=true
- describeChange: sha 변경 시 hooksStateOnly 라벨 + changedSections 포함
- main 처리: hooksStateOnly + port drift 없음 → informational warning + exit 0.
  그 외는 기존대로 mutation 메시지 + exit 2 (tfx-hub url drift 등 triflux
  자체 mutation 은 여전히 감지)
- packages/triflux mirror byte-identical
- tests/unit/check-codex-config-stable.test.mjs 11 신규 (splitTomlSections 2 +
  classifySectionDiff 4 + describeChange 5). 11/11 pass + lint clean.
