### PR TITLE
test(store-adapter): better-sqlite3 native binding probe 강화

### DIFF
--- a/tests/unit/store-adapter-tier2.test.mjs
+++ b/tests/unit/store-adapter-tier2.test.mjs
@@ -39,6 +39,15 @@ async function createSqliteStore(t) {
     t.skip("better-sqlite3 unavailable in this environment");
     return null;
   }
+  // native binding 검증 — import 성공해도 native fn 호출 시 fail 가능 (예: Node v26 + 12.6.2)
+  try {
+    const probe = new sqliteCtor(":memory:");
+    probe.prepare("SELECT 1").get();
+    probe.close();
+  } catch {
+    t.skip("better-sqlite3 native binding unavailable in this environment");
+    return null;
+  }
 
   return createStoreAdapter(tempDbPath(), {
     loadDatabase: async () => sqliteCtor,

--- a/tests/unit/store-adapter.test.mjs
+++ b/tests/unit/store-adapter.test.mjs
@@ -67,6 +67,15 @@ describe("hub/store-adapter.mjs", () => {
       t.skip("better-sqlite3 unavailable in this environment");
       return;
     }
+    // native binding 검증 — import 성공해도 native fn 호출 시 fail 가능 (예: Node v26 + 12.6.2)
+    try {
+      const probe = new sqliteCtor(":memory:");
+      probe.prepare("SELECT 1").get();
+      probe.close();
+    } catch {
+      t.skip("better-sqlite3 native binding unavailable in this environment");
+      return;
+    }
 
     const store = await createStoreAdapter(dbPath, {
       loadDatabase: async () => sqliteCtor,


### PR DESCRIPTION
## Summary

`store-adapter*.test.mjs` 의 graceful skip 로직이 `await import("better-sqlite3")`
성공 시 즉시 통과시켰다. dynamic loader 는 native `.node` 파일 미해상 상황
에서도 module export 자체는 성공시키는 경우가 있어 (예: Node v26.0.0 +
better-sqlite3 12.6.2 — node-gyp rebuild 실패), 후속 `new Database(...)` /
`db.prepare("...")` 호출에서 `TypeError: Cannot read properties of null
(reading "prepare")` 가 발생했다.

release `prepare.mjs` 가 native test runner 의 exit non-zero 를 그대로
감지해 release 가 abort 되는 회귀.

## 변경

`import` 성공 후 즉시 `new ctor(":memory:")` + `prepare("SELECT 1").get()`
probe 호출. native binding 미해상 시 throw → `t.skip(...)` 으로 graceful
skip.

| 환경 | 동작 |
|---|---|
| CI (Linux Ubuntu, fresh install) | native binding 정상 → 실제 sqlite path 검증 (기존과 동일) |
| mac Node v26 + better-sqlite3 12.6.2 | native binding 미해상 → graceful skip (회귀 가드) |

## Test plan

- [x] `node --test tests/unit/store-adapter.test.mjs tests/unit/store-adapter-tier2.test.mjs`
  → 4 tests / 2 pass / 2 skipped / 0 fail (native binding 미해상 환경)
- [x] `npm run lint` clean
- [ ] CI green (Linux Ubuntu — 실제 sqlite path 검증 유지)

## 동기

v10.21.0 release 의 `prepare:execute` 가 본 native binding 미해상으로 abort
하여 `--skip-tests` 우회로 진행. 본 fix 로 후속 release 는 mac Node v26
환경에서도 정상 prepare 통과 가능.