### PR TITLE
docs(routing): tfx-remote alias 통일 + auto router 갭 가이드 강화 (D1+D2)

### DIFF
--- a/.claude/rules/tfx-execution-skill-map.md
+++ b/.claude/rules/tfx-execution-skill-map.md
@@ -13,7 +13,7 @@
 | 2+ 태스크 + 코드 변경 **없음** | **tfx-multi** (로컬 headless 병렬) |
 | 2+ 태스크 + 코드 변경 **포함** | **tfx-swarm** (worktree 격리 필수) |
 | 원격 + 코드 변경 | **tfx-swarm** (shard `host:`) |
-| 원격 + 탐색/대화형 | **tfx-remote-spawn** (세션 관리 + resume) |
+| 원격 + 탐색/대화형 | **tfx-remote** (세션 관리 + resume) |
 
 ## 엔진 역할
 
@@ -21,12 +21,13 @@
 |------|------|----------|
 | tfx-multi | 로컬 headless 병렬 (cwd 공유, worktree 불필요) | auto 내부 dispatch 또는 `/tfx-multi` |
 | tfx-swarm | 격리 + 다기기 + auto merge (로컬/원격) | auto 내부 dispatch 또는 `/tfx-swarm` |
-| tfx-remote-spawn | 단일 세션 관리 (list/attach/send/resume/탐색) | 직접 `/tfx-remote-spawn` |
+| tfx-remote | 단일 세션 관리 (list/attach/send/resume/탐색) | 직접 호출: `/tfx-remote` |
+| tfx-remote-spawn | **DEPRECATED** — tfx-remote로 통합됨 | 사용 금지 |
 | tfx-codex-swarm | **DEPRECATED** — tfx-swarm으로 통합됨 | 사용 금지 |
 
 ## 핵심 차이 (격리 기준)
 
-| 항목 | tfx-swarm | tfx-remote-spawn | tfx-multi |
+| 항목 | tfx-swarm | tfx-remote | tfx-multi |
 |------|-----------|------------------|-----------|
 | Working tree 격리 | **YES** (shard별 `.codex-swarm/wt-*`) | NO (cwd 공유) | NO (cwd 공유) |
 | 원격 지원 | shard별 `host:` 자동 분배 (격리 유지) | SSH 단일 세션 | 로컬 전용 |
@@ -35,13 +36,17 @@
 
 ## 안티패턴 (실제 사고)
 
-- PR conflict 해결을 `tfx-remote-spawn`으로 실행 → WT 세션 `git checkout feat/X` → 메인 세션 working tree도 함께 전환 → race (2026-04-17 PR #72 사고)
-- 단일 파일 수정을 `tfx-swarm`으로 → PRD + worktree 오버헤드 과잉 → `tfx-autopilot` 사용
-- `tfx-multi`로 코드 수정 병렬 → cwd 공유 파일 race → `tfx-swarm`
+| 패턴 | 문제 | 대체 |
+|------|------|------|
+| PR conflict 해결을 `tfx-remote`로 실행 | WT 세션 `git checkout feat/X` → 메인 세션 working tree도 함께 전환 → race (2026-04-17 PR #72 사고) | `tfx-swarm` |
+| 단일 파일 수정을 `tfx-swarm`으로 실행 | PRD + worktree 오버헤드 과잉 | `tfx-autopilot` |
+| `tfx-multi`로 코드 수정 병렬 | cwd 공유 파일 race | `tfx-swarm` |
+| `tfx-auto --parallel` 만 명시하고 코드 변경 포함 | Issue #87 미해결 갭으로 multi dispatch + cwd 공유 race | 코드 변경 시 반드시 `--parallel swarm --isolation worktree` 명시 |
 
 ## 핵심 룰
 
-> **코드 변경 = tfx-swarm만** (로컬/원격 동일). remote-spawn은 원격 대화형/탐색 전용. multi는 로컬 headless 병렬 (worktree 불필요 read-only 작업).
+> **코드 변경 = tfx-swarm만** (로컬/원격 동일). tfx-remote는 원격 대화형/탐색 전용. multi는 로컬 headless 병렬 (worktree 불필요 read-only 작업).
+> **MANDATORY**: 코드 변경 포함 병렬은 사용자가 직접 `--parallel swarm --isolation worktree` 플래그 명시. tfx-auto 자동 swarm dispatch 는 Issue #87 미해결.
 
 ## Retry 정책 (Phase 3+)
 

--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -15,4 +15,4 @@
 - `git reset --hard`는 safety-guard가 차단 → `git merge --ff-only`로 우회
 - OMC drift 감지 시 plugin/npm/CLAUDE.md 3개 컴포넌트를 반드시 함께 갱신 (한쪽만 새 버전이면 훅/라우팅 호환성 깨짐)
 - gstack 업그레이드 후 `~/.gstack/just-upgraded-from`을 체크해서 CHANGELOG 하이라이트 표시
-- 원격 머신 업그레이드 전파는 `tfx-remote-spawn` + SSH scp로 수동 (자동화 예정)
+- 원격 머신 업그레이드 전파는 `tfx-remote` + SSH scp로 수동 (자동화 예정)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,11 @@ conductor, headless, swarm-hypervisor가 하나의 AccountBroker 싱글턴을 �
 | 스킬 | 대상 | 방식 |
 |------|------|------|
 | tfx-codex-swarm | 로컬 전용 | 로컬 worktree + psmux |
-| tfx-remote-spawn | Claude Code 원격 | SSH → Claude Code 세션 → 내부 tfx 라우팅 |
+| tfx-remote | Claude Code 원격 | SSH → Claude Code 세션 → 내부 tfx 라우팅 |
+| tfx-remote-spawn | deprecated alias | tfx-remote로 통합됨; 직접 호출 금지 |
 
 codex를 SSH 너머로 직접 실행하지 않는다. config.toml 충돌 + TTY 문제.
-원격에서 codex가 필요하면: remote-spawn → Claude Code → Claude가 내부에서 codex 호출.
+원격에서 codex가 필요하면: tfx-remote → Claude Code → Claude가 내부에서 codex 호출.
 
 ### SSH 패턴
 


### PR DESCRIPTION
## Summary

라우팅 SSOT audit (tfx-harness 2026-05-19) 의 docs drift 2건 통합 fix.

### D1 (Medium) — tfx-remote alias 통일 + DEPRECATED 마커

- `.claude/rules/tfx-execution-skill-map.md` 의 모든 정식 표기 `tfx-remote-spawn` → `tfx-remote` 치환
- 엔진 역할 표에 신규 행 추가: `| tfx-remote-spawn | **DEPRECATED** — tfx-remote로 통합됨 | 사용 금지 |` (`tfx-codex-swarm` DEPRECATED 스타일 미러)
- 핵심 차이 표 + 안티패턴 사고 인용 (PR #72 race) 표기 갱신
- `CLAUDE.md` 의 `<remote>` 섹션 정식 표기 통일 (legacy alias 표기 보존)

### D2 (High) — auto router 갭 가이드 강화

- `.claude/rules/tfx-execution-skill-map.md` "## 안티패턴" 섹션을 표 형식으로 재구성 + 신규 행 추가:
  - `tfx-auto --parallel` 만 명시하고 코드 변경 포함 → Issue #87 미해결 갭으로 multi dispatch + cwd 공유 race
- "## 핵심 룰" 섹션에 **MANDATORY** 한 줄 추가: 코드 변경 포함 병렬은 `--parallel swarm --isolation worktree` 플래그 명시 강제

### 후속 (별도)

- Issue #281 (auto router #87 격상): https://github.com/tellang/triflux/issues/281
- `~/.claude/skills/tfx-harness/SKILL.md` Issue-Resolution 강화 (user-level, 본 PR 외부)

## Test plan

- [x] `grep -rn "tfx-remote-spawn" .claude/rules/ CLAUDE.md` 결과가 DEPRECATED/legacy 마커 라인만 잔존
- [x] `grep -n "parallel swarm --isolation worktree" .claude/rules/tfx-execution-skill-map.md` 결과 ≥ 2 라인
- [x] `git diff --check` 통과
- [ ] docs-only 변경, lint/format/build 영향 없음

## Audit source

tfx-harness 라우팅 로직 점검 (2026-05-19) D1 (Medium) + D2 docs (High). codex worker (gpt-5.5 xhigh) tfx-swarm 격리 실행 산출물.