### PR TITLE
fix(psmux-info): mac/Linux 환경에 OS-aware 설치 안내 추가

### DIFF
--- a/hub/team/tui-viewer.mjs
+++ b/hub/team/tui-viewer.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { formatPsmuxInstallGuidance } from "../../scripts/lib/psmux-info.mjs";
 import { openHeadlessDashboardTarget } from "./dashboard-open.mjs";
 import { processHandoff } from "./handoff.mjs";
 import { createLogDashboard } from "./tui.mjs";
@@ -35,7 +36,7 @@ try {
   execFileSync("psmux", ["--version"], { encoding: "utf8", timeout: 2000 });
 } catch {
   process.stderr.write(
-    "ERROR: psmux 미설치. 설치: winget install marlocarlo.psmux (또는 npm i -g psmux)\n",
+    `ERROR: psmux 미설치. 설치 방법:\n${formatPsmuxInstallGuidance("  ")}\n`,
   );
   process.exit(1);
 }

--- a/packages/core/scripts/lib/psmux-info.mjs
+++ b/packages/core/scripts/lib/psmux-info.mjs
@@ -10,6 +10,7 @@ export const PSMUX_REQUIRED_COMMANDS = [
 
 export const PSMUX_OPTIONAL_COMMANDS = ["detach-client"];
 
+// Windows 패키지 매니저 — winget/scoop/choco 는 Windows 전용
 export const PSMUX_INSTALL_COMMANDS = [
   "winget install marlocarlo.psmux",
   "scoop install psmux",
@@ -24,6 +25,51 @@ export const PSMUX_UPDATE_COMMANDS = [
   "cargo install psmux --force",
 ];
 
+// macOS 전용 — brew 가 표준, cargo 는 cross-platform fallback
+export const PSMUX_INSTALL_COMMANDS_DARWIN = [
+  "brew install psmux",
+  "cargo install psmux",
+];
+
+export const PSMUX_UPDATE_COMMANDS_DARWIN = [
+  "brew upgrade psmux",
+  "cargo install psmux --force",
+];
+
+// Linux 전용 — cargo 만 cross-platform 지원, distro 패키지는 미제공
+export const PSMUX_INSTALL_COMMANDS_LINUX = ["cargo install psmux"];
+
+export const PSMUX_UPDATE_COMMANDS_LINUX = ["cargo install psmux --force"];
+
+// PR #258 OS-primary 분기 정책: macOS/Linux 는 tmux 가 POSIX 표준 primary,
+// psmux 는 선택형. native teams fallback (tmux 또는 child process spawn) 으로 동작 가능.
+export const PSMUX_FALLBACK_NOTE_DARWIN =
+  "macOS 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export const PSMUX_FALLBACK_NOTE_LINUX =
+  "Linux 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export function getPsmuxInstallCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_INSTALL_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_INSTALL_COMMANDS_LINUX;
+  // win32 또는 기타 (BSD 등) → Windows 풀 리스트로 폴백 (변경 전 동작 유지)
+  return PSMUX_INSTALL_COMMANDS;
+}
+
+export function getPsmuxUpdateCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_UPDATE_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_UPDATE_COMMANDS_LINUX;
+  return PSMUX_UPDATE_COMMANDS;
+}
+
+export function getPsmuxFallbackNoteFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_FALLBACK_NOTE_DARWIN;
+  if (platform === "linux") return PSMUX_FALLBACK_NOTE_LINUX;
+  return null;
+}
+
 export function formatPsmuxCommandList(
   commands = PSMUX_INSTALL_COMMANDS,
   indent = "",
@@ -31,12 +77,21 @@ export function formatPsmuxCommandList(
   return commands.map((command) => `${indent}${command}`).join("\n");
 }
 
-export function formatPsmuxInstallGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_INSTALL_COMMANDS, indent);
+export function formatPsmuxInstallGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  const commands = getPsmuxInstallCommandsFor(platform);
+  const list = formatPsmuxCommandList(commands, indent);
+  const note = getPsmuxFallbackNoteFor(platform);
+  return note ? `${list}\n${indent}(${note})` : list;
 }
 
-export function formatPsmuxUpdateGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_UPDATE_COMMANDS, indent);
+export function formatPsmuxUpdateGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  return formatPsmuxCommandList(getPsmuxUpdateCommandsFor(platform), indent);
 }
 
 export function parsePsmuxVersion(output = "") {

--- a/packages/remote/scripts/lib/psmux-info.mjs
+++ b/packages/remote/scripts/lib/psmux-info.mjs
@@ -10,6 +10,7 @@ export const PSMUX_REQUIRED_COMMANDS = [
 
 export const PSMUX_OPTIONAL_COMMANDS = ["detach-client"];
 
+// Windows 패키지 매니저 — winget/scoop/choco 는 Windows 전용
 export const PSMUX_INSTALL_COMMANDS = [
   "winget install marlocarlo.psmux",
   "scoop install psmux",
@@ -24,6 +25,51 @@ export const PSMUX_UPDATE_COMMANDS = [
   "cargo install psmux --force",
 ];
 
+// macOS 전용 — brew 가 표준, cargo 는 cross-platform fallback
+export const PSMUX_INSTALL_COMMANDS_DARWIN = [
+  "brew install psmux",
+  "cargo install psmux",
+];
+
+export const PSMUX_UPDATE_COMMANDS_DARWIN = [
+  "brew upgrade psmux",
+  "cargo install psmux --force",
+];
+
+// Linux 전용 — cargo 만 cross-platform 지원, distro 패키지는 미제공
+export const PSMUX_INSTALL_COMMANDS_LINUX = ["cargo install psmux"];
+
+export const PSMUX_UPDATE_COMMANDS_LINUX = ["cargo install psmux --force"];
+
+// PR #258 OS-primary 분기 정책: macOS/Linux 는 tmux 가 POSIX 표준 primary,
+// psmux 는 선택형. native teams fallback (tmux 또는 child process spawn) 으로 동작 가능.
+export const PSMUX_FALLBACK_NOTE_DARWIN =
+  "macOS 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export const PSMUX_FALLBACK_NOTE_LINUX =
+  "Linux 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export function getPsmuxInstallCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_INSTALL_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_INSTALL_COMMANDS_LINUX;
+  // win32 또는 기타 (BSD 등) → Windows 풀 리스트로 폴백 (변경 전 동작 유지)
+  return PSMUX_INSTALL_COMMANDS;
+}
+
+export function getPsmuxUpdateCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_UPDATE_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_UPDATE_COMMANDS_LINUX;
+  return PSMUX_UPDATE_COMMANDS;
+}
+
+export function getPsmuxFallbackNoteFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_FALLBACK_NOTE_DARWIN;
+  if (platform === "linux") return PSMUX_FALLBACK_NOTE_LINUX;
+  return null;
+}
+
 export function formatPsmuxCommandList(
   commands = PSMUX_INSTALL_COMMANDS,
   indent = "",
@@ -31,12 +77,21 @@ export function formatPsmuxCommandList(
   return commands.map((command) => `${indent}${command}`).join("\n");
 }
 
-export function formatPsmuxInstallGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_INSTALL_COMMANDS, indent);
+export function formatPsmuxInstallGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  const commands = getPsmuxInstallCommandsFor(platform);
+  const list = formatPsmuxCommandList(commands, indent);
+  const note = getPsmuxFallbackNoteFor(platform);
+  return note ? `${list}\n${indent}(${note})` : list;
 }
 
-export function formatPsmuxUpdateGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_UPDATE_COMMANDS, indent);
+export function formatPsmuxUpdateGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  return formatPsmuxCommandList(getPsmuxUpdateCommandsFor(platform), indent);
 }
 
 export function parsePsmuxVersion(output = "") {

--- a/packages/triflux/hub/team/tui-viewer.mjs
+++ b/packages/triflux/hub/team/tui-viewer.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { formatPsmuxInstallGuidance } from "../../scripts/lib/psmux-info.mjs";
 import { openHeadlessDashboardTarget } from "./dashboard-open.mjs";
 import { processHandoff } from "./handoff.mjs";
 import { createLogDashboard } from "./tui.mjs";
@@ -35,7 +36,7 @@ try {
   execFileSync("psmux", ["--version"], { encoding: "utf8", timeout: 2000 });
 } catch {
   process.stderr.write(
-    "ERROR: psmux 미설치. 설치: winget install marlocarlo.psmux (또는 npm i -g psmux)\n",
+    `ERROR: psmux 미설치. 설치 방법:\n${formatPsmuxInstallGuidance("  ")}\n`,
   );
   process.exit(1);
 }

--- a/packages/triflux/scripts/lib/psmux-info.mjs
+++ b/packages/triflux/scripts/lib/psmux-info.mjs
@@ -10,6 +10,7 @@ export const PSMUX_REQUIRED_COMMANDS = [
 
 export const PSMUX_OPTIONAL_COMMANDS = ["detach-client"];
 
+// Windows 패키지 매니저 — winget/scoop/choco 는 Windows 전용
 export const PSMUX_INSTALL_COMMANDS = [
   "winget install marlocarlo.psmux",
   "scoop install psmux",
@@ -24,6 +25,51 @@ export const PSMUX_UPDATE_COMMANDS = [
   "cargo install psmux --force",
 ];
 
+// macOS 전용 — brew 가 표준, cargo 는 cross-platform fallback
+export const PSMUX_INSTALL_COMMANDS_DARWIN = [
+  "brew install psmux",
+  "cargo install psmux",
+];
+
+export const PSMUX_UPDATE_COMMANDS_DARWIN = [
+  "brew upgrade psmux",
+  "cargo install psmux --force",
+];
+
+// Linux 전용 — cargo 만 cross-platform 지원, distro 패키지는 미제공
+export const PSMUX_INSTALL_COMMANDS_LINUX = ["cargo install psmux"];
+
+export const PSMUX_UPDATE_COMMANDS_LINUX = ["cargo install psmux --force"];
+
+// PR #258 OS-primary 분기 정책: macOS/Linux 는 tmux 가 POSIX 표준 primary,
+// psmux 는 선택형. native teams fallback (tmux 또는 child process spawn) 으로 동작 가능.
+export const PSMUX_FALLBACK_NOTE_DARWIN =
+  "macOS 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export const PSMUX_FALLBACK_NOTE_LINUX =
+  "Linux 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export function getPsmuxInstallCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_INSTALL_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_INSTALL_COMMANDS_LINUX;
+  // win32 또는 기타 (BSD 등) → Windows 풀 리스트로 폴백 (변경 전 동작 유지)
+  return PSMUX_INSTALL_COMMANDS;
+}
+
+export function getPsmuxUpdateCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_UPDATE_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_UPDATE_COMMANDS_LINUX;
+  return PSMUX_UPDATE_COMMANDS;
+}
+
+export function getPsmuxFallbackNoteFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_FALLBACK_NOTE_DARWIN;
+  if (platform === "linux") return PSMUX_FALLBACK_NOTE_LINUX;
+  return null;
+}
+
 export function formatPsmuxCommandList(
   commands = PSMUX_INSTALL_COMMANDS,
   indent = "",
@@ -31,12 +77,21 @@ export function formatPsmuxCommandList(
   return commands.map((command) => `${indent}${command}`).join("\n");
 }
 
-export function formatPsmuxInstallGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_INSTALL_COMMANDS, indent);
+export function formatPsmuxInstallGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  const commands = getPsmuxInstallCommandsFor(platform);
+  const list = formatPsmuxCommandList(commands, indent);
+  const note = getPsmuxFallbackNoteFor(platform);
+  return note ? `${list}\n${indent}(${note})` : list;
 }
 
-export function formatPsmuxUpdateGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_UPDATE_COMMANDS, indent);
+export function formatPsmuxUpdateGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  return formatPsmuxCommandList(getPsmuxUpdateCommandsFor(platform), indent);
 }
 
 export function parsePsmuxVersion(output = "") {

--- a/packages/triflux/scripts/session-spawn-helper.mjs
+++ b/packages/triflux/scripts/session-spawn-helper.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createWtManager } from "../hub/team/wt-manager.mjs";
+import { formatPsmuxInstallGuidance } from "./lib/psmux-info.mjs";
 
 const SESSION_PREFIX = "tfx-isolated";
 const DEFAULT_ATTACH_PROFILE = "triflux";
@@ -224,7 +225,7 @@ async function main() {
 
   if (!hasPsmux()) {
     process.stderr.write(
-      "ERROR: psmux 미설치. 설치: winget install marlocarlo.psmux (또는 npm i -g psmux)\n",
+      `ERROR: psmux 미설치. 설치 방법:\n${formatPsmuxInstallGuidance("  ")}\n`,
     );
     process.exit(1);
   }

--- a/scripts/lib/psmux-info.mjs
+++ b/scripts/lib/psmux-info.mjs
@@ -10,6 +10,7 @@ export const PSMUX_REQUIRED_COMMANDS = [
 
 export const PSMUX_OPTIONAL_COMMANDS = ["detach-client"];
 
+// Windows 패키지 매니저 — winget/scoop/choco 는 Windows 전용
 export const PSMUX_INSTALL_COMMANDS = [
   "winget install marlocarlo.psmux",
   "scoop install psmux",
@@ -24,6 +25,51 @@ export const PSMUX_UPDATE_COMMANDS = [
   "cargo install psmux --force",
 ];
 
+// macOS 전용 — brew 가 표준, cargo 는 cross-platform fallback
+export const PSMUX_INSTALL_COMMANDS_DARWIN = [
+  "brew install psmux",
+  "cargo install psmux",
+];
+
+export const PSMUX_UPDATE_COMMANDS_DARWIN = [
+  "brew upgrade psmux",
+  "cargo install psmux --force",
+];
+
+// Linux 전용 — cargo 만 cross-platform 지원, distro 패키지는 미제공
+export const PSMUX_INSTALL_COMMANDS_LINUX = ["cargo install psmux"];
+
+export const PSMUX_UPDATE_COMMANDS_LINUX = ["cargo install psmux --force"];
+
+// PR #258 OS-primary 분기 정책: macOS/Linux 는 tmux 가 POSIX 표준 primary,
+// psmux 는 선택형. native teams fallback (tmux 또는 child process spawn) 으로 동작 가능.
+export const PSMUX_FALLBACK_NOTE_DARWIN =
+  "macOS 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export const PSMUX_FALLBACK_NOTE_LINUX =
+  "Linux 에서는 tmux 가 표준 멀티플렉서이며, " +
+  "triflux 는 psmux 없이도 native teams fallback 으로 멀티모델 병렬 실행을 지원합니다.";
+
+export function getPsmuxInstallCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_INSTALL_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_INSTALL_COMMANDS_LINUX;
+  // win32 또는 기타 (BSD 등) → Windows 풀 리스트로 폴백 (변경 전 동작 유지)
+  return PSMUX_INSTALL_COMMANDS;
+}
+
+export function getPsmuxUpdateCommandsFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_UPDATE_COMMANDS_DARWIN;
+  if (platform === "linux") return PSMUX_UPDATE_COMMANDS_LINUX;
+  return PSMUX_UPDATE_COMMANDS;
+}
+
+export function getPsmuxFallbackNoteFor(platform = process.platform) {
+  if (platform === "darwin") return PSMUX_FALLBACK_NOTE_DARWIN;
+  if (platform === "linux") return PSMUX_FALLBACK_NOTE_LINUX;
+  return null;
+}
+
 export function formatPsmuxCommandList(
   commands = PSMUX_INSTALL_COMMANDS,
   indent = "",
@@ -31,12 +77,21 @@ export function formatPsmuxCommandList(
   return commands.map((command) => `${indent}${command}`).join("\n");
 }
 
-export function formatPsmuxInstallGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_INSTALL_COMMANDS, indent);
+export function formatPsmuxInstallGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  const commands = getPsmuxInstallCommandsFor(platform);
+  const list = formatPsmuxCommandList(commands, indent);
+  const note = getPsmuxFallbackNoteFor(platform);
+  return note ? `${list}\n${indent}(${note})` : list;
 }
 
-export function formatPsmuxUpdateGuidance(indent = "") {
-  return formatPsmuxCommandList(PSMUX_UPDATE_COMMANDS, indent);
+export function formatPsmuxUpdateGuidance(
+  indent = "",
+  platform = process.platform,
+) {
+  return formatPsmuxCommandList(getPsmuxUpdateCommandsFor(platform), indent);
 }
 
 export function parsePsmuxVersion(output = "") {

--- a/scripts/session-spawn-helper.mjs
+++ b/scripts/session-spawn-helper.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createWtManager } from "../hub/team/wt-manager.mjs";
+import { formatPsmuxInstallGuidance } from "./lib/psmux-info.mjs";
 
 const SESSION_PREFIX = "tfx-isolated";
 const DEFAULT_ATTACH_PROFILE = "triflux";
@@ -224,7 +225,7 @@ async function main() {
 
   if (!hasPsmux()) {
     process.stderr.write(
-      "ERROR: psmux 미설치. 설치: winget install marlocarlo.psmux (또는 npm i -g psmux)\n",
+      `ERROR: psmux 미설치. 설치 방법:\n${formatPsmuxInstallGuidance("  ")}\n`,
     );
     process.exit(1);
   }

--- a/tests/unit/psmux-info.test.mjs
+++ b/tests/unit/psmux-info.test.mjs
@@ -22,13 +22,37 @@ describe("psmux-info", () => {
     assert.equal(compareSemver("3.2.9", "3.3.1"), -1);
   });
 
-  it("guidance formatters include official install/update commands", () => {
-    const installText = formatPsmuxInstallGuidance();
-    const updateText = formatPsmuxUpdateGuidance();
+  it("guidance formatters include official install/update commands (win32)", () => {
+    const installText = formatPsmuxInstallGuidance("", "win32");
+    const updateText = formatPsmuxUpdateGuidance("", "win32");
     assert.match(installText, /winget install marlocarlo\.psmux/);
     assert.match(installText, /scoop install psmux/);
     assert.match(updateText, /winget upgrade marlocarlo\.psmux/);
     assert.match(updateText, /cargo install psmux --force/);
+  });
+
+  it("guidance formatters suggest brew + cargo + tmux fallback on darwin", () => {
+    const installText = formatPsmuxInstallGuidance("", "darwin");
+    const updateText = formatPsmuxUpdateGuidance("", "darwin");
+    // Windows-only 패키지매니저는 mac 안내에서 빠진다.
+    assert.doesNotMatch(installText, /winget|scoop|choco/);
+    assert.match(installText, /brew install psmux/);
+    assert.match(installText, /cargo install psmux/);
+    // tmux native fallback 안내가 mac 가이드에 포함된다.
+    assert.match(installText, /tmux|native teams fallback/);
+    assert.match(updateText, /brew upgrade psmux/);
+    assert.match(updateText, /cargo install psmux --force/);
+    assert.doesNotMatch(updateText, /winget|choco/);
+  });
+
+  it("guidance formatters use cargo + tmux fallback on linux", () => {
+    const installText = formatPsmuxInstallGuidance("", "linux");
+    const updateText = formatPsmuxUpdateGuidance("", "linux");
+    assert.doesNotMatch(installText, /winget|scoop|choco|brew/);
+    assert.match(installText, /cargo install psmux/);
+    assert.match(installText, /tmux|native teams fallback/);
+    assert.match(updateText, /cargo install psmux --force/);
+    assert.doesNotMatch(updateText, /winget|brew/);
   });
 
   it("probePsmuxSupport detects required commands from help output", () => {


### PR DESCRIPTION
기존 psmux 미설치 메시지는 winget/scoop/choco/cargo 만 안내해 macOS/Linux
사용자에게는 cargo 외 모두 무의미. PR #258 OS-primary 분기 정책 (mac/Linux =
tmux primary, psmux 선택형) 과 정합하게 OS 별 안내로 분기.

- PSMUX_INSTALL_COMMANDS_DARWIN: brew install + cargo
- PSMUX_INSTALL_COMMANDS_LINUX: cargo only (distro 패키지 미제공 명시)
- PSMUX_UPDATE_COMMANDS_DARWIN/LINUX: 동일 패턴
- PSMUX_FALLBACK_NOTE_DARWIN/LINUX: tmux + native teams fallback 안내
- getPsmuxInstallCommandsFor / getPsmuxUpdateCommandsFor /
  getPsmuxFallbackNoteFor helper (platform 인자, default process.platform)
- formatPsmuxInstallGuidance / formatPsmuxUpdateGuidance 에 platform 인자 추가
- caller (tui-viewer.mjs, session-spawn-helper.mjs) 가 platform-aware
  메시지 호출하도록 변경
- 4-mirror byte-identical (root + core + remote + triflux)
- tests/unit/psmux-info.test.mjs 회귀 가드 강화 — 기존 winget 테스트는
  platform: "win32" 명시 (Windows 동작 보존 가드) + darwin/linux 신규 가드 2개
- 6/6 pass + lint clean
