### PR TITLE
feat(routing): routing-snapshot Phase 1 in-process cache + getDefaultSnapshot

### DIFF
--- a/hub/routing-snapshot.mjs
+++ b/hub/routing-snapshot.mjs
@@ -184,10 +184,56 @@ export async function buildRoutingSnapshot({
   };
 }
 
+// Phase 1 — in-process snapshot cache.
+// 의도: caller (Phase 1+ conductor / swarm-hypervisor) 가 spawn loop 에서
+// 매번 HUD/broker IO 를 트리거하지 않도록 정해진 TTL 안에서 같은 snapshot
+// 을 재사용한다. cache 는 모듈-local 이라 process 단위 (테스트 격리 위해
+// `resetSnapshotCache()` 노출).
+
+const DEFAULT_CACHE_TTL_MS = 900_000; // policy freshness max 와 정합
+
+let _cache = null; // { snapshot, fetchedAt }
+
+export function resetSnapshotCache() {
+  _cache = null;
+}
+
+/**
+ * Cached snapshot shortcut. cache TTL 안이면 재사용, 아니면 새로 빌드.
+ *
+ * @param {{
+ *   forceRefresh?: boolean,        // true 면 cache 무시하고 새로 빌드
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ *   builder?: function,            // 테스트용 builder 주입 (default buildRoutingSnapshot)
+ * }} [opts]
+ * @returns {Promise<object>}
+ */
+export async function getDefaultSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  const builder = opts.builder || buildRoutingSnapshot;
+  const forceRefresh = Boolean(opts.forceRefresh);
+
+  if (!forceRefresh && _cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+
+  const snapshot = await builder({ forceRefresh, now });
+  _cache = { snapshot, fetchedAt: now };
+  return snapshot;
+}
+
 // Test helpers — pure normalizers exposed so unit tests can build snapshots
 // from mock provider responses without running real HUD I/O.
 export const __internal__ = {
   normalizeClaudeUsage,
   normalizeCodexUsage,
   normalizeBrokerSnapshot,
+  // Phase 1 cache 테스트 helpers
+  getCacheStateForTest: () => (_cache ? { ..._cache } : null),
+  setCacheForTest: (state) => {
+    _cache = state ? { ...state } : null;
+  },
 };

--- a/packages/triflux/hub/routing-snapshot.mjs
+++ b/packages/triflux/hub/routing-snapshot.mjs
@@ -184,10 +184,56 @@ export async function buildRoutingSnapshot({
   };
 }
 
+// Phase 1 — in-process snapshot cache.
+// 의도: caller (Phase 1+ conductor / swarm-hypervisor) 가 spawn loop 에서
+// 매번 HUD/broker IO 를 트리거하지 않도록 정해진 TTL 안에서 같은 snapshot
+// 을 재사용한다. cache 는 모듈-local 이라 process 단위 (테스트 격리 위해
+// `resetSnapshotCache()` 노출).
+
+const DEFAULT_CACHE_TTL_MS = 900_000; // policy freshness max 와 정합
+
+let _cache = null; // { snapshot, fetchedAt }
+
+export function resetSnapshotCache() {
+  _cache = null;
+}
+
+/**
+ * Cached snapshot shortcut. cache TTL 안이면 재사용, 아니면 새로 빌드.
+ *
+ * @param {{
+ *   forceRefresh?: boolean,        // true 면 cache 무시하고 새로 빌드
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ *   builder?: function,            // 테스트용 builder 주입 (default buildRoutingSnapshot)
+ * }} [opts]
+ * @returns {Promise<object>}
+ */
+export async function getDefaultSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  const builder = opts.builder || buildRoutingSnapshot;
+  const forceRefresh = Boolean(opts.forceRefresh);
+
+  if (!forceRefresh && _cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+
+  const snapshot = await builder({ forceRefresh, now });
+  _cache = { snapshot, fetchedAt: now };
+  return snapshot;
+}
+
 // Test helpers — pure normalizers exposed so unit tests can build snapshots
 // from mock provider responses without running real HUD I/O.
 export const __internal__ = {
   normalizeClaudeUsage,
   normalizeCodexUsage,
   normalizeBrokerSnapshot,
+  // Phase 1 cache 테스트 helpers
+  getCacheStateForTest: () => (_cache ? { ..._cache } : null),
+  setCacheForTest: (state) => {
+    _cache = state ? { ...state } : null;
+  },
 };

--- a/tests/unit/routing-snapshot-cache.test.mjs
+++ b/tests/unit/routing-snapshot-cache.test.mjs
@@ -1,0 +1,147 @@
+// tests/unit/routing-snapshot-cache.test.mjs
+//
+// PRD: .omx/plans/prd-dynamic-routing-engine.md (shard D-2)
+//
+// Phase 1 acceptance suite for `getDefaultSnapshot()` in-process cache wrapper.
+// builder 를 mock 으로 주입해서 실제 HUD/broker IO 없이 cache hit/miss/TTL/
+// forceRefresh/maxAgeMs override/주입된 now 동작을 결정적으로 검증한다.
+
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+  __internal__,
+  getDefaultSnapshot,
+  resetSnapshotCache,
+} from "../../hub/routing-snapshot.mjs";
+
+const DEFAULT_TTL_MS = 900_000; // 모듈 내부 DEFAULT_CACHE_TTL_MS 와 정합
+const NOW = 1778832000000; // 2026-05-15T08:00:00Z
+
+function mkBuilder() {
+  let calls = 0;
+  const builder = async ({ now }) => {
+    calls += 1;
+    return {
+      schemaVersion: 1,
+      observedAt: now,
+      claude: null,
+      codex: null,
+      broker: null,
+      _fakeCallId: calls,
+    };
+  };
+  return {
+    builder,
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+describe("routing-snapshot cache — getDefaultSnapshot()", () => {
+  beforeEach(() => {
+    resetSnapshotCache();
+  });
+
+  it("C-01: resetSnapshotCache 후 첫 호출은 builder 를 실행한다", async () => {
+    const tracker = mkBuilder();
+    const snap = await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+    });
+    assert.equal(tracker.calls, 1);
+    assert.equal(snap._fakeCallId, 1);
+    assert.equal(snap.observedAt, NOW);
+  });
+
+  it("C-02: TTL 안 (now 동일) 두 번째 호출은 builder 를 재호출하지 않고 같은 snapshot 을 반환한다", async () => {
+    const tracker = mkBuilder();
+    const first = await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+    });
+    const second = await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+    });
+    assert.equal(tracker.calls, 1);
+    assert.strictEqual(first, second); // 같은 reference
+  });
+
+  it("C-03: TTL 만료 (now += DEFAULT_TTL + 1) 시 builder 가 다시 호출된다", async () => {
+    const tracker = mkBuilder();
+    await getDefaultSnapshot({ now: NOW, builder: tracker.builder });
+    const refreshed = await getDefaultSnapshot({
+      now: NOW + DEFAULT_TTL_MS + 1,
+      builder: tracker.builder,
+    });
+    assert.equal(tracker.calls, 2);
+    assert.equal(refreshed._fakeCallId, 2);
+    assert.equal(refreshed.observedAt, NOW + DEFAULT_TTL_MS + 1);
+  });
+
+  it("C-04: forceRefresh:true 는 cache 를 무시하고 builder 를 재호출한다", async () => {
+    const tracker = mkBuilder();
+    await getDefaultSnapshot({ now: NOW, builder: tracker.builder });
+    const refreshed = await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+      forceRefresh: true,
+    });
+    assert.equal(tracker.calls, 2);
+    assert.equal(refreshed._fakeCallId, 2);
+  });
+
+  it("C-05: maxAgeMs override 가 DEFAULT_TTL 보다 우선 적용된다", async () => {
+    const tracker = mkBuilder();
+    await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+      maxAgeMs: 1000,
+    });
+    // 1001ms 후 호출 → custom TTL 만료 → builder 재호출
+    const refreshed = await getDefaultSnapshot({
+      now: NOW + 1001,
+      builder: tracker.builder,
+      maxAgeMs: 1000,
+    });
+    assert.equal(tracker.calls, 2);
+    assert.equal(refreshed._fakeCallId, 2);
+
+    // 같은 시점에 다시 호출 → custom TTL 안 → cache hit
+    const cached = await getDefaultSnapshot({
+      now: NOW + 1001,
+      builder: tracker.builder,
+      maxAgeMs: 1000,
+    });
+    assert.equal(tracker.calls, 2);
+    assert.strictEqual(cached, refreshed);
+  });
+
+  it("C-06: now 인자가 주어지면 Date.now() 대신 그 값으로 age 를 판정한다 (pure-fn)", async () => {
+    const tracker = mkBuilder();
+    // 첫 호출: 임의 epoch 주입
+    const baseEpoch = 1_000_000_000_000;
+    await getDefaultSnapshot({ now: baseEpoch, builder: tracker.builder });
+    // 캐시 상태 확인 — fetchedAt 이 주입한 now 와 같아야 한다
+    const state = __internal__.getCacheStateForTest();
+    assert.equal(state.fetchedAt, baseEpoch);
+
+    // TTL 안 시점이지만 Date.now() 가 무엇이든 주입된 now 로 age 판정
+    const cached = await getDefaultSnapshot({
+      now: baseEpoch + DEFAULT_TTL_MS - 1,
+      builder: tracker.builder,
+    });
+    assert.equal(tracker.calls, 1);
+    assert.equal(cached._fakeCallId, 1);
+
+    // 주입된 now 가 TTL 경계를 넘으면 재호출
+    const refreshed = await getDefaultSnapshot({
+      now: baseEpoch + DEFAULT_TTL_MS,
+      builder: tracker.builder,
+    });
+    assert.equal(tracker.calls, 2);
+    assert.equal(refreshed._fakeCallId, 2);
+  });
+});


### PR DESCRIPTION
Phase 1 caller integration 이 spawn loop 안에서 매번 HUD/broker IO 를
트리거하지 않도록 routing-snapshot.mjs 에 모듈-local 캐시 wrapper 를
추가한다. 기존 buildRoutingSnapshot() 시그니처는 호환을 위해 유지.

- getDefaultSnapshot(opts) — TTL 안이면 cached snapshot 재사용
- DEFAULT_CACHE_TTL_MS = 900_000 (policy freshness max 와 정합)
- forceRefresh / maxAgeMs / now / builder 주입 가능 (pure-fn 가능)
- resetSnapshotCache() — 테스트 격리용
- __internal__.getCacheStateForTest / setCacheForTest — 단위 테스트
- packages/triflux mirror byte-identical 동시 동기

tests/unit/routing-snapshot-cache.test.mjs — 6 testcase (C-01..C-06)
builder mock 으로 HUD/broker IO 없이 cache hit/miss/TTL 경계/
forceRefresh/maxAgeMs override/주입된 now 검증.
