### PR TITLE
feat(routing): conductor.spawnSession sync dynamic routing wire-up (Phase 1)

### DIFF
--- a/hub/routing-snapshot.mjs
+++ b/hub/routing-snapshot.mjs
@@ -225,6 +225,28 @@ export async function getDefaultSnapshot(opts = {}) {
   return snapshot;
 }
 
+/**
+ * Synchronous cache shortcut. cache TTL 안에 fresh snapshot이 있으면 즉시 반환,
+ * 아니면 null. caller (sync hot path — e.g. conductor.spawnSession) 가 broker.lease
+ * atomic 인변량을 깨지 않고 dynamic routing decision 을 sync 로 평가할 수 있도록 한다.
+ * builder 호출(IO)은 하지 않는다 — cache miss 면 caller 가 fallback decision 사용.
+ *
+ * @param {{
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ * }} [opts]
+ * @returns {object|null} cache fresh이면 snapshot, 아니면 null
+ */
+export function tryGetCachedSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  if (_cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+  return null;
+}
+
 // Test helpers — pure normalizers exposed so unit tests can build snapshots
 // from mock provider responses without running real HUD I/O.
 export const __internal__ = {

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -21,12 +21,18 @@ import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
 import {
+  __internal__ as dynamicRoutingInternal,
+  evaluateDynamicRoute,
+  isDynamicRoutingEnabled,
+} from "../dynamic-routing-engine.mjs";
+import {
   findProcessTree,
   killProcessTree,
   killProcessTreeSnapshot,
 } from "../lib/process-utils.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
+import { tryGetCachedSnapshot } from "../routing-snapshot.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
@@ -1034,6 +1040,49 @@ export function createConductor(opts = {}) {
       throw new Error(`Session "${config.id}" already exists`);
     if (config.remote && !config.host)
       throw new Error("host is required for remote sessions");
+
+    // Phase 1 dynamic routing wire-up (opt-in env TRIFLUX_DYNAMIC_ROUTING).
+    // sync 로만 평가해서 broker.lease atomic 인변량 (commit 761fb7a8 — leased
+    // account = executing account) 을 깨지 않는다. snapshot 은 D-2 cache 의
+    // sync getter 만 사용 — cache miss 면 evaluateDynamicRoute 가 fail-closed
+    // 로 codex-default 를 반환한다.
+    if (
+      isDynamicRoutingEnabled(process.env) &&
+      !config.remote &&
+      config.agent
+    ) {
+      try {
+        const policy = dynamicRoutingInternal.loadPolicy();
+        const snapshot = tryGetCachedSnapshot();
+        const decision = evaluateDynamicRoute(
+          {
+            task_id: config.id,
+            team_size: 1,
+            agent_hint: config.agent,
+          },
+          snapshot || {},
+          policy,
+          { now: Date.now() },
+        );
+        const shard = decision?.shards?.[0];
+        if (shard?.cli && shard.cli !== config.agent) {
+          eventLog.append("dynamic_route_override", {
+            session: config.id,
+            original: config.agent,
+            override: shard.cli,
+            scenario: decision.scenario ?? "unknown",
+            decisionId: decision.decisionId ?? null,
+            snapshotAgeMs: decision.snapshotAgeMs ?? null,
+          });
+          config = { ...config, agent: shard.cli };
+        }
+      } catch (err) {
+        eventLog.append("dynamic_route_error", {
+          session: config.id,
+          error: err?.message || String(err),
+        });
+      }
+    }
 
     // broker lease (graceful — broker null if accounts.json absent)
     let lease = null;

--- a/packages/core/hub/routing-snapshot.mjs
+++ b/packages/core/hub/routing-snapshot.mjs
@@ -184,10 +184,78 @@ export async function buildRoutingSnapshot({
   };
 }
 
+// Phase 1 — in-process snapshot cache.
+// 의도: caller (Phase 1+ conductor / swarm-hypervisor) 가 spawn loop 에서
+// 매번 HUD/broker IO 를 트리거하지 않도록 정해진 TTL 안에서 같은 snapshot
+// 을 재사용한다. cache 는 모듈-local 이라 process 단위 (테스트 격리 위해
+// `resetSnapshotCache()` 노출).
+
+const DEFAULT_CACHE_TTL_MS = 900_000; // policy freshness max 와 정합
+
+let _cache = null; // { snapshot, fetchedAt }
+
+export function resetSnapshotCache() {
+  _cache = null;
+}
+
+/**
+ * Cached snapshot shortcut. cache TTL 안이면 재사용, 아니면 새로 빌드.
+ *
+ * @param {{
+ *   forceRefresh?: boolean,        // true 면 cache 무시하고 새로 빌드
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ *   builder?: function,            // 테스트용 builder 주입 (default buildRoutingSnapshot)
+ * }} [opts]
+ * @returns {Promise<object>}
+ */
+export async function getDefaultSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  const builder = opts.builder || buildRoutingSnapshot;
+  const forceRefresh = Boolean(opts.forceRefresh);
+
+  if (!forceRefresh && _cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+
+  const snapshot = await builder({ forceRefresh, now });
+  _cache = { snapshot, fetchedAt: now };
+  return snapshot;
+}
+
+/**
+ * Synchronous cache shortcut. cache TTL 안에 fresh snapshot이 있으면 즉시 반환,
+ * 아니면 null. caller (sync hot path — e.g. conductor.spawnSession) 가 broker.lease
+ * atomic 인변량을 깨지 않고 dynamic routing decision 을 sync 로 평가할 수 있도록 한다.
+ * builder 호출(IO)은 하지 않는다 — cache miss 면 caller 가 fallback decision 사용.
+ *
+ * @param {{
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ * }} [opts]
+ * @returns {object|null} cache fresh이면 snapshot, 아니면 null
+ */
+export function tryGetCachedSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  if (_cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+  return null;
+}
+
 // Test helpers — pure normalizers exposed so unit tests can build snapshots
 // from mock provider responses without running real HUD I/O.
 export const __internal__ = {
   normalizeClaudeUsage,
   normalizeCodexUsage,
   normalizeBrokerSnapshot,
+  // Phase 1 cache 테스트 helpers
+  getCacheStateForTest: () => (_cache ? { ..._cache } : null),
+  setCacheForTest: (state) => {
+    _cache = state ? { ...state } : null;
+  },
 };

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -21,12 +21,18 @@ import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "@triflux/core/hub/account-broker.mjs";
 import {
+  __internal__ as dynamicRoutingInternal,
+  evaluateDynamicRoute,
+  isDynamicRoutingEnabled,
+} from "@triflux/core/hub/dynamic-routing-engine.mjs";
+import {
   findProcessTree,
   killProcessTree,
   killProcessTreeSnapshot,
 } from "@triflux/core/hub/lib/process-utils.mjs";
 import { execFile, spawn } from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { killProcess } from "@triflux/core/hub/platform.mjs";
+import { tryGetCachedSnapshot } from "@triflux/core/hub/routing-snapshot.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
@@ -1013,6 +1019,45 @@ export function createConductor(opts = {}) {
       throw new Error(`Session "${config.id}" already exists`);
     if (config.remote && !config.host)
       throw new Error("host is required for remote sessions");
+
+    // Phase 1 dynamic routing wire-up (opt-in env TRIFLUX_DYNAMIC_ROUTING).
+    // sync 로만 평가해서 broker.lease atomic 인변량 (commit 761fb7a8 — leased
+    // account = executing account) 을 깨지 않는다. snapshot 은 D-2 cache 의
+    // sync getter 만 사용 — cache miss 면 evaluateDynamicRoute 가 fail-closed
+    // 로 codex-default 를 반환한다.
+    if (isDynamicRoutingEnabled(process.env) && !config.remote && config.agent) {
+      try {
+        const policy = dynamicRoutingInternal.loadPolicy();
+        const snapshot = tryGetCachedSnapshot();
+        const decision = evaluateDynamicRoute(
+          {
+            task_id: config.id,
+            team_size: 1,
+            agent_hint: config.agent,
+          },
+          snapshot || {},
+          policy,
+          { now: Date.now() },
+        );
+        const shard = decision?.shards?.[0];
+        if (shard?.cli && shard.cli !== config.agent) {
+          eventLog.append("dynamic_route_override", {
+            session: config.id,
+            original: config.agent,
+            override: shard.cli,
+            scenario: decision.scenario ?? "unknown",
+            decisionId: decision.decisionId ?? null,
+            snapshotAgeMs: decision.snapshotAgeMs ?? null,
+          });
+          config = { ...config, agent: shard.cli };
+        }
+      } catch (err) {
+        eventLog.append("dynamic_route_error", {
+          session: config.id,
+          error: err?.message || String(err),
+        });
+      }
+    }
 
     // broker lease (graceful — broker null if accounts.json absent)
     let lease = null;

--- a/packages/triflux/hub/routing-snapshot.mjs
+++ b/packages/triflux/hub/routing-snapshot.mjs
@@ -225,6 +225,28 @@ export async function getDefaultSnapshot(opts = {}) {
   return snapshot;
 }
 
+/**
+ * Synchronous cache shortcut. cache TTL 안에 fresh snapshot이 있으면 즉시 반환,
+ * 아니면 null. caller (sync hot path — e.g. conductor.spawnSession) 가 broker.lease
+ * atomic 인변량을 깨지 않고 dynamic routing decision 을 sync 로 평가할 수 있도록 한다.
+ * builder 호출(IO)은 하지 않는다 — cache miss 면 caller 가 fallback decision 사용.
+ *
+ * @param {{
+ *   maxAgeMs?: number,             // override cache TTL (default 900_000)
+ *   now?: number,                  // pure-fn: caller 가 epoch 주입 (default Date.now())
+ * }} [opts]
+ * @returns {object|null} cache fresh이면 snapshot, 아니면 null
+ */
+export function tryGetCachedSnapshot(opts = {}) {
+  const now = typeof opts.now === "number" ? opts.now : Date.now();
+  const maxAgeMs =
+    typeof opts.maxAgeMs === "number" ? opts.maxAgeMs : DEFAULT_CACHE_TTL_MS;
+  if (_cache && now - _cache.fetchedAt < maxAgeMs) {
+    return _cache.snapshot;
+  }
+  return null;
+}
+
 // Test helpers — pure normalizers exposed so unit tests can build snapshots
 // from mock provider responses without running real HUD I/O.
 export const __internal__ = {

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -21,12 +21,18 @@ import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
 import {
+  __internal__ as dynamicRoutingInternal,
+  evaluateDynamicRoute,
+  isDynamicRoutingEnabled,
+} from "../dynamic-routing-engine.mjs";
+import {
   findProcessTree,
   killProcessTree,
   killProcessTreeSnapshot,
 } from "../lib/process-utils.mjs";
 import { execFile, spawn } from "../lib/spawn-trace.mjs";
 import { killProcess } from "../platform.mjs";
+import { tryGetCachedSnapshot } from "../routing-snapshot.mjs";
 import { createHubHealthChecker } from "./check-mcp-hub.mjs";
 import { createConductorMeshBridge } from "./conductor-mesh-bridge.mjs";
 import {
@@ -1034,6 +1040,49 @@ export function createConductor(opts = {}) {
       throw new Error(`Session "${config.id}" already exists`);
     if (config.remote && !config.host)
       throw new Error("host is required for remote sessions");
+
+    // Phase 1 dynamic routing wire-up (opt-in env TRIFLUX_DYNAMIC_ROUTING).
+    // sync 로만 평가해서 broker.lease atomic 인변량 (commit 761fb7a8 — leased
+    // account = executing account) 을 깨지 않는다. snapshot 은 D-2 cache 의
+    // sync getter 만 사용 — cache miss 면 evaluateDynamicRoute 가 fail-closed
+    // 로 codex-default 를 반환한다.
+    if (
+      isDynamicRoutingEnabled(process.env) &&
+      !config.remote &&
+      config.agent
+    ) {
+      try {
+        const policy = dynamicRoutingInternal.loadPolicy();
+        const snapshot = tryGetCachedSnapshot();
+        const decision = evaluateDynamicRoute(
+          {
+            task_id: config.id,
+            team_size: 1,
+            agent_hint: config.agent,
+          },
+          snapshot || {},
+          policy,
+          { now: Date.now() },
+        );
+        const shard = decision?.shards?.[0];
+        if (shard?.cli && shard.cli !== config.agent) {
+          eventLog.append("dynamic_route_override", {
+            session: config.id,
+            original: config.agent,
+            override: shard.cli,
+            scenario: decision.scenario ?? "unknown",
+            decisionId: decision.decisionId ?? null,
+            snapshotAgeMs: decision.snapshotAgeMs ?? null,
+          });
+          config = { ...config, agent: shard.cli };
+        }
+      } catch (err) {
+        eventLog.append("dynamic_route_error", {
+          session: config.id,
+          error: err?.message || String(err),
+        });
+      }
+    }
 
     // broker lease (graceful — broker null if accounts.json absent)
     let lease = null;

--- a/tests/unit/conductor-dynamic-routing.test.mjs
+++ b/tests/unit/conductor-dynamic-routing.test.mjs
@@ -1,0 +1,307 @@
+// tests/unit/conductor-dynamic-routing.test.mjs
+//
+// Phase 1 wire-up — conductor.spawnSession 안의 sync dynamic routing override.
+//
+// 인변량 검증:
+//   1. spawnSession 은 여전히 sync 함수 — broker.lease atomic 체인 보존 (commit 761fb7a8).
+//   2. env opt-in (TRIFLUX_DYNAMIC_ROUTING=1|true) 일 때만 발화.
+//   3. 원격 세션은 wire-up skip.
+//   4. snapshot 은 D-2 cache 의 sync getter 만 사용 — cache miss 면 fail-closed.
+//   5. evaluator 의 결정이 config.agent 와 다를 때만 override + eventLog 기록.
+
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { resetSnapshotCache } from "../../hub/routing-snapshot.mjs";
+import { createConductor, STATES } from "../../hub/team/conductor.mjs";
+
+process.setMaxListeners(50);
+
+const ENV_FLAG = "TRIFLUX_DYNAMIC_ROUTING";
+
+function makeTmpDir() {
+  const dir = join(
+    tmpdir(),
+    `tfx-conductor-dr-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeMockSpawn() {
+  return function mockSpawn() {
+    const child = new EventEmitter();
+    child.pid = Math.floor(Math.random() * 1_000_000) + 1;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = () => true;
+    setImmediate(() => {
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("exit", 0, null);
+    });
+    return child;
+  };
+}
+
+function makeConductor(logsDir, overrides = {}) {
+  return createConductor({
+    logsDir,
+    maxRestarts: 1,
+    graceMs: 200,
+    probeOpts: {
+      intervalMs: 999_999,
+      l1ThresholdMs: 999_999,
+      l3ThresholdMs: 999_999,
+    },
+    ...overrides,
+    deps: {
+      spawn: makeMockSpawn(),
+      ...(overrides.deps || {}),
+    },
+  });
+}
+
+function readEvents(path) {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8").trim();
+  if (!raw) return [];
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function waitForEvents(conductor, predicate, timeoutMs = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const events = readEvents(conductor.eventLogPath);
+    if (predicate(events)) return events;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return readEvents(conductor.eventLogPath);
+}
+
+let logsDir;
+let conductor;
+let originalEnvFlag;
+
+beforeEach(() => {
+  logsDir = makeTmpDir();
+  conductor = makeConductor(logsDir);
+  originalEnvFlag = process.env[ENV_FLAG];
+  delete process.env[ENV_FLAG];
+  resetSnapshotCache();
+});
+
+afterEach(async () => {
+  if (originalEnvFlag === undefined) {
+    delete process.env[ENV_FLAG];
+  } else {
+    process.env[ENV_FLAG] = originalEnvFlag;
+  }
+  try {
+    await conductor.shutdown("afterEach_cleanup");
+  } catch {
+    /* already shutdown */
+  }
+  try {
+    rmSync(logsDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("conductor: dynamic routing wire-up — env gate", () => {
+  it("D-01: env 미설정 시 override event 가 발생하지 않는다", async () => {
+    const cfg = {
+      id: "no-env-flag",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(conductor, (es) =>
+      es.some((e) => e.event === "spawn"),
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.equal(
+      override,
+      undefined,
+      "env OFF 인데 dynamic_route_override 가 발생했다",
+    );
+  });
+
+  it("D-02: env=1 + cache empty + agent=claude → codex 로 override (fail-closed)", async () => {
+    process.env[ENV_FLAG] = "1";
+    const cfg = {
+      id: "fail-closed-claude",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(conductor, (es) =>
+      es.some((e) => e.event === "dynamic_route_override"),
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.ok(override, "override event 가 발생하지 않았다");
+    assert.equal(override.session, cfg.id);
+    assert.equal(override.original, "claude");
+    assert.equal(override.override, "codex");
+    // fail-closed = makeFallback → scenario:"fallback"
+    assert.equal(override.scenario, "fallback");
+    assert.equal(typeof override.decisionId, "string");
+  });
+
+  it("D-03: env='true' string 도 활성화한다", async () => {
+    process.env[ENV_FLAG] = "true";
+    const cfg = {
+      id: "env-true-string",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(conductor, (es) =>
+      es.some((e) => e.event === "dynamic_route_override"),
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.ok(override, "env='true' 인데 override 안 발생");
+  });
+
+  it("D-04: env=0 (명시 비활성) 시 wire-up 발화하지 않는다", async () => {
+    process.env[ENV_FLAG] = "0";
+    const cfg = {
+      id: "env-explicit-off",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(conductor, (es) =>
+      es.some((e) => e.event === "spawn"),
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.equal(override, undefined, "env=0 인데 override 가 발생");
+  });
+});
+
+describe("conductor: dynamic routing wire-up — no-op cases", () => {
+  it("D-05: env=1 + agent=codex (fallback decision 과 동일) → override event 없음", async () => {
+    process.env[ENV_FLAG] = "1";
+    const cfg = {
+      id: "noop-codex",
+      agent: "codex",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(conductor, (es) =>
+      es.some((e) => e.event === "spawn"),
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.equal(
+      override,
+      undefined,
+      "agent=codex 인데 override 발생 (no-op이어야 함)",
+    );
+  });
+
+  it("D-06: env=1 + remote=true → wire-up skip (override event 없음)", async () => {
+    process.env[ENV_FLAG] = "1";
+    const cfg = {
+      id: "remote-skip",
+      agent: "claude",
+      prompt: "echo",
+      remote: true,
+      host: "test-host",
+    };
+    // remote 세션은 launcher 없이 startRemoteSession 으로 진입. mock 환경에서는
+    // 곧바로 종료되지만 wire-up gate 만 검증한다.
+    try {
+      conductor.spawnSession(cfg);
+    } catch {
+      /* remote start mock 부족 — gate 결과만 검증 */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+    const events = readEvents(conductor.eventLogPath);
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    assert.equal(override, undefined, "remote 세션인데 override 발생");
+  });
+});
+
+describe("conductor: dynamic routing wire-up — invariant 보존", () => {
+  it("D-07: spawnSession 은 여전히 sync 함수 — string id 즉시 반환", () => {
+    process.env[ENV_FLAG] = "1";
+    const cfg = {
+      id: "sync-return-check",
+      agent: "claude",
+      prompt: "echo",
+    };
+    const id = conductor.spawnSession(cfg);
+    assert.equal(typeof id, "string");
+    assert.equal(id, "sync-return-check");
+  });
+
+  it("D-08: env=1 + override 발생 시에도 spawn 흐름이 정상 완료된다", async () => {
+    process.env[ENV_FLAG] = "1";
+    const cfg = {
+      id: "spawn-after-override",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+    const events = await waitForEvents(
+      conductor,
+      (es) =>
+        es.some((e) => e.event === "dynamic_route_override") &&
+        es.some((e) => e.event === "spawn"),
+      3000,
+    );
+    const override = events.find((e) => e.event === "dynamic_route_override");
+    const spawn = events.find((e) => e.event === "spawn");
+    assert.ok(override, "override event 누락");
+    assert.ok(spawn, "spawn event 누락 — override 후 spawn 흐름 끊김");
+    // override 후 spawn 의 agent 가 override 된 cli 와 일치해야 한다
+    assert.equal(spawn.agent, override.override);
+  });
+
+  it("D-09: env=1 + cache miss 흐름이 broker.lease 흐름과 충돌하지 않는다", async () => {
+    process.env[ENV_FLAG] = "1";
+    // broker mock 으로 lease 호출 추적
+    const leaseCalls = [];
+    const mockBroker = new EventEmitter();
+    mockBroker.lease = (req) => {
+      leaseCalls.push(req);
+      return null; // no lease available
+    };
+    mockBroker.nextAvailableEta = () => Date.now() + 60_000;
+    mockBroker.release = () => {};
+
+    await conductor.shutdown("recreate_for_broker_test");
+    conductor = makeConductor(logsDir, { broker: mockBroker });
+
+    const cfg = {
+      id: "broker-after-override",
+      agent: "claude",
+      prompt: "echo",
+    };
+    conductor.spawnSession(cfg);
+
+    await waitForEvents(
+      conductor,
+      (es) =>
+        es.some((e) => e.event === "dynamic_route_override") &&
+        es.some((e) => e.event === "broker_no_lease"),
+      3000,
+    );
+    // broker.lease 호출은 override 된 cli (codex) 로 일어나야 한다
+    assert.ok(leaseCalls.length > 0, "broker.lease 호출 안 됨");
+    assert.equal(
+      leaseCalls[0].provider,
+      "codex",
+      "broker.lease 가 override 전 agent 로 호출됨 — atomic 체인 깨짐",
+    );
+  });
+});

--- a/tests/unit/routing-snapshot-cache.test.mjs
+++ b/tests/unit/routing-snapshot-cache.test.mjs
@@ -13,6 +13,7 @@ import {
   __internal__,
   getDefaultSnapshot,
   resetSnapshotCache,
+  tryGetCachedSnapshot,
 } from "../../hub/routing-snapshot.mjs";
 
 const DEFAULT_TTL_MS = 900_000; // 모듈 내부 DEFAULT_CACHE_TTL_MS 와 정합
@@ -143,5 +144,84 @@ describe("routing-snapshot cache — getDefaultSnapshot()", () => {
     });
     assert.equal(tracker.calls, 2);
     assert.equal(refreshed._fakeCallId, 2);
+  });
+});
+
+// Phase 1 wire-up 보강 — sync hot path (conductor.spawnSession) 가 broker.lease
+// atomic 인변량을 깨지 않고 dynamic routing decision 을 평가하려면 cache 의
+// fresh entry 를 sync 로 읽을 수 있어야 한다. tryGetCachedSnapshot() 는
+// builder 를 호출하지 않고, fresh 면 snapshot, 아니면 null 만 반환한다.
+describe("routing-snapshot cache — tryGetCachedSnapshot() sync getter", () => {
+  beforeEach(() => {
+    resetSnapshotCache();
+  });
+
+  it("S-01: cache 가 비어있으면 null 을 반환한다 (cache miss)", () => {
+    assert.equal(tryGetCachedSnapshot({ now: NOW }), null);
+  });
+
+  it("S-02: getDefaultSnapshot 으로 채운 cache 를 sync 로 읽을 수 있다", async () => {
+    const tracker = mkBuilder();
+    const built = await getDefaultSnapshot({
+      now: NOW,
+      builder: tracker.builder,
+    });
+    const cached = tryGetCachedSnapshot({ now: NOW });
+    assert.strictEqual(cached, built);
+  });
+
+  it("S-03: TTL 만료 시 builder 호출 없이 null 을 반환한다 (sync fail-closed)", async () => {
+    const tracker = mkBuilder();
+    await getDefaultSnapshot({ now: NOW, builder: tracker.builder });
+    const expired = tryGetCachedSnapshot({ now: NOW + DEFAULT_TTL_MS + 1 });
+    assert.equal(expired, null);
+    // builder 는 호출되지 않아야 한다 (sync IO 없음 보장)
+    assert.equal(tracker.calls, 1);
+  });
+
+  it("S-04: maxAgeMs override 가 적용된다", async () => {
+    const tracker = mkBuilder();
+    await getDefaultSnapshot({ now: NOW, builder: tracker.builder });
+    // custom 짧은 TTL (1000ms) — 1001ms 후 호출 → cache miss
+    const expired = tryGetCachedSnapshot({
+      now: NOW + 1001,
+      maxAgeMs: 1000,
+    });
+    assert.equal(expired, null);
+    // 같은 시점이라도 default TTL 안이면 hit
+    const hit = tryGetCachedSnapshot({ now: NOW + 1001 });
+    assert.ok(hit, "default TTL 안에서는 hit 이어야 한다");
+  });
+
+  it("S-05: __internal__.setCacheForTest 로 주입된 cache 도 읽힌다", () => {
+    const fakeSnapshot = {
+      schemaVersion: 1,
+      observedAt: NOW,
+      claude: null,
+      codex: null,
+      broker: null,
+      _injected: true,
+    };
+    __internal__.setCacheForTest({ snapshot: fakeSnapshot, fetchedAt: NOW });
+    const cached = tryGetCachedSnapshot({ now: NOW + 100 });
+    assert.strictEqual(cached, fakeSnapshot);
+  });
+
+  it("S-06: now 인자 미주입 시 Date.now() 사용 — fresh cache hit 보장", () => {
+    const fakeSnapshot = {
+      schemaVersion: 1,
+      observedAt: Date.now(),
+      claude: null,
+      codex: null,
+      broker: null,
+    };
+    // 현재 시각으로 cache 주입
+    __internal__.setCacheForTest({
+      snapshot: fakeSnapshot,
+      fetchedAt: Date.now(),
+    });
+    // now 인자 없이 호출 — Date.now() 가 fetchedAt 근처라 TTL 안
+    const cached = tryGetCachedSnapshot();
+    assert.strictEqual(cached, fakeSnapshot);
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 caller wire-up 1 — `conductor.spawnSession` 에서 opt-in env
`TRIFLUX_DYNAMIC_ROUTING=1|true` 시 dynamic routing decision 으로
`config.agent` 를 override. **sync 만 사용** 해서 broker.lease atomic
인변량 ("leased account = executing account", commit 761fb7a8) 을
보존한다.

## 의도 분석 — 왜 sync 인가

PRD `.omx/plans/prd-dynamic-routing-engine.md` 의사 코드는
`await router.routeRequest(...)` 를 spawnSession 안에서 호출 가정.
그러나 broker.lease() 와 spawnSession() 은 둘 다 **sync** 가
의도된 인변량:

- broker.lease() — 메모리상 round-robin, IO 없음, atomic.
- spawnSession() — lease → swapAuthFile → spawn 흐름 보장.
  async 변환 시 await yield 사이에 다른 spawn 이 lease 를 가로채는
  race 가능.

따라서 wire-up 은 **sync 전용 path** 로 처리:

| 단계 | 호출 | 비용 |
|------|------|------|
| 1 | `isDynamicRoutingEnabled(process.env)` | sync, env read 1회 |
| 2 | `dynamicRoutingInternal.loadPolicy()` | sync `readFileSync`, 작은 JSON |
| 3 | `tryGetCachedSnapshot()` (신규) | sync, cache fresh 면 snapshot / 아니면 null |
| 4 | `evaluateDynamicRoute()` | pure-fn sync |
| 5 | shard.cli override + eventLog | sync write |

cache miss → evaluator 가 fail-closed (`"hud_null"` veto) → codex-default
fallback. PRD §"Fallback Policy" 정합.

## 변경

- `hub/routing-snapshot.mjs` — `tryGetCachedSnapshot({ maxAgeMs, now })`
  sync getter 신규 export. builder 호출 (IO) 없음.
- `hub/team/conductor.mjs` — `spawnSession()` 안 broker.lease 직전
  sync wire-up block 추가. error graceful (eventLog 에 남기고 원본
  config 로 계속).
- `packages/core/hub/routing-snapshot.mjs` — 단순 cp.
- `packages/triflux/hub/{routing-snapshot,team/conductor}.mjs` —
  byte-identical mirror.
- `packages/remote/hub/team/conductor.mjs` — `@triflux/core/...`
  import path 보존하며 wire-up 적용.

## Event log

- `dynamic_route_override`: `{session, original, override, scenario,
  decisionId, snapshotAgeMs}` — override 발생 시 가시화.
- `dynamic_route_error`: `{session, error}` — wire-up 자체 throw
  (드문 경우. 정상 fallback 은 evaluator 가 처리).

## Scope 의도적 제외

- `accountId` hint 적용 — broker.lease 시그니처가 hint 인자 미수용.
  Phase 4 (`leaseMany`) 와 함께 검토. 본 PR 은 cli override 만
  (PRD §"위험" §3 degraded path).

## Test plan

- [x] `node --test tests/unit/conductor-dynamic-routing.test.mjs` — 9/9
  (D-01..D-09: env gate, fail-closed, no-op, remote skip, invariant
  보존, broker.lease 충돌 없음)
- [x] `node --test tests/unit/routing-snapshot-cache.test.mjs` —
  6+6/12 (기존 C-01..C-06 + 신규 S-01..S-06)
- [x] `node --test tests/unit/dynamic-routing-engine.test.mjs` — 24/24
  (Phase 0 회귀)
- [x] `node --test tests/unit/dynamic-router-factory.test.mjs` — 22/22
  (Phase 1 D-1 회귀)
- [x] `node --test tests/unit/conductor.test.mjs` — pass (sync
  invariant 회귀 가드 포함)
- [x] `npm run lint` clean (warning 1 pre-existing)
- [x] `node scripts/release/check-packages-mirror.mjs` → Mirror OK
- [ ] CI green
- [ ] (수동) `TRIFLUX_DYNAMIC_ROUTING=1 tfx multi --teammate-mode
  headless --auto-attach --assign 'claude:ACK:smoke' --timeout 60` →
  `dynamic_route_override` eventLog 확인

## 후속 (별도 PR)

- Wire-up 2: `hub/team/swarm-hypervisor.mjs` (이미 async 라 facade
  await 가능)
- Wire-up 3: `scripts/tfx-route.sh` + `scripts/lib/dynamic-route-cli.mjs`
- 진단 도구: `tfx doctor --dynamic-routing`
- broker.lease accountId hint 확장 (Phase 4 leaseMany 동반)