### PR TITLE
fix(macos): P1 mux identity returns tmux not psmux on darwin without binary (macos-lifecycle)

### DIFF
--- a/hub/team/session.mjs
+++ b/hub/team/session.mjs
@@ -8,8 +8,9 @@ import {
   capturePsmuxPane,
   configurePsmuxKeybindings,
   createPsmuxSession,
+  getMultiplexerType,
   getPsmuxSessionAttachedCount,
-  hasPsmux,
+  hasMultiplexer,
   killPsmuxSession,
   listPsmuxSessions,
   psmuxExec,
@@ -68,6 +69,38 @@ function hasGitBashTmux() {
   }
 }
 
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    timeout: 3000,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
+function isPsmuxVersion(command) {
+  try {
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
+  } catch {
+    return false;
+  }
+}
+
+function isPsmuxCommandName(command) {
+  const name = String(command || "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    .toLowerCase();
+  return name === "psmux" || name === "psmux.exe" || name === "psmux.cmd";
+}
+
+function hasLiteralPsmuxBinary(command = process.env.PSMUX_BIN || "psmux") {
+  return isPsmuxVersion(command);
+}
+
 /**
  * 터미널 멀티플렉서 감지 (결과 캐싱 — 프로세스 수명 동안 불변)
  * @returns {'tmux'|'git-bash-tmux'|'wsl-tmux'|'psmux'|null}
@@ -75,7 +108,26 @@ function hasGitBashTmux() {
 let _cachedMux;
 export function detectMultiplexer() {
   if (_cachedMux !== undefined) return _cachedMux;
-  if (hasPsmux()) {
+
+  if (process.platform !== "win32") {
+    const primaryMux = getMultiplexerType();
+    if (primaryMux === "tmux" && hasMultiplexer()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasTmux()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasLiteralPsmuxBinary()) {
+      _cachedMux = "psmux";
+      return _cachedMux;
+    }
+    _cachedMux = null;
+    return _cachedMux;
+  }
+
+  if (hasMultiplexer() && isPsmuxCommandName(getMultiplexerType())) {
     _cachedMux = "psmux";
     return _cachedMux;
   }

--- a/hub/team/terminal-opener.mjs
+++ b/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec } from "node:child_process";
+import { exec as defaultExec, execFileSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,9 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
-function buildAttachCommand(mux, sessionName) {
+function defaultPsmuxBinaryExists(command) {
+  try {
+    const output = execFileSync(command, ["-V"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 3000,
+      windowsHide: true,
+    });
+    return /\bpsmux\b/i.test(String(output || ""));
+  } catch {
+    return false;
+  }
+}
+
+function buildAttachCommand(mux, sessionName, deps = {}) {
   if (mux === "psmux") {
-    return `${shellCommandName(process.env.PSMUX_BIN || "psmux")} attach-session -t ${shellQuote(sessionName)}`;
+    const command = process.env.PSMUX_BIN || "psmux";
+    const psmuxBinaryExists =
+      deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+    if (!psmuxBinaryExists(command)) return null;
+    return `${shellCommandName(command)} attach-session -t ${shellQuote(sessionName)}`;
   }
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
@@ -138,9 +156,11 @@ export function createTerminalOpener(deps = {}) {
 
     const mux = resolveMux(deps);
     if (isTmuxLikeMux(mux, platform)) {
+      const attachCommand = buildAttachCommand(mux, sessionName, deps);
+      if (!attachCommand) return false;
       tmuxExec(
         `new-window -n ${shellQuote(opts.title ?? sessionName)} ${shellQuote(
-          buildAttachCommand(mux, sessionName),
+          attachCommand,
         )}`,
       );
       return true;

--- a/packages/remote/hub/team/session.mjs
+++ b/packages/remote/hub/team/session.mjs
@@ -8,8 +8,9 @@ import {
   capturePsmuxPane,
   configurePsmuxKeybindings,
   createPsmuxSession,
+  getMultiplexerType,
   getPsmuxSessionAttachedCount,
-  hasPsmux,
+  hasMultiplexer,
   killPsmuxSession,
   listPsmuxSessions,
   psmuxExec,
@@ -68,6 +69,38 @@ function hasGitBashTmux() {
   }
 }
 
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    timeout: 3000,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
+function isPsmuxVersion(command) {
+  try {
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
+  } catch {
+    return false;
+  }
+}
+
+function isPsmuxCommandName(command) {
+  const name = String(command || "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    .toLowerCase();
+  return name === "psmux" || name === "psmux.exe" || name === "psmux.cmd";
+}
+
+function hasLiteralPsmuxBinary(command = process.env.PSMUX_BIN || "psmux") {
+  return isPsmuxVersion(command);
+}
+
 /**
  * 터미널 멀티플렉서 감지 (결과 캐싱 — 프로세스 수명 동안 불변)
  * @returns {'tmux'|'git-bash-tmux'|'wsl-tmux'|'psmux'|null}
@@ -75,7 +108,26 @@ function hasGitBashTmux() {
 let _cachedMux;
 export function detectMultiplexer() {
   if (_cachedMux !== undefined) return _cachedMux;
-  if (hasPsmux()) {
+
+  if (process.platform !== "win32") {
+    const primaryMux = getMultiplexerType();
+    if (primaryMux === "tmux" && hasMultiplexer()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasTmux()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasLiteralPsmuxBinary()) {
+      _cachedMux = "psmux";
+      return _cachedMux;
+    }
+    _cachedMux = null;
+    return _cachedMux;
+  }
+
+  if (hasMultiplexer() && isPsmuxCommandName(getMultiplexerType())) {
     _cachedMux = "psmux";
     return _cachedMux;
   }

--- a/packages/remote/hub/team/terminal-opener.mjs
+++ b/packages/remote/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec } from "node:child_process";
+import { exec as defaultExec, execFileSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,9 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
-function buildAttachCommand(mux, sessionName) {
+function defaultPsmuxBinaryExists(command) {
+  try {
+    const output = execFileSync(command, ["-V"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 3000,
+      windowsHide: true,
+    });
+    return /\bpsmux\b/i.test(String(output || ""));
+  } catch {
+    return false;
+  }
+}
+
+function buildAttachCommand(mux, sessionName, deps = {}) {
   if (mux === "psmux") {
-    return `${shellCommandName(process.env.PSMUX_BIN || "psmux")} attach-session -t ${shellQuote(sessionName)}`;
+    const command = process.env.PSMUX_BIN || "psmux";
+    const psmuxBinaryExists =
+      deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+    if (!psmuxBinaryExists(command)) return null;
+    return `${shellCommandName(command)} attach-session -t ${shellQuote(sessionName)}`;
   }
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
@@ -138,9 +156,11 @@ export function createTerminalOpener(deps = {}) {
 
     const mux = resolveMux(deps);
     if (isTmuxLikeMux(mux, platform)) {
+      const attachCommand = buildAttachCommand(mux, sessionName, deps);
+      if (!attachCommand) return false;
       tmuxExec(
         `new-window -n ${shellQuote(opts.title ?? sessionName)} ${shellQuote(
-          buildAttachCommand(mux, sessionName),
+          attachCommand,
         )}`,
       );
       return true;

--- a/packages/triflux/hub/team/session.mjs
+++ b/packages/triflux/hub/team/session.mjs
@@ -8,8 +8,9 @@ import {
   capturePsmuxPane,
   configurePsmuxKeybindings,
   createPsmuxSession,
+  getMultiplexerType,
   getPsmuxSessionAttachedCount,
-  hasPsmux,
+  hasMultiplexer,
   killPsmuxSession,
   listPsmuxSessions,
   psmuxExec,
@@ -68,6 +69,38 @@ function hasGitBashTmux() {
   }
 }
 
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    timeout: 3000,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
+function isPsmuxVersion(command) {
+  try {
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
+  } catch {
+    return false;
+  }
+}
+
+function isPsmuxCommandName(command) {
+  const name = String(command || "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    .toLowerCase();
+  return name === "psmux" || name === "psmux.exe" || name === "psmux.cmd";
+}
+
+function hasLiteralPsmuxBinary(command = process.env.PSMUX_BIN || "psmux") {
+  return isPsmuxVersion(command);
+}
+
 /**
  * 터미널 멀티플렉서 감지 (결과 캐싱 — 프로세스 수명 동안 불변)
  * @returns {'tmux'|'git-bash-tmux'|'wsl-tmux'|'psmux'|null}
@@ -75,7 +108,26 @@ function hasGitBashTmux() {
 let _cachedMux;
 export function detectMultiplexer() {
   if (_cachedMux !== undefined) return _cachedMux;
-  if (hasPsmux()) {
+
+  if (process.platform !== "win32") {
+    const primaryMux = getMultiplexerType();
+    if (primaryMux === "tmux" && hasMultiplexer()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasTmux()) {
+      _cachedMux = "tmux";
+      return _cachedMux;
+    }
+    if (hasLiteralPsmuxBinary()) {
+      _cachedMux = "psmux";
+      return _cachedMux;
+    }
+    _cachedMux = null;
+    return _cachedMux;
+  }
+
+  if (hasMultiplexer() && isPsmuxCommandName(getMultiplexerType())) {
     _cachedMux = "psmux";
     return _cachedMux;
   }

--- a/packages/triflux/hub/team/terminal-opener.mjs
+++ b/packages/triflux/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec } from "node:child_process";
+import { exec as defaultExec, execFileSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,9 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
-function buildAttachCommand(mux, sessionName) {
+function defaultPsmuxBinaryExists(command) {
+  try {
+    const output = execFileSync(command, ["-V"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 3000,
+      windowsHide: true,
+    });
+    return /\bpsmux\b/i.test(String(output || ""));
+  } catch {
+    return false;
+  }
+}
+
+function buildAttachCommand(mux, sessionName, deps = {}) {
   if (mux === "psmux") {
-    return `${shellCommandName(process.env.PSMUX_BIN || "psmux")} attach-session -t ${shellQuote(sessionName)}`;
+    const command = process.env.PSMUX_BIN || "psmux";
+    const psmuxBinaryExists =
+      deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+    if (!psmuxBinaryExists(command)) return null;
+    return `${shellCommandName(command)} attach-session -t ${shellQuote(sessionName)}`;
   }
   return `tmux attach-session -t ${shellQuote(sessionName)}`;
 }
@@ -138,9 +156,11 @@ export function createTerminalOpener(deps = {}) {
 
     const mux = resolveMux(deps);
     if (isTmuxLikeMux(mux, platform)) {
+      const attachCommand = buildAttachCommand(mux, sessionName, deps);
+      if (!attachCommand) return false;
       tmuxExec(
         `new-window -n ${shellQuote(opts.title ?? sessionName)} ${shellQuote(
-          buildAttachCommand(mux, sessionName),
+          attachCommand,
         )}`,
       );
       return true;

--- a/tests/unit/multiplexer-resolution.test.mjs
+++ b/tests/unit/multiplexer-resolution.test.mjs
@@ -7,6 +7,7 @@
 // 그리고 execution-mode.mjs 의 dead buildCommandForMode 가 제거됐는지 가드.
 
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -17,6 +18,65 @@ function pathFromHere(rel) {
   const here = new URL(import.meta.url).pathname;
   const dir = here.substring(0, here.lastIndexOf("/"));
   return join(dir, rel);
+}
+
+function runSessionProbe({ platform, execFileOk = {}, execSyncOk = {} }) {
+  const script = `
+    import childProcess from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+
+    Object.defineProperty(process, "platform", {
+      value: ${JSON.stringify(platform)},
+      configurable: true,
+    });
+
+    const execFileOk = new Set(${JSON.stringify(Object.keys(execFileOk))});
+    const execSyncOk = new Set(${JSON.stringify(Object.keys(execSyncOk))});
+
+    childProcess.execFileSync = (file, args = []) => {
+      const key = [file, ...args].join(" ");
+      if (execFileOk.has(key)) return Buffer.from(key + "\\n");
+      throw Object.assign(new Error("mock missing execFileSync: " + key), {
+        status: 1,
+      });
+    };
+
+    childProcess.execSync = (command) => {
+      if (execSyncOk.has(command)) return command + "\\n";
+      throw Object.assign(new Error("mock missing execSync: " + command), {
+        status: 1,
+      });
+    };
+
+    childProcess.spawnSync = (file, args = []) => ({
+      status: 1,
+      stdout: "",
+      stderr: "mock missing spawnSync: " + [file, ...args].join(" "),
+    });
+
+    syncBuiltinESMExports();
+
+    const session = await import("./hub/team/session.mjs");
+    const psmux = await import("./hub/team/psmux.mjs");
+    console.log(JSON.stringify({
+      detectMultiplexer: session.detectMultiplexer(),
+      hasPsmuxAlias: psmux.hasPsmux(),
+      multiplexerType: psmux.getMultiplexerType(),
+    }));
+  `;
+
+  const result = spawnSync(process.execPath, ["--input-type=module"], {
+    cwd: ROOT,
+    input: script,
+    encoding: "utf8",
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    result.stderr || result.stdout || "session probe failed",
+  );
+  return JSON.parse(result.stdout.trim());
 }
 
 describe("psmux.mjs: OS primary multiplexer 명시 분기", () => {
@@ -85,5 +145,51 @@ describe("execution-mode.mjs: dead buildCommandForMode 제거", () => {
   it("buildSpawnSpecForMode 는 유지된다 (conductor.mjs:544 의 활성 caller)", async () => {
     const mod = await import("../../hub/team/execution-mode.mjs");
     assert.equal(typeof mod.buildSpawnSpecForMode, "function");
+  });
+});
+
+describe("session.mjs: literal multiplexer identity", () => {
+  it("darwin + tmux available + psmux absent resolves to tmux", () => {
+    const probe = runSessionProbe({
+      platform: "darwin",
+      execFileOk: { "tmux -V": true },
+      execSyncOk: { "tmux -V": true },
+    });
+
+    assert.deepEqual(probe, {
+      detectMultiplexer: "tmux",
+      hasPsmuxAlias: true,
+      multiplexerType: "tmux",
+    });
+  });
+
+  it("hasPsmux alias truth on darwin does not become literal psmux identity", () => {
+    const probe = runSessionProbe({
+      platform: "darwin",
+      execFileOk: { "tmux -V": true },
+      execSyncOk: { "tmux -V": true },
+    });
+
+    assert.equal(probe.hasPsmuxAlias, true);
+    assert.notEqual(probe.detectMultiplexer, "psmux");
+  });
+
+  it("linux + tmux available resolves to tmux", () => {
+    const probe = runSessionProbe({
+      platform: "linux",
+      execFileOk: { "tmux -V": true },
+      execSyncOk: { "tmux -V": true },
+    });
+
+    assert.equal(probe.detectMultiplexer, "tmux");
+  });
+
+  it("Windows primary remains psmux when psmux is available", () => {
+    const probe = runSessionProbe({
+      platform: "win32",
+      execFileOk: { "psmux -V": true },
+    });
+
+    assert.equal(probe.detectMultiplexer, "psmux");
   });
 });

--- a/tests/unit/terminal-opener.test.mjs
+++ b/tests/unit/terminal-opener.test.mjs
@@ -158,6 +158,23 @@ describe("terminal-opener adapter", () => {
     assert.match(calls[0], /cd '\\''\/tmp\/work tree'\\'' && /);
   });
 
+  it("macOS tmux openSession opens tmux attach-session in a new window", async () => {
+    const calls = [];
+    const opener = createTerminalOpener({
+      platform: "darwin",
+      mux: "tmux",
+      tmuxExec: (command) => calls.push(command),
+    });
+
+    assert.equal(
+      await opener.openSession("demo", { title: "Demo Session" }),
+      true,
+    );
+    assert.match(calls[0], /^new-window -n 'Demo Session' /);
+    assert.match(calls[0], /tmux attach-session -t/);
+    assert.doesNotMatch(calls[0], /psmux attach-session -t/);
+  });
+
   it("macOS psmux fallback is treated as tmux-compatible for openCommand", async () => {
     const calls = [];
     const opener = createTerminalOpener({
@@ -178,6 +195,7 @@ describe("terminal-opener adapter", () => {
     const opener = createTerminalOpener({
       platform: "darwin",
       mux: "psmux",
+      psmuxBinaryExists: () => true,
       tmuxExec: (command) => calls.push(command),
     });
 
@@ -188,6 +206,19 @@ describe("terminal-opener adapter", () => {
     assert.match(calls[0], /^new-window -n 'Demo Session' /);
     assert.match(calls[0], /psmux attach-session -t/);
     assert.doesNotMatch(calls[0], /tmux attach-session -t/);
+  });
+
+  it("macOS psmux openSession refuses to emit attach command when psmux binary is absent", async () => {
+    const calls = [];
+    const opener = createTerminalOpener({
+      platform: "darwin",
+      mux: "psmux",
+      psmuxBinaryExists: () => false,
+      tmuxExec: (command) => calls.push(command),
+    });
+
+    assert.equal(await opener.openSession("demo"), false);
+    assert.deepEqual(calls, []);
   });
 
   it("macOS without mux falls back to exec open -a Terminal", async () => {


### PR DESCRIPTION
## macos-lifecycle Shard 1 of 4 — Highest risk (ultrareview target)

Fixes P1 macOS multiplexer identity from [audit report](https://github.com/tellang/triflux/blob/main/docs/research/macos-process-lifecycle-leak-report-2026-05-18.md) §P1 (lines 99-134, 273-326, 391-408).

### Changes
- `hub/team/session.mjs::detectMultiplexer()` — replace hasPsmux() alias check with literal mux-type resolver
- `hub/team/terminal-opener.mjs::buildAttachCommand` — guard psmux branch with PSMUX_BIN + binary existence
- packages/triflux + packages/remote mirror (@triflux/core/* imports preserved)
- Tests: tests/unit/multiplexer-resolution + tests/unit/terminal-opener

### Verify
```
pnpm test tests/unit/multiplexer-resolution.test.mjs tests/unit/terminal-opener.test.mjs
node -e "import('./hub/team/session.mjs').then(m=>console.log(m.detectMultiplexer()))"   # != 'psmux' on darwin without psmux bin
diff -q hub/team/session.mjs packages/triflux/hub/team/session.mjs
grep '@triflux/core/' packages/remote/hub/team/session.mjs
```

**ultrareview target**: `claude ultrareview <this-pr>` before merge — platform edge case verification.

Part of 4-PR series.