### PR TITLE
feat(routing): tfx-route.sh sh-path dynamic routing wire-up (Phase 1)

### DIFF
--- a/packages/core/scripts/lib/dynamic-route-cli.mjs
+++ b/packages/core/scripts/lib/dynamic-route-cli.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// scripts/lib/dynamic-route-cli.mjs
+//
+// Phase 1 Wire-up 3 helper — tfx-route.sh 등 sh 경로에서 dynamic routing
+// decision 을 받아 단일 CLI 문자열 (또는 JSON) 으로 출력한다.
+//
+// 사용:
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex
+//   → "codex"
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --json
+//   → {"scenario":"fallback","mode":"codex-default","shards":[{"cli":"codex",...}]}
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --field scenario
+//   → "fallback"
+//
+// 정책:
+//   - opt-in env TRIFLUX_DYNAMIC_ROUTING=1|true 미설정 시 즉시 silent exit 0
+//     (override 없음 = stdout empty, sh caller 가 graceful no-op).
+//   - error 발생 시 stderr 에 한 줄 + exit 0 (sh caller 가 fallback path 진행).
+
+import { createDynamicRouter } from "../../hub/dynamic-routing-engine.mjs";
+
+function parseArgs(argv) {
+  const args = {
+    taskId: `tfx-route-${process.pid}-${Date.now()}`,
+    agentHint: "codex",
+    teamSize: 1,
+    json: false,
+    field: null,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const v = argv[i];
+    switch (v) {
+      case "--task-id":
+        args.taskId = argv[++i] || args.taskId;
+        break;
+      case "--agent-hint":
+        args.agentHint = argv[++i] || args.agentHint;
+        break;
+      case "--team-size":
+        args.teamSize = Number(argv[++i]) || args.teamSize;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--field":
+        args.field = argv[++i] || null;
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(
+          "Usage: dynamic-route-cli.mjs [--task-id ID] [--agent-hint CLI] [--team-size N] [--json|--field FIELD]\n",
+        );
+        process.exit(0);
+        break;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  // opt-in env 미설정 시 silent no-op (sh caller graceful path)
+  const flag = process.env.TRIFLUX_DYNAMIC_ROUTING;
+  if (flag !== "1" && flag !== "true") return;
+
+  let decision;
+  try {
+    const router = createDynamicRouter();
+    decision = await router.routeRequest({
+      task_id: args.taskId,
+      team_size: args.teamSize,
+      agent_hint: args.agentHint,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[dynamic-route-cli] error: ${err?.message || String(err)}\n`,
+    );
+    return;
+  }
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(decision));
+    return;
+  }
+
+  if (args.field) {
+    const value = decision?.[args.field];
+    if (value !== undefined && value !== null) {
+      process.stdout.write(String(value));
+    }
+    return;
+  }
+
+  // 기본 — shards[0].cli 만 stdout 으로 (sh caller 가 즉시 비교)
+  const cli = decision?.shards?.[0]?.cli;
+  if (cli) {
+    process.stdout.write(String(cli));
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[dynamic-route-cli] fatal: ${err?.message || String(err)}\n`,
+  );
+  process.exit(0); // sh caller 가 정상 fallback 하도록 always 0
+});

--- a/packages/triflux/scripts/lib/dynamic-route-cli.mjs
+++ b/packages/triflux/scripts/lib/dynamic-route-cli.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// scripts/lib/dynamic-route-cli.mjs
+//
+// Phase 1 Wire-up 3 helper — tfx-route.sh 등 sh 경로에서 dynamic routing
+// decision 을 받아 단일 CLI 문자열 (또는 JSON) 으로 출력한다.
+//
+// 사용:
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex
+//   → "codex"
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --json
+//   → {"scenario":"fallback","mode":"codex-default","shards":[{"cli":"codex",...}]}
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --field scenario
+//   → "fallback"
+//
+// 정책:
+//   - opt-in env TRIFLUX_DYNAMIC_ROUTING=1|true 미설정 시 즉시 silent exit 0
+//     (override 없음 = stdout empty, sh caller 가 graceful no-op).
+//   - error 발생 시 stderr 에 한 줄 + exit 0 (sh caller 가 fallback path 진행).
+
+import { createDynamicRouter } from "../../hub/dynamic-routing-engine.mjs";
+
+function parseArgs(argv) {
+  const args = {
+    taskId: `tfx-route-${process.pid}-${Date.now()}`,
+    agentHint: "codex",
+    teamSize: 1,
+    json: false,
+    field: null,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const v = argv[i];
+    switch (v) {
+      case "--task-id":
+        args.taskId = argv[++i] || args.taskId;
+        break;
+      case "--agent-hint":
+        args.agentHint = argv[++i] || args.agentHint;
+        break;
+      case "--team-size":
+        args.teamSize = Number(argv[++i]) || args.teamSize;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--field":
+        args.field = argv[++i] || null;
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(
+          "Usage: dynamic-route-cli.mjs [--task-id ID] [--agent-hint CLI] [--team-size N] [--json|--field FIELD]\n",
+        );
+        process.exit(0);
+        break;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  // opt-in env 미설정 시 silent no-op (sh caller graceful path)
+  const flag = process.env.TRIFLUX_DYNAMIC_ROUTING;
+  if (flag !== "1" && flag !== "true") return;
+
+  let decision;
+  try {
+    const router = createDynamicRouter();
+    decision = await router.routeRequest({
+      task_id: args.taskId,
+      team_size: args.teamSize,
+      agent_hint: args.agentHint,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[dynamic-route-cli] error: ${err?.message || String(err)}\n`,
+    );
+    return;
+  }
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(decision));
+    return;
+  }
+
+  if (args.field) {
+    const value = decision?.[args.field];
+    if (value !== undefined && value !== null) {
+      process.stdout.write(String(value));
+    }
+    return;
+  }
+
+  // 기본 — shards[0].cli 만 stdout 으로 (sh caller 가 즉시 비교)
+  const cli = decision?.shards?.[0]?.cli;
+  if (cli) {
+    process.stdout.write(String(cli));
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[dynamic-route-cli] fatal: ${err?.message || String(err)}\n`,
+  );
+  process.exit(0); // sh caller 가 정상 fallback 하도록 always 0
+});

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1295,6 +1295,39 @@ apply_no_claude_native_mode() {
   echo "[tfx-route] TFX_NO_CLAUDE_NATIVE=1: $AGENT_TYPE -> codex($CLI_EFFORT) 리매핑" >&2
 }
 
+## ── Phase 1 dynamic routing override (opt-in env TRIFLUX_DYNAMIC_ROUTING) ──
+## scripts/lib/dynamic-route-cli.mjs 가 routing decision 의 shards[0].cli 만
+## stdout 으로 반환. env 미설정 시 helper 가 silent no-op (stdout empty) →
+## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
+## 과 의도 정합한 sh 경로 wire-up.
+apply_dynamic_routing_override() {
+  [[ "$TRIFLUX_DYNAMIC_ROUTING" != "1" && "$TRIFLUX_DYNAMIC_ROUTING" != "true" ]] && return
+  [[ -z "$CLI_TYPE" ]] && return
+  [[ "$CLI_TYPE" == "claude-native" ]] && return
+
+  local cli_helper="${REPO_ROOT}/scripts/lib/dynamic-route-cli.mjs"
+  [[ ! -f "$cli_helper" ]] && return
+
+  local override_cli
+  override_cli=$(node "$cli_helper" \
+    --task-id "tfx-route-${AGENT_TYPE:-unknown}-$$" \
+    --agent-hint "$CLI_TYPE" \
+    --team-size 1 2>/dev/null) || return
+
+  [[ -z "$override_cli" ]] && return
+  [[ "$override_cli" == "$CLI_TYPE" ]] && return
+
+  # 지원하는 CLI 만 적용 — 알 수 없는 값은 무시
+  case "$override_cli" in
+    codex|gemini|claude) ;;
+    *) return ;;
+  esac
+
+  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=$TRIFLUX_DYNAMIC_ROUTING)" >&2
+  CLI_TYPE="$override_cli"
+  CLI_CMD="$override_cli"
+}
+
 apply_verifier_override() {
   [[ "$AGENT_TYPE" != "verifier" ]] && return
 
@@ -2119,6 +2152,7 @@ main() {
   apply_no_claude_native_mode
   apply_plan_guard
   apply_verifier_override
+  apply_dynamic_routing_override
 
   # CLI 경로 해석
   case "$CLI_CMD" in

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1301,11 +1301,13 @@ apply_no_claude_native_mode() {
 ## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
 ## 과 의도 정합한 sh 경로 wire-up.
 apply_dynamic_routing_override() {
-  [[ "$TRIFLUX_DYNAMIC_ROUTING" != "1" && "$TRIFLUX_DYNAMIC_ROUTING" != "true" ]] && return
-  [[ -z "$CLI_TYPE" ]] && return
-  [[ "$CLI_TYPE" == "claude-native" ]] && return
+  # set -u 환경 safe — 모든 env 변수 default 값 패턴 적용.
+  local flag="${TRIFLUX_DYNAMIC_ROUTING:-}"
+  [[ "$flag" != "1" && "$flag" != "true" ]] && return
+  [[ -z "${CLI_TYPE:-}" ]] && return
+  [[ "${CLI_TYPE}" == "claude-native" ]] && return
 
-  local cli_helper="${REPO_ROOT}/scripts/lib/dynamic-route-cli.mjs"
+  local cli_helper="${REPO_ROOT:-}/scripts/lib/dynamic-route-cli.mjs"
   [[ ! -f "$cli_helper" ]] && return
 
   local override_cli
@@ -1323,7 +1325,7 @@ apply_dynamic_routing_override() {
     *) return ;;
   esac
 
-  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=$TRIFLUX_DYNAMIC_ROUTING)" >&2
+  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=${flag})" >&2
   CLI_TYPE="$override_cli"
   CLI_CMD="$override_cli"
 }

--- a/scripts/lib/dynamic-route-cli.mjs
+++ b/scripts/lib/dynamic-route-cli.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// scripts/lib/dynamic-route-cli.mjs
+//
+// Phase 1 Wire-up 3 helper — tfx-route.sh 등 sh 경로에서 dynamic routing
+// decision 을 받아 단일 CLI 문자열 (또는 JSON) 으로 출력한다.
+//
+// 사용:
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex
+//   → "codex"
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --json
+//   → {"scenario":"fallback","mode":"codex-default","shards":[{"cli":"codex",...}]}
+//   node scripts/lib/dynamic-route-cli.mjs --agent-hint codex --field scenario
+//   → "fallback"
+//
+// 정책:
+//   - opt-in env TRIFLUX_DYNAMIC_ROUTING=1|true 미설정 시 즉시 silent exit 0
+//     (override 없음 = stdout empty, sh caller 가 graceful no-op).
+//   - error 발생 시 stderr 에 한 줄 + exit 0 (sh caller 가 fallback path 진행).
+
+import { createDynamicRouter } from "../../hub/dynamic-routing-engine.mjs";
+
+function parseArgs(argv) {
+  const args = {
+    taskId: `tfx-route-${process.pid}-${Date.now()}`,
+    agentHint: "codex",
+    teamSize: 1,
+    json: false,
+    field: null,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const v = argv[i];
+    switch (v) {
+      case "--task-id":
+        args.taskId = argv[++i] || args.taskId;
+        break;
+      case "--agent-hint":
+        args.agentHint = argv[++i] || args.agentHint;
+        break;
+      case "--team-size":
+        args.teamSize = Number(argv[++i]) || args.teamSize;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--field":
+        args.field = argv[++i] || null;
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(
+          "Usage: dynamic-route-cli.mjs [--task-id ID] [--agent-hint CLI] [--team-size N] [--json|--field FIELD]\n",
+        );
+        process.exit(0);
+        break;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  // opt-in env 미설정 시 silent no-op (sh caller graceful path)
+  const flag = process.env.TRIFLUX_DYNAMIC_ROUTING;
+  if (flag !== "1" && flag !== "true") return;
+
+  let decision;
+  try {
+    const router = createDynamicRouter();
+    decision = await router.routeRequest({
+      task_id: args.taskId,
+      team_size: args.teamSize,
+      agent_hint: args.agentHint,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[dynamic-route-cli] error: ${err?.message || String(err)}\n`,
+    );
+    return;
+  }
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(decision));
+    return;
+  }
+
+  if (args.field) {
+    const value = decision?.[args.field];
+    if (value !== undefined && value !== null) {
+      process.stdout.write(String(value));
+    }
+    return;
+  }
+
+  // 기본 — shards[0].cli 만 stdout 으로 (sh caller 가 즉시 비교)
+  const cli = decision?.shards?.[0]?.cli;
+  if (cli) {
+    process.stdout.write(String(cli));
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[dynamic-route-cli] fatal: ${err?.message || String(err)}\n`,
+  );
+  process.exit(0); // sh caller 가 정상 fallback 하도록 always 0
+});

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1295,6 +1295,39 @@ apply_no_claude_native_mode() {
   echo "[tfx-route] TFX_NO_CLAUDE_NATIVE=1: $AGENT_TYPE -> codex($CLI_EFFORT) 리매핑" >&2
 }
 
+## ── Phase 1 dynamic routing override (opt-in env TRIFLUX_DYNAMIC_ROUTING) ──
+## scripts/lib/dynamic-route-cli.mjs 가 routing decision 의 shards[0].cli 만
+## stdout 으로 반환. env 미설정 시 helper 가 silent no-op (stdout empty) →
+## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
+## 과 의도 정합한 sh 경로 wire-up.
+apply_dynamic_routing_override() {
+  [[ "$TRIFLUX_DYNAMIC_ROUTING" != "1" && "$TRIFLUX_DYNAMIC_ROUTING" != "true" ]] && return
+  [[ -z "$CLI_TYPE" ]] && return
+  [[ "$CLI_TYPE" == "claude-native" ]] && return
+
+  local cli_helper="${REPO_ROOT}/scripts/lib/dynamic-route-cli.mjs"
+  [[ ! -f "$cli_helper" ]] && return
+
+  local override_cli
+  override_cli=$(node "$cli_helper" \
+    --task-id "tfx-route-${AGENT_TYPE:-unknown}-$$" \
+    --agent-hint "$CLI_TYPE" \
+    --team-size 1 2>/dev/null) || return
+
+  [[ -z "$override_cli" ]] && return
+  [[ "$override_cli" == "$CLI_TYPE" ]] && return
+
+  # 지원하는 CLI 만 적용 — 알 수 없는 값은 무시
+  case "$override_cli" in
+    codex|gemini|claude) ;;
+    *) return ;;
+  esac
+
+  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=$TRIFLUX_DYNAMIC_ROUTING)" >&2
+  CLI_TYPE="$override_cli"
+  CLI_CMD="$override_cli"
+}
+
 apply_verifier_override() {
   [[ "$AGENT_TYPE" != "verifier" ]] && return
 
@@ -2119,6 +2152,7 @@ main() {
   apply_no_claude_native_mode
   apply_plan_guard
   apply_verifier_override
+  apply_dynamic_routing_override
 
   # CLI 경로 해석
   case "$CLI_CMD" in

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1301,11 +1301,13 @@ apply_no_claude_native_mode() {
 ## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
 ## 과 의도 정합한 sh 경로 wire-up.
 apply_dynamic_routing_override() {
-  [[ "$TRIFLUX_DYNAMIC_ROUTING" != "1" && "$TRIFLUX_DYNAMIC_ROUTING" != "true" ]] && return
-  [[ -z "$CLI_TYPE" ]] && return
-  [[ "$CLI_TYPE" == "claude-native" ]] && return
+  # set -u 환경 safe — 모든 env 변수 default 값 패턴 적용.
+  local flag="${TRIFLUX_DYNAMIC_ROUTING:-}"
+  [[ "$flag" != "1" && "$flag" != "true" ]] && return
+  [[ -z "${CLI_TYPE:-}" ]] && return
+  [[ "${CLI_TYPE}" == "claude-native" ]] && return
 
-  local cli_helper="${REPO_ROOT}/scripts/lib/dynamic-route-cli.mjs"
+  local cli_helper="${REPO_ROOT:-}/scripts/lib/dynamic-route-cli.mjs"
   [[ ! -f "$cli_helper" ]] && return
 
   local override_cli
@@ -1323,7 +1325,7 @@ apply_dynamic_routing_override() {
     *) return ;;
   esac
 
-  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=$TRIFLUX_DYNAMIC_ROUTING)" >&2
+  echo "[tfx-route] dynamic_route_override: ${CLI_TYPE} -> ${override_cli} (TRIFLUX_DYNAMIC_ROUTING=${flag})" >&2
   CLI_TYPE="$override_cli"
   CLI_CMD="$override_cli"
 }

--- a/tests/unit/dynamic-route-cli.test.mjs
+++ b/tests/unit/dynamic-route-cli.test.mjs
@@ -1,0 +1,131 @@
+// tests/unit/dynamic-route-cli.test.mjs
+//
+// Phase 1 Wire-up 3 helper — scripts/lib/dynamic-route-cli.mjs.
+// sh 경로 (tfx-route.sh) 가 stdout 한 줄로 받는 contract 검증.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HELPER = join(
+  HERE,
+  "..",
+  "..",
+  "scripts",
+  "lib",
+  "dynamic-route-cli.mjs",
+);
+
+const ENV_FLAG = "TRIFLUX_DYNAMIC_ROUTING";
+
+function runHelper(args = [], extraEnv = {}) {
+  const env = { ...process.env, ...extraEnv };
+  // 부모 env 에서 본 flag 제거 후 extraEnv 가 명시한 경우만 set
+  delete env[ENV_FLAG];
+  if (Object.hasOwn(extraEnv, ENV_FLAG)) {
+    env[ENV_FLAG] = extraEnv[ENV_FLAG];
+  }
+  const result = spawnSync(process.execPath, [HELPER, ...args], {
+    env,
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    code: result.status,
+  };
+}
+
+let originalEnvFlag;
+
+beforeEach(() => {
+  originalEnvFlag = process.env[ENV_FLAG];
+  delete process.env[ENV_FLAG];
+});
+
+afterEach(() => {
+  if (originalEnvFlag === undefined) {
+    delete process.env[ENV_FLAG];
+  } else {
+    process.env[ENV_FLAG] = originalEnvFlag;
+  }
+});
+
+describe("dynamic-route-cli helper", () => {
+  it("R-01: env 미설정 시 stdout empty + exit 0", () => {
+    const r = runHelper(["--agent-hint", "codex"]);
+    assert.equal(r.stdout, "", "stdout 가 empty 가 아니다 (no-op 기대)");
+    assert.equal(r.code, 0);
+  });
+
+  it("R-02: env=1 + agent-hint=claude → 'codex' 한 줄 (fallback 결정)", () => {
+    const r = runHelper(["--agent-hint", "claude"], { [ENV_FLAG]: "1" });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), "codex");
+  });
+
+  it("R-03: env=true 도 활성화", () => {
+    const r = runHelper(["--agent-hint", "claude"], { [ENV_FLAG]: "true" });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), "codex");
+  });
+
+  it("R-04: env=0 (명시 비활성) — stdout empty", () => {
+    const r = runHelper(["--agent-hint", "claude"], { [ENV_FLAG]: "0" });
+    assert.equal(r.stdout, "");
+    assert.equal(r.code, 0);
+  });
+
+  it("R-05: --json 옵션 — JSON 결정 전체를 stdout 으로", () => {
+    const r = runHelper(["--agent-hint", "claude", "--json"], {
+      [ENV_FLAG]: "1",
+    });
+    assert.equal(r.code, 0);
+    const decision = JSON.parse(r.stdout);
+    assert.equal(typeof decision.decisionId, "string");
+    assert.equal(decision.mode, "codex-default");
+    assert.equal(decision.scenario, "fallback");
+    assert.equal(decision.shards[0].cli, "codex");
+  });
+
+  it("R-06: --field scenario — scenario 문자열만 출력", () => {
+    const r = runHelper(["--agent-hint", "claude", "--field", "scenario"], {
+      [ENV_FLAG]: "1",
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), "fallback");
+  });
+
+  it("R-07: --team-size 가 호출 시 valid decision 으로 결과 반환", () => {
+    // helper 는 매 호출마다 새 snapshot 을 빌드 (HUD/broker IO time-dependent)
+    // 라 decisionId 결정성은 evaluator 단계에서 검증 (dynamic-routing-engine.test).
+    // 본 가드는 sh caller contract 만 검증: team_size 인자가 정상 흐름으로 통과.
+    const r = runHelper(
+      [
+        "--task-id",
+        "tfx-route-test-team-size",
+        "--agent-hint",
+        "codex",
+        "--team-size",
+        "2",
+        "--json",
+      ],
+      { [ENV_FLAG]: "1" },
+    );
+    assert.equal(r.code, 0);
+    const decision = JSON.parse(r.stdout);
+    assert.equal(typeof decision.decisionId, "string");
+    assert.equal(typeof decision.scenario, "string");
+    assert.ok(Array.isArray(decision.shards), "shards 가 배열이어야 한다");
+  });
+
+  it("R-08: --help 출력 후 exit 0", () => {
+    const r = runHelper(["--help"]);
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Usage:/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 caller wire-up 3 — `scripts/tfx-route.sh` 가 opt-in env
`TRIFLUX_DYNAMIC_ROUTING=1|true` 시 routing decision 의 `shards[0].cli` 로
`CLI_TYPE`/`CLI_CMD` 를 override 한다. sh 가 ESM 모듈을 직접 import 할 수
없으므로 `scripts/lib/dynamic-route-cli.mjs` helper 가 routing decision 을
stdout 한 줄로 반환하는 contract 으로 다리 놓는다.

## helper contract — sh caller 친화

`scripts/lib/dynamic-route-cli.mjs` (신규):

| 옵션 | 출력 |
|---|---|
| 기본 | `shards[0].cli` 한 단어 (`codex` / `claude` / `gemini`) — sh `$(...)` 친화 |
| `--json` | decision 전체 (디버깅용) |
| `--field <name>` | decision 최상위 필드 값 (예: `scenario`) |
| env 미설정 | stdout empty + exit 0 (silent no-op) |
| error | stderr 한 줄 + exit 0 (fail-closed) |

## tfx-route.sh wire-up

`apply_dynamic_routing_override()` 신규:
- opt-in env 미설정 / `CLI_TYPE` 빈 값 / `claude-native` 시 return
- 지원하는 cli (codex/gemini/claude) 만 적용
- stderr `[tfx-route] dynamic_route_override: X -> Y` 가시화

호출 위치 — main flow 의 마지막 override 단계 (`apply_verifier_override`
다음). 다른 시스템 override 가 최종 적용된 후 user-intent dynamic decision
이 추가 override.

## 변경

| 파일 | 변경 |
|---|---|
| `scripts/lib/dynamic-route-cli.mjs` | 신규 helper (~105 line) |
| `packages/core/scripts/lib/dynamic-route-cli.mjs` | byte-identical mirror |
| `packages/triflux/scripts/lib/dynamic-route-cli.mjs` | byte-identical mirror |
| `scripts/tfx-route.sh` | `apply_dynamic_routing_override()` + main 호출 |
| `packages/triflux/scripts/tfx-route.sh` | byte-identical mirror |
| `tests/unit/dynamic-route-cli.test.mjs` | 신규 8 케이스 |

## Test plan

- [x] `node --test tests/unit/dynamic-route-cli.test.mjs` — 8/8
  (R-01..R-08): env gate (1/true/0/미설정), --json, --field, --team-size,
  --help
- [x] 인라인 sh smoke: `TRIFLUX_DYNAMIC_ROUTING=1 CLI_TYPE=claude` 에서
  helper 호출 → `codex` 반환 → override fire
- [x] `npm run lint` clean (warning 1 pre-existing)
- [x] `node scripts/release/check-packages-mirror.mjs` → Mirror OK
- [ ] CI green
- [ ] (수동) `TRIFLUX_DYNAMIC_ROUTING=1 ./scripts/tfx-route.sh executor "echo
  test" implement` → stderr 에 `dynamic_route_override` 로그 확인

## 의존성

- PR #266 (Wire-up 1 conductor) 와 PR #268 (Wire-up 2 swarm-hypervisor) 와
  독립. base = `main`.

## 후속

- 진단 도구 `tfx doctor --dynamic-routing` (Phase 1 마지막 작업)
- helper 결과를 conductor / swarm wire-up 의 eventLog 체계로 통합 (현재
  stderr 만)