### PR TITLE
fix(hub): P3a stale retirement + P3b version drift diagnostic + opt-in cleanup (macos-lifecycle)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -12,6 +12,7 @@ import {
   readdirSync,
   readFileSync,
   readSync,
+  realpathSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -26,6 +27,7 @@ import {
   validateRuntimeCachePaths,
 } from "../hub/lib/cache-guard.mjs";
 import { getPipelineStateDbPath } from "../hub/pipeline/state.mjs";
+import { getVersionHash } from "../hub/state.mjs";
 import { forceCleanupTeam } from "../hub/team/nativeProxy.mjs";
 import {
   detectMultiplexer,
@@ -119,6 +121,8 @@ const LINE = `${GRAY}${"─".repeat(48)}${RESET}`;
 const _DOT = `${GRAY}·${RESET}`;
 const STALE_TEAM_MAX_AGE_SEC = 3600;
 const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const HUB_DEFAULT_PORT = 27888;
+const DOCTOR_HUB_PID_FILE = join(CLAUDE_DIR, "cache", "tfx-hub", "hub.pid");
 
 const _EXIT_SUCCESS = 0;
 const EXIT_ERROR = 1;
@@ -151,7 +155,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -186,6 +190,24 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "Phase 1 dynamic routing 상태 진단 (env / policy / snapshot cache / preview decision)",
+      },
+      {
+        name: "--cleanup-stale-hubs",
+        type: "boolean",
+        description:
+          "PPID=1 hub/server.mjs 후보를 보고하고 opt-in 정리 모드를 활성화",
+      },
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description:
+          "--cleanup-stale-hubs 와 함께 사용. active healthy hub를 제외하고 정리 후보만 표시",
+      },
+      {
+        name: "--apply",
+        type: "boolean",
+        description:
+          "--cleanup-stale-hubs 와 함께 사용. active healthy hub 제외 후 stale hub 종료",
       },
       {
         name: "--json",
@@ -503,6 +525,403 @@ function createCliError(
   error.fix = fix;
   if (cause) error.cause = cause;
   return error;
+}
+
+function parseHubPort(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isPidAliveForHub(pid, killFn = process.kill) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return false;
+  try {
+    killFn(resolvedPid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function isHubServerCommand(command) {
+  return /(^|[\\/,\s])hub[\\/]server\.mjs(?=$|[\s"'`])/i.test(
+    String(command || ""),
+  );
+}
+
+function parsePortFromAddress(address) {
+  const match = String(address || "").match(/:(\d+)(?:\s|$)/);
+  return parseHubPort(match?.[1]);
+}
+
+export function parseDetachedHubProcessRows(output) {
+  const rows = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    if (!match) continue;
+    const [, pidText, ppidText, rssText, uptime, command] = match;
+    const pid = Number.parseInt(pidText, 10);
+    const ppid = Number.parseInt(ppidText, 10);
+    const rssKb = Number.parseInt(rssText, 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    if (ppid !== 1) continue;
+    if (!isHubServerCommand(command)) continue;
+    rows.push({
+      pid,
+      ppid,
+      rssKb: Number.isFinite(rssKb) ? rssKb : null,
+      uptime,
+      command: command.trim(),
+    });
+  }
+  return rows;
+}
+
+function queryDetachedHubProcessRows({
+  platform = process.platform,
+  execFile = execFileSync,
+} = {}) {
+  if (platform === "win32") return [];
+  try {
+    const output = execFile("ps", ["-axo", "pid=,ppid=,rss=,etime=,command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    return parseDetachedHubProcessRows(output);
+  } catch {
+    return [];
+  }
+}
+
+function parseLsofListeningPorts(output) {
+  const ports = new Set();
+  for (const line of String(output || "").split(/\r?\n/)) {
+    if (!/\(LISTEN\)/i.test(line)) continue;
+    const match = line.match(/TCP\s+\S+:(\d+)\s+\(LISTEN\)/i);
+    const port = parseHubPort(match?.[1]) ?? parsePortFromAddress(line);
+    if (port) ports.add(port);
+  }
+  return [...ports];
+}
+
+function queryListeningPortsForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return [];
+  if (platform === "win32") return [];
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:LISTEN"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return parseLsofListeningPorts(output);
+  } catch {
+    return [];
+  }
+}
+
+function queryEstablishedCountForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return 0;
+  if (platform === "win32") return 0;
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:ESTABLISHED"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return Math.max(0, output.trim().split(/\r?\n/).filter(Boolean).length - 1);
+  } catch {
+    return 0;
+  }
+}
+
+function queryPidCommand(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return "";
+  try {
+    if (platform === "win32") return "";
+    return execFile("ps", ["-p", String(resolvedPid), "-o", "command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function queryListeningPidByPort(
+  port,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const targetPort = parseHubPort(port);
+  if (!targetPort || platform === "win32") return null;
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-iTCP:" + targetPort, "-sTCP:LISTEN", "-t"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    const pid = Number.parseInt(output.trim().split(/\r?\n/)[0] ?? "", 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHubHealthForDoctor(
+  host,
+  port,
+  { fetchImpl = fetch, timeoutMs = 1000 } = {},
+) {
+  try {
+    const urlHost = String(host || "127.0.0.1").includes(":")
+      ? `[${host}]`
+      : host || "127.0.0.1";
+    const response = await fetchImpl(`http://${urlHost}:${port}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return { ok: false, version: null };
+    const body = await response.json().catch(() => null);
+    return {
+      ok: body?.ok === true,
+      version: typeof body?.version === "string" ? body.version : null,
+      raw: body,
+    };
+  } catch (error) {
+    return { ok: false, version: null, error };
+  }
+}
+
+function readHubPidInfo({
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+} = {}) {
+  if (!exists(pidFilePath)) return null;
+  try {
+    return JSON.parse(readFile(pidFilePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function resolveActiveHealthyHub({
+  expectedVersion = getVersionHash(),
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const info = readHubPidInfo({ pidFilePath, exists, readFile });
+  const pid = Number(info?.pid);
+  const port = parseHubPort(info?.port);
+  const host =
+    typeof info?.host === "string" && info.host.trim()
+      ? info.host.trim()
+      : "127.0.0.1";
+  if (pid && port && isPidAliveForHub(pid, killFn)) {
+    const command = queryPidCommand(pid, { platform, execFile });
+    const health = await fetchHubHealthForDoctor(host, port, { fetchImpl });
+    if (
+      isHubServerCommand(command) &&
+      health.ok &&
+      health.version === expectedVersion
+    ) {
+      return { pid, port, host, version: health.version, source: "pid-file" };
+    }
+  }
+
+  const defaultPid = queryListeningPidByPort(HUB_DEFAULT_PORT, {
+    platform,
+    execFile,
+  });
+  if (!defaultPid || !isPidAliveForHub(defaultPid, killFn)) return null;
+  const command = queryPidCommand(defaultPid, { platform, execFile });
+  if (!isHubServerCommand(command)) return null;
+  const health = await fetchHubHealthForDoctor("127.0.0.1", HUB_DEFAULT_PORT, {
+    fetchImpl,
+  });
+  if (!health.ok || health.version !== expectedVersion) return null;
+  return {
+    pid: defaultPid,
+    port: HUB_DEFAULT_PORT,
+    host: "127.0.0.1",
+    version: health.version,
+    source: "default-port",
+  };
+}
+
+export async function inspectDetachedHubProcesses({
+  expectedVersion = getVersionHash(),
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const rows = queryDetachedHubProcessRows({ platform, execFile });
+  const activeHealthy = await resolveActiveHealthyHub({
+    expectedVersion,
+    pidFilePath,
+    exists,
+    readFile,
+    killFn,
+    platform,
+    execFile,
+    fetchImpl,
+  });
+
+  const hubs = [];
+  for (const row of rows) {
+    const ports = queryListeningPortsForPid(row.pid, { platform, execFile });
+    const established = queryEstablishedCountForPid(row.pid, {
+      platform,
+      execFile,
+    });
+    let version = null;
+    let healthy = false;
+    for (const port of ports) {
+      const health = await fetchHubHealthForDoctor("127.0.0.1", port, {
+        fetchImpl,
+      });
+      if (!health.ok) continue;
+      version = health.version;
+      healthy = true;
+      break;
+    }
+    hubs.push({
+      ...row,
+      ports,
+      established,
+      version,
+      healthy,
+      activeHealthy: activeHealthy?.pid === row.pid,
+      staleCandidate: activeHealthy?.pid !== row.pid,
+    });
+  }
+
+  return {
+    expectedVersion,
+    activeHealthy,
+    hubs,
+    staleCandidates: hubs.filter((hub) => hub.staleCandidate),
+  };
+}
+
+async function waitForHubProcessExit(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const deadline = Date.now() + Math.max(0, graceMs);
+  while (Date.now() <= deadline) {
+    if (!isPidAliveForHub(pid, killFn)) return true;
+    await delay(pollMs);
+  }
+  return !isPidAliveForHub(pid, killFn);
+}
+
+async function retireDetachedHubPid(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  if (!isPidAliveForHub(pid, killFn)) return { ok: true, reason: "dead" };
+  try {
+    killFn(pid, "SIGTERM");
+  } catch (error) {
+    return { ok: false, reason: "sigterm_failed", error };
+  }
+  if (await waitForHubProcessExit(pid, { killFn, graceMs, pollMs })) {
+    return { ok: true, reason: "sigterm" };
+  }
+  try {
+    killFn(pid, "SIGKILL");
+  } catch (error) {
+    return { ok: false, reason: "sigkill_failed", error };
+  }
+  const exited = await waitForHubProcessExit(pid, {
+    killFn,
+    graceMs: 1000,
+    pollMs,
+  });
+  return { ok: exited, reason: exited ? "sigkill" : "still_alive" };
+}
+
+export async function cleanupDetachedHubProcesses({
+  hubs,
+  activeHealthy,
+  dryRun = true,
+  apply = false,
+  killFn = process.kill,
+  graceMs = 5000,
+  pollMs = 100,
+} = {}) {
+  const results = [];
+  for (const hub of hubs || []) {
+    if (activeHealthy?.pid === hub.pid || hub.activeHealthy) {
+      results.push({ pid: hub.pid, action: "excluded-active", ok: true, hub });
+      continue;
+    }
+    if (!apply || dryRun) {
+      results.push({ pid: hub.pid, action: "dry-run-skip", ok: true, hub });
+      continue;
+    }
+    const retired = await retireDetachedHubPid(hub.pid, {
+      killFn,
+      graceMs,
+      pollMs,
+    });
+    results.push({
+      pid: hub.pid,
+      action: retired.ok ? "retired" : "failed",
+      ok: retired.ok,
+      reason: retired.reason,
+      hub,
+    });
+  }
+  return {
+    dryRun: !apply || dryRun,
+    results,
+    failed: results.filter((result) => result.ok === false).length,
+    retired: results.filter((result) => result.action === "retired").length,
+    skipped: results.filter((result) => result.action === "dry-run-skip")
+      .length,
+    excluded: results.filter((result) => result.action === "excluded-active")
+      .length,
+  };
 }
 
 function inferExitCode(error) {
@@ -1864,6 +2283,9 @@ async function cmdDoctor(options = {}) {
     fix = false,
     reset = false,
     purgeLogs = false,
+    cleanupStaleHubs = false,
+    cleanupStaleHubsDryRun = true,
+    cleanupStaleHubsApply = false,
     json = false,
   } = options;
   const report = {
@@ -1873,6 +2295,7 @@ async function cmdDoctor(options = {}) {
     actions: [],
     hook_coverage: { total: 0, registered: 0, missing: [] },
     fsmonitorDaemons: { stale: 0, killed: 0 },
+    hubServers: { detached: 0, stale: 0, activeHealthy: null },
     issue_count: 0,
   };
 
@@ -3230,6 +3653,96 @@ async function cmdDoctor(options = {}) {
         info("정리: tfx doctor --fix");
         issues += omcTeamReport.entries.length;
       }
+    }
+
+    // 12.4. detached tfx-hub/server.mjs 누적 감지 및 opt-in 정리
+    section("Hub Servers");
+    try {
+      const hubReport = await inspectDetachedHubProcesses();
+      report.hubServers = {
+        detached: hubReport.hubs.length,
+        stale: hubReport.staleCandidates.length,
+        activeHealthy: hubReport.activeHealthy,
+        expectedVersion: hubReport.expectedVersion,
+        hubs: hubReport.hubs.map((hub) => ({
+          pid: hub.pid,
+          ppid: hub.ppid,
+          version: hub.version,
+          uptime: hub.uptime,
+          ports: hub.ports,
+          established: hub.established,
+          rssKb: hub.rssKb,
+          activeHealthy: hub.activeHealthy,
+          staleCandidate: hub.staleCandidate,
+        })),
+      };
+      addDoctorCheck(report, {
+        name: "hub-server-processes",
+        status: hubReport.staleCandidates.length > 0 ? "warning" : "ok",
+        detached: hubReport.hubs.length,
+        stale: hubReport.staleCandidates.length,
+        activeHealthy: hubReport.activeHealthy,
+      });
+
+      if (hubReport.hubs.length === 0) {
+        ok("PPID=1 hub/server.mjs 없음");
+      } else {
+        for (const hub of hubReport.hubs) {
+          const portLabel = hub.ports.length > 0 ? hub.ports.join(",") : "?";
+          const versionLabel = hub.version || "unknown";
+          const rssLabel = hub.rssKb == null ? "?" : `${hub.rssKb}KB`;
+          const activeLabel = hub.activeHealthy
+            ? " active healthy excluded"
+            : " stale candidate";
+          const line = `PID=${hub.pid} PPID=${hub.ppid} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
+          if (hub.activeHealthy) ok(line);
+          else warn(line);
+        }
+      }
+
+      if (cleanupStaleHubs) {
+        const cleanupResult = await cleanupDetachedHubProcesses({
+          hubs: hubReport.hubs,
+          activeHealthy: hubReport.activeHealthy,
+          dryRun: cleanupStaleHubsDryRun,
+          apply: cleanupStaleHubsApply,
+        });
+        report.actions.push({
+          type: "cleanup-stale-hubs",
+          status: cleanupResult.failed > 0 ? "failed" : "ok",
+          dryRun: cleanupResult.dryRun,
+          retired: cleanupResult.retired,
+          skipped: cleanupResult.skipped,
+          excluded: cleanupResult.excluded,
+          failed: cleanupResult.failed,
+        });
+        for (const result of cleanupResult.results) {
+          if (result.action === "excluded-active") {
+            ok(`active healthy hub excluded: PID=${result.pid}`);
+          } else if (result.action === "dry-run-skip") {
+            info(`dry-run skip stale hub: PID=${result.pid}`);
+          } else if (result.action === "retired") {
+            ok(`stale hub retired: PID=${result.pid} (${result.reason})`);
+          } else {
+            fail(`stale hub cleanup failed: PID=${result.pid}`);
+          }
+        }
+        issues += cleanupResult.failed;
+        if (cleanupResult.dryRun && hubReport.staleCandidates.length > 0) {
+          issues += hubReport.staleCandidates.length;
+        }
+      } else if (hubReport.staleCandidates.length > 0) {
+        info("정리: tfx doctor --cleanup-stale-hubs --dry-run|--apply");
+        issues += hubReport.staleCandidates.length;
+      }
+    } catch (error) {
+      addDoctorCheck(report, {
+        name: "hub-server-processes",
+        status: "warning",
+        error: error.message,
+      });
+      warn(`hub/server.mjs 검사 실패: ${error.message}`);
+      issues++;
     }
 
     // 12.5. 고아 node.exe 프로세스 정리 (Windows)
@@ -6012,7 +6525,28 @@ async function main() {
       const fix = cmdArgs.includes("--fix");
       const reset = cmdArgs.includes("--reset");
       const purgeLogs = cmdArgs.includes("--purge-logs");
-      await cmdDoctor({ fix, reset, purgeLogs, json: JSON_OUTPUT });
+      const cleanupStaleHubs = cmdArgs.includes("--cleanup-stale-hubs");
+      const cleanupApply = cmdArgs.includes("--apply");
+      const cleanupDryRun = cmdArgs.includes("--dry-run") || !cleanupApply;
+      if (cleanupStaleHubs && cleanupApply && cmdArgs.includes("--dry-run")) {
+        throw createCliError(
+          "--cleanup-stale-hubs 에서는 --dry-run 과 --apply 중 하나만 지정하세요",
+          {
+            exitCode: EXIT_ARG_ERROR,
+            reason: "argError",
+            fix: "tfx doctor --cleanup-stale-hubs --dry-run",
+          },
+        );
+      }
+      await cmdDoctor({
+        fix,
+        reset,
+        purgeLogs,
+        cleanupStaleHubs,
+        cleanupStaleHubsDryRun: cleanupDryRun,
+        cleanupStaleHubsApply: cleanupApply,
+        json: JSON_OUTPUT,
+      });
       return;
     }
     case "mcp":
@@ -6286,8 +6820,20 @@ ${s.options.map((o) => `    ${DIM}${o.name.padEnd(16)}${RESET} ${GRAY}${o.descri
   }
 }
 
-try {
-  await main();
-} catch (error) {
-  handleFatalError(error, { json: JSON_OUTPUT });
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(process.argv[1]) === modulePath;
+  } catch {
+    return resolve(process.argv[1]) === modulePath;
+  }
+}
+
+if (isMainModule()) {
+  try {
+    await main();
+  } catch (error) {
+    handleFatalError(error, { json: JSON_OUTPUT });
+  }
 }

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -12,6 +12,7 @@ import {
   readdirSync,
   readFileSync,
   readSync,
+  realpathSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -26,6 +27,7 @@ import {
   validateRuntimeCachePaths,
 } from "../hub/lib/cache-guard.mjs";
 import { getPipelineStateDbPath } from "../hub/pipeline/state.mjs";
+import { getVersionHash } from "../hub/state.mjs";
 import { forceCleanupTeam } from "../hub/team/nativeProxy.mjs";
 import {
   detectMultiplexer,
@@ -119,6 +121,8 @@ const LINE = `${GRAY}${"─".repeat(48)}${RESET}`;
 const _DOT = `${GRAY}·${RESET}`;
 const STALE_TEAM_MAX_AGE_SEC = 3600;
 const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const HUB_DEFAULT_PORT = 27888;
+const DOCTOR_HUB_PID_FILE = join(CLAUDE_DIR, "cache", "tfx-hub", "hub.pid");
 
 const _EXIT_SUCCESS = 0;
 const EXIT_ERROR = 1;
@@ -151,7 +155,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -186,6 +190,24 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         type: "boolean",
         description:
           "Phase 1 dynamic routing 상태 진단 (env / policy / snapshot cache / preview decision)",
+      },
+      {
+        name: "--cleanup-stale-hubs",
+        type: "boolean",
+        description:
+          "PPID=1 hub/server.mjs 후보를 보고하고 opt-in 정리 모드를 활성화",
+      },
+      {
+        name: "--dry-run",
+        type: "boolean",
+        description:
+          "--cleanup-stale-hubs 와 함께 사용. active healthy hub를 제외하고 정리 후보만 표시",
+      },
+      {
+        name: "--apply",
+        type: "boolean",
+        description:
+          "--cleanup-stale-hubs 와 함께 사용. active healthy hub 제외 후 stale hub 종료",
       },
       {
         name: "--json",
@@ -503,6 +525,403 @@ function createCliError(
   error.fix = fix;
   if (cause) error.cause = cause;
   return error;
+}
+
+function parseHubPort(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isPidAliveForHub(pid, killFn = process.kill) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return false;
+  try {
+    killFn(resolvedPid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function isHubServerCommand(command) {
+  return /(^|[\\/,\s])hub[\\/]server\.mjs(?=$|[\s"'`])/i.test(
+    String(command || ""),
+  );
+}
+
+function parsePortFromAddress(address) {
+  const match = String(address || "").match(/:(\d+)(?:\s|$)/);
+  return parseHubPort(match?.[1]);
+}
+
+export function parseDetachedHubProcessRows(output) {
+  const rows = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+    if (!match) continue;
+    const [, pidText, ppidText, rssText, uptime, command] = match;
+    const pid = Number.parseInt(pidText, 10);
+    const ppid = Number.parseInt(ppidText, 10);
+    const rssKb = Number.parseInt(rssText, 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    if (ppid !== 1) continue;
+    if (!isHubServerCommand(command)) continue;
+    rows.push({
+      pid,
+      ppid,
+      rssKb: Number.isFinite(rssKb) ? rssKb : null,
+      uptime,
+      command: command.trim(),
+    });
+  }
+  return rows;
+}
+
+function queryDetachedHubProcessRows({
+  platform = process.platform,
+  execFile = execFileSync,
+} = {}) {
+  if (platform === "win32") return [];
+  try {
+    const output = execFile("ps", ["-axo", "pid=,ppid=,rss=,etime=,command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    return parseDetachedHubProcessRows(output);
+  } catch {
+    return [];
+  }
+}
+
+function parseLsofListeningPorts(output) {
+  const ports = new Set();
+  for (const line of String(output || "").split(/\r?\n/)) {
+    if (!/\(LISTEN\)/i.test(line)) continue;
+    const match = line.match(/TCP\s+\S+:(\d+)\s+\(LISTEN\)/i);
+    const port = parseHubPort(match?.[1]) ?? parsePortFromAddress(line);
+    if (port) ports.add(port);
+  }
+  return [...ports];
+}
+
+function queryListeningPortsForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return [];
+  if (platform === "win32") return [];
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:LISTEN"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return parseLsofListeningPorts(output);
+  } catch {
+    return [];
+  }
+}
+
+function queryEstablishedCountForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return 0;
+  if (platform === "win32") return 0;
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:ESTABLISHED"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return Math.max(0, output.trim().split(/\r?\n/).filter(Boolean).length - 1);
+  } catch {
+    return 0;
+  }
+}
+
+function queryPidCommand(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return "";
+  try {
+    if (platform === "win32") return "";
+    return execFile("ps", ["-p", String(resolvedPid), "-o", "command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function queryListeningPidByPort(
+  port,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const targetPort = parseHubPort(port);
+  if (!targetPort || platform === "win32") return null;
+  try {
+    const output = execFile(
+      "lsof",
+      ["-nP", "-iTCP:" + targetPort, "-sTCP:LISTEN", "-t"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    const pid = Number.parseInt(output.trim().split(/\r?\n/)[0] ?? "", 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHubHealthForDoctor(
+  host,
+  port,
+  { fetchImpl = fetch, timeoutMs = 1000 } = {},
+) {
+  try {
+    const urlHost = String(host || "127.0.0.1").includes(":")
+      ? `[${host}]`
+      : host || "127.0.0.1";
+    const response = await fetchImpl(`http://${urlHost}:${port}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return { ok: false, version: null };
+    const body = await response.json().catch(() => null);
+    return {
+      ok: body?.ok === true,
+      version: typeof body?.version === "string" ? body.version : null,
+      raw: body,
+    };
+  } catch (error) {
+    return { ok: false, version: null, error };
+  }
+}
+
+function readHubPidInfo({
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+} = {}) {
+  if (!exists(pidFilePath)) return null;
+  try {
+    return JSON.parse(readFile(pidFilePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function resolveActiveHealthyHub({
+  expectedVersion = getVersionHash(),
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const info = readHubPidInfo({ pidFilePath, exists, readFile });
+  const pid = Number(info?.pid);
+  const port = parseHubPort(info?.port);
+  const host =
+    typeof info?.host === "string" && info.host.trim()
+      ? info.host.trim()
+      : "127.0.0.1";
+  if (pid && port && isPidAliveForHub(pid, killFn)) {
+    const command = queryPidCommand(pid, { platform, execFile });
+    const health = await fetchHubHealthForDoctor(host, port, { fetchImpl });
+    if (
+      isHubServerCommand(command) &&
+      health.ok &&
+      health.version === expectedVersion
+    ) {
+      return { pid, port, host, version: health.version, source: "pid-file" };
+    }
+  }
+
+  const defaultPid = queryListeningPidByPort(HUB_DEFAULT_PORT, {
+    platform,
+    execFile,
+  });
+  if (!defaultPid || !isPidAliveForHub(defaultPid, killFn)) return null;
+  const command = queryPidCommand(defaultPid, { platform, execFile });
+  if (!isHubServerCommand(command)) return null;
+  const health = await fetchHubHealthForDoctor("127.0.0.1", HUB_DEFAULT_PORT, {
+    fetchImpl,
+  });
+  if (!health.ok || health.version !== expectedVersion) return null;
+  return {
+    pid: defaultPid,
+    port: HUB_DEFAULT_PORT,
+    host: "127.0.0.1",
+    version: health.version,
+    source: "default-port",
+  };
+}
+
+export async function inspectDetachedHubProcesses({
+  expectedVersion = getVersionHash(),
+  pidFilePath = DOCTOR_HUB_PID_FILE,
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const rows = queryDetachedHubProcessRows({ platform, execFile });
+  const activeHealthy = await resolveActiveHealthyHub({
+    expectedVersion,
+    pidFilePath,
+    exists,
+    readFile,
+    killFn,
+    platform,
+    execFile,
+    fetchImpl,
+  });
+
+  const hubs = [];
+  for (const row of rows) {
+    const ports = queryListeningPortsForPid(row.pid, { platform, execFile });
+    const established = queryEstablishedCountForPid(row.pid, {
+      platform,
+      execFile,
+    });
+    let version = null;
+    let healthy = false;
+    for (const port of ports) {
+      const health = await fetchHubHealthForDoctor("127.0.0.1", port, {
+        fetchImpl,
+      });
+      if (!health.ok) continue;
+      version = health.version;
+      healthy = true;
+      break;
+    }
+    hubs.push({
+      ...row,
+      ports,
+      established,
+      version,
+      healthy,
+      activeHealthy: activeHealthy?.pid === row.pid,
+      staleCandidate: activeHealthy?.pid !== row.pid,
+    });
+  }
+
+  return {
+    expectedVersion,
+    activeHealthy,
+    hubs,
+    staleCandidates: hubs.filter((hub) => hub.staleCandidate),
+  };
+}
+
+async function waitForHubProcessExit(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const deadline = Date.now() + Math.max(0, graceMs);
+  while (Date.now() <= deadline) {
+    if (!isPidAliveForHub(pid, killFn)) return true;
+    await delay(pollMs);
+  }
+  return !isPidAliveForHub(pid, killFn);
+}
+
+async function retireDetachedHubPid(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  if (!isPidAliveForHub(pid, killFn)) return { ok: true, reason: "dead" };
+  try {
+    killFn(pid, "SIGTERM");
+  } catch (error) {
+    return { ok: false, reason: "sigterm_failed", error };
+  }
+  if (await waitForHubProcessExit(pid, { killFn, graceMs, pollMs })) {
+    return { ok: true, reason: "sigterm" };
+  }
+  try {
+    killFn(pid, "SIGKILL");
+  } catch (error) {
+    return { ok: false, reason: "sigkill_failed", error };
+  }
+  const exited = await waitForHubProcessExit(pid, {
+    killFn,
+    graceMs: 1000,
+    pollMs,
+  });
+  return { ok: exited, reason: exited ? "sigkill" : "still_alive" };
+}
+
+export async function cleanupDetachedHubProcesses({
+  hubs,
+  activeHealthy,
+  dryRun = true,
+  apply = false,
+  killFn = process.kill,
+  graceMs = 5000,
+  pollMs = 100,
+} = {}) {
+  const results = [];
+  for (const hub of hubs || []) {
+    if (activeHealthy?.pid === hub.pid || hub.activeHealthy) {
+      results.push({ pid: hub.pid, action: "excluded-active", ok: true, hub });
+      continue;
+    }
+    if (!apply || dryRun) {
+      results.push({ pid: hub.pid, action: "dry-run-skip", ok: true, hub });
+      continue;
+    }
+    const retired = await retireDetachedHubPid(hub.pid, {
+      killFn,
+      graceMs,
+      pollMs,
+    });
+    results.push({
+      pid: hub.pid,
+      action: retired.ok ? "retired" : "failed",
+      ok: retired.ok,
+      reason: retired.reason,
+      hub,
+    });
+  }
+  return {
+    dryRun: !apply || dryRun,
+    results,
+    failed: results.filter((result) => result.ok === false).length,
+    retired: results.filter((result) => result.action === "retired").length,
+    skipped: results.filter((result) => result.action === "dry-run-skip")
+      .length,
+    excluded: results.filter((result) => result.action === "excluded-active")
+      .length,
+  };
 }
 
 function inferExitCode(error) {
@@ -1864,6 +2283,9 @@ async function cmdDoctor(options = {}) {
     fix = false,
     reset = false,
     purgeLogs = false,
+    cleanupStaleHubs = false,
+    cleanupStaleHubsDryRun = true,
+    cleanupStaleHubsApply = false,
     json = false,
   } = options;
   const report = {
@@ -1873,6 +2295,7 @@ async function cmdDoctor(options = {}) {
     actions: [],
     hook_coverage: { total: 0, registered: 0, missing: [] },
     fsmonitorDaemons: { stale: 0, killed: 0 },
+    hubServers: { detached: 0, stale: 0, activeHealthy: null },
     issue_count: 0,
   };
 
@@ -3230,6 +3653,96 @@ async function cmdDoctor(options = {}) {
         info("정리: tfx doctor --fix");
         issues += omcTeamReport.entries.length;
       }
+    }
+
+    // 12.4. detached tfx-hub/server.mjs 누적 감지 및 opt-in 정리
+    section("Hub Servers");
+    try {
+      const hubReport = await inspectDetachedHubProcesses();
+      report.hubServers = {
+        detached: hubReport.hubs.length,
+        stale: hubReport.staleCandidates.length,
+        activeHealthy: hubReport.activeHealthy,
+        expectedVersion: hubReport.expectedVersion,
+        hubs: hubReport.hubs.map((hub) => ({
+          pid: hub.pid,
+          ppid: hub.ppid,
+          version: hub.version,
+          uptime: hub.uptime,
+          ports: hub.ports,
+          established: hub.established,
+          rssKb: hub.rssKb,
+          activeHealthy: hub.activeHealthy,
+          staleCandidate: hub.staleCandidate,
+        })),
+      };
+      addDoctorCheck(report, {
+        name: "hub-server-processes",
+        status: hubReport.staleCandidates.length > 0 ? "warning" : "ok",
+        detached: hubReport.hubs.length,
+        stale: hubReport.staleCandidates.length,
+        activeHealthy: hubReport.activeHealthy,
+      });
+
+      if (hubReport.hubs.length === 0) {
+        ok("PPID=1 hub/server.mjs 없음");
+      } else {
+        for (const hub of hubReport.hubs) {
+          const portLabel = hub.ports.length > 0 ? hub.ports.join(",") : "?";
+          const versionLabel = hub.version || "unknown";
+          const rssLabel = hub.rssKb == null ? "?" : `${hub.rssKb}KB`;
+          const activeLabel = hub.activeHealthy
+            ? " active healthy excluded"
+            : " stale candidate";
+          const line = `PID=${hub.pid} PPID=${hub.ppid} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
+          if (hub.activeHealthy) ok(line);
+          else warn(line);
+        }
+      }
+
+      if (cleanupStaleHubs) {
+        const cleanupResult = await cleanupDetachedHubProcesses({
+          hubs: hubReport.hubs,
+          activeHealthy: hubReport.activeHealthy,
+          dryRun: cleanupStaleHubsDryRun,
+          apply: cleanupStaleHubsApply,
+        });
+        report.actions.push({
+          type: "cleanup-stale-hubs",
+          status: cleanupResult.failed > 0 ? "failed" : "ok",
+          dryRun: cleanupResult.dryRun,
+          retired: cleanupResult.retired,
+          skipped: cleanupResult.skipped,
+          excluded: cleanupResult.excluded,
+          failed: cleanupResult.failed,
+        });
+        for (const result of cleanupResult.results) {
+          if (result.action === "excluded-active") {
+            ok(`active healthy hub excluded: PID=${result.pid}`);
+          } else if (result.action === "dry-run-skip") {
+            info(`dry-run skip stale hub: PID=${result.pid}`);
+          } else if (result.action === "retired") {
+            ok(`stale hub retired: PID=${result.pid} (${result.reason})`);
+          } else {
+            fail(`stale hub cleanup failed: PID=${result.pid}`);
+          }
+        }
+        issues += cleanupResult.failed;
+        if (cleanupResult.dryRun && hubReport.staleCandidates.length > 0) {
+          issues += hubReport.staleCandidates.length;
+        }
+      } else if (hubReport.staleCandidates.length > 0) {
+        info("정리: tfx doctor --cleanup-stale-hubs --dry-run|--apply");
+        issues += hubReport.staleCandidates.length;
+      }
+    } catch (error) {
+      addDoctorCheck(report, {
+        name: "hub-server-processes",
+        status: "warning",
+        error: error.message,
+      });
+      warn(`hub/server.mjs 검사 실패: ${error.message}`);
+      issues++;
     }
 
     // 12.5. 고아 node.exe 프로세스 정리 (Windows)
@@ -6012,7 +6525,28 @@ async function main() {
       const fix = cmdArgs.includes("--fix");
       const reset = cmdArgs.includes("--reset");
       const purgeLogs = cmdArgs.includes("--purge-logs");
-      await cmdDoctor({ fix, reset, purgeLogs, json: JSON_OUTPUT });
+      const cleanupStaleHubs = cmdArgs.includes("--cleanup-stale-hubs");
+      const cleanupApply = cmdArgs.includes("--apply");
+      const cleanupDryRun = cmdArgs.includes("--dry-run") || !cleanupApply;
+      if (cleanupStaleHubs && cleanupApply && cmdArgs.includes("--dry-run")) {
+        throw createCliError(
+          "--cleanup-stale-hubs 에서는 --dry-run 과 --apply 중 하나만 지정하세요",
+          {
+            exitCode: EXIT_ARG_ERROR,
+            reason: "argError",
+            fix: "tfx doctor --cleanup-stale-hubs --dry-run",
+          },
+        );
+      }
+      await cmdDoctor({
+        fix,
+        reset,
+        purgeLogs,
+        cleanupStaleHubs,
+        cleanupStaleHubsDryRun: cleanupDryRun,
+        cleanupStaleHubsApply: cleanupApply,
+        json: JSON_OUTPUT,
+      });
       return;
     }
     case "mcp":
@@ -6286,8 +6820,20 @@ ${s.options.map((o) => `    ${DIM}${o.name.padEnd(16)}${RESET} ${GRAY}${o.descri
   }
 }
 
-try {
-  await main();
-} catch (error) {
-  handleFatalError(error, { json: JSON_OUTPUT });
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(process.argv[1]) === modulePath;
+  } catch {
+    return resolve(process.argv[1]) === modulePath;
+  }
+}
+
+if (isMainModule()) {
+  try {
+    await main();
+  } catch (error) {
+    handleFatalError(error, { json: JSON_OUTPUT });
+  }
 }

--- a/packages/triflux/scripts/hub-ensure.mjs
+++ b/packages/triflux/scripts/hub-ensure.mjs
@@ -4,11 +4,12 @@
 // - /status 기반 헬스체크
 // - 비정상 시 Hub를 detached로 기동
 
-import { spawn } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { execFileSync, spawn } from "child_process";
+import { existsSync, readFileSync, unlinkSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { getVersionHash } from "../hub/state.mjs";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -67,7 +68,532 @@ function snapshotUserStateBestEffort() {
   }
 }
 
-export function resolveHubTarget() {
+function parsePort(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function formatWarning(message) {
+  return `[hub-ensure] ${message}\n`;
+}
+
+function readHubPidFile(
+  pidFilePath = HUB_PID_FILE,
+  { exists = existsSync, readFile = readFileSync } = {},
+) {
+  if (!exists(pidFilePath)) {
+    return { exists: false, info: null, error: null };
+  }
+  try {
+    return {
+      exists: true,
+      info: JSON.parse(readFile(pidFilePath, "utf8")),
+      error: null,
+    };
+  } catch (error) {
+    return { exists: true, info: null, error };
+  }
+}
+
+function isPidAlive(pid, killFn = process.kill) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return false;
+  try {
+    killFn(resolvedPid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function getPidCommand(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return "";
+
+  try {
+    if (platform === "win32") {
+      return execFile(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${resolvedPid}" | Select-Object -ExpandProperty CommandLine)`,
+        ],
+        {
+          encoding: "utf8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
+        },
+      ).trim();
+    }
+
+    return execFile("ps", ["-p", String(resolvedPid), "-o", "command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export function isHubServerCommand(command) {
+  return /(^|[\\/,\s])hub[\\/]server\.mjs(?=$|[\s"'`])/i.test(
+    String(command || ""),
+  );
+}
+
+function parsePortFromAddress(address) {
+  const match = String(address || "").match(/:(\d+)(?:\s|$)/);
+  return parsePort(match?.[1]);
+}
+
+function parseLsofListeningPorts(output) {
+  const ports = new Set();
+  for (const line of String(output || "").split(/\r?\n/)) {
+    if (!/\(LISTEN\)/i.test(line)) continue;
+    const match = line.match(/TCP\s+\S+:(\d+)\s+\(LISTEN\)/i);
+    const port = parsePort(match?.[1]) ?? parsePortFromAddress(line);
+    if (port) ports.add(port);
+  }
+  return [...ports];
+}
+
+function findListeningPortsForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return [];
+
+  try {
+    if (platform === "win32") {
+      const output = execFile("netstat", ["-ano", "-p", "tcp"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      });
+      const ports = new Set();
+      for (const line of output.split(/\r?\n/)) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const [proto, localAddress, , state, pidText] = parts;
+        if (proto?.toUpperCase() !== "TCP") continue;
+        if (state?.toUpperCase() !== "LISTENING") continue;
+        if (Number(pidText) !== resolvedPid) continue;
+        const port = parsePortFromAddress(localAddress);
+        if (port) ports.add(port);
+      }
+      return [...ports];
+    }
+
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:LISTEN"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return parseLsofListeningPorts(output);
+  } catch {
+    return [];
+  }
+}
+
+function findListeningPidByPort(
+  port,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const targetPort = parsePort(port);
+  if (!targetPort) return null;
+
+  try {
+    if (platform === "win32") {
+      const output = execFile("netstat", ["-ano", "-p", "tcp"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      });
+      for (const line of output.split(/\r?\n/)) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const [proto, localAddress, , state, pidText] = parts;
+        if (proto?.toUpperCase() !== "TCP") continue;
+        if (state?.toUpperCase() !== "LISTENING") continue;
+        if (parsePortFromAddress(localAddress) !== targetPort) continue;
+        const pid = Number.parseInt(pidText, 10);
+        if (Number.isFinite(pid) && pid > 0) return pid;
+      }
+      return null;
+    }
+
+    const output = execFile(
+      "lsof",
+      ["-nP", "-iTCP:" + targetPort, "-sTCP:LISTEN", "-t"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    const pid = Number.parseInt(output.trim().split(/\r?\n/)[0] ?? "", 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHubHealth(
+  host,
+  port,
+  { fetchImpl = fetch, timeoutMs = 1000 } = {},
+) {
+  try {
+    const res = await fetchImpl(`${buildHubBaseUrl(host, port)}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return { ok: false, version: null };
+    const data = await res.json();
+    return {
+      ok: data?.ok === true,
+      version: typeof data?.version === "string" ? data.version : null,
+      raw: data,
+    };
+  } catch (error) {
+    return { ok: false, version: null, error };
+  }
+}
+
+export async function inspectPidFileHub({
+  expectedVersion = getVersionHash(),
+  pidFilePath = HUB_PID_FILE,
+  host = "127.0.0.1",
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const warnings = [];
+  const state = readHubPidFile(pidFilePath, { exists, readFile });
+  if (!state.exists) {
+    return { exists: false, valid: false, warnings, retirePid: null };
+  }
+  if (state.error) {
+    warnings.push(formatWarning(`invalid hub pid file: ${pidFilePath}`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      reason: "invalid_json",
+    };
+  }
+
+  const pid = Number(state.info?.pid);
+  const port = parsePort(state.info?.port);
+  const pidHost =
+    typeof state.info?.host === "string" && state.info.host.trim()
+      ? state.info.host.trim()
+      : host;
+
+  if (!Number.isFinite(pid) || pid <= 0) {
+    warnings.push(formatWarning("hub pid file has invalid PID"));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      reason: "invalid_pid",
+    };
+  }
+
+  if (!isPidAlive(pid, killFn)) {
+    warnings.push(formatWarning(`stale hub pid file: PID ${pid} is not alive`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid,
+      port,
+      reason: "dead_pid",
+    };
+  }
+
+  const command = getPidCommand(pid, { platform, execFile });
+  if (!isHubServerCommand(command)) {
+    warnings.push(
+      formatWarning(`hub pid file PID ${pid} is not hub/server.mjs`),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid,
+      port,
+      command,
+      reason: "not_hub_server",
+    };
+  }
+
+  if (!port) {
+    warnings.push(formatWarning(`hub pid file PID ${pid} has no valid port`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      command,
+      reason: "invalid_port",
+    };
+  }
+
+  const listeningPorts = findListeningPortsForPid(pid, { platform, execFile });
+  if (!listeningPorts.includes(port)) {
+    warnings.push(
+      formatWarning(
+        `hub pid file mismatch: PID ${pid} is not listening on port ${port}`,
+      ),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      reason: "port_mismatch",
+    };
+  }
+
+  const health = await fetchHubHealth(pidHost, port, { fetchImpl });
+  if (!health.ok) {
+    warnings.push(
+      formatWarning(`hub pid file PID ${pid} port ${port} is not healthy`),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      health,
+      reason: "unhealthy",
+    };
+  }
+
+  if (health.version !== expectedVersion) {
+    warnings.push(
+      formatWarning(
+        `hub pid file version mismatch: expected ${expectedVersion}, got ${
+          health.version ?? "unknown"
+        }`,
+      ),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      health,
+      reason: "version_mismatch",
+    };
+  }
+
+  return {
+    exists: true,
+    valid: true,
+    warnings,
+    retirePid: null,
+    pid,
+    port,
+    command,
+    listeningPorts,
+    health,
+    reason: "ok",
+  };
+}
+
+async function waitUntilProcessExits(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const deadline = Date.now() + Math.max(0, graceMs);
+  while (Date.now() <= deadline) {
+    if (!isPidAlive(pid, killFn)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return !isPidAlive(pid, killFn);
+}
+
+export async function retireHubProcess(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) {
+    return { ok: false, pid: resolvedPid, reason: "invalid_pid" };
+  }
+  if (!isPidAlive(resolvedPid, killFn)) {
+    return { ok: true, pid: resolvedPid, reason: "already_dead" };
+  }
+
+  try {
+    killFn(resolvedPid, "SIGTERM");
+  } catch (error) {
+    return { ok: false, pid: resolvedPid, reason: "sigterm_failed", error };
+  }
+
+  if (await waitUntilProcessExits(resolvedPid, { killFn, graceMs, pollMs })) {
+    return { ok: true, pid: resolvedPid, reason: "sigterm" };
+  }
+
+  try {
+    killFn(resolvedPid, "SIGKILL");
+  } catch (error) {
+    return { ok: false, pid: resolvedPid, reason: "sigkill_failed", error };
+  }
+
+  const exited = await waitUntilProcessExits(resolvedPid, {
+    killFn,
+    graceMs: 1000,
+    pollMs,
+  });
+  return {
+    ok: exited,
+    pid: resolvedPid,
+    reason: exited ? "sigkill" : "still_alive",
+  };
+}
+
+export async function inspectListeningHub({
+  host,
+  port,
+  expectedVersion = getVersionHash(),
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const warnings = [];
+  const health = await fetchHubHealth(host, port, { fetchImpl });
+  if (!health.ok) {
+    return {
+      listening: false,
+      valid: false,
+      warnings,
+      retirePid: null,
+      health,
+    };
+  }
+
+  const ownerPid = findListeningPidByPort(port, { platform, execFile });
+  const command = ownerPid
+    ? getPidCommand(ownerPid, { platform, execFile })
+    : "";
+  const ownerIsHub = ownerPid ? isHubServerCommand(command) : false;
+  if (health.version === expectedVersion && ownerIsHub) {
+    return {
+      listening: true,
+      valid: true,
+      warnings,
+      retirePid: null,
+      pid: ownerPid,
+      command,
+      health,
+      reason: "ok",
+    };
+  }
+
+  if (health.version === expectedVersion) {
+    warnings.push(
+      formatWarning(
+        `hub health on ${host}:${port} is not owned by hub/server.mjs (pid=${
+          ownerPid ?? "unknown"
+        })`,
+      ),
+    );
+    return {
+      listening: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid: ownerPid,
+      command,
+      health,
+      reason: "not_hub_server",
+    };
+  }
+
+  warnings.push(
+    formatWarning(
+      `hub version mismatch on ${host}:${port}: expected ${expectedVersion}, got ${
+        health.version ?? "unknown"
+      }`,
+    ),
+  );
+  return {
+    listening: true,
+    valid: false,
+    warnings,
+    retirePid: ownerIsHub ? ownerPid : null,
+    pid: ownerPid,
+    command,
+    health,
+    reason: "version_mismatch",
+  };
+}
+
+function cleanupPidFileBestEffort(pidFilePath, unlink = unlinkSync) {
+  try {
+    unlink(pidFilePath);
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+function chooseCascadePort(
+  startPort,
+  {
+    maxAttempts = 200,
+    platform = process.platform,
+    execFile = execFileSync,
+  } = {},
+) {
+  const base = parsePort(startPort) ?? HUB_DEFAULT_PORT;
+  for (let offset = 1; offset <= maxAttempts; offset++) {
+    const candidate = base + offset;
+    if (!findListeningPidByPort(candidate, { platform, execFile })) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function resolveHubTarget({ pidFilePath = HUB_PID_FILE } = {}) {
   const envPortRaw = Number(process.env.TFX_HUB_PORT || "");
   const envPort =
     Number.isFinite(envPortRaw) && envPortRaw > 0 ? envPortRaw : null;
@@ -81,9 +607,9 @@ export function resolveHubTarget() {
   // 이는 이전 세션의 오염된 port(비표준 포트)가 cascade로 영속화되는 버그 원인이었다.
   // 포트는 오직 TFX_HUB_PORT env(없으면 HUB_DEFAULT_PORT=27888)만 source of truth다.
   // client config 는 sync-hub-mcp-settings.mjs가 이 hubUrl로 재동기화한다.
-  if (existsSync(HUB_PID_FILE)) {
+  if (existsSync(pidFilePath)) {
     try {
-      const info = JSON.parse(readFileSync(HUB_PID_FILE, "utf8"));
+      const info = JSON.parse(readFileSync(pidFilePath, "utf8"));
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;
@@ -96,26 +622,19 @@ export function resolveHubTarget() {
   return target;
 }
 
-async function isHubHealthy(host, port) {
-  try {
-    const res = await fetch(`${buildHubBaseUrl(host, port)}/health`, {
-      signal: AbortSignal.timeout(1000),
-    });
-    if (!res.ok) return false;
-    const data = await res.json();
-    return data?.ok === true;
-  } catch {
-    return false;
-  }
+async function isHubHealthy(host, port, expectedVersion, deps = {}) {
+  const health = await fetchHubHealth(host, port, deps);
+  if (!health.ok) return false;
+  return expectedVersion ? health.version === expectedVersion : true;
 }
 
-function startHubDetached(port) {
+function startHubDetached(port, { spawnFn = spawn } = {}) {
   const serverPath = join(PLUGIN_ROOT, "hub", "server.mjs");
   if (!existsSync(serverPath)) return false;
 
   try {
     const env = { ...process.env, TFX_HUB_PORT: String(port) };
-    const child = spawn(process.execPath, [serverPath], {
+    const child = spawnFn(process.execPath, [serverPath], {
       env,
       detached: true,
       stdio: "ignore",
@@ -128,41 +647,178 @@ function startHubDetached(port) {
   }
 }
 
-async function waitForHubReady(host, port, maxWaitMs = 5000) {
+async function waitForHubReady(host, port, maxWaitMs = 5000, expectedVersion) {
   const interval = 250;
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
-    if (await isHubHealthy(host, port)) return true;
+    if (await isHubHealthy(host, port, expectedVersion)) return true;
     await new Promise((resolve) => setTimeout(resolve, interval));
   }
   return false;
 }
 
-export async function run(stdinData) {
+export async function run(stdinData, deps = {}) {
   void stdinData;
 
-  const { host, port } = resolveHubTarget();
-  const hubUrl = `${buildHubBaseUrl(host, port)}/mcp`;
-  if (await isHubHealthy(host, port)) {
-    await syncHubConfigsIfAvailable({ hubUrl });
-    snapshotUserStateBestEffort();
-    return { code: 0, stdout: "hub: ok", stderr: "" };
+  const pidFilePath = deps.pidFilePath ?? HUB_PID_FILE;
+  const expectedVersion = deps.expectedVersion ?? getVersionHash();
+  const warnings = [];
+  const retiredPids = new Set();
+
+  const { host, port } = resolveHubTarget({ pidFilePath });
+  const pidInspection = await inspectPidFileHub({
+    expectedVersion,
+    pidFilePath,
+    host,
+    exists: deps.exists ?? existsSync,
+    readFile: deps.readFile ?? readFileSync,
+    killFn: deps.killFn ?? process.kill,
+    platform: deps.platform ?? process.platform,
+    execFile: deps.execFile ?? execFileSync,
+    fetchImpl: deps.fetchImpl ?? fetch,
+  });
+  warnings.push(...pidInspection.warnings);
+  if (pidInspection.retirePid) {
+    const retired = await retireHubProcess(pidInspection.retirePid, {
+      killFn: deps.killFn ?? process.kill,
+      graceMs: deps.retireGraceMs ?? 5000,
+      pollMs: deps.retirePollMs ?? 100,
+    });
+    retiredPids.add(pidInspection.retirePid);
+    if (retired.ok) {
+      warnings.push(
+        formatWarning(
+          `retired stale hub PID ${pidInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
+    } else {
+      warnings.push(
+        formatWarning(
+          `failed to retire stale hub PID ${pidInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+    }
+  } else if (
+    pidInspection.exists &&
+    !pidInspection.valid &&
+    ["dead_pid", "invalid_json", "invalid_pid"].includes(pidInspection.reason)
+  ) {
+    cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
   }
 
-  const started = startHubDetached(port);
+  const targetInspection = await inspectListeningHub({
+    host,
+    port,
+    expectedVersion,
+    killFn: deps.killFn ?? process.kill,
+    platform: deps.platform ?? process.platform,
+    execFile: deps.execFile ?? execFileSync,
+    fetchImpl: deps.fetchImpl ?? fetch,
+  });
+  warnings.push(...targetInspection.warnings);
+  if (targetInspection.valid) {
+    const hubUrl = `${buildHubBaseUrl(host, port)}/mcp`;
+    if (typeof deps.syncHubConfigs === "function") {
+      await deps.syncHubConfigs({ hubUrl });
+    } else {
+      await syncHubConfigsIfAvailable({ hubUrl });
+    }
+    if (typeof deps.snapshotUserState === "function") {
+      deps.snapshotUserState();
+    } else {
+      snapshotUserStateBestEffort();
+    }
+    return { code: 0, stdout: "hub: ok", stderr: warnings.join("") };
+  }
+
+  let startPort = port;
+  if (
+    targetInspection.retirePid &&
+    !retiredPids.has(targetInspection.retirePid)
+  ) {
+    const retired = await retireHubProcess(targetInspection.retirePid, {
+      killFn: deps.killFn ?? process.kill,
+      graceMs: deps.retireGraceMs ?? 5000,
+      pollMs: deps.retirePollMs ?? 100,
+    });
+    if (retired.ok) {
+      warnings.push(
+        formatWarning(
+          `retired port ${port} hub PID ${targetInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
+    } else {
+      warnings.push(
+        formatWarning(
+          `failed to retire port ${port} hub PID ${targetInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      const cascadePort = chooseCascadePort(port, {
+        platform: deps.platform ?? process.platform,
+        execFile: deps.execFile ?? execFileSync,
+      });
+      if (cascadePort) {
+        startPort = cascadePort;
+        warnings.push(
+          formatWarning(
+            `falling back to cascade port ${startPort}; default port ${port} remains occupied`,
+          ),
+        );
+      }
+    }
+  } else if (
+    targetInspection.listening &&
+    ["version_mismatch", "not_hub_server"].includes(targetInspection.reason)
+  ) {
+    const cascadePort = chooseCascadePort(port, {
+      platform: deps.platform ?? process.platform,
+      execFile: deps.execFile ?? execFileSync,
+    });
+    if (cascadePort) {
+      startPort = cascadePort;
+      warnings.push(
+        formatWarning(
+          `unable to identify a retirable hub on port ${port}; falling back to cascade port ${startPort}`,
+        ),
+      );
+    }
+  }
+
+  const started =
+    typeof deps.startHubDetached === "function"
+      ? deps.startHubDetached(startPort)
+      : startHubDetached(startPort, { spawnFn: deps.spawnFn ?? spawn });
   if (!started) {
-    return { code: 1, stdout: "", stderr: "[hub-ensure] hub 시작 실패" };
+    return {
+      code: 1,
+      stdout: "",
+      stderr: `${warnings.join("")}[hub-ensure] hub 시작 실패`,
+    };
   }
 
-  const ready = await waitForHubReady(host, port, 5000);
+  const ready =
+    typeof deps.waitForHubReady === "function"
+      ? await deps.waitForHubReady(host, startPort, 5000, expectedVersion)
+      : await waitForHubReady(host, startPort, 5000, expectedVersion);
   if (ready) {
-    await syncHubConfigsIfAvailable({ hubUrl });
-    snapshotUserStateBestEffort();
+    const hubUrl = `${buildHubBaseUrl(host, startPort)}/mcp`;
+    if (typeof deps.syncHubConfigs === "function") {
+      await deps.syncHubConfigs({ hubUrl });
+    } else {
+      await syncHubConfigsIfAvailable({ hubUrl });
+    }
+    if (typeof deps.snapshotUserState === "function") {
+      deps.snapshotUserState();
+    } else {
+      snapshotUserStateBestEffort();
+    }
   }
   return {
     code: ready ? 0 : 2,
     stdout: ready ? "hub: ok" : "hub: starting (timeout)",
-    stderr: "",
+    stderr: warnings.join(""),
   };
 }
 

--- a/scripts/hub-ensure.mjs
+++ b/scripts/hub-ensure.mjs
@@ -4,11 +4,12 @@
 // - /status 기반 헬스체크
 // - 비정상 시 Hub를 detached로 기동
 
-import { spawn } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { execFileSync, spawn } from "child_process";
+import { existsSync, readFileSync, unlinkSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { getVersionHash } from "../hub/state.mjs";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -67,7 +68,532 @@ function snapshotUserStateBestEffort() {
   }
 }
 
-export function resolveHubTarget() {
+function parsePort(value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function formatWarning(message) {
+  return `[hub-ensure] ${message}\n`;
+}
+
+function readHubPidFile(
+  pidFilePath = HUB_PID_FILE,
+  { exists = existsSync, readFile = readFileSync } = {},
+) {
+  if (!exists(pidFilePath)) {
+    return { exists: false, info: null, error: null };
+  }
+  try {
+    return {
+      exists: true,
+      info: JSON.parse(readFile(pidFilePath, "utf8")),
+      error: null,
+    };
+  } catch (error) {
+    return { exists: true, info: null, error };
+  }
+}
+
+function isPidAlive(pid, killFn = process.kill) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return false;
+  try {
+    killFn(resolvedPid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function getPidCommand(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return "";
+
+  try {
+    if (platform === "win32") {
+      return execFile(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${resolvedPid}" | Select-Object -ExpandProperty CommandLine)`,
+        ],
+        {
+          encoding: "utf8",
+          timeout: 5000,
+          stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
+        },
+      ).trim();
+    }
+
+    return execFile("ps", ["-p", String(resolvedPid), "-o", "command="], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export function isHubServerCommand(command) {
+  return /(^|[\\/,\s])hub[\\/]server\.mjs(?=$|[\s"'`])/i.test(
+    String(command || ""),
+  );
+}
+
+function parsePortFromAddress(address) {
+  const match = String(address || "").match(/:(\d+)(?:\s|$)/);
+  return parsePort(match?.[1]);
+}
+
+function parseLsofListeningPorts(output) {
+  const ports = new Set();
+  for (const line of String(output || "").split(/\r?\n/)) {
+    if (!/\(LISTEN\)/i.test(line)) continue;
+    const match = line.match(/TCP\s+\S+:(\d+)\s+\(LISTEN\)/i);
+    const port = parsePort(match?.[1]) ?? parsePortFromAddress(line);
+    if (port) ports.add(port);
+  }
+  return [...ports];
+}
+
+function findListeningPortsForPid(
+  pid,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return [];
+
+  try {
+    if (platform === "win32") {
+      const output = execFile("netstat", ["-ano", "-p", "tcp"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      });
+      const ports = new Set();
+      for (const line of output.split(/\r?\n/)) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const [proto, localAddress, , state, pidText] = parts;
+        if (proto?.toUpperCase() !== "TCP") continue;
+        if (state?.toUpperCase() !== "LISTENING") continue;
+        if (Number(pidText) !== resolvedPid) continue;
+        const port = parsePortFromAddress(localAddress);
+        if (port) ports.add(port);
+      }
+      return [...ports];
+    }
+
+    const output = execFile(
+      "lsof",
+      ["-nP", "-Pan", "-p", String(resolvedPid), "-iTCP", "-sTCP:LISTEN"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    return parseLsofListeningPorts(output);
+  } catch {
+    return [];
+  }
+}
+
+function findListeningPidByPort(
+  port,
+  { platform = process.platform, execFile = execFileSync } = {},
+) {
+  const targetPort = parsePort(port);
+  if (!targetPort) return null;
+
+  try {
+    if (platform === "win32") {
+      const output = execFile("netstat", ["-ano", "-p", "tcp"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      });
+      for (const line of output.split(/\r?\n/)) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const [proto, localAddress, , state, pidText] = parts;
+        if (proto?.toUpperCase() !== "TCP") continue;
+        if (state?.toUpperCase() !== "LISTENING") continue;
+        if (parsePortFromAddress(localAddress) !== targetPort) continue;
+        const pid = Number.parseInt(pidText, 10);
+        if (Number.isFinite(pid) && pid > 0) return pid;
+      }
+      return null;
+    }
+
+    const output = execFile(
+      "lsof",
+      ["-nP", "-iTCP:" + targetPort, "-sTCP:LISTEN", "-t"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+    const pid = Number.parseInt(output.trim().split(/\r?\n/)[0] ?? "", 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHubHealth(
+  host,
+  port,
+  { fetchImpl = fetch, timeoutMs = 1000 } = {},
+) {
+  try {
+    const res = await fetchImpl(`${buildHubBaseUrl(host, port)}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return { ok: false, version: null };
+    const data = await res.json();
+    return {
+      ok: data?.ok === true,
+      version: typeof data?.version === "string" ? data.version : null,
+      raw: data,
+    };
+  } catch (error) {
+    return { ok: false, version: null, error };
+  }
+}
+
+export async function inspectPidFileHub({
+  expectedVersion = getVersionHash(),
+  pidFilePath = HUB_PID_FILE,
+  host = "127.0.0.1",
+  exists = existsSync,
+  readFile = readFileSync,
+  killFn = process.kill,
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const warnings = [];
+  const state = readHubPidFile(pidFilePath, { exists, readFile });
+  if (!state.exists) {
+    return { exists: false, valid: false, warnings, retirePid: null };
+  }
+  if (state.error) {
+    warnings.push(formatWarning(`invalid hub pid file: ${pidFilePath}`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      reason: "invalid_json",
+    };
+  }
+
+  const pid = Number(state.info?.pid);
+  const port = parsePort(state.info?.port);
+  const pidHost =
+    typeof state.info?.host === "string" && state.info.host.trim()
+      ? state.info.host.trim()
+      : host;
+
+  if (!Number.isFinite(pid) || pid <= 0) {
+    warnings.push(formatWarning("hub pid file has invalid PID"));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      reason: "invalid_pid",
+    };
+  }
+
+  if (!isPidAlive(pid, killFn)) {
+    warnings.push(formatWarning(`stale hub pid file: PID ${pid} is not alive`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid,
+      port,
+      reason: "dead_pid",
+    };
+  }
+
+  const command = getPidCommand(pid, { platform, execFile });
+  if (!isHubServerCommand(command)) {
+    warnings.push(
+      formatWarning(`hub pid file PID ${pid} is not hub/server.mjs`),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid,
+      port,
+      command,
+      reason: "not_hub_server",
+    };
+  }
+
+  if (!port) {
+    warnings.push(formatWarning(`hub pid file PID ${pid} has no valid port`));
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      command,
+      reason: "invalid_port",
+    };
+  }
+
+  const listeningPorts = findListeningPortsForPid(pid, { platform, execFile });
+  if (!listeningPorts.includes(port)) {
+    warnings.push(
+      formatWarning(
+        `hub pid file mismatch: PID ${pid} is not listening on port ${port}`,
+      ),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      reason: "port_mismatch",
+    };
+  }
+
+  const health = await fetchHubHealth(pidHost, port, { fetchImpl });
+  if (!health.ok) {
+    warnings.push(
+      formatWarning(`hub pid file PID ${pid} port ${port} is not healthy`),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      health,
+      reason: "unhealthy",
+    };
+  }
+
+  if (health.version !== expectedVersion) {
+    warnings.push(
+      formatWarning(
+        `hub pid file version mismatch: expected ${expectedVersion}, got ${
+          health.version ?? "unknown"
+        }`,
+      ),
+    );
+    return {
+      exists: true,
+      valid: false,
+      warnings,
+      retirePid: pid,
+      pid,
+      port,
+      command,
+      listeningPorts,
+      health,
+      reason: "version_mismatch",
+    };
+  }
+
+  return {
+    exists: true,
+    valid: true,
+    warnings,
+    retirePid: null,
+    pid,
+    port,
+    command,
+    listeningPorts,
+    health,
+    reason: "ok",
+  };
+}
+
+async function waitUntilProcessExits(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const deadline = Date.now() + Math.max(0, graceMs);
+  while (Date.now() <= deadline) {
+    if (!isPidAlive(pid, killFn)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return !isPidAlive(pid, killFn);
+}
+
+export async function retireHubProcess(
+  pid,
+  { killFn = process.kill, graceMs = 5000, pollMs = 100 } = {},
+) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) {
+    return { ok: false, pid: resolvedPid, reason: "invalid_pid" };
+  }
+  if (!isPidAlive(resolvedPid, killFn)) {
+    return { ok: true, pid: resolvedPid, reason: "already_dead" };
+  }
+
+  try {
+    killFn(resolvedPid, "SIGTERM");
+  } catch (error) {
+    return { ok: false, pid: resolvedPid, reason: "sigterm_failed", error };
+  }
+
+  if (await waitUntilProcessExits(resolvedPid, { killFn, graceMs, pollMs })) {
+    return { ok: true, pid: resolvedPid, reason: "sigterm" };
+  }
+
+  try {
+    killFn(resolvedPid, "SIGKILL");
+  } catch (error) {
+    return { ok: false, pid: resolvedPid, reason: "sigkill_failed", error };
+  }
+
+  const exited = await waitUntilProcessExits(resolvedPid, {
+    killFn,
+    graceMs: 1000,
+    pollMs,
+  });
+  return {
+    ok: exited,
+    pid: resolvedPid,
+    reason: exited ? "sigkill" : "still_alive",
+  };
+}
+
+export async function inspectListeningHub({
+  host,
+  port,
+  expectedVersion = getVersionHash(),
+  platform = process.platform,
+  execFile = execFileSync,
+  fetchImpl = fetch,
+} = {}) {
+  const warnings = [];
+  const health = await fetchHubHealth(host, port, { fetchImpl });
+  if (!health.ok) {
+    return {
+      listening: false,
+      valid: false,
+      warnings,
+      retirePid: null,
+      health,
+    };
+  }
+
+  const ownerPid = findListeningPidByPort(port, { platform, execFile });
+  const command = ownerPid
+    ? getPidCommand(ownerPid, { platform, execFile })
+    : "";
+  const ownerIsHub = ownerPid ? isHubServerCommand(command) : false;
+  if (health.version === expectedVersion && ownerIsHub) {
+    return {
+      listening: true,
+      valid: true,
+      warnings,
+      retirePid: null,
+      pid: ownerPid,
+      command,
+      health,
+      reason: "ok",
+    };
+  }
+
+  if (health.version === expectedVersion) {
+    warnings.push(
+      formatWarning(
+        `hub health on ${host}:${port} is not owned by hub/server.mjs (pid=${
+          ownerPid ?? "unknown"
+        })`,
+      ),
+    );
+    return {
+      listening: true,
+      valid: false,
+      warnings,
+      retirePid: null,
+      pid: ownerPid,
+      command,
+      health,
+      reason: "not_hub_server",
+    };
+  }
+
+  warnings.push(
+    formatWarning(
+      `hub version mismatch on ${host}:${port}: expected ${expectedVersion}, got ${
+        health.version ?? "unknown"
+      }`,
+    ),
+  );
+  return {
+    listening: true,
+    valid: false,
+    warnings,
+    retirePid: ownerIsHub ? ownerPid : null,
+    pid: ownerPid,
+    command,
+    health,
+    reason: "version_mismatch",
+  };
+}
+
+function cleanupPidFileBestEffort(pidFilePath, unlink = unlinkSync) {
+  try {
+    unlink(pidFilePath);
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+function chooseCascadePort(
+  startPort,
+  {
+    maxAttempts = 200,
+    platform = process.platform,
+    execFile = execFileSync,
+  } = {},
+) {
+  const base = parsePort(startPort) ?? HUB_DEFAULT_PORT;
+  for (let offset = 1; offset <= maxAttempts; offset++) {
+    const candidate = base + offset;
+    if (!findListeningPidByPort(candidate, { platform, execFile })) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function resolveHubTarget({ pidFilePath = HUB_PID_FILE } = {}) {
   const envPortRaw = Number(process.env.TFX_HUB_PORT || "");
   const envPort =
     Number.isFinite(envPortRaw) && envPortRaw > 0 ? envPortRaw : null;
@@ -81,9 +607,9 @@ export function resolveHubTarget() {
   // 이는 이전 세션의 오염된 port(비표준 포트)가 cascade로 영속화되는 버그 원인이었다.
   // 포트는 오직 TFX_HUB_PORT env(없으면 HUB_DEFAULT_PORT=27888)만 source of truth다.
   // client config 는 sync-hub-mcp-settings.mjs가 이 hubUrl로 재동기화한다.
-  if (existsSync(HUB_PID_FILE)) {
+  if (existsSync(pidFilePath)) {
     try {
-      const info = JSON.parse(readFileSync(HUB_PID_FILE, "utf8"));
+      const info = JSON.parse(readFileSync(pidFilePath, "utf8"));
       if (typeof info?.host === "string") {
         const host = info.host.trim();
         if (LOOPBACK_HOSTS.has(host)) target.host = host;
@@ -96,26 +622,19 @@ export function resolveHubTarget() {
   return target;
 }
 
-async function isHubHealthy(host, port) {
-  try {
-    const res = await fetch(`${buildHubBaseUrl(host, port)}/health`, {
-      signal: AbortSignal.timeout(1000),
-    });
-    if (!res.ok) return false;
-    const data = await res.json();
-    return data?.ok === true;
-  } catch {
-    return false;
-  }
+async function isHubHealthy(host, port, expectedVersion, deps = {}) {
+  const health = await fetchHubHealth(host, port, deps);
+  if (!health.ok) return false;
+  return expectedVersion ? health.version === expectedVersion : true;
 }
 
-function startHubDetached(port) {
+function startHubDetached(port, { spawnFn = spawn } = {}) {
   const serverPath = join(PLUGIN_ROOT, "hub", "server.mjs");
   if (!existsSync(serverPath)) return false;
 
   try {
     const env = { ...process.env, TFX_HUB_PORT: String(port) };
-    const child = spawn(process.execPath, [serverPath], {
+    const child = spawnFn(process.execPath, [serverPath], {
       env,
       detached: true,
       stdio: "ignore",
@@ -128,41 +647,178 @@ function startHubDetached(port) {
   }
 }
 
-async function waitForHubReady(host, port, maxWaitMs = 5000) {
+async function waitForHubReady(host, port, maxWaitMs = 5000, expectedVersion) {
   const interval = 250;
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
-    if (await isHubHealthy(host, port)) return true;
+    if (await isHubHealthy(host, port, expectedVersion)) return true;
     await new Promise((resolve) => setTimeout(resolve, interval));
   }
   return false;
 }
 
-export async function run(stdinData) {
+export async function run(stdinData, deps = {}) {
   void stdinData;
 
-  const { host, port } = resolveHubTarget();
-  const hubUrl = `${buildHubBaseUrl(host, port)}/mcp`;
-  if (await isHubHealthy(host, port)) {
-    await syncHubConfigsIfAvailable({ hubUrl });
-    snapshotUserStateBestEffort();
-    return { code: 0, stdout: "hub: ok", stderr: "" };
+  const pidFilePath = deps.pidFilePath ?? HUB_PID_FILE;
+  const expectedVersion = deps.expectedVersion ?? getVersionHash();
+  const warnings = [];
+  const retiredPids = new Set();
+
+  const { host, port } = resolveHubTarget({ pidFilePath });
+  const pidInspection = await inspectPidFileHub({
+    expectedVersion,
+    pidFilePath,
+    host,
+    exists: deps.exists ?? existsSync,
+    readFile: deps.readFile ?? readFileSync,
+    killFn: deps.killFn ?? process.kill,
+    platform: deps.platform ?? process.platform,
+    execFile: deps.execFile ?? execFileSync,
+    fetchImpl: deps.fetchImpl ?? fetch,
+  });
+  warnings.push(...pidInspection.warnings);
+  if (pidInspection.retirePid) {
+    const retired = await retireHubProcess(pidInspection.retirePid, {
+      killFn: deps.killFn ?? process.kill,
+      graceMs: deps.retireGraceMs ?? 5000,
+      pollMs: deps.retirePollMs ?? 100,
+    });
+    retiredPids.add(pidInspection.retirePid);
+    if (retired.ok) {
+      warnings.push(
+        formatWarning(
+          `retired stale hub PID ${pidInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
+    } else {
+      warnings.push(
+        formatWarning(
+          `failed to retire stale hub PID ${pidInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+    }
+  } else if (
+    pidInspection.exists &&
+    !pidInspection.valid &&
+    ["dead_pid", "invalid_json", "invalid_pid"].includes(pidInspection.reason)
+  ) {
+    cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
   }
 
-  const started = startHubDetached(port);
+  const targetInspection = await inspectListeningHub({
+    host,
+    port,
+    expectedVersion,
+    killFn: deps.killFn ?? process.kill,
+    platform: deps.platform ?? process.platform,
+    execFile: deps.execFile ?? execFileSync,
+    fetchImpl: deps.fetchImpl ?? fetch,
+  });
+  warnings.push(...targetInspection.warnings);
+  if (targetInspection.valid) {
+    const hubUrl = `${buildHubBaseUrl(host, port)}/mcp`;
+    if (typeof deps.syncHubConfigs === "function") {
+      await deps.syncHubConfigs({ hubUrl });
+    } else {
+      await syncHubConfigsIfAvailable({ hubUrl });
+    }
+    if (typeof deps.snapshotUserState === "function") {
+      deps.snapshotUserState();
+    } else {
+      snapshotUserStateBestEffort();
+    }
+    return { code: 0, stdout: "hub: ok", stderr: warnings.join("") };
+  }
+
+  let startPort = port;
+  if (
+    targetInspection.retirePid &&
+    !retiredPids.has(targetInspection.retirePid)
+  ) {
+    const retired = await retireHubProcess(targetInspection.retirePid, {
+      killFn: deps.killFn ?? process.kill,
+      graceMs: deps.retireGraceMs ?? 5000,
+      pollMs: deps.retirePollMs ?? 100,
+    });
+    if (retired.ok) {
+      warnings.push(
+        formatWarning(
+          `retired port ${port} hub PID ${targetInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      cleanupPidFileBestEffort(pidFilePath, deps.unlink ?? unlinkSync);
+    } else {
+      warnings.push(
+        formatWarning(
+          `failed to retire port ${port} hub PID ${targetInspection.retirePid} (${retired.reason})`,
+        ),
+      );
+      const cascadePort = chooseCascadePort(port, {
+        platform: deps.platform ?? process.platform,
+        execFile: deps.execFile ?? execFileSync,
+      });
+      if (cascadePort) {
+        startPort = cascadePort;
+        warnings.push(
+          formatWarning(
+            `falling back to cascade port ${startPort}; default port ${port} remains occupied`,
+          ),
+        );
+      }
+    }
+  } else if (
+    targetInspection.listening &&
+    ["version_mismatch", "not_hub_server"].includes(targetInspection.reason)
+  ) {
+    const cascadePort = chooseCascadePort(port, {
+      platform: deps.platform ?? process.platform,
+      execFile: deps.execFile ?? execFileSync,
+    });
+    if (cascadePort) {
+      startPort = cascadePort;
+      warnings.push(
+        formatWarning(
+          `unable to identify a retirable hub on port ${port}; falling back to cascade port ${startPort}`,
+        ),
+      );
+    }
+  }
+
+  const started =
+    typeof deps.startHubDetached === "function"
+      ? deps.startHubDetached(startPort)
+      : startHubDetached(startPort, { spawnFn: deps.spawnFn ?? spawn });
   if (!started) {
-    return { code: 1, stdout: "", stderr: "[hub-ensure] hub 시작 실패" };
+    return {
+      code: 1,
+      stdout: "",
+      stderr: `${warnings.join("")}[hub-ensure] hub 시작 실패`,
+    };
   }
 
-  const ready = await waitForHubReady(host, port, 5000);
+  const ready =
+    typeof deps.waitForHubReady === "function"
+      ? await deps.waitForHubReady(host, startPort, 5000, expectedVersion)
+      : await waitForHubReady(host, startPort, 5000, expectedVersion);
   if (ready) {
-    await syncHubConfigsIfAvailable({ hubUrl });
-    snapshotUserStateBestEffort();
+    const hubUrl = `${buildHubBaseUrl(host, startPort)}/mcp`;
+    if (typeof deps.syncHubConfigs === "function") {
+      await deps.syncHubConfigs({ hubUrl });
+    } else {
+      await syncHubConfigsIfAvailable({ hubUrl });
+    }
+    if (typeof deps.snapshotUserState === "function") {
+      deps.snapshotUserState();
+    } else {
+      snapshotUserStateBestEffort();
+    }
   }
   return {
     code: ready ? 0 : 2,
     stdout: ready ? "hub: ok" : "hub: starting (timeout)",
-    stderr: "",
+    stderr: warnings.join(""),
   };
 }
 

--- a/tests/integration/hub-singleton.test.mjs
+++ b/tests/integration/hub-singleton.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { run as runHubEnsure } from "../../scripts/hub-ensure.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const HUB_SERVER_URL = pathToFileURL(resolve(ROOT, "hub", "server.mjs")).href;
@@ -53,6 +54,41 @@ function createDelegatorWorker() {
   return {
     async start() {},
     async stop() {},
+  };
+}
+
+function healthResponse(body) {
+  return {
+    ok: true,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function makeEnsureExecFile({ commands = {}, listening = {} } = {}) {
+  return (cmd, args) => {
+    if (cmd === "ps") return commands[args[1]] || "";
+    if (cmd === "lsof" && args.includes("-p")) {
+      const pid = args[args.indexOf("-p") + 1];
+      const ports = listening[pid] || [];
+      return [
+        "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME",
+        ...ports.map(
+          (port) =>
+            `node ${pid} user 20u IPv4 0x0 0t0 TCP 127.0.0.1:${port} (LISTEN)`,
+        ),
+      ].join("\n");
+    }
+    if (cmd === "lsof" && args.some((arg) => arg.startsWith("-iTCP:"))) {
+      const port = Number(
+        args.find((arg) => arg.startsWith("-iTCP:")).replace("-iTCP:", ""),
+      );
+      for (const [pid, ports] of Object.entries(listening)) {
+        if (ports.includes(port)) return `${pid}\n`;
+      }
+    }
+    return "";
   };
 }
 
@@ -174,6 +210,206 @@ describe("hub singleton", () => {
           },
         );
       } catch {}
+      ctx.cleanup();
+    }
+  });
+
+  it("hub-ensure는 stale pid file이 있어도 active default hub를 가리지 않는다", async () => {
+    const ctx = createTestContext();
+    let hub = null;
+    try {
+      await withEnv(
+        {
+          HOME: ctx.homeDir,
+          USERPROFILE: ctx.homeDir,
+          TFX_HUB_PORT: String(ctx.port),
+          TFX_HUB_STATE_DIR: ctx.stateDir,
+        },
+        async () => {
+          const mod = await import(
+            `${HUB_SERVER_URL}?ensure-stale-pid=${Date.now()}-${Math.random()}`
+          );
+          hub = await mod.startHub({
+            port: ctx.port,
+            host: "127.0.0.1",
+            dbPath: ctx.dbPath("stale-pid"),
+            sessionId: `hub-singleton-stale-pid-${randomUUID()}`,
+            createDelegatorWorker,
+          });
+          writeFileSync(
+            join(ctx.stateDir, "hub.pid"),
+            `${JSON.stringify({
+              pid: 99999999,
+              port: ctx.port + 1,
+              host: "127.0.0.1",
+              version: "old",
+            })}\n`,
+            "utf8",
+          );
+
+          const result = await runHubEnsure("", {
+            pidFilePath: join(ctx.stateDir, "hub.pid"),
+            killFn(pid, signal) {
+              if (pid === 99999999 && signal === 0) {
+                const error = new Error("dead");
+                error.code = "ESRCH";
+                throw error;
+              }
+              return process.kill(pid, signal);
+            },
+            execFile: makeEnsureExecFile({
+              commands: { [hub.pid]: "node /repo/hub/server.mjs" },
+              listening: { [hub.pid]: [ctx.port] },
+            }),
+            startHubDetached() {
+              throw new Error("active hub should be reused");
+            },
+            syncHubConfigs: async () => {},
+            snapshotUserState: () => {},
+          });
+
+          assert.equal(result.code, 0);
+          assert.equal(result.stdout, "hub: ok");
+          assert.match(result.stderr, /stale hub pid file/);
+        },
+      );
+    } finally {
+      try {
+        await withEnv(
+          { HOME: ctx.homeDir, USERPROFILE: ctx.homeDir },
+          async () => {
+            await hub?.stop?.();
+          },
+        );
+      } catch {}
+      ctx.cleanup();
+    }
+  });
+
+  it("hub-ensure는 pid-file port mismatch hub를 retire한 뒤 기본 포트로 시작한다", async () => {
+    const ctx = createTestContext();
+    const pidFilePath = join(ctx.stateDir, "hub.pid");
+    writeFileSync(
+      pidFilePath,
+      `${JSON.stringify({ pid: 2222, port: ctx.port + 5, host: "127.0.0.1" })}\n`,
+      "utf8",
+    );
+    const alive = new Set([2222]);
+    const kills = [];
+    const started = [];
+
+    try {
+      await withEnv(
+        {
+          HOME: ctx.homeDir,
+          USERPROFILE: ctx.homeDir,
+          TFX_HUB_PORT: String(ctx.port),
+        },
+        async () => {
+          const result = await runHubEnsure("", {
+            expectedVersion: "10.21.0-test",
+            pidFilePath,
+            retireGraceMs: 0,
+            killFn(pid, signal) {
+              if (signal === 0) {
+                if (!alive.has(pid)) {
+                  const error = new Error("dead");
+                  error.code = "ESRCH";
+                  throw error;
+                }
+                return;
+              }
+              kills.push([pid, signal]);
+              alive.delete(pid);
+            },
+            execFile: makeEnsureExecFile({
+              commands: { 2222: "node /repo/hub/server.mjs" },
+              listening: { 2222: [ctx.port] },
+            }),
+            fetchImpl: async () => ({ ok: false, async json() {} }),
+            startHubDetached(port) {
+              started.push(port);
+              return true;
+            },
+            waitForHubReady: async () => true,
+            syncHubConfigs: async () => {},
+            snapshotUserState: () => {},
+          });
+
+          assert.equal(result.code, 0);
+          assert.deepEqual(kills, [[2222, "SIGTERM"]]);
+          assert.deepEqual(started, [ctx.port]);
+          assert.match(result.stderr, /not listening on port/);
+        },
+      );
+    } finally {
+      ctx.cleanup();
+    }
+  });
+
+  it("hub-ensure는 version mismatch retire 실패 시 cascade port를 명시 경고한다", async () => {
+    const ctx = createTestContext();
+    const pidFilePath = join(ctx.stateDir, "hub.pid");
+    writeFileSync(
+      pidFilePath,
+      `${JSON.stringify({ pid: 86156, port: ctx.port + 9, host: "127.0.0.1" })}\n`,
+      "utf8",
+    );
+    const kills = [];
+    const started = [];
+
+    try {
+      await withEnv(
+        {
+          HOME: ctx.homeDir,
+          USERPROFILE: ctx.homeDir,
+          TFX_HUB_PORT: String(ctx.port),
+        },
+        async () => {
+          const result = await runHubEnsure("", {
+            expectedVersion: "10.21.0-new",
+            pidFilePath,
+            retireGraceMs: 0,
+            killFn(pid, signal) {
+              if (signal === 0) {
+                if (pid === 86156) {
+                  const error = new Error("dead");
+                  error.code = "ESRCH";
+                  throw error;
+                }
+                return;
+              }
+              kills.push([pid, signal]);
+            },
+            execFile: makeEnsureExecFile({
+              commands: { 61463: "node /repo/hub/server.mjs" },
+              listening: { 61463: [ctx.port] },
+            }),
+            fetchImpl: async (url) => {
+              if (String(url).includes(`:${ctx.port}/health`)) {
+                return healthResponse({ ok: true, version: "10.20.2-old" });
+              }
+              return { ok: false, async json() {} };
+            },
+            startHubDetached(port) {
+              started.push(port);
+              return true;
+            },
+            waitForHubReady: async (_host, port) => port === ctx.port + 1,
+            syncHubConfigs: async () => {},
+            snapshotUserState: () => {},
+          });
+
+          assert.equal(result.code, 0);
+          assert.deepEqual(kills, [
+            [61463, "SIGTERM"],
+            [61463, "SIGKILL"],
+          ]);
+          assert.deepEqual(started, [ctx.port + 1]);
+          assert.match(result.stderr, /falling back to cascade port/);
+        },
+      );
+    } finally {
       ctx.cleanup();
     }
   });

--- a/tests/unit/doctor-stale-hubs.test.mjs
+++ b/tests/unit/doctor-stale-hubs.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  cleanupDetachedHubProcesses,
+  parseDetachedHubProcessRows,
+} from "../../bin/triflux.mjs";
+
+describe("doctor stale hub diagnostics", () => {
+  it("reports only PPID=1 hub/server.mjs processes from ps output", () => {
+    const rows = parseDetachedHubProcessRows(`
+      101     1  12000 01:02:03 node /repo/hub/server.mjs
+      102    99  12000 00:00:05 node /repo/hub/server.mjs
+      103     1   9000 00:01:00 node /repo/other/server.mjs
+      104     1  24000 2-03:04:05 /opt/node /repo/packages/triflux/hub/server.mjs --flag
+    `);
+
+    assert.deepEqual(
+      rows.map((row) => ({
+        pid: row.pid,
+        ppid: row.ppid,
+        rssKb: row.rssKb,
+        uptime: row.uptime,
+      })),
+      [
+        { pid: 101, ppid: 1, rssKb: 12000, uptime: "01:02:03" },
+        { pid: 104, ppid: 1, rssKb: 24000, uptime: "2-03:04:05" },
+      ],
+    );
+  });
+
+  it("dry-run cleanup excludes the active healthy hub and skips stale candidates", async () => {
+    const result = await cleanupDetachedHubProcesses({
+      activeHealthy: { pid: 101, port: 27888 },
+      dryRun: true,
+      apply: false,
+      hubs: [
+        { pid: 101, activeHealthy: true },
+        { pid: 104, activeHealthy: false },
+        { pid: 105, activeHealthy: false },
+      ],
+      killFn() {
+        throw new Error("dry-run must not signal processes");
+      },
+    });
+
+    assert.equal(result.excluded, 1);
+    assert.equal(result.skipped, 2);
+    assert.equal(result.retired, 0);
+    assert.deepEqual(
+      result.results.map((entry) => [entry.pid, entry.action]),
+      [
+        [101, "excluded-active"],
+        [104, "dry-run-skip"],
+        [105, "dry-run-skip"],
+      ],
+    );
+  });
+});

--- a/tests/unit/hub-ensure-version-drift.test.mjs
+++ b/tests/unit/hub-ensure-version-drift.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { inspectPidFileHub, run } from "../../scripts/hub-ensure.mjs";
+
+const TEMP_DIRS = [];
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-hub-ensure-drift-"));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+function writePidFile(dir, payload) {
+  const pidDir = join(dir, ".claude", "cache", "tfx-hub");
+  mkdirSync(pidDir, { recursive: true });
+  const pidFile = join(pidDir, "hub.pid");
+  writeFileSync(pidFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return pidFile;
+}
+
+function response(body) {
+  return {
+    ok: true,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function makeExecFile({ commands = {}, listening = {} } = {}) {
+  return (cmd, args) => {
+    if (cmd === "ps") {
+      const pid = args[1];
+      return commands[pid] || "";
+    }
+    if (cmd === "lsof" && args.includes("-p")) {
+      const pid = args[args.indexOf("-p") + 1];
+      const ports = listening[pid] || [];
+      return [
+        "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME",
+        ...ports.map(
+          (port) =>
+            `node ${pid} user 20u IPv4 0x0 0t0 TCP 127.0.0.1:${port} (LISTEN)`,
+        ),
+      ].join("\n");
+    }
+    if (cmd === "lsof" && args.some((arg) => arg.startsWith("-iTCP:"))) {
+      const port = Number(
+        args.find((arg) => arg.startsWith("-iTCP:")).replace("-iTCP:", ""),
+      );
+      for (const [pid, ports] of Object.entries(listening)) {
+        if (ports.includes(port)) return `${pid}\n`;
+      }
+    }
+    return "";
+  };
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("hub-ensure version drift guard", () => {
+  it("rejects a live pid-file PID that is not hub/server.mjs", async () => {
+    const home = makeTempDir();
+    const pidFilePath = writePidFile(home, {
+      pid: 1234,
+      port: 27888,
+      host: "127.0.0.1",
+    });
+
+    const inspected = await inspectPidFileHub({
+      expectedVersion: "10.21.0-test",
+      pidFilePath,
+      killFn(pid, signal) {
+        assert.equal(pid, 1234);
+        assert.equal(signal, 0);
+      },
+      execFile: makeExecFile({
+        commands: { 1234: "node /tmp/not-hub/server.mjs" },
+        listening: { 1234: [27888] },
+      }),
+      fetchImpl: async () => response({ ok: true, version: "10.21.0-test" }),
+    });
+
+    assert.equal(inspected.valid, false);
+    assert.equal(inspected.reason, "not_hub_server");
+    assert.equal(inspected.retirePid, null);
+  });
+
+  it("retires a hub pid-file PID when its LISTEN port differs from the pid file", async () => {
+    const home = makeTempDir();
+    const pidFilePath = writePidFile(home, {
+      pid: 2222,
+      port: 29196,
+      host: "127.0.0.1",
+    });
+    const kills = [];
+    const alive = new Set([2222]);
+
+    const result = await run("", {
+      expectedVersion: "10.21.0-test",
+      pidFilePath,
+      retireGraceMs: 0,
+      killFn(pid, signal) {
+        if (signal === 0) {
+          if (!alive.has(pid)) {
+            const error = new Error("dead");
+            error.code = "ESRCH";
+            throw error;
+          }
+          return;
+        }
+        kills.push([pid, signal]);
+        alive.delete(pid);
+      },
+      execFile: makeExecFile({
+        commands: { 2222: "node /repo/hub/server.mjs" },
+        listening: { 2222: [27888] },
+      }),
+      fetchImpl: async () => ({ ok: false, async json() {} }),
+      startHubDetached(port) {
+        assert.equal(port, 27888);
+        return true;
+      },
+      waitForHubReady: async () => true,
+      syncHubConfigs: async () => {},
+      snapshotUserState: () => {},
+    });
+
+    assert.equal(result.code, 0);
+    assert.deepEqual(kills, [[2222, "SIGTERM"]]);
+    assert.match(result.stderr, /not listening on port 29196/);
+  });
+
+  it("P3b: retires an old-version default-port hub before starting the expected version", async () => {
+    const home = makeTempDir();
+    const pidFilePath = writePidFile(home, {
+      pid: 86156,
+      port: 29196,
+      host: "127.0.0.1",
+    });
+    const alive = new Set([61463]);
+    const kills = [];
+    const startedPorts = [];
+
+    const result = await run("", {
+      expectedVersion: "10.21.0-new",
+      pidFilePath,
+      retireGraceMs: 0,
+      killFn(pid, signal) {
+        if (signal === 0) {
+          if (!alive.has(pid)) {
+            const error = new Error("dead");
+            error.code = "ESRCH";
+            throw error;
+          }
+          return;
+        }
+        kills.push([pid, signal]);
+        alive.delete(pid);
+      },
+      execFile: makeExecFile({
+        commands: { 61463: "node /repo/hub/server.mjs" },
+        listening: { 61463: [27888] },
+      }),
+      fetchImpl: async (url) => {
+        if (String(url).includes(":27888/health")) {
+          return response({ ok: true, version: "10.20.2-old" });
+        }
+        return { ok: false, async json() {} };
+      },
+      startHubDetached(port) {
+        startedPorts.push(port);
+        return true;
+      },
+      waitForHubReady: async (_host, port) => port === 27888,
+      syncHubConfigs: async () => {},
+      snapshotUserState: () => {},
+    });
+
+    assert.equal(result.code, 0);
+    assert.deepEqual(kills, [[61463, "SIGTERM"]]);
+    assert.deepEqual(startedPorts, [27888]);
+    assert.match(result.stderr, /version mismatch/);
+    assert.match(result.stderr, /retired port 27888 hub PID 61463/);
+  });
+});


### PR DESCRIPTION
## macos-lifecycle Shard 3 of 4

Implements P3a hub stale retirement + P3b version drift from [audit report](https://github.com/tellang/triflux/blob/main/docs/research/macos-process-lifecycle-leak-report-2026-05-18.md) §P3 (lines 56-97, 234-271, 430-447).

### Changes
- `scripts/hub-ensure.mjs` — pid file validation (live process + port + version), port-collision version compare, retire old hub
- `bin/triflux.mjs doctor` — stale hub diagnostic + `--cleanup-stale-hubs --dry-run|--apply`
- packages/triflux mirror (byte-identical)
- Tests: tests/integration/hub-singleton + tests/unit/hub-ensure-version-drift + tests/unit/doctor-stale-hubs (~3 new tests)

### Verify
```
pnpm test tests/integration/hub-singleton.test.mjs tests/unit/hub-ensure-version-drift.test.mjs tests/unit/doctor-stale-hubs.test.mjs
tfx doctor 2>&1 | grep -iE 'stale|hub|PPID'
tfx doctor --cleanup-stale-hubs --dry-run 2>&1 | grep -iE 'active|excluded|skip'
diff -q scripts/hub-ensure.mjs packages/triflux/scripts/hub-ensure.mjs
```

Part of 4-PR series: S1 mux identity, S2 test-lock supervisor, S3 hub retirement (this), S4 tmux+hook schema (separate).