### PR TITLE
fix(hooks): hub token snapshots ignored in pipeline-stop context guard

### DIFF
--- a/hooks/hook-orchestrator.mjs
+++ b/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/hooks/pipeline-stop.mjs
+++ b/hooks/pipeline-stop.mjs
@@ -228,6 +228,16 @@ function contextPercentFromTranscript(payload) {
   return percents.length > 0 ? Math.max(...percents) : null;
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
 function contextPercentFromCache() {
   const home = process.env.HOME || process.env.USERPROFILE;
   if (!home) return null;
@@ -243,6 +253,7 @@ function contextPercentFromCache() {
   try {
     const parsed = parseJsonCandidate(readFileSync(cachePath, "utf8"));
     if (!parsed) return null;
+    if (isHubTokenMonitorSnapshot(parsed)) return null;
     const direct = contextPercentFromPayload(parsed);
     if (direct !== null) return direct;
     const percents = contextPercentsFromObject(parsed);

--- a/packages/core/hooks/hook-orchestrator.mjs
+++ b/packages/core/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/packages/core/hooks/pipeline-stop.mjs
+++ b/packages/core/hooks/pipeline-stop.mjs
@@ -228,6 +228,16 @@ function contextPercentFromTranscript(payload) {
   return percents.length > 0 ? Math.max(...percents) : null;
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
 function contextPercentFromCache() {
   const home = process.env.HOME || process.env.USERPROFILE;
   if (!home) return null;
@@ -243,6 +253,7 @@ function contextPercentFromCache() {
   try {
     const parsed = parseJsonCandidate(readFileSync(cachePath, "utf8"));
     if (!parsed) return null;
+    if (isHubTokenMonitorSnapshot(parsed)) return null;
     const direct = contextPercentFromPayload(parsed);
     if (direct !== null) return direct;
     const percents = contextPercentsFromObject(parsed);

--- a/packages/triflux/hooks/hook-orchestrator.mjs
+++ b/packages/triflux/hooks/hook-orchestrator.mjs
@@ -343,6 +343,23 @@ function recordRouteOutcome(slug, mode, outcome) {
   writeFileSync(weightsPath, JSON.stringify(weights, null, 2), "utf8");
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
+function readCompactNudgePercent(snapshot) {
+  if (isHubTokenMonitorSnapshot(snapshot)) return null;
+  const percent = Number(snapshot?.percent ?? 0);
+  if (!Number.isFinite(percent)) return null;
+  return Math.max(0, Math.min(100, percent));
+}
+
 // ── 메인 ────────────────────────────────────────────────────
 async function main() {
   // CLI: --record-route <slug> <mode> <outcome>
@@ -517,8 +534,8 @@ async function main() {
       const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
       if (existsSync(snapshotPath) && !existsSync(nudgeMarker)) {
         const snap = JSON.parse(readFileSync(snapshotPath, "utf8"));
-        const percent = Number(snap.percent || 0);
-        if (percent >= 80) {
+        const percent = readCompactNudgePercent(snap);
+        if (percent != null && percent >= 80) {
           const level = percent >= 90 ? "critical" : "warn";
           const msg =
             level === "critical"

--- a/packages/triflux/hooks/pipeline-stop.mjs
+++ b/packages/triflux/hooks/pipeline-stop.mjs
@@ -228,6 +228,16 @@ function contextPercentFromTranscript(payload) {
   return percents.length > 0 ? Math.max(...percents) : null;
 }
 
+function isHubTokenMonitorSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return false;
+  return (
+    Object.hasOwn(snapshot, "requestTokens") ||
+    Object.hasOwn(snapshot, "responseTokens") ||
+    Object.hasOwn(snapshot, "totalUpdates") ||
+    (snapshot.byTool && typeof snapshot.byTool === "object")
+  );
+}
+
 function contextPercentFromCache() {
   const home = process.env.HOME || process.env.USERPROFILE;
   if (!home) return null;
@@ -243,6 +253,7 @@ function contextPercentFromCache() {
   try {
     const parsed = parseJsonCandidate(readFileSync(cachePath, "utf8"));
     if (!parsed) return null;
+    if (isHubTokenMonitorSnapshot(parsed)) return null;
     const direct = contextPercentFromPayload(parsed);
     if (direct !== null) return direct;
     const percents = contextPercentsFromObject(parsed);

--- a/tests/unit/hook-orchestrator.test.mjs
+++ b/tests/unit/hook-orchestrator.test.mjs
@@ -267,6 +267,69 @@ describe("hook-orchestrator PreToolUse:Bash dedupe", () => {
     rmSync(nudgeMarker, { force: true });
   });
 
+  it("does not emit compact nudge from hub token monitor snapshots", () => {
+    const nudgeMarker = join(tmpdir(), "tfx-compact-nudge-sent");
+    rmSync(nudgeMarker, { force: true });
+
+    const homeDir = join(sandboxDir, "home-hub-token-monitor");
+    const monitorDir = join(homeDir, ".claude", "cache", "tfx-hub");
+    mkdirSync(monitorDir, { recursive: true });
+    writeFileSync(
+      join(monitorDir, "context-monitor.json"),
+      JSON.stringify({
+        sessionId: "88b086d5",
+        limitTokens: 200_000,
+        usedTokens: 12_194_022,
+        requestTokens: 142_336,
+        responseTokens: 12_051_686,
+        totalUpdates: 5_646,
+        byTool: { "tools/list": 11_888_383 },
+        display: "12.2M/200K (100%)",
+        percent: 100,
+      }),
+      "utf8",
+    );
+
+    const marker = join(sandboxDir, "posttool-edit-noop.txt");
+    writeFileSync(
+      registryPath,
+      JSON.stringify(
+        createRegistry(
+          [
+            {
+              id: "noop-posttool-edit",
+              matcher: "Edit",
+              command: hookCommand(hookScriptPath, marker, "noop", "", "noop"),
+              priority: 0,
+              enabled: true,
+            },
+          ],
+          "PostToolUse",
+        ),
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = runOrchestrator({
+      cwd: sandboxDir,
+      registryPath,
+      cacheDir,
+      env: { HOME: homeDir, USERPROFILE: homeDir, TFX_POST_TOOL_TIPS: "" },
+      payload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Edit",
+        tool_input: { file_path: "README.md" },
+      },
+    });
+
+    assert.equal(result.status, 0);
+    assert.ok(existsSync(marker));
+    assert.equal(result.stdout.trim(), "");
+    rmSync(nudgeMarker, { force: true });
+  });
+
   it("caches identical PreToolUse:Bash results to avoid recomputing hooks", () => {
     const markerPath = join(sandboxDir, "cached-output.txt");
     const counterPath = join(sandboxDir, "counter.txt");

--- a/tests/unit/pipeline-stop.test.mjs
+++ b/tests/unit/pipeline-stop.test.mjs
@@ -216,6 +216,72 @@ describe("pipeline-stop hook", () => {
     assert.equal(result.stderr.trim(), "");
   });
 
+  it("hub token monitor shape의 cache snapshot은 context guard를 트리거하지 않는다", () => {
+    const cacheDir = join(homeDir, ".claude", "cache", "tfx-hub");
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, "context-monitor.json"),
+      JSON.stringify({
+        sessionId: "88b086d5",
+        limitTokens: 200_000,
+        usedTokens: 12_194_022,
+        requestTokens: 142_336,
+        responseTokens: 12_051_686,
+        totalUpdates: 5_646,
+        byTool: { "tools/list": 11_888_383 },
+        display: "12.2M/200K (100%)",
+        percent: 100,
+      }),
+      "utf8",
+    );
+
+    const result = runHook({
+      cwd: projectRoot,
+      homeDir,
+      pluginRoot,
+      input: {
+        hook_event_name: "Stop",
+        session_id: "hub-token-monitor-cache-passthrough",
+        stop_reason: "end_turn",
+      },
+      env: { TRIFLUX_CONTEXT_GUARD_STATE_DIR: guardStateDir },
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), "");
+    assert.equal(result.stderr.trim(), "");
+  });
+
+  it("일반 context-monitor.json cache의 높은 percent는 여전히 block한다", () => {
+    const cacheDir = join(homeDir, ".claude", "cache", "tfx-hub");
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, "context-monitor.json"),
+      JSON.stringify({
+        used_percentage: 85,
+        context_window_size: 200_000,
+      }),
+      "utf8",
+    );
+
+    const output = parseStdout(
+      runHook({
+        cwd: projectRoot,
+        homeDir,
+        pluginRoot,
+        input: {
+          hook_event_name: "Stop",
+          session_id: "non-hub-token-cache-block",
+          stop_reason: "end_turn",
+        },
+        env: { TRIFLUX_CONTEXT_GUARD_STATE_DIR: guardStateDir },
+      }),
+    );
+
+    assert.equal(output.decision, "block");
+    assert.match(output.reason, /context/i);
+  });
+
   it("context guard state write failure 후에도 active pipeline block 동작은 유지한다", () => {
     writePipelineState(projectRoot, "project-active-team", "exec");
     const guardStateFile = join(sandboxDir, "context-guard-state-file");


### PR DESCRIPTION
## Summary

- `contextPercentFromCache()` in `pipeline-stop.mjs` reads the same shared `~/.claude/cache/tfx-hub/context-monitor.json` file that `hook-orchestrator.mjs` reads for its compact nudge. When that file currently holds a hub-token-monitor snapshot (`requestTokens` / `responseTokens` / `totalUpdates` / `byTool` fields filled by long-running MCP traffic), pipeline-stop reads `percent: 100` and emits the context guard block decision even when the active Claude session still has 1M-context headroom.
- Adds the same `isHubTokenMonitorSnapshot()` guard 867d18a3 introduced in `hook-orchestrator.mjs`, applied at the cache-fallback path only. Payload and transcript percent paths are unchanged.
- Mirrors the change across the 3-layer published surface (`hooks/`, `packages/core/hooks/`, `packages/triflux/hooks/`) per `.claude/rules/tfx-mirror-policy.md`.
- Adds two regression tests on `tests/unit/pipeline-stop.test.mjs`: hub-token-monitor cache snapshot passes through silently; a non-hub-token cache snapshot with high `used_percentage` still blocks (false-positive guard).

Includes 867d18a3 (`Prevent hub token snapshots from forcing compact nudges`, cherry-picked as 068598cf) so the two related guards land together on main — the original fix never landed on main, only on `fix/context-compact-nudge-hub-snapshot`.

## Test plan

- [x] `node --test --test-name-pattern='hub token monitor|context-monitor.json cache' tests/unit/pipeline-stop.test.mjs` — 2/2 pass
- [x] `npm run release:check-mirror` — packages/triflux matches root
- [x] `npx biome check` on the 3 mirror files + test file — no fixes applied
- [ ] Full `tests/unit/pipeline-stop.test.mjs` suite (one pre-existing pipeline test requires a rebuilt better-sqlite3 native binding on Node 26.0.0 / arm64 — unrelated environmental issue, not introduced here)