### PR TITLE
docs(routing): ralph 의미 통일 - 충돌 해소 섹션 1줄 추가 (D3)

### DIFF
--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -116,6 +116,7 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 - "코드에서 찾아" → tfx-find. "알아봐" → tfx-research
 - 복합 의도: "구현하고 리뷰까지" → tfx-auto → cross-review hook
 - "합의해서 비교해" 류 요청은 alias 대신 기본적으로 `tfx-auto --mode consensus --shape debate` 로 fold 한다
+- `ralph` 표기는 항상 `--retry ralph` mode 를 지칭. persist 스킬도 동일 의미. `--retry auto-escalate` 와 동시 사용 불가 (escalation-chain.md 규약).
 
 ## Q-Learning 동적 라우팅 (실험적)
 


### PR DESCRIPTION
## Summary

라우팅 SSOT audit (tfx-harness 2026-05-19) 의 docs drift D3 fix.

### D3 (Low) — ralph 의미 통일

`ralph` 표기가 라우팅 SSOT 3개 파일에서 3중 정의:
- `.claude/rules/tfx-routing.md:50` "ralph = persist alias"
- `.claude/rules/tfx-execution-skill-map.md:51` `--retry ralph` true state machine
- `.claude/rules/tfx-escalation-chain.md:67` "ralph 와 auto-escalate 조합 불가"

신규 사용자/온보딩에서 혼란. SSOT 레벨에서 한 줄로 통일.

### 변경

`.claude/rules/tfx-routing.md` 의 "## 충돌 해소" 섹션 끝에 한 줄 추가:

```
- `ralph` 표기는 항상 `--retry ralph` mode 를 지칭. persist 스킬도 동일 의미. `--retry auto-escalate` 와 동시 사용 불가 (escalation-chain.md 규약).
```

기존 `ralph = persist alias` 라인은 그대로 보존.

## Test plan

- [x] `grep -nE "ralph.*--retry ralph.*auto-escalate" .claude/rules/tfx-routing.md` 결과 ≥ 1
- [x] 기존 `ralph = persist alias` 라인 보존 (line 50)
- [x] `git diff` 검토: +1 라인만 추가
- [ ] docs-only 변경, lint/format/build 영향 없음

## Audit source

tfx-harness 라우팅 로직 점검 (2026-05-19) D3 (Low severity). codex worker (gpt-5.5 xhigh) tfx-swarm 격리 실행 산출물.