### PR TITLE
fix(hooks): suppress compact nudge for hub token monitor snapshots

### DIFF
--- a/hooks/hook-orchestrator.mjs
+++ b/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/packages/core/hooks/hook-orchestrator.mjs
+++ b/packages/core/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/packages/triflux/hooks/hook-orchestrator.mjs
+++ b/packages/triflux/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/tests/unit/hook-orchestrator.test.mjs
+++ b/tests/unit/hook-orchestrator.test.mjs
@@ -267,6 +267,69 @@ describe("hook-orchestrator PreToolUse:Bash dedupe", () => {
     rmSync(nudgeMarker, { force: true });
   });
 
+  it("does not emit compact nudge from hub token monitor snapshots", () => {
+    const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
+    rmSync(nudgeMarker, { force: true });
+
+    const homeDir = join(sandboxDir, "home-hub-token-monitor");
+    const monitorDir = join(homeDir, ".claude", "cache", "tfx-hub");
+    mkdirSync(monitorDir, { recursive: true });
+    writeFileSync(
+      join(monitorDir, "context-monitor.json"),
+      JSON.stringify({
+        sessionId: "88b086d5",
+        limitTokens: 200_000,
+        usedTokens: 12_194_022,
+        requestTokens: 142_336,
+        responseTokens: 12_051_686,
+        totalUpdates: 5_646,
+        byTool: { "tools/list": 11_888_383 },
+        display: "12.2M/200K (100%)",
+        percent: 100,
+      }),
+      "utf8",
+    );
+
+    const marker = join(sandboxDir, "posttool-edit-noop.txt");
+    writeFileSync(
+      registryPath,
+      JSON.stringify(
+        createRegistry(
+          [
+            {
+              id: "noop-posttool-edit",
+              matcher: "Edit",
+              command: hookCommand(hookScriptPath, marker, "noop", "", "noop"),
+              priority: 0,
+              enabled: true,
+            },
+          ],
+          "PostToolUse",
+        ),
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = runOrchestrator({
+      cwd: sandboxDir,
+      registryPath,
+      cacheDir,
+      env: { HOME: homeDir, USERPROFILE: homeDir, TFX_POST_TOOL_TIPS: "" },
+      payload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Edit",
+        tool_input: { file_path: "README.md" },
+      },
+    });
+
+    assert.equal(result.status, 0);
+    assert.ok(existsSync(marker));
+    assert.equal(result.stdout.trim(), "");
+    rmSync(nudgeMarker, { force: true });
+  });
+
   it("caches identical PreToolUse:Bash results to avoid recomputing hooks", () => {
     const markerPath = join(sandboxDir, "cached-output.txt");
     const counterPath = join(sandboxDir, "counter.txt");


### PR DESCRIPTION
## Summary

PostToolUse compact nudge was reading `~/.claude/cache/tfx-hub/context-monitor.json` and trusting raw `percent` as Claude session context usage.

That snapshot is written by the Hub HTTP request logger. Long-lived MCP traffic, especially `tools/list`, can inflate it to `12.2M/200K (100%)`, which caused false `[context 100%] ... /compact ...` warnings during 1M-context Opus sessions.

## Change

- Detect the existing Hub token-monitor snapshot shape: `requestTokens`, `responseTokens`, `totalUpdates`, or `byTool`.
- Skip compact nudge emission for those snapshots.
- Preserve compact nudge behavior for non-Hub context snapshots.
- Mirror the hook change into `packages/triflux` and `packages/core`.

## Verification

- [x] `node --test tests/unit/hook-orchestrator.test.mjs`
- [x] `npm run release:check-mirror`
- [x] `npm run release:check-sync`
- [x] `npx biome check hooks/hook-orchestrator.mjs packages/core/hooks/hook-orchestrator.mjs packages/triflux/hooks/hook-orchestrator.mjs tests/unit/hook-orchestrator.test.mjs`
- [x] `npm run lint` exits 0. Existing unrelated warning remains in `tests/unit/conductor-dynamic-routing.test.mjs` for unused `STATES` import.

## Not tested

- Live Claude Code hook render after this branch is installed into an active Claude session.