### PR TITLE
docs+plans: macOS process lifecycle audit + 4-shard PRD prep

### DIFF
--- a/.triflux/plans/macos-lifecycle-index.md
+++ b/.triflux/plans/macos-lifecycle-index.md
@@ -1,0 +1,69 @@
+# macOS Process Lifecycle Fix — Master PRD
+
+> Generated: 2026-05-18
+> Source of truth: [docs/research/macos-process-lifecycle-leak-report-2026-05-18.md](../../docs/research/macos-process-lifecycle-leak-report-2026-05-18.md)
+> Workflow: tfx-swarm 4 worktrees → PR 4개 → Shard 1 PR `/ultrareview` 1회 → squash-merge → `/tfx-ship`
+
+## Overview
+
+보고서 §"Recommended Fix Plan" (lines 379-465) 의 P1~P4 + 본 작업 중 실측으로 발견한 P3b (version drift) / P4b (SessionEnd hook JSON schema mismatch) 를 4개 shard 로 분해. 각 shard 는 worktree 격리 병렬 구현. 보고서 파일이 single source of truth — PRD 는 line range 만 인용.
+
+## Shard 매트릭스
+
+| Shard | Subject | Root files | Mirror targets | Cross-review | Source lines |
+|-------|---------|------------|----------------|--------------|--------------|
+| 1 | P1 macOS mux identity | hub/team/session.mjs, hub/team/terminal-opener.mjs | packages/triflux + packages/remote (Edit) | codex → claude + ultrareview 1회 | 99-134, 273-326, 391-408 |
+| 2 | P2 test-lock supervisor | scripts/test-lock.mjs | packages/triflux/scripts/ | codex → claude | 167-232, 410-428 |
+| 3 | P3a hub stale + P3b version drift | scripts/hub-ensure.mjs, bin/triflux.mjs (doctor) | packages/triflux | codex → gemini | 56-97, 234-271, 430-447 |
+| 4 | P4a tmux cleanup + P4b SessionEnd schema | hooks/session-end-cleanup.mjs, bin/triflux.mjs (doctor) | packages/triflux | codex → claude | 136-163, 328-342, 449-465 |
+
+## 병렬 / 순서 제약
+
+- 기본: 4 shard 모두 worktree 격리 병렬 (tfx-swarm 자동)
+- **Cross-cut**: Shard 3 과 Shard 4 모두 `bin/triflux.mjs doctor` 확장 → 머지 순서 **S3 → S4** (S4 PR 이 S3 branch 위 rebase 또는 stacked) 또는 S4 가 머지 시점에 S3 변경 incorporate
+- Shard 4 의 macOS cleanup path 는 Shard 1 의 mux identity fix 에 의존 (`mux === "tmux"` 검증) — 단 PR 단위 독립 (S4 의 cleanup 호출 시 인터페이스는 S1 fix 이후에도 안정)
+
+## Global Constraints (전 shard 적용)
+
+- 보고서 파일은 본 chore PR 에서 main 으로 commit (PRD 가 line range 인용)
+- No public API signature changes 단독 — caller-impact 분석 동반
+- No `tests/legacy/` 편집, DB/스키마 migration 0, package.json 신규 dep 0
+- `git add -A` 금지 — 의도된 파일만 stage
+- AI attribution footer 금지 (Co-Authored-By 등) — `/tfx-ship` 정책
+- packages mirror policy 준수 (`.claude/rules/tfx-mirror-policy.md`):
+  - hub/, scripts/, hooks/ → `packages/triflux/` byte-identical
+  - hub/lib/, scripts/lib/ → `packages/core/` byte-identical
+  - `packages/remote/` → **Edit only** (`@triflux/core/*` import 보존; cp 사용 시 import 경로 revert 위험)
+  - `tests/` → mirror **제외** (npm files 미포함)
+- 동일 모델 self-approve 금지 — Claude 작성물은 Codex 가, Codex 작성물은 Claude/Gemini 가 리뷰
+
+## ultrareview 예산
+
+- **Shard 1 PR 1회만 사용** — macOS platform edge case 가 가장 위험 (`detectMultiplexer()` 회귀가 attach/cleanup 광범위 영향)
+- Shard 2/3/4 는 Claude<->Codex (또는 ↔ Gemini) cross-review 만
+
+## Done When (전체)
+
+- `gh pr list --search "macos-lifecycle" --state merged --json number | jq length` == 4
+- `pnpm test tests/unit/multiplexer-resolution.test.mjs tests/unit/test-lock.test.mjs tests/integration/hub-singleton.test.mjs tests/unit/session-end-cleanup.test.mjs` exits 0
+- darwin without psmux binary 환경에서 `node -e "import('./hub/team/session.mjs').then(m=>console.log(m.detectMultiplexer()))"` 출력 ≠ `"psmux"`
+- `tfx --version` 이 v10.22.x 출력
+- GitHub release CHANGELOG 가 4 shard 모두 명시
+
+## Worktree Branches (tfx-swarm 가 자동 생성)
+
+- `fix/macos-lifecycle-s1-mux-identity`
+- `fix/macos-lifecycle-s2-test-lock-supervisor`
+- `fix/macos-lifecycle-s3-hub-retirement`
+- `fix/macos-lifecycle-s4-tmux-cleanup-schema`
+
+## Acceptance Criteria 매핑 (보고서 §Acceptance Criteria, lines 466-476)
+
+| 보고서 항목 | 담당 shard |
+|-------------|------------|
+| (1) darwin tmux-only → `detectMultiplexer() === "tmux"` + attach 명령 `tmux attach-session` | S1 |
+| (2) `npm test` orphan node --test 잔존 안 함 | S2 |
+| (3) test-lock stale handling 이 dead lock vs live stale 구분 | S2 |
+| (4) `tfx doctor` 가 stale hub clusters + tmux sessions 보고 | S3 + S4 |
+| (5) hub startup 후 stale hub instances 누적 안 함 | S3 |
+| (6) darwin mux identity / test child cleanup / stale hub 회귀 테스트 | S1 + S2 + S3 |

--- a/.triflux/plans/macos-lifecycle-shard-1.md
+++ b/.triflux/plans/macos-lifecycle-shard-1.md
@@ -1,0 +1,99 @@
+# Shard 1 — P1 macOS Multiplexer Identity Fix
+
+> Source: [docs/research/macos-process-lifecycle-leak-report-2026-05-18.md](../../docs/research/macos-process-lifecycle-leak-report-2026-05-18.md)
+> Cited ranges: §"Multiplexer identity mismatch" (lines 99-134), §"macOS tmux/psmux compatibility regression" (lines 273-326), §"P1 Recommended Fix" (lines 391-408)
+> Worktree branch: `fix/macos-lifecycle-s1-mux-identity`
+
+## Problem
+
+`hub/team/session.mjs::detectMultiplexer()` 가 `hasPsmux()` alias 를 literal mux identity 로 변환:
+
+- 보고서 lines 300-311 의 발췌:
+  ```
+  if (hasPsmux()) {
+    _cachedMux = "psmux";
+    return _cachedMux;
+  }
+  if (hasTmux()) {
+    _cachedMux = "tmux";
+    return _cachedMux;
+  }
+  ```
+- `hasPsmux = hasMultiplexer` 는 psmux.mjs 가 정의한 alias (보고서 line 294) — 의미는 "primary mux 가용", 즉 darwin/Linux 에서는 tmux 도 true 반환
+- session.mjs 는 이 alias 를 "literal psmux binary 존재" 로 오인 → darwin + tmux only host 에서 cache 가 `"psmux"`
+- `terminal-opener.mjs::buildAttachCommand` (보고서 lines 318-323) 가 `mux === "psmux"` 분기에서 `psmux attach-session` 명령 emit → host 에 psmux 바이너리 없으니 실행 실패
+
+라이브 evidence (보고서 lines 111-119):
+```
+platform: darwin
+psmuxModuleMultiplexerType: tmux  ← psmux.mjs 는 옳게 tmux 해석
+sessionDetectMultiplexer: psmux   ← session.mjs 가 오해
+hasMultiplexer: true
+hasPsmuxAlias: true
+```
+
+## Fix Direction (보고서 lines 396-401)
+
+1. `hub/team/session.mjs::detectMultiplexer()`:
+   - `hasPsmux()` first-check 제거
+   - 대신 `psmux.mjs::getMultiplexerType()` (= `PSMUX_BIN` 환경 또는 platform-aware default) 를 literal mux-type resolver 로 사용
+   - 또는 platform + binary 존재 검증으로 분기: darwin/linux + tmux 가용 → `"tmux"`; psmux 바이너리 명시 + 가용 → `"psmux"`; 그 외 → null
+2. Windows primary 는 `"psmux"` 유지 (보고서 line 398) — POSIX 와 분기 명시
+3. `hub/team/terminal-opener.mjs::buildAttachCommand`:
+   - `mux === "psmux"` 분기는 보존 (Windows path 용)
+   - 단 호출 전제 강화: `PSMUX_BIN` env 명시 + 바이너리 존재 검증 동반 (그렇지 않으면 darwin 에서 호출되지 않음)
+4. `hasPsmux` backward-compatible alias 는 그대로 export — 외부 호출자 가 있을 수 있음 — 단 session.mjs 내부에서는 신뢰 금지 (literal mux identity 추론 우회)
+
+## Acceptance Criteria (보고서 lines 404-408)
+
+- darwin + tmux 가용 + psmux 부재 → `detectMultiplexer() === "tmux"`
+- darwin 의 terminal opener → attach command 가 `tmux attach-session` 포함
+- Windows path → 여전히 `detectMultiplexer() === "psmux"`
+- `hasPsmux` alias 는 literal mux identity 로 누설되지 않음 (호출 시점에 의미 명확)
+
+## Regression Tests (필수 추가)
+
+`tests/unit/multiplexer-resolution.test.mjs` 확장:
+- `darwin + tmux available + psmux missing → detectMultiplexer() === "tmux"` (보고서 line 405)
+- `darwin terminal-opener emits "tmux attach-session"` (line 406)
+- `windows path remains "psmux"` (line 407)
+- `hasPsmux() alias true on darwin (because tmux available) but detectMultiplexer() !== "psmux"` (line 408)
+
+`tests/unit/terminal-opener.test.mjs`:
+- `buildAttachCommand("tmux", "demo")` returns string containing `tmux attach-session -t 'demo'`
+- `buildAttachCommand("psmux", "demo")` 호출은 `PSMUX_BIN` env 명시 + 가상 binary 존재 stub 시에만 정상 — 그 외에는 호출 자체가 darwin 에서 일어나지 않도록 caller 검증
+
+## Files (root + mirror)
+
+| Root path | packages/triflux mirror | packages/remote mirror |
+|-----------|-------------------------|------------------------|
+| `hub/team/session.mjs` | byte-identical (cp 또는 동시 Edit) | **Edit only** — `@triflux/core/*` import 경로 보존 |
+| `hub/team/terminal-opener.mjs` | byte-identical | Edit only |
+| `tests/unit/multiplexer-resolution.test.mjs` | mirror 제외 (npm files 미포함) | mirror 제외 |
+| `tests/unit/terminal-opener.test.mjs` | mirror 제외 | mirror 제외 |
+
+Mirror verify (`.claude/rules/tfx-mirror-policy.md §검증`):
+```bash
+diff -q hub/team/session.mjs packages/triflux/hub/team/session.mjs   # exit 0
+diff -q hub/team/terminal-opener.mjs packages/triflux/hub/team/terminal-opener.mjs   # exit 0
+grep -E "@triflux/core/" packages/remote/hub/team/session.mjs   # non-empty
+grep -E "@triflux/core/" packages/remote/hub/team/terminal-opener.mjs   # non-empty
+```
+
+## Cross-review
+
+- Author CLI: codex (gpt-5.3-codex)
+- Reviewer: claude (opus-4-7) — platform edge case
+- ultrareview 1회: 머지 직전 `claude ultrareview <pr-s1>` (Pro 무료 1회 소비, severity=critical 시 머지 차단)
+
+## Verify (PR body 에 포함)
+
+```bash
+pnpm test tests/unit/multiplexer-resolution.test.mjs tests/unit/terminal-opener.test.mjs
+node -e "import('./hub/team/session.mjs').then(m=>console.log(m.detectMultiplexer()))"
+diff -q hub/team/session.mjs packages/triflux/hub/team/session.mjs
+diff -q hub/team/terminal-opener.mjs packages/triflux/hub/team/terminal-opener.mjs
+grep "@triflux/core/" packages/remote/hub/team/session.mjs
+```
+
+기대 결과: 모두 0 또는 비어있지 않은 출력. darwin 명령 출력은 `"tmux"` (또는 null), 절대 `"psmux"` 아님.

--- a/.triflux/plans/macos-lifecycle-shard-2.md
+++ b/.triflux/plans/macos-lifecycle-shard-2.md
@@ -1,0 +1,100 @@
+# Shard 2 — P2 `scripts/test-lock.mjs` Supervisor Hardening
+
+> Source: [docs/research/macos-process-lifecycle-leak-report-2026-05-18.md](../../docs/research/macos-process-lifecycle-leak-report-2026-05-18.md)
+> Cited ranges: §"Test runner supervision gap" (lines 167-232), §"P2 Recommended Fix" (lines 410-428)
+> Worktree branch: `fix/macos-lifecycle-s2-test-lock-supervisor`
+
+## Problem
+
+`scripts/test-lock.mjs` 는 concurrent start 만 막고 child lifetime 을 owning 하지 않음:
+
+- 보고서 lines 192-207 의 발췌:
+  ```
+  process.on("SIGTERM", () => {
+    releaseLock();
+    process.exit(143);
+  });
+  const child = spawn(process.execPath, args, {
+    stdio: ["pipe", "inherit", "inherit"],
+    env: { ...process.env, TEST_LOCK_PID: String(process.pid) },
+  });
+  child.on("exit", (code) => {
+    releaseLock();
+    process.exit(code ?? 1);
+  });
+  ```
+- 누락 (보고서 lines 209-216):
+  - timeout 없음
+  - SIGINT/SIGTERM/SIGHUP child 로 forward 안 함
+  - parent exit 시 child kill 안 함
+  - process group / detached group 관리 없음
+  - 10분 이상 lock 시 stale child 검출 없음
+  - stale lock 제거 ≠ stale process cleanup
+- `scripts/release/prepare.mjs` 의 10분 timeout (보고서 lines 220-228) 은 release path 한정 — `npm test`, `npm run test:unit`, `npm run test:integration` 미상속
+
+라이브 evidence (보고서 lines 25-31, 35-38):
+```
+PID 72215, PPID 1, age ≈ 2일, 29.7GB footprint
+Command: node --test --test-force-exit --test-concurrency=8 …
+```
+parent 가 죽고 launchd 가 reparent → 본 보고서의 30GB / 16GB RAM 사고 직접 원인
+
+## Fix Direction (보고서 lines 414-421)
+
+1. **timeout 도입**: env `TEST_LOCK_TIMEOUT_MS` (default 10min, release prepare 와 동일). 초과 시 child kill + non-zero exit
+2. **signal forwarding**: parent 가 SIGINT/SIGTERM/SIGHUP 수신 → child 에 동일 signal forward → wait → exit
+3. **parent shutdown → child kill**: child.kill('SIGTERM') → 5s grace → SIGKILL → wait → exit
+4. **process group**: POSIX 환경에서 `detached: true` + `process.kill(-pid, 'SIGTERM')` 또는 동등한 group kill 검토 (보고서 line 419) — Windows 호환성 영향 분석 동반
+5. **lock metadata 에 child PID 추가**: lock 파일 schema 에 `{ parent_pid, child_pid, started_at, timeout_ms }` 저장 — cleanup 이 정확한 PID 추적
+6. **stale lock 처리 분기** (보고서 lines 427-428):
+   - stale lock + live child PID → actionable diagnostic + non-zero exit (overwrite 금지, 보고서 line 420)
+   - stale lock + dead child PID → cleanup + 정상 진행
+
+## Acceptance Criteria (보고서 lines 425-428)
+
+- Parent SIGTERM 수신 → child 종료 (forward 또는 kill)
+- Child timeout 초과 → wrapper non-zero exit + child not alive (`kill -0 child_pid` exit non-zero)
+- Stale lock + live child → actionable diagnostic (PID + age + command 노출), exit non-zero, lock 보존
+- Stale lock + dead child → cleanup + 정상 진행
+- 정상 종료 flow (timeout 미트리거) → 기존 동작 보존
+
+## Regression Tests (필수 추가)
+
+`tests/unit/test-lock.test.mjs` (신규):
+- `parent SIGTERM forwarded to child` (보고서 line 425)
+- `child timeout → non-zero exit + child killed within 5s grace` (line 426)
+- `stale lock with live child → actionable diagnostic + non-zero exit + lock preserved` (line 427)
+- `stale lock with dead child → cleanup + proceed` (line 428)
+- `lock metadata schema includes child_pid` (회귀: schema 변경)
+
+## Files (root + mirror)
+
+| Root path | packages/triflux mirror |
+|-----------|-------------------------|
+| `scripts/test-lock.mjs` | byte-identical (cp 또는 동시 Edit) |
+| `tests/unit/test-lock.test.mjs` | **mirror 제외** (`tests/` 는 npm files 미포함, `.claude/rules/tfx-mirror-policy.md §mirror 제외`) |
+
+Mirror verify:
+```bash
+diff -q scripts/test-lock.mjs packages/triflux/scripts/test-lock.mjs   # exit 0
+```
+
+Note: `packages/triflux/scripts/__tests__/` 가 따로 테스트 mirror 한다면 동기 (PR #222 패턴), 단 일반 `tests/unit/` 은 미포함.
+
+## Cross-review
+
+- Author CLI: codex (gpt-5.3-codex)
+- Reviewer: claude (opus-4-7)
+- ultrareview 미사용
+
+## Verify (PR body 에 포함)
+
+```bash
+pnpm test tests/unit/test-lock.test.mjs
+TEST_LOCK_TIMEOUT_MS=500 node scripts/test-lock.mjs --test tests/unit/runtime-strategy.test.mjs
+echo "exit: $?"
+pgrep -f "node --test --test-force-exit" | wc -l   # 0
+diff -q scripts/test-lock.mjs packages/triflux/scripts/test-lock.mjs
+```
+
+기대 결과: pnpm test 통과; 짧은 timeout 으로 child 즉시 종료 (non-zero exit + pgrep 0).

--- a/.triflux/plans/macos-lifecycle-shard-3.md
+++ b/.triflux/plans/macos-lifecycle-shard-3.md
@@ -1,0 +1,126 @@
+# Shard 3 — P3a Hub Stale Retirement + P3b Version Drift
+
+> Source: [docs/research/macos-process-lifecycle-leak-report-2026-05-18.md](../../docs/research/macos-process-lifecycle-leak-report-2026-05-18.md)
+> Cited ranges: §"Hub server accumulation" (lines 56-97), §"Hub detached singleton gap" (lines 234-271), §"P3 Recommended Fix" (lines 430-447)
+> Live evidence (P3b, 본 작업 중 추가 발견 — 2026-05-18 재부팅 직전 캡처): pid file 가리키는 `PID 86156 / port 29196 / v10.21.0-867d18a3` 는 dead, active hub 는 `PID 61463 / port 27888 / v10.20.2-efabb91b` (옛 version). 재부팅으로 자연 해결됐으나 동일 재발 방지를 위해 코드 fix 필수.
+> Worktree branch: `fix/macos-lifecycle-s3-hub-retirement`
+
+## Problem
+
+### P3a — Hub stale retirement (보고서 §"Hub detached singleton gap", lines 234-271)
+
+`scripts/hub-ensure.mjs` 가 detached + unref start 후 target host/port health 만 확인:
+
+- 보고서 lines 242-249 의 발췌:
+  ```
+  const child = spawn(process.execPath, [serverPath], {
+    env,
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  child.unref();
+  ```
+- 보고서 lines 254-262 의 발췌:
+  ```
+  if (await isHubHealthy(host, port)) { … return … }
+  const started = startHubDetached(port);
+  ```
+- 누락 (보고서 lines 264-270):
+  - repo-wide / user-wide stale hub reaper 없음
+  - `~/.claude/cache/tfx-hub/hub.pid` 가 live current hub 가리키는지 검증 안 함
+  - random port 위 옛 hub 정리 안 함
+  - 새/옛 hub 공존 시 version-aware retirement 없음
+
+라이브 evidence (보고서 lines 60-91): 46개 hub/server.mjs (전부 PPID=1, 누적 RSS 677 MB), pid file (port 29196, v10.21.0-867d18a3) vs active /health (port 27888, v10.20.2-efabb91b) 불일치.
+
+### P3b — Version drift (작업 중 추가 발견, 보고서 §P3 의 구체 사례)
+
+- v10.21.0 새 hub 가 :27888 점유 시도 → 옛 v10.20.2 LISTEN 중 → `:29196` 으로 cascade → pid file 갱신
+- PID 86156 (:29196) 죽고 옛 PID 61463 (:27888) 살아남음
+- 결과: 사용자가 옛 version 으로 작업 (pid file 은 새 version 가리키지만 실제 traffic 은 옛 version 으로)
+- 보고서 P3 가 명시한 "version-aware retirement" 부재의 구체 사례
+
+## Fix Direction (보고서 lines 434-440)
+
+1. **`scripts/hub-ensure.mjs` startup 검증 강화**:
+   - pid file 의 PID alive 확인 (`process.kill(pid, 0)` exit code)
+   - 해당 PID 가 실제 `hub/server.mjs` 인지 (proc cmd 매칭)
+   - listening port == pid file port (`lsof -nP -iTCP:<port> -sTCP:LISTEN`)
+   - `/health` 응답 `version` == 기대 version
+   - 불일치 시 명시 warn + retirement 시도
+2. **port-collision + version mismatch → retire**:
+   - 옛 hub 에 SIGTERM → 5s grace → SIGKILL → port 점유 풀린 뒤 새 hub bind
+   - retire 실패 시 random-port cascade 허용하되 stderr warn (silent 금지)
+3. **`bin/triflux.mjs doctor` stale hub diagnostic 추가**:
+   - PPID=1 인 hub/server.mjs 목록: PID, version, uptime, port, 외부 ESTABLISHED connection count
+   - 총 RSS estimate
+4. **opt-in cleanup CLI**:
+   - `tfx doctor --cleanup-stale-hubs` (active healthy hub 명시 제외)
+   - default dry-run (보고서 line 446: "cleanup excludes the active healthy hub")
+   - 명시 `--apply` 시 실제 SIGTERM/SIGKILL
+
+## Acceptance Criteria (보고서 lines 442-447)
+
+- Stale pid file 이 active default hub 를 masking 안 함 (line 444)
+- 여러 옛 hub 가 doctor 에서 보고됨 (line 445)
+- cleanup 이 active healthy hub 제외 (line 446)
+- repo/worktree 별 hub 격리 또는 명시 cross-worktree 보고 (line 447)
+- P3b 회귀: port-collision + version mismatch → 옛 hub retire 시도 + 새 hub bind 또는 명시 warn
+
+## Regression Tests
+
+`tests/integration/hub-singleton.test.mjs` 확장:
+- `stale pid file does not mask active default hub` (보고서 line 444)
+- `multiple old hubs reported in doctor output` (line 445)
+- `cleanup excludes the active healthy hub` (line 446)
+
+`tests/unit/hub-ensure-version-drift.test.mjs` (신규, P3b 회귀):
+- `port-collision + version mismatch → old hub retire attempted`
+- `retire failure → cascade with stderr warn (not silent)`
+- `pid file pointing to dead PID → invalidated and rewritten`
+
+`tests/unit/doctor-stale-hubs.test.mjs` (신규):
+- `doctor lists PPID=1 hub/server.mjs with version + uptime + port`
+- `doctor --cleanup-stale-hubs --dry-run excludes active healthy hub`
+
+## Files (root + mirror)
+
+| Root path | packages/triflux mirror |
+|-----------|-------------------------|
+| `scripts/hub-ensure.mjs` | byte-identical |
+| `bin/triflux.mjs` (doctor 명령 확장) | byte-identical |
+| `tests/integration/hub-singleton.test.mjs` | mirror 제외 |
+| `tests/unit/hub-ensure-version-drift.test.mjs` | mirror 제외 |
+| `tests/unit/doctor-stale-hubs.test.mjs` | mirror 제외 |
+
+Mirror verify:
+```bash
+diff -q scripts/hub-ensure.mjs packages/triflux/scripts/hub-ensure.mjs   # exit 0
+diff -q bin/triflux.mjs packages/triflux/bin/triflux.mjs   # exit 0
+```
+
+## Cross-review
+
+- Author CLI: codex (gpt-5.3-codex)
+- Reviewer: gemini (pro25) — architecture cross-check (Plan-level)
+- ultrareview 미사용
+
+## Cross-cut Coordination
+
+`bin/triflux.mjs doctor` 는 Shard 4 도 확장 (P4b SessionEnd schema + detached tmux reporting). **머지 순서**:
+- 권장: S3 → S4 (S4 PR 이 S3 branch 위 rebase) — doctor 출력 conflict 회피
+- 또는 stacked PR (S4 base = S3 branch)
+- swarm worker 가 자동 rebase 못 하면 PR head 사용자 또는 다음 lane (S4 worker) 가 명시 rebase
+
+## Verify (PR body 에 포함)
+
+```bash
+pnpm test tests/integration/hub-singleton.test.mjs tests/unit/hub-ensure-version-drift.test.mjs tests/unit/doctor-stale-hubs.test.mjs
+tfx doctor 2>&1 | grep -E "stale|hub|PPID"   # stale hub 항목 노출
+tfx doctor --cleanup-stale-hubs --dry-run 2>&1 | grep -E "active|excluded|skip"   # active 제외
+diff -q scripts/hub-ensure.mjs packages/triflux/scripts/hub-ensure.mjs
+diff -q bin/triflux.mjs packages/triflux/bin/triflux.mjs
+```
+
+기대 결과: 모든 명령 0 exit. doctor 가 stale hub 보고. cleanup --dry-run 출력에 active hub 가 "skipped/excluded" 로 명시.

--- a/.triflux/plans/macos-lifecycle-shard-4.md
+++ b/.triflux/plans/macos-lifecycle-shard-4.md
@@ -1,0 +1,115 @@
+# Shard 4 — P4a tmux Cleanup Policy + P4b SessionEnd Hook JSON Schema
+
+> Source: [docs/research/macos-process-lifecycle-leak-report-2026-05-18.md](../../docs/research/macos-process-lifecycle-leak-report-2026-05-18.md)
+> Cited ranges: §"Detached tmux sessions and zombies" (lines 136-163), §"SessionEnd cleanup is intentionally report-only" (lines 328-342), §"P4 Recommended Fix" (lines 449-465)
+> Live evidence (P4b, 본 작업 중 추가 발견 — 세션 종료 hook 라이브 캡처):
+> ```
+> Hook JSON output validation failed — (root): Invalid input
+> ```
+> 출력 schema 가 `{systemMessage, hookSpecificOutput: {hookEventName, additionalContext}}` 인데 Claude Code 최신 SessionEnd hook schema 와 mismatch — 매 세션 종료 시 validation error 발생.
+> Worktree branch: `fix/macos-lifecycle-s4-tmux-cleanup-schema`
+
+## Problem
+
+### P4a — tmux cleanup policy gap (보고서 §"Detached tmux sessions and zombies", lines 136-163)
+
+라이브 evidence (보고서 lines 139-156): 11개 detached tmux session (omx-projects-*, tfx-mac-multi-smoke-*, tpcg-brief-* 등) + 8 zombie. tmux 가 detached session 을 설계대로 보존 — 단 cross-project + 오래된 unattended 세션이 누적되는 workflow 와 충돌. 보고서 line 162: "lifecycle policy is too weak for this workflow".
+
+`hooks/session-end-cleanup.mjs` 는 의도적으로 report-only (보고서 lines 336-340):
+```
+// Report-only by default. Opt-in cleanup only removes the repo-local
+// .triflux/subagents/subagents.json file when stale running lifecycle state is
+// present. It never kills processes or touches external HOME/MCP configs.
+```
+안전하지만 lifecycle gap 보존 — Shard 1 의 mux identity fix 와 결합해야 macOS path 에서 `tmux` 사용.
+
+### P4b — SessionEnd hook JSON schema mismatch (작업 중 추가 발견)
+
+- `hooks/session-end-cleanup.mjs::buildOutput()` 가 `{systemMessage, hookSpecificOutput: {hookEventName, additionalContext}}` 반환
+- Claude Code current hook schema 는 PreToolUse / PostToolUse / Stop / SessionEnd 마다 `hookSpecificOutput` 구조 다름 — SessionEnd 의 정확한 shape 미일치
+- 매 세션 종료 시 `Hook JSON output validation failed — (root): Invalid input` 발생 → hook 의 cleanup signal 이 Claude Code 에 미반영, 로그만 누적
+
+## Fix Direction (보고서 lines 453-459)
+
+### P4a
+
+1. **`hooks/session-end-cleanup.mjs` detached tmux session 리포트 확장**:
+   - 각 session 의 age, cwd, command, 추정 process tree memory (보고서 line 456)
+   - macOS path 는 mux === "tmux" 사용 (Shard 1 의 fix 의존)
+   - psmux-specific Windows cleanup 과 분리 보존 (보고서 line 458)
+2. **`bin/triflux.mjs doctor` 에 detached session 항목 추가** (S3 와 lockstep)
+3. **명시 cleanup CLI**:
+   - `tfx doctor --cleanup-stale-tmux --prefix tfx-*` (age threshold 옵션, default dry-run)
+   - prefix/scope 밖 session 거부 (보고서 line 464)
+4. **report-only default 유지** — 명시 옵션 없이 session kill 안 함 (line 463)
+
+### P4b
+
+1. **SessionEnd hook schema 정합화**:
+   - Claude Code current spec (SessionEnd hookSpecificOutput) 확인 후 `buildOutput()` return shape 갱신
+   - shape 후보: `{ continue: boolean, suppressOutput?: boolean, decision?: 'allow'|'block', reason?: string }` 또는 SessionEnd 전용 키 — spec 우선
+2. **출력 검증**:
+   - `buildOutput()` 가 spec 준수하는지 inline shape check 또는 (가능하면) zod 같은 validation 도입은 dep 추가 금지 정책 위반 — 자체 함수
+3. **회귀 방어**:
+   - validation error 0 회귀 테스트
+
+## Acceptance Criteria (보고서 lines 462-465 + P4b)
+
+- macOS cleanup path 가 `tmux` 사용 (line 462; Shard 1 의존)
+- report-only default path 가 session kill 안 함 (line 463)
+- explicit cleanup 이 prefix/scope 밖 session 거부 (line 464)
+- doctor 출력에 detached session count + memory estimate 포함
+- SessionEnd hook 출력 → Claude Code validation 통과 (Invalid input 0)
+
+## Regression Tests
+
+`tests/unit/session-end-cleanup.test.mjs` (신규):
+- `report-only default → sessions not killed (mock spawn assertion)`
+- `cleanup with --prefix tfx-* matching → only matching sessions killed (default dry-run)`
+- `cleanup with prefix not matching → session refused with diagnostic`
+- `buildOutput() return value passes SessionEnd hook spec shape check`
+
+`tests/unit/doctor-macos-hooks.test.mjs` 확장:
+- `doctor output includes detached tmux session count`
+- `doctor output includes memory estimate per session`
+
+## Files (root + mirror)
+
+| Root path | packages/triflux mirror |
+|-----------|-------------------------|
+| `hooks/session-end-cleanup.mjs` | byte-identical |
+| `bin/triflux.mjs` (doctor 확장 — S3 와 lockstep) | byte-identical |
+| `tests/unit/session-end-cleanup.test.mjs` | mirror 제외 |
+| `tests/unit/doctor-macos-hooks.test.mjs` | mirror 제외 |
+
+Mirror verify:
+```bash
+diff -q hooks/session-end-cleanup.mjs packages/triflux/hooks/session-end-cleanup.mjs   # exit 0
+diff -q bin/triflux.mjs packages/triflux/bin/triflux.mjs   # exit 0
+```
+
+## Cross-review
+
+- Author CLI: codex (gpt-5.3-codex)
+- Reviewer: claude (opus-4-7)
+- ultrareview 미사용
+
+## Cross-cut Coordination
+
+`bin/triflux.mjs doctor` 는 Shard 3 의 stale hub diagnostic 과 함께 확장. **머지 순서 S3 → S4 권장**:
+- S4 PR 은 S3 branch (`fix/macos-lifecycle-s3-hub-retirement`) 위 rebase 또는 stacked
+- S3 머지 후 S4 가 main rebase 후 doctor 출력 통합
+
+Shard 1 의존: macOS cleanup path 가 `mux === "tmux"` 로 동작하려면 S1 의 `detectMultiplexer()` fix 가 main 에 머지된 상태여야 자연스러움. 단 PR 단위에서는 독립 (S4 의 cleanup 호출이 S1 fix 이후에도 인터페이스 안정).
+
+## Verify (PR body 에 포함)
+
+```bash
+pnpm test tests/unit/session-end-cleanup.test.mjs tests/unit/doctor-macos-hooks.test.mjs
+tfx doctor 2>&1 | grep -iE "detached|tmux|session"   # detached session 항목 노출
+node hooks/session-end-cleanup.mjs --self-test 2>&1 | grep -i "schema"   # validation pass
+diff -q hooks/session-end-cleanup.mjs packages/triflux/hooks/session-end-cleanup.mjs
+diff -q bin/triflux.mjs packages/triflux/bin/triflux.mjs
+```
+
+기대 결과: 모든 명령 0 exit. doctor 가 detached tmux session 보고. SessionEnd hook self-test 가 schema validation pass.

--- a/docs/research/macos-process-lifecycle-leak-report-2026-05-18.md
+++ b/docs/research/macos-process-lifecycle-leak-report-2026-05-18.md
@@ -1,0 +1,499 @@
+# macOS Process Lifecycle Leak Report
+
+Date: 2026-05-18
+Host: macOS / darwin
+Repo: `triflux`
+Scope: read-only investigation and problem definition. No process cleanup or code changes were performed.
+
+## Executive Summary
+
+This is not a single macOS compatibility bug. The observed RAM/process issue is a layered failure:
+
+1. A runaway orphaned `node --test` process is the direct high-memory offender.
+2. Detached `hub/server.mjs` instances accumulate because hub lifecycle cleanup is not global enough.
+3. macOS multiplexer detection incorrectly reports `psmux` even though this host is tmux-only.
+4. Detached tmux sessions and zombie processes are secondary cleanup-policy symptoms, not the main RAM source.
+
+The biggest RAM symptom is a design/lifecycle bug in the test runner supervision path, not a psmux/tmux issue. The true macOS compatibility regression is the multiplexer identity mismatch: `session.mjs` reports `"psmux"` on darwin while the resolved primary multiplexer is `"tmux"` and no `psmux` binary exists.
+
+## Current Live Evidence
+
+### High-memory test process
+
+Current process:
+
+```text
+PID: 72215
+PPID: 1
+Started: Sat May 16 13:29:06 2026
+Age at sampling: about 2 days
+Command: /opt/homebrew/Cellar/node/26.0.0/bin/node --test --test-force-exit --test-concurrency=8 ...
+```
+
+`top` sample:
+
+```text
+PID    PPID COMMAND MEM RSIZE STATE    TIME
+72215  1    node    30G 30G   sleeping 49:25:37
+```
+
+`vmmap -summary` sample:
+
+```text
+Physical footprint:         29.7G
+Physical footprint (peak):  29.7G
+Writable regions: Total=31.4G written=29.7G resident=22.4M swapped_out=29.7G
+MALLOC_SMALL                      26.9G
+DefaultMallocZone_0x103a6c000     31.0G ... 29.7G ...
+```
+
+Interpretation:
+
+- Stats.app showing Node around 24-30 GB is materially correct when reading footprint/pressure, even if RSS-only tools undercount it.
+- Most of the footprint is swapped/compressed rather than resident, but it is still real memory pressure.
+- `PPID=1` means the test process has been reparented to launchd and is no longer supervised by its original parent.
+
+### Hub server accumulation
+
+Current aggregate:
+
+```text
+hub_server_count=46
+hub_server_ppid1=46
+hub_server_total_rss_kb=693312
+hub_server_total_rss_mb=677.1
+```
+
+All observed `hub/server.mjs` processes are orphan-like `PPID=1` detached processes.
+
+The pid file is stale or at least not the active source of truth:
+
+```json
+{
+  "pid": 86156,
+  "port": 29196,
+  "version": "10.21.0-867d18a3",
+  "url": "http://127.0.0.1:29196/mcp"
+}
+```
+
+But the default live health endpoint responds on port `27888`:
+
+```json
+{
+  "ok": true,
+  "version": "10.20.2-efabb91b",
+  "platform": "darwin",
+  "uptime_s": 260690,
+  "node": "v26.0.0",
+  "sessions": 8
+}
+```
+
+Interpretation:
+
+- The active hub and the pid-file hub do not agree.
+- Multiple detached hubs can survive across sessions, versions, and worktrees.
+- The total hub memory is not the 30 GB problem, but it is a persistent process leak.
+
+### Multiplexer identity mismatch
+
+Host state:
+
+```text
+psmux_path=MISSING
+tmux_path=/opt/homebrew/bin/tmux
+tmux 3.6a
+```
+
+Runtime module state:
+
+```json
+{
+  "platform": "darwin",
+  "sessionDetectMultiplexer": "psmux",
+  "psmuxModuleMultiplexerType": "tmux",
+  "hasMultiplexer": true,
+  "hasPsmuxAlias": true
+}
+```
+
+Terminal opener command generation:
+
+```text
+psmux: new-window -n 'Demo' 'psmux attach-session -t '\''demo-session'\'''
+tmux:  new-window -n 'Demo' 'tmux attach-session -t '\''demo-session'\'''
+```
+
+Interpretation:
+
+- macOS is correctly configured as tmux-only at the host level.
+- `psmux.mjs` internally resolves the primary multiplexer to `tmux`.
+- `session.mjs` still converts the backward-compatible `hasPsmux` alias into the literal mux identity `"psmux"`.
+- Any caller that uses the literal detected mux to build attach commands may emit `psmux attach-session` on macOS, which will fail on this host.
+
+### Detached tmux sessions and zombies
+
+Detached sessions observed:
+
+```text
+omx-projects-detached-1778545119011-924vgc
+omx-projects-detached-1778550044173-9cxefn
+omx-projects-detached-1778804860192-a4p8pm
+omx-tpcg-mailrouter-main-1778811369664-0uuxot
+omx-triflux-fix-codex-exec-stdin-redirect-1778823416380-nujufh
+omx-work-detached-1778633591273-xqcz4d
+tfx-mac-multi-smoke-6ncsss
+tfx-multi-wsn7jknb
+tpcg-brief-53631
+tpcg-brief-8878
+tpcg-demo-server
+```
+
+Zombie count:
+
+```text
+zombie_count=8
+```
+
+Interpretation:
+
+- tmux is preserving detached sessions exactly as designed.
+- Some sessions are old and unattended, so lifecycle policy is too weak for this workflow.
+- Zombies have zero meaningful memory footprint, but they are evidence of missing reap/cleanup in some parent chains.
+
+## Code Evidence
+
+### Test runner supervision gap
+
+Relevant files:
+
+- `package.json`
+- `scripts/test-lock.mjs`
+- `scripts/release/prepare.mjs`
+
+`package.json` routes normal tests through the lock wrapper:
+
+```json
+"test": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 \"tests/**/*.test.mjs\" \"scripts/__tests__/**/*.test.mjs\"",
+"test:unit": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/unit/**/*.test.mjs",
+"test:integration": "node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/integration/**/*.test.mjs"
+```
+
+`scripts/test-lock.mjs` is explicitly designed to avoid concurrent test memory explosions:
+
+```js
+// npm test 동시 실행 방지. conductor 같은 child-spawn 테스트가
+// 3중 실행되면 WT ConPTY 수백 개 -> 16GB RAM 사고 발생.
+```
+
+But the wrapper only guards concurrent start, not child lifetime:
+
+```js
+process.on("SIGTERM", () => {
+  releaseLock();
+  process.exit(143);
+});
+
+const child = spawn(process.execPath, args, {
+  stdio: ["pipe", "inherit", "inherit"],
+  env: { ...process.env, TEST_LOCK_PID: String(process.pid) },
+});
+
+child.on("exit", (code) => {
+  releaseLock();
+  process.exit(code ?? 1);
+});
+```
+
+Missing pieces:
+
+- No timeout in `scripts/test-lock.mjs`.
+- No signal forwarding to the child.
+- No child kill on parent exit.
+- No process group / detached group management.
+- No stale child detection when a lock is older than 10 minutes.
+- Stale lock removal does not imply stale process cleanup.
+
+`scripts/release/prepare.mjs` has a 10-minute timeout for the release path:
+
+```js
+const TEST_TIMEOUT_MS = 10 * 60 * 1000;
+...
+options: {
+  timeoutMs: TEST_TIMEOUT_MS,
+  maxBuffer: 128 * 1024 * 1024,
+  shell: false,
+}
+```
+
+But normal `npm test`, `npm run test:unit`, and `npm run test:integration` do not inherit that timeout unless they are executed through the release prepare command.
+
+Classification: design error. macOS exposes the failure clearly because orphaned children are reparented to launchd and memory pressure is visible in footprint/swap metrics, but the underlying supervision gap is cross-platform.
+
+### Hub detached singleton gap
+
+Relevant file:
+
+- `scripts/hub-ensure.mjs`
+
+The hub is started as a detached, unreferenced process:
+
+```js
+const child = spawn(process.execPath, [serverPath], {
+  env,
+  detached: true,
+  stdio: "ignore",
+  windowsHide: true,
+});
+child.unref();
+```
+
+The startup path checks only the target host/port health:
+
+```js
+if (await isHubHealthy(host, port)) {
+  await syncHubConfigsIfAvailable({ hubUrl });
+  snapshotUserStateBestEffort();
+  return { code: 0, stdout: "hub: ok", stderr: "" };
+}
+
+const started = startHubDetached(port);
+```
+
+Missing pieces:
+
+- No repo-wide or user-wide stale hub reaper.
+- No active validation that `~/.claude/cache/tfx-hub/hub.pid` points to a live current hub.
+- No cleanup of older hub processes on random ports.
+- No version-aware retirement when newer/older hubs coexist.
+
+Classification: design/operational lifecycle error. This is not the immediate 30 GB offender, but it is a real leak pattern.
+
+### macOS tmux/psmux compatibility regression
+
+Relevant files:
+
+- `hub/team/psmux.mjs`
+- `hub/team/session.mjs`
+- `hub/team/terminal-opener.mjs`
+
+`hub/team/psmux.mjs` correctly documents and resolves mac/Linux primary mux as tmux:
+
+```js
+//   - mac/Linux: tmux 가 primary (POSIX 표준)
+//   - Windows: psmux 가 primary (Windows pwsh7 전용)
+...
+// mac/Linux primary: tmux (POSIX 표준). silent fallback 아님 — 정식 primary.
+```
+
+It also preserves a backward-compatible alias:
+
+```js
+export function hasMultiplexer() { ... }
+export const hasPsmux = hasMultiplexer;
+export function getMultiplexerType() {
+  return PSMUX_BIN;
+}
+```
+
+`hub/team/session.mjs` treats that alias as literal psmux identity:
+
+```js
+if (hasPsmux()) {
+  _cachedMux = "psmux";
+  return _cachedMux;
+}
+if (hasTmux()) {
+  _cachedMux = "tmux";
+  return _cachedMux;
+}
+```
+
+That is the regression. On macOS, `hasPsmux()` means "the OS primary mux is available", not "literal psmux binary is available".
+
+`hub/team/terminal-opener.mjs` then builds literal attach commands from the mux identity:
+
+```js
+function buildAttachCommand(mux, sessionName) {
+  if (mux === "psmux") {
+    return `${shellCommandName(process.env.PSMUX_BIN || "psmux")} attach-session -t ${shellQuote(sessionName)}`;
+  }
+  return `tmux attach-session -t ${shellQuote(sessionName)}`;
+}
+```
+
+Classification: macOS compatibility regression. It does not explain the 30 GB test process, but it can break attach/open/doctor/team-session behavior on tmux-only macOS hosts.
+
+### SessionEnd cleanup is intentionally report-only
+
+Relevant file:
+
+- `hooks/session-end-cleanup.mjs`
+
+The hook states its boundary:
+
+```js
+// Report-only by default. Opt-in cleanup only removes the repo-local
+// .triflux/subagents/subagents.json file when stale running lifecycle state is
+// present. It never kills processes or touches external HOME/MCP configs.
+```
+
+Classification: cleanup-policy gap. This is safe by design, but it means stale sessions and child processes require separate lifecycle management.
+
+## Root Cause Classification
+
+| Symptom | Primary classification | Evidence | RAM relevance |
+| --- | --- | --- | --- |
+| `node --test` PID 72215, 29.7G footprint, `PPID=1` | Design/lifecycle bug | `test-lock` has no timeout or child-kill supervision | Direct high-memory root |
+| 46 orphan-like `hub/server.mjs` processes | Design/operational lifecycle bug | detached `unref()` start; no stale hub reaper | Medium, about 677 MB RSS |
+| mac detects `"psmux"` while psmux is missing and tmux exists | macOS compatibility regression | `hasPsmux` alias used as literal mux identity | Indirect; breaks attach/cleanup surfaces |
+| Detached tmux sessions | Cleanup-policy gap | tmux sessions all `attached=0`; no destructive cleanup by default | Indirect |
+| 8 zombies | Process reap gap | `<defunct>` entries | Negligible memory |
+
+## Why Existing Tests Did Not Catch This
+
+Targeted tests run during investigation passed:
+
+```text
+node --test --test-force-exit tests/unit/runtime-strategy.test.mjs tests/unit/terminal-opener.test.mjs tests/unit/process-cleanup.test.mjs tests/unit/hub-ensure-port-cascade.test.mjs tests/integration/hub-singleton.test.mjs
+
+55 tests passed
+```
+
+```text
+node --test --test-force-exit tests/unit/multiplexer-resolution.test.mjs tests/unit/env-detect.test.mjs tests/unit/doctor-macos-hooks.test.mjs
+
+14 tests passed
+```
+
+Likely coverage gaps:
+
+- No test asserts that darwin `detectMultiplexer()` returns `"tmux"` when `getMultiplexerType()` resolves `tmux`.
+- No test exercises `hasPsmux` alias misuse in `session.mjs`.
+- No test verifies that `test-lock` kills or forwards signals to its child.
+- No test verifies a max runtime for normal `npm test` outside release prepare.
+- No test verifies stale hub process retirement across multiple ports or versions.
+- Hub singleton tests likely validate "current target port is healthy" rather than "only one repo/user hub remains alive".
+
+## Recommended Fix Plan
+
+### P0: Stabilize local machine state after explicit cleanup approval
+
+No cleanup was performed in this investigation. If cleanup is requested, handle it as a separate execution step because it kills live processes.
+
+Candidate cleanup targets:
+
+- Kill orphaned `node --test` PID `72215`.
+- Retire stale `hub/server.mjs` processes that are not the active default hub.
+- Review old detached tmux sessions before killing them, especially cross-project sessions.
+
+### P1: Fix macOS multiplexer identity
+
+Goal: darwin/Linux must report and use literal `tmux`, not `psmux`, unless a user override explicitly points somewhere else.
+
+Implementation direction:
+
+- Replace `session.mjs` `hasPsmux()` first check with a literal mux-type resolver.
+- Use `getMultiplexerType()` or equivalent from `psmux.mjs`.
+- Preserve Windows behavior: Windows primary remains `psmux`.
+- On darwin/Linux, `detectMultiplexer()` should return `"tmux"` when tmux is available.
+- `terminal-opener` should never emit `psmux attach-session` on darwin unless `PSMUX_BIN` is explicitly set to a real psmux-compatible binary and the detection type is intentionally `psmux`.
+
+Regression tests:
+
+- darwin + tmux available + psmux missing -> `detectMultiplexer() === "tmux"`.
+- darwin terminal opener -> attach command contains `tmux attach-session`.
+- Windows path remains psmux.
+- Backward-compatible `hasPsmux` alias does not leak into literal mux identity.
+
+### P2: Harden `scripts/test-lock.mjs` into a real supervisor
+
+Goal: the wrapper must own the child test process lifetime.
+
+Implementation direction:
+
+- Add a default timeout to `test-lock`, preferably configurable via env.
+- Forward `SIGINT`, `SIGTERM`, and `SIGHUP` to the child.
+- On parent shutdown, kill the child and wait briefly.
+- Consider spawning the child in a process group where platform behavior permits.
+- Treat stale lock as a diagnostic signal; do not silently overwrite when the recorded process or child is still alive.
+- Persist child PID in the lock file so cleanup can target the correct process.
+
+Regression tests:
+
+- Parent receives `SIGTERM` -> child receives termination.
+- Child exceeds timeout -> wrapper exits non-zero and child is not left alive.
+- Stale lock with live child -> fail with actionable diagnostic instead of overwrite.
+- Stale lock with dead child -> cleanup and proceed.
+
+### P3: Add hub stale-process diagnostics and bounded retirement
+
+Goal: one intended hub per effective user/repo/default-port context, with explicit diagnostics when drift exists.
+
+Implementation direction:
+
+- Validate pid file against live process, port, version, and health endpoint.
+- Detect stale `hub/server.mjs` processes for this repo/worktree.
+- Add a safe doctor/report mode first.
+- Add opt-in cleanup mode that kills only known stale hubs, never arbitrary node processes.
+- Prevent random-port cascade from becoming long-lived source of truth.
+
+Regression tests:
+
+- Stale pid file does not mask active default hub.
+- Multiple old hubs are reported.
+- Cleanup excludes the active healthy hub.
+- Different repo/worktree hubs are either isolated by policy or explicitly reported as cross-worktree.
+
+### P4: Define tmux session cleanup policy
+
+Goal: avoid unbounded detached team/session accumulation without surprising users.
+
+Implementation direction:
+
+- Keep default report-only behavior for external/destructive cleanup.
+- Add `doctor` diagnostics showing detached session age, cwd, command, and estimated process tree memory.
+- Add explicit cleanup command for known `tfx-*` sessions after an age threshold.
+- Keep psmux-specific Windows cleanup separate from tmux macOS cleanup.
+
+Regression tests:
+
+- macOS cleanup path uses `tmux`, not `psmux`.
+- Report-only path never kills sessions.
+- Explicit cleanup refuses sessions outside configured prefix/scope.
+
+## Acceptance Criteria
+
+The issue should be considered fixed only when all claims below are true:
+
+1. On macOS tmux-only hosts, `detectMultiplexer()` returns `"tmux"` and attach commands use `tmux attach-session`.
+2. Normal `npm test` cannot leave an orphaned `node --test` process after parent termination or timeout.
+3. `test-lock` stale handling distinguishes dead lock files from live stale test processes.
+4. `tfx doctor` or an equivalent diagnostic reports stale hub clusters and stale tmux sessions with counts and memory estimates.
+5. Hub startup does not leave multiple stale `hub/server.mjs` instances across routine session starts.
+6. Regression tests cover darwin mux identity, test child cleanup, and stale hub detection.
+
+## Current Severity
+
+Severity: high for local development reliability.
+
+Reason:
+
+- The runaway `node --test` process has a roughly 30 GB physical footprint on a 16 GB machine.
+- The process is orphaned and no longer controlled by the original test wrapper.
+- Hub leakage is smaller but persistent and cumulative.
+- macOS mux identity is wrong and can break cleanup/attach flows, making recovery harder.
+
+## Final Classification
+
+The RAM incident is primarily a process lifecycle design failure. The macOS-specific compatibility regression exists, but it is the tmux/psmux identity bug, not the high-memory root cause.
+
+Short form:
+
+```text
+RAM root cause: test runner lifecycle design bug
+Persistent process leak: hub detached lifecycle design bug
+mac compatibility regression: tmux host misreported as psmux
+secondary cleanup smell: old detached tmux sessions and zombies
+```


### PR DESCRIPTION
## Summary
- macOS process lifecycle leak audit report at `docs/research/macos-process-lifecycle-leak-report-2026-05-18.md` (~500 lines)
- 5 PRD files in `.triflux/plans/` (index + 4 shards) for `tfx-swarm` consumption
- Read-only audit prep — no code changes

## Shards (각 PRD가 보고서 line range 인용)
- **S1**: P1 macOS mux identity — `hub/team/session.mjs`, `hub/team/terminal-opener.mjs`
- **S2**: P2 test-lock supervisor — `scripts/test-lock.mjs`
- **S3**: P3a hub stale retirement + P3b version drift — `scripts/hub-ensure.mjs`, `bin/triflux.mjs`
- **S4**: P4a tmux cleanup + P4b SessionEnd hook schema — `hooks/session-end-cleanup.mjs`, `bin/triflux.mjs`

## Next Steps (after merge)
1. `tfx-swarm .triflux/plans/macos-lifecycle-index.md` — 4 worker worktrees 병렬
2. Shard 1 PR 머지 직전 `claude ultrareview <pr-s1>` 1회 (Pro 무료 1회 소비)
3. S2/S3/S4: Claude↔Codex cross-review only
4. 4 PR squash-merge → `/tfx-ship` minor bump (v10.22.x) + GH release

## Test plan
- [x] Report copied byte-identical from source (`diff -q` verified)
- [x] 5 PRDs cite report line ranges (S1: 99-134/273-326/391-408, S2: 167-232/410-428, S3: 56-97/234-271/430-447, S4: 136-163/328-342/449-465)
- [x] No code changes — CI should pass trivially
- [x] No AI attribution trailers (Co-Authored-By 등)