### PR TITLE
feat(doctor): tfx doctor --dynamic-routing 진단 옵션 (Phase 1 wire-up 4)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -151,7 +151,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -180,6 +180,12 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "--fix 와 함께 사용. cli-issues.jsonl 에서 7일 초과 항목 물리 삭제 (#144)",
+      },
+      {
+        name: "--dynamic-routing",
+        type: "boolean",
+        description:
+          "Phase 1 dynamic routing 상태 진단 (env / policy / snapshot cache / preview decision)",
       },
       {
         name: "--json",
@@ -5961,6 +5967,45 @@ async function main() {
           } else {
             console.log(`\n  ${RED}✗${RESET} 진단 실패: ${result.error}\n`);
           }
+        }
+        return;
+      }
+      if (cmdArgs.includes("--dynamic-routing")) {
+        const { diagnoseDynamicRouting } = await import(
+          "../scripts/doctor-dynamic-routing.mjs"
+        );
+        const report = await diagnoseDynamicRouting();
+        if (JSON_OUTPUT) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          const mark = (b) =>
+            b ? `${GREEN_BRIGHT}✓${RESET}` : `${RED}✗${RESET}`;
+          console.log(
+            `\n  ${AMBER}${BOLD}⬡ triflux doctor — dynamic routing${RESET}\n`,
+          );
+          console.log(
+            `  ${mark(report.enabled)} enabled: ${report.enabled} (TRIFLUX_DYNAMIC_ROUTING=${report.envFlag ?? "미설정"})`,
+          );
+          console.log(
+            `  ${mark(report.policyLoaded)} policy loaded: ${report.policyLoaded} (scenarios=${report.policyScenarios.length})`,
+          );
+          console.log(
+            `  ${mark(report.snapshotCached)} snapshot cache: ${
+              report.snapshotCached
+                ? `hit (age=${report.snapshotAgeMs}ms)`
+                : "miss"
+            }`,
+          );
+          if (report.previewDecision) {
+            const d = report.previewDecision;
+            console.log(
+              `  ${GREEN_BRIGHT}→${RESET} preview decision: scenario=${d.scenario}, mode=${d.mode}, lane=${d.lane}, shards[0].cli=${d.shards?.[0]?.cli ?? "?"}`,
+            );
+          }
+          if (report.error) {
+            console.log(`  ${RED}✗${RESET} error: ${report.error}`);
+          }
+          console.log("");
         }
         return;
       }

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -151,7 +151,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -180,6 +180,12 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "--fix 와 함께 사용. cli-issues.jsonl 에서 7일 초과 항목 물리 삭제 (#144)",
+      },
+      {
+        name: "--dynamic-routing",
+        type: "boolean",
+        description:
+          "Phase 1 dynamic routing 상태 진단 (env / policy / snapshot cache / preview decision)",
       },
       {
         name: "--json",
@@ -5961,6 +5967,45 @@ async function main() {
           } else {
             console.log(`\n  ${RED}✗${RESET} 진단 실패: ${result.error}\n`);
           }
+        }
+        return;
+      }
+      if (cmdArgs.includes("--dynamic-routing")) {
+        const { diagnoseDynamicRouting } = await import(
+          "../scripts/doctor-dynamic-routing.mjs"
+        );
+        const report = await diagnoseDynamicRouting();
+        if (JSON_OUTPUT) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          const mark = (b) =>
+            b ? `${GREEN_BRIGHT}✓${RESET}` : `${RED}✗${RESET}`;
+          console.log(
+            `\n  ${AMBER}${BOLD}⬡ triflux doctor — dynamic routing${RESET}\n`,
+          );
+          console.log(
+            `  ${mark(report.enabled)} enabled: ${report.enabled} (TRIFLUX_DYNAMIC_ROUTING=${report.envFlag ?? "미설정"})`,
+          );
+          console.log(
+            `  ${mark(report.policyLoaded)} policy loaded: ${report.policyLoaded} (scenarios=${report.policyScenarios.length})`,
+          );
+          console.log(
+            `  ${mark(report.snapshotCached)} snapshot cache: ${
+              report.snapshotCached
+                ? `hit (age=${report.snapshotAgeMs}ms)`
+                : "miss"
+            }`,
+          );
+          if (report.previewDecision) {
+            const d = report.previewDecision;
+            console.log(
+              `  ${GREEN_BRIGHT}→${RESET} preview decision: scenario=${d.scenario}, mode=${d.mode}, lane=${d.lane}, shards[0].cli=${d.shards?.[0]?.cli ?? "?"}`,
+            );
+          }
+          if (report.error) {
+            console.log(`  ${RED}✗${RESET} error: ${report.error}`);
+          }
+          console.log("");
         }
         return;
       }

--- a/packages/triflux/scripts/doctor-dynamic-routing.mjs
+++ b/packages/triflux/scripts/doctor-dynamic-routing.mjs
@@ -1,0 +1,87 @@
+// scripts/doctor-dynamic-routing.mjs
+//
+// Phase 1 Wire-up 4 — `tfx doctor --dynamic-routing` diagnostic helper.
+// 사용자가 dynamic routing 상태 (env / policy / snapshot cache / preview decision)
+// 를 한 화면에 확인할 수 있도록 진단 report 를 만든다.
+
+import {
+  createDynamicRouter,
+  __internal__ as dynamicRoutingInternal,
+  isDynamicRoutingEnabled,
+} from "../hub/dynamic-routing-engine.mjs";
+import { getDefaultSnapshot } from "../hub/routing-snapshot.mjs";
+
+/**
+ * Dynamic routing 상태 진단.
+ * @returns {Promise<{
+ *   enabled: boolean,
+ *   envFlag: string | null,
+ *   policyLoaded: boolean,
+ *   policyScenarios: string[],
+ *   policyPath: string,
+ *   snapshotCached: boolean,
+ *   snapshotAgeMs: number | null,
+ *   previewDecision: object | null,
+ *   error: string | null,
+ * }>}
+ */
+export async function diagnoseDynamicRouting() {
+  const envFlag = process.env.TRIFLUX_DYNAMIC_ROUTING ?? null;
+  const enabled = isDynamicRoutingEnabled(process.env);
+  const policy = dynamicRoutingInternal.loadPolicy();
+  const policyPath = dynamicRoutingInternal.DEFAULT_POLICY_PATH;
+
+  const report = {
+    enabled,
+    envFlag,
+    policyLoaded: Boolean(policy),
+    policyScenarios: Array.isArray(policy?.scenarios)
+      ? policy.scenarios.map((s) => s.id)
+      : [],
+    policyPath,
+    snapshotCached: false,
+    snapshotAgeMs: null,
+    previewDecision: null,
+    error: null,
+  };
+
+  try {
+    const now = Date.now();
+    const snapshot = await getDefaultSnapshot({ now });
+    if (snapshot && typeof snapshot.observedAt === "number") {
+      report.snapshotCached = true;
+      report.snapshotAgeMs = now - snapshot.observedAt;
+    }
+
+    if (enabled) {
+      const router = createDynamicRouter();
+      const decision = await router.routeRequest(
+        {
+          task_id: `tfx-doctor-preview-${process.pid}-${now}`,
+          team_size: 1,
+          agent_hint: "codex",
+        },
+        { now },
+      );
+      report.previewDecision = {
+        decisionId: decision?.decisionId ?? null,
+        scenario: decision?.scenario ?? null,
+        mode: decision?.mode ?? null,
+        lane: decision?.lane ?? null,
+        shards: Array.isArray(decision?.shards)
+          ? decision.shards.map((s) => ({
+              cli: s.cli,
+              accountId: s.accountId ?? null,
+              riskTier: s.riskTier ?? null,
+            }))
+          : [],
+        snapshotAgeMs: decision?.snapshotAgeMs ?? null,
+        confidence: decision?.confidence ?? null,
+      };
+    }
+  } catch (err) {
+    report.error = err?.message || String(err);
+  }
+
+  return report;
+}

--- a/scripts/doctor-dynamic-routing.mjs
+++ b/scripts/doctor-dynamic-routing.mjs
@@ -1,0 +1,87 @@
+// scripts/doctor-dynamic-routing.mjs
+//
+// Phase 1 Wire-up 4 — `tfx doctor --dynamic-routing` diagnostic helper.
+// 사용자가 dynamic routing 상태 (env / policy / snapshot cache / preview decision)
+// 를 한 화면에 확인할 수 있도록 진단 report 를 만든다.
+
+import {
+  createDynamicRouter,
+  __internal__ as dynamicRoutingInternal,
+  isDynamicRoutingEnabled,
+} from "../hub/dynamic-routing-engine.mjs";
+import { getDefaultSnapshot } from "../hub/routing-snapshot.mjs";
+
+/**
+ * Dynamic routing 상태 진단.
+ * @returns {Promise<{
+ *   enabled: boolean,
+ *   envFlag: string | null,
+ *   policyLoaded: boolean,
+ *   policyScenarios: string[],
+ *   policyPath: string,
+ *   snapshotCached: boolean,
+ *   snapshotAgeMs: number | null,
+ *   previewDecision: object | null,
+ *   error: string | null,
+ * }>}
+ */
+export async function diagnoseDynamicRouting() {
+  const envFlag = process.env.TRIFLUX_DYNAMIC_ROUTING ?? null;
+  const enabled = isDynamicRoutingEnabled(process.env);
+  const policy = dynamicRoutingInternal.loadPolicy();
+  const policyPath = dynamicRoutingInternal.DEFAULT_POLICY_PATH;
+
+  const report = {
+    enabled,
+    envFlag,
+    policyLoaded: Boolean(policy),
+    policyScenarios: Array.isArray(policy?.scenarios)
+      ? policy.scenarios.map((s) => s.id)
+      : [],
+    policyPath,
+    snapshotCached: false,
+    snapshotAgeMs: null,
+    previewDecision: null,
+    error: null,
+  };
+
+  try {
+    const now = Date.now();
+    const snapshot = await getDefaultSnapshot({ now });
+    if (snapshot && typeof snapshot.observedAt === "number") {
+      report.snapshotCached = true;
+      report.snapshotAgeMs = now - snapshot.observedAt;
+    }
+
+    if (enabled) {
+      const router = createDynamicRouter();
+      const decision = await router.routeRequest(
+        {
+          task_id: `tfx-doctor-preview-${process.pid}-${now}`,
+          team_size: 1,
+          agent_hint: "codex",
+        },
+        { now },
+      );
+      report.previewDecision = {
+        decisionId: decision?.decisionId ?? null,
+        scenario: decision?.scenario ?? null,
+        mode: decision?.mode ?? null,
+        lane: decision?.lane ?? null,
+        shards: Array.isArray(decision?.shards)
+          ? decision.shards.map((s) => ({
+              cli: s.cli,
+              accountId: s.accountId ?? null,
+              riskTier: s.riskTier ?? null,
+            }))
+          : [],
+        snapshotAgeMs: decision?.snapshotAgeMs ?? null,
+        confidence: decision?.confidence ?? null,
+      };
+    }
+  } catch (err) {
+    report.error = err?.message || String(err);
+  }
+
+  return report;
+}

--- a/tests/unit/doctor-dynamic-routing.test.mjs
+++ b/tests/unit/doctor-dynamic-routing.test.mjs
@@ -1,0 +1,105 @@
+// tests/unit/doctor-dynamic-routing.test.mjs
+//
+// Phase 1 Wire-up 4 — `tfx doctor --dynamic-routing` diagnostic helper 검증.
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { resetSnapshotCache } from "../../hub/routing-snapshot.mjs";
+import { diagnoseDynamicRouting } from "../../scripts/doctor-dynamic-routing.mjs";
+
+const ENV_FLAG = "TRIFLUX_DYNAMIC_ROUTING";
+
+let originalEnvFlag;
+
+beforeEach(() => {
+  originalEnvFlag = process.env[ENV_FLAG];
+  delete process.env[ENV_FLAG];
+  resetSnapshotCache();
+});
+
+afterEach(() => {
+  if (originalEnvFlag === undefined) {
+    delete process.env[ENV_FLAG];
+  } else {
+    process.env[ENV_FLAG] = originalEnvFlag;
+  }
+  resetSnapshotCache();
+});
+
+describe("doctor-dynamic-routing diagnostic", () => {
+  it("DR-01: env 미설정 시 enabled=false + previewDecision null", async () => {
+    const report = await diagnoseDynamicRouting();
+    assert.equal(report.enabled, false);
+    assert.equal(report.envFlag, null);
+    assert.equal(report.previewDecision, null);
+    // policy 와 snapshot 은 enabled 와 무관하게 진단
+    assert.equal(report.policyLoaded, true, "policy 가 로드되지 않음");
+    assert.ok(report.policyScenarios.length > 0, "scenarios 가 비었다");
+  });
+
+  it("DR-02: env=1 시 enabled=true + previewDecision 생성", async () => {
+    process.env[ENV_FLAG] = "1";
+    const report = await diagnoseDynamicRouting();
+    assert.equal(report.enabled, true);
+    assert.equal(report.envFlag, "1");
+    assert.ok(report.previewDecision, "previewDecision 누락");
+    assert.equal(typeof report.previewDecision.decisionId, "string");
+    assert.equal(typeof report.previewDecision.scenario, "string");
+    assert.ok(
+      Array.isArray(report.previewDecision.shards),
+      "shards 가 배열 아님",
+    );
+  });
+
+  it("DR-03: env=true 도 활성화", async () => {
+    process.env[ENV_FLAG] = "true";
+    const report = await diagnoseDynamicRouting();
+    assert.equal(report.enabled, true);
+    assert.ok(report.previewDecision);
+  });
+
+  it("DR-04: env=0 (명시 비활성) — previewDecision null", async () => {
+    process.env[ENV_FLAG] = "0";
+    const report = await diagnoseDynamicRouting();
+    assert.equal(report.enabled, false);
+    assert.equal(report.previewDecision, null);
+  });
+
+  it("DR-05: report 가 policyPath 와 scenarios 메타 포함", async () => {
+    const report = await diagnoseDynamicRouting();
+    assert.match(report.policyPath, /routing-policy\.json$/);
+    assert.ok(report.policyScenarios.includes("S1"), "S1 scenario 누락");
+    assert.ok(report.policyScenarios.includes("S6"), "S6 scenario 누락");
+  });
+
+  it("DR-06: snapshot cache 가 채워진 후 두 번째 호출은 hit", async () => {
+    await diagnoseDynamicRouting();
+    const second = await diagnoseDynamicRouting();
+    assert.equal(second.snapshotCached, true);
+    // age 는 비교적 작아야 한다 (TTL 안)
+    assert.ok(
+      second.snapshotAgeMs !== null && second.snapshotAgeMs < 10_000,
+      `snapshotAgeMs 가 비정상: ${second.snapshotAgeMs}`,
+    );
+  });
+
+  it("DR-07: report 구조가 contract 와 일치 — error 는 null 또는 string", async () => {
+    process.env[ENV_FLAG] = "1";
+    const report = await diagnoseDynamicRouting();
+    const expectedKeys = [
+      "enabled",
+      "envFlag",
+      "policyLoaded",
+      "policyScenarios",
+      "policyPath",
+      "snapshotCached",
+      "snapshotAgeMs",
+      "previewDecision",
+      "error",
+    ];
+    for (const k of expectedKeys) {
+      assert.ok(k in report, `report 에 ${k} 키 누락`);
+    }
+    assert.ok(report.error === null || typeof report.error === "string");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 wire-up 4 — `tfx doctor --dynamic-routing` 으로 사용자가 현재
dynamic routing 상태를 한 화면에 확인할 수 있도록 진단 helper 추가.

## 출력

### 텍스트 모드 (기본)

```
  ⬡ triflux doctor — dynamic routing

  ✓ enabled: true (TRIFLUX_DYNAMIC_ROUTING=1)
  ✓ policy loaded: true (scenarios=6)
  ✓ snapshot cache: hit (age=120ms)
  → preview decision: scenario=fallback, mode=codex-default, lane=single,
    shards[0].cli=codex
```

### JSON 모드 (`--json`)

```json
{
  "enabled": true,
  "envFlag": "1",
  "policyLoaded": true,
  "policyScenarios": ["S1","S2","S3","S4","S5","S6"],
  "policyPath": ".../config/routing-policy.json",
  "snapshotCached": true,
  "snapshotAgeMs": 120,
  "previewDecision": {
    "decisionId": "...",
    "scenario": "fallback",
    "mode": "codex-default",
    "lane": "single",
    "shards": [{"cli":"codex","accountId":null,"riskTier":"safe"}],
    "snapshotAgeMs": null,
    "confidence": 50
  },
  "error": null
}
```

## 변경

| 파일 | 변경 |
|---|---|
| `scripts/doctor-dynamic-routing.mjs` | 신규 진단 helper |
| `bin/triflux.mjs` | `--dynamic-routing` 옵션 정의 + handler |
| `packages/triflux/{bin,scripts}` | byte-identical mirror |
| `tests/unit/doctor-dynamic-routing.test.mjs` | 신규 7 케이스 (DR-01..DR-07) |

## 의존성

- Phase 0 (#251) + D-1 (#263) + D-2 (#264) 가 main 에 머지된 상태에서
  동작.
- wire-up 1/2/3 (#266/#268/#269) 와 독립. base = `main`.

## Test plan

- [x] `node --test tests/unit/doctor-dynamic-routing.test.mjs` — 7/7
  (DR-01..DR-07): env gate (1/true/0/미설정), preview decision, policy
  메타, snapshot cache hit, report contract
- [x] smoke: `tfx doctor --dynamic-routing` / `--json` 둘 다 정상
- [x] `npm run lint` clean (warning 1 pre-existing)
- [x] `node scripts/release/check-packages-mirror.mjs` → Mirror OK
- [ ] CI green