### PR TITLE
fix(test-lock): P2 supervisor with timeout, signal forward, child PID tracking (macos-lifecycle)

### DIFF
--- a/packages/triflux/scripts/test-lock.mjs
+++ b/packages/triflux/scripts/test-lock.mjs
@@ -21,7 +21,8 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const LOCK_DIR = join(dirname(SCRIPT_PATH), "..", ".test-lock");
 const LOCK_FILE = join(LOCK_DIR, "pid.lock");
-const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10분 넘으면 stale
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // release prepare 와 동일
+const SHUTDOWN_GRACE_MS = 5 * 1000;
 
 function toPosixPath(path) {
   return path.replace(/\\/g, "/");
@@ -109,25 +110,81 @@ export function expandTestArgs(args, { cwd = process.cwd() } = {}) {
   });
 }
 
+function parseTimeoutMs(value = process.env.TEST_LOCK_TIMEOUT_MS) {
+  if (value === undefined || value === "") return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  return Math.trunc(parsed);
+}
+
+function normalizeLock(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      parent_pid: Number(parsed.parent_pid),
+      child_pid:
+        parsed.child_pid === null || parsed.child_pid === undefined
+          ? null
+          : Number(parsed.child_pid),
+      started_at: Number(parsed.started_at),
+      timeout_ms: Number(parsed.timeout_ms) || DEFAULT_TIMEOUT_MS,
+    };
+  } catch {
+    const [pidStr, tsStr] = raw.trim().split("\n");
+    const parentPid = Number(pidStr);
+    const startedAt = Number(tsStr);
+    if (!Number.isFinite(parentPid)) return null;
+    return {
+      parent_pid: parentPid,
+      child_pid: null,
+      started_at: Number.isFinite(startedAt) ? startedAt : 0,
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+    };
+  }
+}
+
 function readLock() {
   try {
     const content = readFileSync(LOCK_FILE, "utf8").trim();
-    const [pidStr, tsStr] = content.split("\n");
-    return { pid: Number(pidStr), ts: Number(tsStr) };
+    if (!content) return null;
+    return normalizeLock(content);
   } catch {
     return null;
   }
 }
 
-function acquireLock() {
+function writeLock(metadata) {
+  writeFileSync(LOCK_FILE, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+}
+
+function isPidAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function lockAgeMs(lock) {
+  if (!Number.isFinite(lock?.started_at)) return Number.POSITIVE_INFINITY;
+  return Date.now() - lock.started_at;
+}
+
+function formatAge(ms) {
+  if (!Number.isFinite(ms)) return "unknown";
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+function acquireLock(timeoutMs) {
   const existing = readLock();
   if (existing) {
-    const age = Date.now() - existing.ts;
-    // Windows에서 process.kill(pid,0)이 git-bash PID를 못 잡음.
-    // 단순하게: lockfile이 있고 STALE_THRESHOLD 이내면 거부.
-    if (age >= 0 && age < STALE_THRESHOLD_MS) {
+    const age = lockAgeMs(existing);
+    const existingTimeoutMs = existing.timeout_ms || DEFAULT_TIMEOUT_MS;
+    if (age >= 0 && age < existingTimeoutMs) {
       console.error(
-        `\x1b[31m✗ 테스트 이미 실행 중 (PID ${existing.pid}, ${Math.round(age / 1000)}초 전 시작)\x1b[0m`,
+        `\x1b[31m✗ 테스트 이미 실행 중 (parent PID ${existing.parent_pid}, child PID ${existing.child_pid ?? "unknown"}, age ${formatAge(age)})\x1b[0m`,
       );
       console.error(
         `  동시 실행은 WT 메모리 폭발을 유발합니다. 기다리거나 PID를 kill하세요.`,
@@ -135,34 +192,76 @@ function acquireLock() {
       console.error(`  강제 해제: rm ${LOCK_FILE}`);
       process.exit(1);
     }
-    // stale (>10분) — 덮어쓰기
+    if (existing.child_pid && isPidAlive(existing.child_pid)) {
+      console.error(
+        `\x1b[31m✗ stale test lock has live child PID ${existing.child_pid} (age ${formatAge(age)}, timeout ${existingTimeoutMs}ms)\x1b[0m`,
+      );
+      console.error(`  lock 보존: ${LOCK_FILE}`);
+      console.error(
+        `  child 상태를 확인한 뒤 종료하거나, 안전하다고 판단될 때 lock을 수동 제거하세요.`,
+      );
+      process.exit(1);
+    }
+    try {
+      unlinkSync(LOCK_FILE);
+    } catch {
+      /* ignore */
+    }
   }
   mkdirSync(LOCK_DIR, { recursive: true });
-  writeFileSync(LOCK_FILE, `${process.pid}\n${Date.now()}`, "utf8");
+  const lock = {
+    parent_pid: process.pid,
+    child_pid: null,
+    started_at: Date.now(),
+    timeout_ms: timeoutMs,
+  };
+  writeLock(lock);
+  return lock;
 }
 
 function releaseLock() {
   try {
     const lock = readLock();
-    if (lock && lock.pid === process.pid) unlinkSync(LOCK_FILE);
+    if (lock && lock.parent_pid === process.pid) unlinkSync(LOCK_FILE);
   } catch {
     /* ignore */
   }
 }
 
-export function main(argv = process.argv.slice(2)) {
-  acquireLock();
+function updateChildPid(lock, childPid) {
+  if (!Number.isFinite(childPid)) return;
+  const current = readLock();
+  if (!current || current.parent_pid !== process.pid) return;
+  writeLock({ ...lock, child_pid: childPid });
+}
 
-  // cleanup on exit
-  process.on("exit", releaseLock);
-  process.on("SIGINT", () => {
-    releaseLock();
-    process.exit(130);
-  });
-  process.on("SIGTERM", () => {
-    releaseLock();
-    process.exit(143);
-  });
+function signalToExitCode(signal) {
+  if (!signal) return 1;
+  const signals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGTERM: 15,
+  };
+  return 128 + (signals[signal] ?? 1);
+}
+
+function childIsRunning(child) {
+  return child && child.exitCode === null && child.signalCode === null;
+}
+
+function terminateChild(child, signal) {
+  if (!childIsRunning(child)) return false;
+  try {
+    child.kill(signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const timeoutMs = parseTimeoutMs();
+  const lock = acquireLock(timeoutMs);
 
   // forward args after -- to node --test
   const args = expandTestArgs(argv);
@@ -175,12 +274,81 @@ export function main(argv = process.argv.slice(2)) {
     stdio: ["pipe", "inherit", "inherit"],
     env: { ...process.env, TEST_LOCK_PID: String(process.pid) },
   });
+  updateChildPid(lock, child.pid);
   // Close stdin immediately so node --test never blocks waiting for input.
   child.stdin?.end();
 
-  child.on("exit", (code) => {
+  let finished = false;
+  let requestedExitCode = null;
+  let timeoutTimer = null;
+  let graceTimer = null;
+
+  function clearTimers() {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    if (graceTimer) clearTimeout(graceTimer);
+    timeoutTimer = null;
+    graceTimer = null;
+  }
+
+  function finish(code) {
+    if (finished) return;
+    finished = true;
+    clearTimers();
     releaseLock();
-    process.exit(code ?? 1);
+    process.exit(code);
+  }
+
+  function forceKillAfterGrace() {
+    if (graceTimer) return;
+    graceTimer = setTimeout(() => {
+      terminateChild(child, "SIGKILL");
+    }, SHUTDOWN_GRACE_MS);
+    graceTimer.unref?.();
+  }
+
+  function requestShutdown(signal, exitCode = signalToExitCode(signal)) {
+    if (finished) return;
+    requestedExitCode = exitCode;
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = null;
+    }
+    if (childIsRunning(child)) {
+      terminateChild(child, signal);
+      forceKillAfterGrace();
+      return;
+    }
+    finish(requestedExitCode);
+  }
+
+  timeoutTimer = setTimeout(() => {
+    console.error(
+      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child.pid})\x1b[0m`,
+    );
+    requestShutdown("SIGTERM", 124);
+  }, timeoutMs);
+  timeoutTimer.unref?.();
+
+  process.once("exit", () => {
+    if (!finished) terminateChild(child, "SIGTERM");
+    releaseLock();
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.once(signal, () => requestShutdown(signal));
+  }
+
+  child.on("error", (error) => {
+    console.error(`test-lock failed to spawn child: ${error.message}`);
+    finish(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (requestedExitCode !== null) {
+      finish(requestedExitCode);
+      return;
+    }
+    finish(code ?? signalToExitCode(signal));
   });
 }
 

--- a/scripts/test-lock.mjs
+++ b/scripts/test-lock.mjs
@@ -21,7 +21,8 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const LOCK_DIR = join(dirname(SCRIPT_PATH), "..", ".test-lock");
 const LOCK_FILE = join(LOCK_DIR, "pid.lock");
-const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10분 넘으면 stale
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // release prepare 와 동일
+const SHUTDOWN_GRACE_MS = 5 * 1000;
 
 function toPosixPath(path) {
   return path.replace(/\\/g, "/");
@@ -109,25 +110,81 @@ export function expandTestArgs(args, { cwd = process.cwd() } = {}) {
   });
 }
 
+function parseTimeoutMs(value = process.env.TEST_LOCK_TIMEOUT_MS) {
+  if (value === undefined || value === "") return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  return Math.trunc(parsed);
+}
+
+function normalizeLock(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      parent_pid: Number(parsed.parent_pid),
+      child_pid:
+        parsed.child_pid === null || parsed.child_pid === undefined
+          ? null
+          : Number(parsed.child_pid),
+      started_at: Number(parsed.started_at),
+      timeout_ms: Number(parsed.timeout_ms) || DEFAULT_TIMEOUT_MS,
+    };
+  } catch {
+    const [pidStr, tsStr] = raw.trim().split("\n");
+    const parentPid = Number(pidStr);
+    const startedAt = Number(tsStr);
+    if (!Number.isFinite(parentPid)) return null;
+    return {
+      parent_pid: parentPid,
+      child_pid: null,
+      started_at: Number.isFinite(startedAt) ? startedAt : 0,
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+    };
+  }
+}
+
 function readLock() {
   try {
     const content = readFileSync(LOCK_FILE, "utf8").trim();
-    const [pidStr, tsStr] = content.split("\n");
-    return { pid: Number(pidStr), ts: Number(tsStr) };
+    if (!content) return null;
+    return normalizeLock(content);
   } catch {
     return null;
   }
 }
 
-function acquireLock() {
+function writeLock(metadata) {
+  writeFileSync(LOCK_FILE, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+}
+
+function isPidAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function lockAgeMs(lock) {
+  if (!Number.isFinite(lock?.started_at)) return Number.POSITIVE_INFINITY;
+  return Date.now() - lock.started_at;
+}
+
+function formatAge(ms) {
+  if (!Number.isFinite(ms)) return "unknown";
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+function acquireLock(timeoutMs) {
   const existing = readLock();
   if (existing) {
-    const age = Date.now() - existing.ts;
-    // Windows에서 process.kill(pid,0)이 git-bash PID를 못 잡음.
-    // 단순하게: lockfile이 있고 STALE_THRESHOLD 이내면 거부.
-    if (age >= 0 && age < STALE_THRESHOLD_MS) {
+    const age = lockAgeMs(existing);
+    const existingTimeoutMs = existing.timeout_ms || DEFAULT_TIMEOUT_MS;
+    if (age >= 0 && age < existingTimeoutMs) {
       console.error(
-        `\x1b[31m✗ 테스트 이미 실행 중 (PID ${existing.pid}, ${Math.round(age / 1000)}초 전 시작)\x1b[0m`,
+        `\x1b[31m✗ 테스트 이미 실행 중 (parent PID ${existing.parent_pid}, child PID ${existing.child_pid ?? "unknown"}, age ${formatAge(age)})\x1b[0m`,
       );
       console.error(
         `  동시 실행은 WT 메모리 폭발을 유발합니다. 기다리거나 PID를 kill하세요.`,
@@ -135,34 +192,76 @@ function acquireLock() {
       console.error(`  강제 해제: rm ${LOCK_FILE}`);
       process.exit(1);
     }
-    // stale (>10분) — 덮어쓰기
+    if (existing.child_pid && isPidAlive(existing.child_pid)) {
+      console.error(
+        `\x1b[31m✗ stale test lock has live child PID ${existing.child_pid} (age ${formatAge(age)}, timeout ${existingTimeoutMs}ms)\x1b[0m`,
+      );
+      console.error(`  lock 보존: ${LOCK_FILE}`);
+      console.error(
+        `  child 상태를 확인한 뒤 종료하거나, 안전하다고 판단될 때 lock을 수동 제거하세요.`,
+      );
+      process.exit(1);
+    }
+    try {
+      unlinkSync(LOCK_FILE);
+    } catch {
+      /* ignore */
+    }
   }
   mkdirSync(LOCK_DIR, { recursive: true });
-  writeFileSync(LOCK_FILE, `${process.pid}\n${Date.now()}`, "utf8");
+  const lock = {
+    parent_pid: process.pid,
+    child_pid: null,
+    started_at: Date.now(),
+    timeout_ms: timeoutMs,
+  };
+  writeLock(lock);
+  return lock;
 }
 
 function releaseLock() {
   try {
     const lock = readLock();
-    if (lock && lock.pid === process.pid) unlinkSync(LOCK_FILE);
+    if (lock && lock.parent_pid === process.pid) unlinkSync(LOCK_FILE);
   } catch {
     /* ignore */
   }
 }
 
-export function main(argv = process.argv.slice(2)) {
-  acquireLock();
+function updateChildPid(lock, childPid) {
+  if (!Number.isFinite(childPid)) return;
+  const current = readLock();
+  if (!current || current.parent_pid !== process.pid) return;
+  writeLock({ ...lock, child_pid: childPid });
+}
 
-  // cleanup on exit
-  process.on("exit", releaseLock);
-  process.on("SIGINT", () => {
-    releaseLock();
-    process.exit(130);
-  });
-  process.on("SIGTERM", () => {
-    releaseLock();
-    process.exit(143);
-  });
+function signalToExitCode(signal) {
+  if (!signal) return 1;
+  const signals = {
+    SIGHUP: 1,
+    SIGINT: 2,
+    SIGTERM: 15,
+  };
+  return 128 + (signals[signal] ?? 1);
+}
+
+function childIsRunning(child) {
+  return child && child.exitCode === null && child.signalCode === null;
+}
+
+function terminateChild(child, signal) {
+  if (!childIsRunning(child)) return false;
+  try {
+    child.kill(signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const timeoutMs = parseTimeoutMs();
+  const lock = acquireLock(timeoutMs);
 
   // forward args after -- to node --test
   const args = expandTestArgs(argv);
@@ -175,12 +274,81 @@ export function main(argv = process.argv.slice(2)) {
     stdio: ["pipe", "inherit", "inherit"],
     env: { ...process.env, TEST_LOCK_PID: String(process.pid) },
   });
+  updateChildPid(lock, child.pid);
   // Close stdin immediately so node --test never blocks waiting for input.
   child.stdin?.end();
 
-  child.on("exit", (code) => {
+  let finished = false;
+  let requestedExitCode = null;
+  let timeoutTimer = null;
+  let graceTimer = null;
+
+  function clearTimers() {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    if (graceTimer) clearTimeout(graceTimer);
+    timeoutTimer = null;
+    graceTimer = null;
+  }
+
+  function finish(code) {
+    if (finished) return;
+    finished = true;
+    clearTimers();
     releaseLock();
-    process.exit(code ?? 1);
+    process.exit(code);
+  }
+
+  function forceKillAfterGrace() {
+    if (graceTimer) return;
+    graceTimer = setTimeout(() => {
+      terminateChild(child, "SIGKILL");
+    }, SHUTDOWN_GRACE_MS);
+    graceTimer.unref?.();
+  }
+
+  function requestShutdown(signal, exitCode = signalToExitCode(signal)) {
+    if (finished) return;
+    requestedExitCode = exitCode;
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = null;
+    }
+    if (childIsRunning(child)) {
+      terminateChild(child, signal);
+      forceKillAfterGrace();
+      return;
+    }
+    finish(requestedExitCode);
+  }
+
+  timeoutTimer = setTimeout(() => {
+    console.error(
+      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child.pid})\x1b[0m`,
+    );
+    requestShutdown("SIGTERM", 124);
+  }, timeoutMs);
+  timeoutTimer.unref?.();
+
+  process.once("exit", () => {
+    if (!finished) terminateChild(child, "SIGTERM");
+    releaseLock();
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.once(signal, () => requestShutdown(signal));
+  }
+
+  child.on("error", (error) => {
+    console.error(`test-lock failed to spawn child: ${error.message}`);
+    finish(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (requestedExitCode !== null) {
+      finish(requestedExitCode);
+      return;
+    }
+    finish(code ?? signalToExitCode(signal));
   });
 }
 

--- a/tests/unit/test-lock.test.mjs
+++ b/tests/unit/test-lock.test.mjs
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SOURCE_SCRIPT = resolve(REPO_ROOT, "scripts", "test-lock.mjs");
+
+function pidAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function killPid(pid, signal = "SIGKILL") {
+  if (!pid || !pidAlive(pid)) return;
+  try {
+    process.kill(pid, signal);
+  } catch {
+    /* already gone */
+  }
+}
+
+function readLock(lockFile) {
+  try {
+    return JSON.parse(readFileSync(lockFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function createHarness() {
+  const root = mkdtempSync(join(tmpdir(), "triflux-test-lock-supervisor-"));
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  copyFileSync(SOURCE_SCRIPT, join(root, "scripts", "test-lock.mjs"));
+  return {
+    root,
+    lockFile: join(root, ".test-lock", "pid.lock"),
+    script: join("scripts", "test-lock.mjs"),
+  };
+}
+
+function cleanupHarness(harness) {
+  const lock = readLock(harness.lockFile);
+  if (lock?.child_pid !== process.pid) killPid(lock?.child_pid);
+  rmSync(harness.root, { recursive: true, force: true });
+}
+
+function writeScript(harness, name, source) {
+  const path = join(harness.root, name);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, source, "utf8");
+  return name;
+}
+
+function writeHoldingScript(harness, name) {
+  return writeScript(
+    harness,
+    name,
+    `
+import { writeFileSync } from "node:fs";
+
+writeFileSync(process.env.CHILD_PID_FILE, String(process.pid));
+
+process.on("SIGTERM", () => {
+  writeFileSync(process.env.CHILD_SIGNAL_FILE, "SIGTERM");
+  process.exit(0);
+});
+
+setInterval(() => {}, 1000);
+`,
+  );
+}
+
+function spawnWrapper(harness, args, env = {}) {
+  return spawn(process.execPath, [harness.script, ...args], {
+    cwd: harness.root,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+async function waitForExit(child, timeoutMs = 7000) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      killPid(child.pid);
+      reject(
+        new Error(`process ${child.pid} did not exit within ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({
+        code,
+        signal,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+async function waitFor(predicate, label, timeoutMs = 5000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = predicate();
+    if (value) return value;
+    await delay(25);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function waitUntilDead(pid) {
+  await waitFor(() => !pidAlive(pid), `pid ${pid} to exit`);
+}
+
+function writeLock(harness, metadata) {
+  mkdirSync(dirname(harness.lockFile), { recursive: true });
+  writeFileSync(
+    harness.lockFile,
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+function readPidFile(path) {
+  try {
+    return Number(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function findDeadPid() {
+  for (let pid = 999_999; pid > 900_000; pid -= 1) {
+    if (!pidAlive(pid)) return pid;
+  }
+  throw new Error("could not find an unused pid for stale lock test");
+}
+
+test("parent SIGTERM forwards to child and waits for child exit", async () => {
+  const harness = createHarness();
+  const childPidFile = join(harness.root, "child.pid");
+  const childSignalFile = join(harness.root, "child.signal");
+  let wrapper;
+  try {
+    const holdScript = writeHoldingScript(harness, "hold.mjs");
+    wrapper = spawnWrapper(harness, [holdScript], {
+      CHILD_PID_FILE: childPidFile,
+      CHILD_SIGNAL_FILE: childSignalFile,
+    });
+
+    const lockChildPid = await waitFor(
+      () => readLock(harness.lockFile)?.child_pid,
+      "lock child pid",
+    );
+    const childPid = await waitFor(
+      () => readPidFile(childPidFile),
+      "child pid file",
+    );
+    assert.equal(lockChildPid, childPid);
+
+    process.kill(wrapper.pid, "SIGTERM");
+    const result = await waitForExit(wrapper);
+
+    assert.equal(result.code, 143);
+    assert.equal(readFileSync(childSignalFile, "utf8"), "SIGTERM");
+    await waitUntilDead(childPid);
+  } finally {
+    killPid(readPidFile(childPidFile));
+    killPid(wrapper?.pid);
+    cleanupHarness(harness);
+  }
+});
+
+test("child timeout exits non-zero and does not leave child alive", async () => {
+  const harness = createHarness();
+  const childPidFile = join(harness.root, "child.pid");
+  const childSignalFile = join(harness.root, "child.signal");
+  let wrapper;
+  try {
+    const holdScript = writeHoldingScript(harness, "hold-timeout.mjs");
+    wrapper = spawnWrapper(harness, [holdScript], {
+      CHILD_PID_FILE: childPidFile,
+      CHILD_SIGNAL_FILE: childSignalFile,
+      TEST_LOCK_TIMEOUT_MS: "200",
+    });
+
+    const childPid = await waitFor(
+      () => readLock(harness.lockFile)?.child_pid,
+      "lock child pid",
+    );
+    const result = await waitForExit(wrapper);
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /timed out/i);
+    assert.ok(!existsSync(harness.lockFile));
+    await waitUntilDead(childPid);
+  } finally {
+    killPid(readPidFile(childPidFile));
+    killPid(wrapper?.pid);
+    cleanupHarness(harness);
+  }
+});
+
+test("stale lock with live child PID exits non-zero and preserves lock", async () => {
+  const harness = createHarness();
+  try {
+    const metadata = {
+      parent_pid: 1,
+      child_pid: process.pid,
+      started_at: Date.now() - 10_000,
+      timeout_ms: 1,
+    };
+    writeLock(harness, metadata);
+    const okScript = writeScript(harness, "ok.mjs", "console.log('ok');\n");
+
+    const wrapper = spawnWrapper(harness, [okScript]);
+    const result = await waitForExit(wrapper);
+
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, new RegExp(`child PID ${process.pid}`));
+    assert.match(result.stderr, /age/i);
+    assert.deepEqual(readLock(harness.lockFile), metadata);
+  } finally {
+    cleanupHarness(harness);
+  }
+});
+
+test("stale lock with dead child PID is cleaned up and command proceeds", async () => {
+  const harness = createHarness();
+  try {
+    writeLock(harness, {
+      parent_pid: 1,
+      child_pid: findDeadPid(),
+      started_at: Date.now() - 10_000,
+      timeout_ms: 1,
+    });
+    const okScript = writeScript(
+      harness,
+      "ok.mjs",
+      "console.log('ok-child');\n",
+    );
+
+    const wrapper = spawnWrapper(harness, [okScript]);
+    const result = await waitForExit(wrapper);
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /ok-child/);
+    assert.ok(!existsSync(harness.lockFile));
+  } finally {
+    cleanupHarness(harness);
+  }
+});
+
+test("normal child exit preserves wrapper success behavior and releases lock", async () => {
+  const harness = createHarness();
+  try {
+    const okScript = writeScript(
+      harness,
+      "ok.mjs",
+      "console.log('normal-ok');\n",
+    );
+
+    const wrapper = spawnWrapper(harness, [okScript]);
+    const result = await waitForExit(wrapper);
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /normal-ok/);
+    assert.ok(!existsSync(harness.lockFile));
+  } finally {
+    cleanupHarness(harness);
+  }
+});


### PR DESCRIPTION
## macos-lifecycle Shard 2 of 4

Fixes P2 test-lock supervisor gap from [audit report](https://github.com/tellang/triflux/blob/main/docs/research/macos-process-lifecycle-leak-report-2026-05-18.md) §P2 (lines 167-232, 410-428).

### Changes
- `scripts/test-lock.mjs` — TEST_LOCK_TIMEOUT_MS env (default 10min), SIGINT/SIGTERM/SIGHUP forward, parent shutdown kill (SIGTERM 5s grace SIGKILL), lock metadata child_pid, stale-lock live-child vs dead-child diagnostic
- packages/triflux mirror (byte-identical)
- Tests: tests/unit/test-lock.test.mjs (5 new tests)

### Verify
```
pnpm test tests/unit/test-lock.test.mjs
TEST_LOCK_TIMEOUT_MS=500 node scripts/test-lock.mjs --test tests/unit/runtime-strategy.test.mjs ; echo "exit: $?"
pgrep -f 'node --test --test-force-exit' | wc -l   # 0 after timeout
diff -q scripts/test-lock.mjs packages/triflux/scripts/test-lock.mjs
```

Part of 4-PR series.