### PR TITLE
fix(terminal-opener): Issue #277 + #278 + #279 통합 cleanup

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -120,6 +120,8 @@ const VER = `${DIM}v${PKG.version}${RESET}`;
 const LINE = `${GRAY}${"─".repeat(48)}${RESET}`;
 const _DOT = `${GRAY}·${RESET}`;
 const STALE_TEAM_MAX_AGE_SEC = 3600;
+const DEFAULT_TMUX_CLEANUP_PREFIX = "tfx-*";
+const DEFAULT_TMUX_CLEANUP_AGE_MIN = 60;
 const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
 const HUB_DEFAULT_PORT = 27888;
 const DOCTOR_HUB_PID_FILE = join(CLAUDE_DIR, "cache", "tfx-hub", "hub.pid");
@@ -155,7 +157,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--cleanup-stale-tmux --prefix tfx-* --age-min N --dry-run|--apply] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -198,16 +200,32 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
           "PPID=1 hub/server.mjs 후보를 보고하고 opt-in 정리 모드를 활성화",
       },
       {
+        name: "--cleanup-stale-tmux",
+        type: "boolean",
+        description:
+          "detached tmux session 후보를 보고하고 opt-in 정리 모드를 활성화",
+      },
+      {
+        name: "--prefix <glob>",
+        type: "string",
+        description: "--cleanup-stale-tmux 와 함께 사용. 기본 tfx-*",
+      },
+      {
+        name: "--age-min <minutes>",
+        type: "number",
+        description: "--cleanup-stale-tmux 와 함께 사용. 기본 60",
+      },
+      {
         name: "--dry-run",
         type: "boolean",
         description:
-          "--cleanup-stale-hubs 와 함께 사용. active healthy hub를 제외하고 정리 후보만 표시",
+          "--cleanup-stale-hubs/--cleanup-stale-tmux 와 함께 사용. 정리 후보만 표시",
       },
       {
         name: "--apply",
         type: "boolean",
         description:
-          "--cleanup-stale-hubs 와 함께 사용. active healthy hub 제외 후 stale hub 종료",
+          "--cleanup-stale-hubs/--cleanup-stale-tmux 와 함께 사용. stale 대상 종료",
       },
       {
         name: "--json",
@@ -823,14 +841,23 @@ export async function inspectDetachedHubProcesses({
       healthy = true;
       break;
     }
+    const activeByPidFile = activeHealthy?.pid === row.pid;
+    const activeByConnection = established >= 1;
+    const isActiveHealthy = activeByPidFile || activeByConnection;
     hubs.push({
       ...row,
       ports,
       established,
       version,
-      healthy,
-      activeHealthy: activeHealthy?.pid === row.pid,
-      staleCandidate: activeHealthy?.pid !== row.pid,
+      healthy: healthy || activeByConnection,
+      activeHealthy: isActiveHealthy,
+      activeReason: activeByPidFile
+        ? "pid-file-health"
+        : activeByConnection
+          ? "established-connection"
+          : null,
+      healthStatus: isActiveHealthy ? "healthy" : "stale",
+      staleCandidate: !isActiveHealthy,
     });
   }
 
@@ -891,12 +918,30 @@ export async function cleanupDetachedHubProcesses({
 } = {}) {
   const results = [];
   for (const hub of hubs || []) {
-    if (activeHealthy?.pid === hub.pid || hub.activeHealthy) {
-      results.push({ pid: hub.pid, action: "excluded-active", ok: true, hub });
+    const classification =
+      activeHealthy?.pid === hub.pid ||
+      hub.activeHealthy ||
+      Number(hub.established) >= 1
+        ? "healthy"
+        : "stale";
+    if (classification === "healthy") {
+      results.push({
+        pid: hub.pid,
+        classification,
+        action: "excluded-active",
+        ok: true,
+        hub,
+      });
       continue;
     }
     if (!apply || dryRun) {
-      results.push({ pid: hub.pid, action: "dry-run-skip", ok: true, hub });
+      results.push({
+        pid: hub.pid,
+        classification,
+        action: "dry-run-skip",
+        ok: true,
+        hub,
+      });
       continue;
     }
     const retired = await retireDetachedHubPid(hub.pid, {
@@ -906,6 +951,7 @@ export async function cleanupDetachedHubProcesses({
     });
     results.push({
       pid: hub.pid,
+      classification,
       action: retired.ok ? "retired" : "failed",
       ok: retired.ok,
       reason: retired.reason,
@@ -1108,6 +1154,240 @@ function formatElapsedAge(ageSec) {
   if (ageSec < 3600) return `${Math.floor(ageSec / 60)}분`;
   if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}시간`;
   return `${Math.floor(ageSec / 86400)}일`;
+}
+
+function compileSimpleGlob(pattern) {
+  const source = String(pattern || DEFAULT_TMUX_CLEANUP_PREFIX)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${source}$`);
+}
+
+function parseDetachedTmuxSessionRows(output, nowSec) {
+  const sessions = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const [name, attachedText, createdText] = line.split("\t");
+    if (!name) continue;
+    const attached = Number.parseInt(attachedText || "0", 10);
+    const createdAt = parseSessionCreated(createdText);
+    sessions.push({
+      name,
+      attached: Number.isFinite(attached) ? attached : 0,
+      ageSec: createdAt == null ? null : Math.max(0, nowSec - createdAt),
+    });
+  }
+  return sessions;
+}
+
+function parseTmuxPaneRows(output) {
+  return String(output || "")
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => {
+      const [cwd, command, pidText] = line.split("\t");
+      const pid = Number.parseInt(pidText || "", 10);
+      return {
+        cwd: cwd || null,
+        command: command || null,
+        pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+      };
+    });
+}
+
+function queryTmuxPaneRows(sessionName, { execFile = execFileSync } = {}) {
+  try {
+    return parseTmuxPaneRows(
+      execFile(
+        "tmux",
+        [
+          "list-panes",
+          "-t",
+          sessionName,
+          "-F",
+          "#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}",
+        ],
+        {
+          encoding: "utf8",
+          timeout: 1000,
+          stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
+        },
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function queryProcessMemoryMb(pid, { execFile = execFileSync } = {}) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return null;
+  try {
+    const output = execFile("ps", ["-o", "rss=", "-p", String(resolvedPid)], {
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const rssKb = Number.parseInt(String(output || "").trim(), 10);
+    if (!Number.isFinite(rssKb) || rssKb < 0) return null;
+    return Math.round(rssKb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+function sumMemoryEstimateMb(panes, { execFile = execFileSync } = {}) {
+  let total = 0;
+  let seen = false;
+  for (const pane of panes) {
+    const memory = queryProcessMemoryMb(pane.pid, { execFile });
+    if (memory == null) continue;
+    total += memory;
+    seen = true;
+  }
+  return seen ? total : null;
+}
+
+export function inspectDetachedTmuxSessions({
+  prefix = DEFAULT_TMUX_CLEANUP_PREFIX,
+  ageMin = DEFAULT_TMUX_CLEANUP_AGE_MIN,
+  platform = process.platform,
+  execFile = execFileSync,
+  now = Date.now(),
+} = {}) {
+  if (platform === "win32") {
+    return {
+      available: false,
+      reason: "unsupported-platform",
+      prefix,
+      ageMin,
+      sessions: [],
+      staleCandidates: [],
+    };
+  }
+
+  let output = "";
+  try {
+    output = execFile(
+      "tmux",
+      [
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}\t#{session_created}",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 1000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+  } catch (error) {
+    return {
+      available: false,
+      reason: error?.code === "ENOENT" ? "tmux-missing" : "tmux-unavailable",
+      prefix,
+      ageMin,
+      sessions: [],
+      staleCandidates: [],
+    };
+  }
+
+  const nowSec = Math.floor(now / 1000);
+  const matcher = compileSimpleGlob(prefix);
+  const minAgeSec = Math.max(0, Number(ageMin) || 0) * 60;
+  const sessions = parseDetachedTmuxSessionRows(output, nowSec)
+    .filter((session) => session.attached === 0 && matcher.test(session.name))
+    .map((session) => {
+      const panes = queryTmuxPaneRows(session.name, { execFile });
+      const commands = [
+        ...new Set(panes.map((pane) => pane.command).filter(Boolean)),
+      ];
+      const cwd = panes.find((pane) => pane.cwd)?.cwd || null;
+      const staleCandidate =
+        session.ageSec != null && session.ageSec >= minAgeSec;
+      return {
+        name: session.name,
+        age: formatElapsedAge(session.ageSec),
+        ageSec: session.ageSec,
+        cwd,
+        command: commands.length > 0 ? commands.join(",") : null,
+        memoryEstimateMb: sumMemoryEstimateMb(panes, { execFile }),
+        staleCandidate,
+      };
+    });
+
+  return {
+    available: true,
+    reason: null,
+    prefix,
+    ageMin,
+    sessions,
+    staleCandidates: sessions.filter((session) => session.staleCandidate),
+  };
+}
+
+export async function cleanupDetachedTmuxSessions({
+  sessions,
+  dryRun = true,
+  apply = false,
+  execFile = execFileSync,
+} = {}) {
+  const results = [];
+  for (const session of sessions || []) {
+    if (!session.staleCandidate) {
+      results.push({
+        name: session.name,
+        action: "excluded-fresh",
+        ok: true,
+        session,
+      });
+      continue;
+    }
+    if (!apply || dryRun) {
+      results.push({
+        name: session.name,
+        action: "dry-run-skip",
+        ok: true,
+        session,
+      });
+      continue;
+    }
+    try {
+      execFile("tmux", ["kill-session", "-t", session.name], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      results.push({
+        name: session.name,
+        action: "retired",
+        ok: true,
+        session,
+      });
+    } catch (error) {
+      results.push({
+        name: session.name,
+        action: "failed",
+        ok: false,
+        error,
+        session,
+      });
+    }
+  }
+
+  return {
+    dryRun: !apply || dryRun,
+    results,
+    failed: results.filter((result) => result.ok === false).length,
+    retired: results.filter((result) => result.action === "retired").length,
+    skipped: results.filter((result) => result.action === "dry-run-skip")
+      .length,
+    excluded: results.filter((result) => result.action === "excluded-fresh")
+      .length,
+  };
 }
 
 function readTeamSessionCreatedMap() {
@@ -2286,6 +2566,11 @@ async function cmdDoctor(options = {}) {
     cleanupStaleHubs = false,
     cleanupStaleHubsDryRun = true,
     cleanupStaleHubsApply = false,
+    cleanupStaleTmux = false,
+    cleanupStaleTmuxDryRun = true,
+    cleanupStaleTmuxApply = false,
+    cleanupStaleTmuxPrefix = DEFAULT_TMUX_CLEANUP_PREFIX,
+    cleanupStaleTmuxAgeMin = DEFAULT_TMUX_CLEANUP_AGE_MIN,
     json = false,
   } = options;
   const report = {
@@ -2296,6 +2581,13 @@ async function cmdDoctor(options = {}) {
     hook_coverage: { total: 0, registered: 0, missing: [] },
     fsmonitorDaemons: { stale: 0, killed: 0 },
     hubServers: { detached: 0, stale: 0, activeHealthy: null },
+    tmuxSessions: {
+      detached: 0,
+      stale: 0,
+      prefix: cleanupStaleTmuxPrefix,
+      ageMin: cleanupStaleTmuxAgeMin,
+      sessions: [],
+    },
     issue_count: 0,
   };
 
@@ -3583,6 +3875,106 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // 12.5. detached tmux session report and opt-in cleanup
+    section("Detached Tmux Sessions");
+    const detachedTmuxReport = inspectDetachedTmuxSessions({
+      prefix: cleanupStaleTmuxPrefix,
+      ageMin: cleanupStaleTmuxAgeMin,
+    });
+    report.tmuxSessions = {
+      detached: detachedTmuxReport.sessions.length,
+      stale: detachedTmuxReport.staleCandidates.length,
+      prefix: detachedTmuxReport.prefix,
+      ageMin: detachedTmuxReport.ageMin,
+      available: detachedTmuxReport.available,
+      reason: detachedTmuxReport.reason,
+      sessions: detachedTmuxReport.sessions.map((session) => ({
+        name: session.name,
+        age: session.age,
+        age_sec: session.ageSec,
+        cwd: session.cwd,
+        command: session.command,
+        memory_estimate_mb: session.memoryEstimateMb,
+        stale: session.staleCandidate,
+      })),
+    };
+    addDoctorCheck(report, {
+      name: "detached-tmux-sessions",
+      status: !detachedTmuxReport.available
+        ? "skipped"
+        : detachedTmuxReport.staleCandidates.length > 0
+          ? "warning"
+          : "ok",
+      prefix: detachedTmuxReport.prefix,
+      age_min: detachedTmuxReport.ageMin,
+      detached: detachedTmuxReport.sessions.length,
+      stale: detachedTmuxReport.staleCandidates.length,
+      reason: detachedTmuxReport.reason,
+    });
+
+    if (!detachedTmuxReport.available) {
+      info(
+        `tmux 미감지 또는 서버 없음 — detached tmux 검사 건너뜀 (${detachedTmuxReport.reason})`,
+      );
+    } else if (detachedTmuxReport.sessions.length === 0) {
+      ok(`detached tmux session 없음 (prefix=${detachedTmuxReport.prefix})`);
+    } else {
+      info(
+        `prefix=${detachedTmuxReport.prefix} age-min=${detachedTmuxReport.ageMin}분`,
+      );
+      for (const session of detachedTmuxReport.sessions) {
+        const memoryLabel =
+          session.memoryEstimateMb == null
+            ? "?"
+            : `${session.memoryEstimateMb}MB`;
+        const cwdLabel = session.cwd || "?";
+        const commandLabel = session.command || "?";
+        const line = `${session.name}: age=${session.age} cwd=${cwdLabel} command=${commandLabel} memory=${memoryLabel}`;
+        if (session.staleCandidate) warn(`${line} stale`);
+        else ok(`${line} fresh`);
+      }
+    }
+
+    if (cleanupStaleTmux) {
+      const cleanupResult = await cleanupDetachedTmuxSessions({
+        sessions: detachedTmuxReport.sessions,
+        dryRun: cleanupStaleTmuxDryRun,
+        apply: cleanupStaleTmuxApply,
+      });
+      report.actions.push({
+        type: "cleanup-stale-tmux",
+        status: cleanupResult.failed > 0 ? "failed" : "ok",
+        dryRun: cleanupResult.dryRun,
+        retired: cleanupResult.retired,
+        skipped: cleanupResult.skipped,
+        excluded: cleanupResult.excluded,
+        failed: cleanupResult.failed,
+      });
+      for (const result of cleanupResult.results) {
+        if (result.action === "excluded-fresh") {
+          ok(`fresh detached tmux excluded: ${result.name}`);
+        } else if (result.action === "dry-run-skip") {
+          info(`dry-run stale tmux target: ${result.name}`);
+        } else if (result.action === "retired") {
+          ok(`stale tmux session killed: ${result.name}`);
+        } else {
+          fail(`stale tmux cleanup failed: ${result.name}`);
+        }
+      }
+      issues += cleanupResult.failed;
+      if (
+        cleanupResult.dryRun &&
+        detachedTmuxReport.staleCandidates.length > 0
+      ) {
+        issues += detachedTmuxReport.staleCandidates.length;
+      }
+    } else if (detachedTmuxReport.staleCandidates.length > 0) {
+      info(
+        "정리: tfx doctor --cleanup-stale-tmux --prefix tfx-* --dry-run|--apply",
+      );
+      issues += detachedTmuxReport.staleCandidates.length;
+    }
+
     // 13. OMC stale team 상태
     section("OMC Stale Teams");
     const omcTeamReport = inspectStaleOmcTeams({
@@ -3673,6 +4065,8 @@ async function cmdDoctor(options = {}) {
           established: hub.established,
           rssKb: hub.rssKb,
           activeHealthy: hub.activeHealthy,
+          activeReason: hub.activeReason,
+          healthStatus: hub.healthStatus,
           staleCandidate: hub.staleCandidate,
         })),
       };
@@ -3692,9 +4086,9 @@ async function cmdDoctor(options = {}) {
           const versionLabel = hub.version || "unknown";
           const rssLabel = hub.rssKb == null ? "?" : `${hub.rssKb}KB`;
           const activeLabel = hub.activeHealthy
-            ? " active healthy excluded"
+            ? ` healthy excluded${hub.activeReason ? ` (${hub.activeReason})` : ""}`
             : " stale candidate";
-          const line = `PID=${hub.pid} PPID=${hub.ppid} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
+          const line = `PID=${hub.pid} PPID=${hub.ppid} status=${hub.healthStatus} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
           if (hub.activeHealthy) ok(line);
           else warn(line);
         }
@@ -3718,9 +4112,9 @@ async function cmdDoctor(options = {}) {
         });
         for (const result of cleanupResult.results) {
           if (result.action === "excluded-active") {
-            ok(`active healthy hub excluded: PID=${result.pid}`);
+            ok(`dry-run healthy hub excluded: PID=${result.pid}`);
           } else if (result.action === "dry-run-skip") {
-            info(`dry-run skip stale hub: PID=${result.pid}`);
+            info(`dry-run stale hub target: PID=${result.pid}`);
           } else if (result.action === "retired") {
             ok(`stale hub retired: PID=${result.pid} (${result.reason})`);
           } else {
@@ -6430,6 +6824,28 @@ async function cmdHub(args = [], options = {}) {
 
 // ── 메인 ──
 
+function readCliOptionValue(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) return null;
+  return value;
+}
+
+function parsePositiveIntegerOption(args, name, fallback) {
+  const value = readCliOptionValue(args, name);
+  if (value == null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw createCliError(`${name} 값은 0 이상의 정수여야 합니다`, {
+      exitCode: EXIT_ARG_ERROR,
+      reason: "argError",
+      fix: `${name} ${fallback}`,
+    });
+  }
+  return parsed;
+}
+
 async function main() {
   const cmd = NORMALIZED_ARGS[0] || "help";
   const cmdArgs = NORMALIZED_ARGS.slice(1);
@@ -6526,18 +6942,30 @@ async function main() {
       const reset = cmdArgs.includes("--reset");
       const purgeLogs = cmdArgs.includes("--purge-logs");
       const cleanupStaleHubs = cmdArgs.includes("--cleanup-stale-hubs");
+      const cleanupStaleTmux = cmdArgs.includes("--cleanup-stale-tmux");
       const cleanupApply = cmdArgs.includes("--apply");
       const cleanupDryRun = cmdArgs.includes("--dry-run") || !cleanupApply;
-      if (cleanupStaleHubs && cleanupApply && cmdArgs.includes("--dry-run")) {
+      if (
+        (cleanupStaleHubs || cleanupStaleTmux) &&
+        cleanupApply &&
+        cmdArgs.includes("--dry-run")
+      ) {
         throw createCliError(
-          "--cleanup-stale-hubs 에서는 --dry-run 과 --apply 중 하나만 지정하세요",
+          "cleanup 옵션에서는 --dry-run 과 --apply 중 하나만 지정하세요",
           {
             exitCode: EXIT_ARG_ERROR,
             reason: "argError",
-            fix: "tfx doctor --cleanup-stale-hubs --dry-run",
+            fix: "tfx doctor --cleanup-stale-tmux --dry-run",
           },
         );
       }
+      const cleanupStaleTmuxPrefix =
+        readCliOptionValue(cmdArgs, "--prefix") || DEFAULT_TMUX_CLEANUP_PREFIX;
+      const cleanupStaleTmuxAgeMin = parsePositiveIntegerOption(
+        cmdArgs,
+        "--age-min",
+        DEFAULT_TMUX_CLEANUP_AGE_MIN,
+      );
       await cmdDoctor({
         fix,
         reset,
@@ -6545,6 +6973,11 @@ async function main() {
         cleanupStaleHubs,
         cleanupStaleHubsDryRun: cleanupDryRun,
         cleanupStaleHubsApply: cleanupApply,
+        cleanupStaleTmux,
+        cleanupStaleTmuxDryRun: cleanupDryRun,
+        cleanupStaleTmuxApply: cleanupApply,
+        cleanupStaleTmuxPrefix,
+        cleanupStaleTmuxAgeMin,
         json: JSON_OUTPUT,
       });
       return;

--- a/hooks/session-end-cleanup.mjs
+++ b/hooks/session-end-cleanup.mjs
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
+
 // hooks/session-end-cleanup.mjs — SessionEnd lifecycle state reporter
 //
 // Report-only by default. Opt-in cleanup only removes the repo-local
 // .triflux/subagents/subagents.json file when stale running lifecycle state is
 // present. It never kills processes or touches external HOME/MCP configs.
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const MARKER = "[session-end-cleanup]";
 const STALE_MS = 30 * 60 * 1000;
 const MAX_OUTPUT_BYTES = 2 * 1024;
+const DEFAULT_TMUX_PREFIX = "tfx-*";
+const MAX_TMUX_REPORT_SESSIONS = 8;
 
 function readStdin() {
   try {
@@ -63,6 +67,140 @@ function agentEntries(state) {
   if (Array.isArray(agents)) return agents;
   if (agents && typeof agents === "object") return Object.values(agents);
   return [];
+}
+
+function compileSimpleGlob(pattern) {
+  const source = String(pattern || DEFAULT_TMUX_PREFIX)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${source}$`);
+}
+
+function formatAge(ageSec) {
+  if (!Number.isFinite(ageSec) || ageSec < 0) return "unknown";
+  if (ageSec < 60) return `${Math.floor(ageSec)}s`;
+  if (ageSec < 3600) return `${Math.floor(ageSec / 60)}m`;
+  if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}h`;
+  return `${Math.floor(ageSec / 86400)}d`;
+}
+
+function parseSessionCreated(rawValue) {
+  const parsed = Number.parseInt(String(rawValue || "").trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseTmuxListSessions(output, nowSec) {
+  const sessions = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const [name, attachedText, createdText] = line.split("\t");
+    if (!name) continue;
+    const attached = Number.parseInt(attachedText || "0", 10);
+    const created = parseSessionCreated(createdText);
+    sessions.push({
+      name,
+      attached: Number.isFinite(attached) ? attached : 0,
+      ageSec: created == null ? null : Math.max(0, nowSec - created),
+    });
+  }
+  return sessions;
+}
+
+function parseFirstPane(output) {
+  const first = String(output || "")
+    .split(/\r?\n/)
+    .find((line) => line.trim());
+  if (!first) return { cwd: null, command: null, pid: null };
+  const [cwd, command, pidText] = first.split("\t");
+  const pid = Number.parseInt(pidText || "", 10);
+  return {
+    cwd: cwd || null,
+    command: command || null,
+    pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+  };
+}
+
+function queryMemoryEstimateMb(pid, execFile = execFileSync) {
+  if (!pid) return null;
+  try {
+    const output = execFile("ps", ["-o", "rss=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 400,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const rssKb = Number.parseInt(String(output || "").trim(), 10);
+    if (!Number.isFinite(rssKb) || rssKb < 0) return null;
+    return Math.round(rssKb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+export function inspectDetachedTmuxSessions({
+  prefix = DEFAULT_TMUX_PREFIX,
+  now = Date.now(),
+  execFile = execFileSync,
+  limit = MAX_TMUX_REPORT_SESSIONS,
+} = {}) {
+  const nowSec = Math.floor(now / 1000);
+  const matcher = compileSimpleGlob(prefix);
+  let output = "";
+  try {
+    output = execFile(
+      "tmux",
+      [
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}\t#{session_created}",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 500,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return { available: false, prefix, sessions: [] };
+  }
+
+  const sessions = [];
+  for (const session of parseTmuxListSessions(output, nowSec)) {
+    if (session.attached !== 0 || !matcher.test(session.name)) continue;
+    let pane = { cwd: null, command: null, pid: null };
+    try {
+      pane = parseFirstPane(
+        execFile(
+          "tmux",
+          [
+            "list-panes",
+            "-t",
+            session.name,
+            "-F",
+            "#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}",
+          ],
+          {
+            encoding: "utf8",
+            timeout: 500,
+            stdio: ["ignore", "pipe", "ignore"],
+            windowsHide: true,
+          },
+        ),
+      );
+    } catch {
+      pane = { cwd: null, command: null, pid: null };
+    }
+    sessions.push({
+      name: session.name,
+      age: formatAge(session.ageSec),
+      cwd: pane.cwd,
+      command: pane.command,
+      memory_estimate_mb: queryMemoryEstimateMb(pane.pid, execFile),
+    });
+    if (sessions.length >= limit) break;
+  }
+
+  return { available: true, prefix, sessions };
 }
 
 export function summarizeLifecycleState(state, now = Date.now()) {
@@ -121,28 +259,31 @@ function pruneStaleRunningAgents(state, now = Date.now()) {
   };
 }
 
-function buildOutput(summary, cleanup) {
-  const context =
+function buildContext(summary, cleanup, tmuxReport) {
+  let context =
     `${MARKER} subagent lifecycle: ` +
     `running=${summary.running} completed=${summary.completed} ` +
     `stale=${summary.stale} total=${summary.total} cleanup=${cleanup}`;
+
+  if (tmuxReport?.sessions?.length > 0) {
+    context += ` detached_tmux_sessions=${JSON.stringify(tmuxReport.sessions)}`;
+  }
+  return context;
+}
+
+function buildOutput(summary, cleanup, tmuxReport) {
+  const context = buildContext(summary, cleanup, tmuxReport);
   const output = {
     systemMessage: context,
-    hookSpecificOutput: {
-      hookEventName: "SessionEnd",
-      additionalContext: context,
-    },
   };
 
   let json = JSON.stringify(output);
   if (Buffer.byteLength(json, "utf8") >= MAX_OUTPUT_BYTES) {
-    const bounded = `${MARKER} subagent lifecycle: running=${summary.running} completed=${summary.completed} stale=${summary.stale} cleanup=${cleanup}`;
+    const bounded = buildContext(summary, cleanup, {
+      sessions: tmuxReport?.sessions?.slice(0, 2) || [],
+    });
     json = JSON.stringify({
       systemMessage: bounded,
-      hookSpecificOutput: {
-        hookEventName: "SessionEnd",
-        additionalContext: bounded,
-      },
     });
   }
   return json;
@@ -160,6 +301,9 @@ export function run(input, env = process.env) {
 
   const summary = summarizeLifecycleState(state);
   let cleanup = "report-only";
+  const tmuxReport = inspectDetachedTmuxSessions({
+    prefix: env.TFX_SESSION_END_TMUX_PREFIX || DEFAULT_TMUX_PREFIX,
+  });
 
   if (env.TFX_SESSION_END_CLEANUP === "1" && summary.stale > 0) {
     try {
@@ -184,7 +328,7 @@ export function run(input, env = process.env) {
     }
   }
 
-  return buildOutput(summary, cleanup);
+  return buildOutput(summary, cleanup, tmuxReport);
 }
 
 function main() {

--- a/hub/team/session.mjs
+++ b/hub/team/session.mjs
@@ -135,11 +135,11 @@ export function detectMultiplexer() {
     _cachedMux = "tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasGitBashTmux()) {
+  if (hasGitBashTmux()) {
     _cachedMux = "git-bash-tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasWslTmux()) {
+  if (hasWslTmux()) {
     _cachedMux = "wsl-tmux";
     return _cachedMux;
   }

--- a/hub/team/terminal-opener.mjs
+++ b/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec, execFileSync } from "node:child_process";
+import { exec as defaultExec, spawnSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,15 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
+function powershellCommandName(value) {
+  const command = String(value);
+  return /^[A-Za-z0-9_.:-]+$/u.test(command)
+    ? command
+    : `& ${powershellSingleQuote(command)}`;
+}
+
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
 function defaultPsmuxBinaryExists(command) {
   try {
-    const output = execFileSync(command, ["-V"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 3000,
-      windowsHide: true,
-    });
-    return /\bpsmux\b/i.test(String(output || ""));
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
   } catch {
     return false;
   }
@@ -139,12 +151,18 @@ export function createTerminalOpener(deps = {}) {
 
   async function openSession(sessionName, opts = {}) {
     if (platform === "win32") {
+      const command = process.env.PSMUX_BIN || "psmux";
+      const psmuxBinaryExists =
+        deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+      if (!psmuxBinaryExists(command)) return false;
       const wt = createWtManager();
       try {
         return wtResultSucceeded(
           await wt.createTab({
             title: sanitizeTerminalTitle(opts.title ?? sessionName),
-            command: `psmux attach-session -t ${powershellSingleQuote(sessionName)}`,
+            command: `${powershellCommandName(
+              command,
+            )} attach-session -t ${powershellSingleQuote(sessionName)}`,
             cwd: opts.cwd,
             profile: opts.profile ?? "triflux",
           }),

--- a/packages/core/hooks/session-end-cleanup.mjs
+++ b/packages/core/hooks/session-end-cleanup.mjs
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
+
 // hooks/session-end-cleanup.mjs — SessionEnd lifecycle state reporter
 //
 // Report-only by default. Opt-in cleanup only removes the repo-local
 // .triflux/subagents/subagents.json file when stale running lifecycle state is
 // present. It never kills processes or touches external HOME/MCP configs.
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const MARKER = "[session-end-cleanup]";
 const STALE_MS = 30 * 60 * 1000;
 const MAX_OUTPUT_BYTES = 2 * 1024;
+const DEFAULT_TMUX_PREFIX = "tfx-*";
+const MAX_TMUX_REPORT_SESSIONS = 8;
 
 function readStdin() {
   try {
@@ -63,6 +67,140 @@ function agentEntries(state) {
   if (Array.isArray(agents)) return agents;
   if (agents && typeof agents === "object") return Object.values(agents);
   return [];
+}
+
+function compileSimpleGlob(pattern) {
+  const source = String(pattern || DEFAULT_TMUX_PREFIX)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${source}$`);
+}
+
+function formatAge(ageSec) {
+  if (!Number.isFinite(ageSec) || ageSec < 0) return "unknown";
+  if (ageSec < 60) return `${Math.floor(ageSec)}s`;
+  if (ageSec < 3600) return `${Math.floor(ageSec / 60)}m`;
+  if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}h`;
+  return `${Math.floor(ageSec / 86400)}d`;
+}
+
+function parseSessionCreated(rawValue) {
+  const parsed = Number.parseInt(String(rawValue || "").trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseTmuxListSessions(output, nowSec) {
+  const sessions = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const [name, attachedText, createdText] = line.split("\t");
+    if (!name) continue;
+    const attached = Number.parseInt(attachedText || "0", 10);
+    const created = parseSessionCreated(createdText);
+    sessions.push({
+      name,
+      attached: Number.isFinite(attached) ? attached : 0,
+      ageSec: created == null ? null : Math.max(0, nowSec - created),
+    });
+  }
+  return sessions;
+}
+
+function parseFirstPane(output) {
+  const first = String(output || "")
+    .split(/\r?\n/)
+    .find((line) => line.trim());
+  if (!first) return { cwd: null, command: null, pid: null };
+  const [cwd, command, pidText] = first.split("\t");
+  const pid = Number.parseInt(pidText || "", 10);
+  return {
+    cwd: cwd || null,
+    command: command || null,
+    pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+  };
+}
+
+function queryMemoryEstimateMb(pid, execFile = execFileSync) {
+  if (!pid) return null;
+  try {
+    const output = execFile("ps", ["-o", "rss=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 400,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const rssKb = Number.parseInt(String(output || "").trim(), 10);
+    if (!Number.isFinite(rssKb) || rssKb < 0) return null;
+    return Math.round(rssKb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+export function inspectDetachedTmuxSessions({
+  prefix = DEFAULT_TMUX_PREFIX,
+  now = Date.now(),
+  execFile = execFileSync,
+  limit = MAX_TMUX_REPORT_SESSIONS,
+} = {}) {
+  const nowSec = Math.floor(now / 1000);
+  const matcher = compileSimpleGlob(prefix);
+  let output = "";
+  try {
+    output = execFile(
+      "tmux",
+      [
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}\t#{session_created}",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 500,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return { available: false, prefix, sessions: [] };
+  }
+
+  const sessions = [];
+  for (const session of parseTmuxListSessions(output, nowSec)) {
+    if (session.attached !== 0 || !matcher.test(session.name)) continue;
+    let pane = { cwd: null, command: null, pid: null };
+    try {
+      pane = parseFirstPane(
+        execFile(
+          "tmux",
+          [
+            "list-panes",
+            "-t",
+            session.name,
+            "-F",
+            "#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}",
+          ],
+          {
+            encoding: "utf8",
+            timeout: 500,
+            stdio: ["ignore", "pipe", "ignore"],
+            windowsHide: true,
+          },
+        ),
+      );
+    } catch {
+      pane = { cwd: null, command: null, pid: null };
+    }
+    sessions.push({
+      name: session.name,
+      age: formatAge(session.ageSec),
+      cwd: pane.cwd,
+      command: pane.command,
+      memory_estimate_mb: queryMemoryEstimateMb(pane.pid, execFile),
+    });
+    if (sessions.length >= limit) break;
+  }
+
+  return { available: true, prefix, sessions };
 }
 
 export function summarizeLifecycleState(state, now = Date.now()) {
@@ -121,28 +259,31 @@ function pruneStaleRunningAgents(state, now = Date.now()) {
   };
 }
 
-function buildOutput(summary, cleanup) {
-  const context =
+function buildContext(summary, cleanup, tmuxReport) {
+  let context =
     `${MARKER} subagent lifecycle: ` +
     `running=${summary.running} completed=${summary.completed} ` +
     `stale=${summary.stale} total=${summary.total} cleanup=${cleanup}`;
+
+  if (tmuxReport?.sessions?.length > 0) {
+    context += ` detached_tmux_sessions=${JSON.stringify(tmuxReport.sessions)}`;
+  }
+  return context;
+}
+
+function buildOutput(summary, cleanup, tmuxReport) {
+  const context = buildContext(summary, cleanup, tmuxReport);
   const output = {
     systemMessage: context,
-    hookSpecificOutput: {
-      hookEventName: "SessionEnd",
-      additionalContext: context,
-    },
   };
 
   let json = JSON.stringify(output);
   if (Buffer.byteLength(json, "utf8") >= MAX_OUTPUT_BYTES) {
-    const bounded = `${MARKER} subagent lifecycle: running=${summary.running} completed=${summary.completed} stale=${summary.stale} cleanup=${cleanup}`;
+    const bounded = buildContext(summary, cleanup, {
+      sessions: tmuxReport?.sessions?.slice(0, 2) || [],
+    });
     json = JSON.stringify({
       systemMessage: bounded,
-      hookSpecificOutput: {
-        hookEventName: "SessionEnd",
-        additionalContext: bounded,
-      },
     });
   }
   return json;
@@ -160,6 +301,9 @@ export function run(input, env = process.env) {
 
   const summary = summarizeLifecycleState(state);
   let cleanup = "report-only";
+  const tmuxReport = inspectDetachedTmuxSessions({
+    prefix: env.TFX_SESSION_END_TMUX_PREFIX || DEFAULT_TMUX_PREFIX,
+  });
 
   if (env.TFX_SESSION_END_CLEANUP === "1" && summary.stale > 0) {
     try {
@@ -184,7 +328,7 @@ export function run(input, env = process.env) {
     }
   }
 
-  return buildOutput(summary, cleanup);
+  return buildOutput(summary, cleanup, tmuxReport);
 }
 
 function main() {

--- a/packages/remote/hub/team/session.mjs
+++ b/packages/remote/hub/team/session.mjs
@@ -135,11 +135,11 @@ export function detectMultiplexer() {
     _cachedMux = "tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasGitBashTmux()) {
+  if (hasGitBashTmux()) {
     _cachedMux = "git-bash-tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasWslTmux()) {
+  if (hasWslTmux()) {
     _cachedMux = "wsl-tmux";
     return _cachedMux;
   }

--- a/packages/remote/hub/team/terminal-opener.mjs
+++ b/packages/remote/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec, execFileSync } from "node:child_process";
+import { exec as defaultExec, spawnSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,15 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
+function powershellCommandName(value) {
+  const command = String(value);
+  return /^[A-Za-z0-9_.:-]+$/u.test(command)
+    ? command
+    : `& ${powershellSingleQuote(command)}`;
+}
+
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
 function defaultPsmuxBinaryExists(command) {
   try {
-    const output = execFileSync(command, ["-V"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 3000,
-      windowsHide: true,
-    });
-    return /\bpsmux\b/i.test(String(output || ""));
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
   } catch {
     return false;
   }
@@ -139,12 +151,18 @@ export function createTerminalOpener(deps = {}) {
 
   async function openSession(sessionName, opts = {}) {
     if (platform === "win32") {
+      const command = process.env.PSMUX_BIN || "psmux";
+      const psmuxBinaryExists =
+        deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+      if (!psmuxBinaryExists(command)) return false;
       const wt = createWtManager();
       try {
         return wtResultSucceeded(
           await wt.createTab({
             title: sanitizeTerminalTitle(opts.title ?? sessionName),
-            command: `psmux attach-session -t ${powershellSingleQuote(sessionName)}`,
+            command: `${powershellCommandName(
+              command,
+            )} attach-session -t ${powershellSingleQuote(sessionName)}`,
             cwd: opts.cwd,
             profile: opts.profile ?? "triflux",
           }),

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -120,6 +120,8 @@ const VER = `${DIM}v${PKG.version}${RESET}`;
 const LINE = `${GRAY}${"─".repeat(48)}${RESET}`;
 const _DOT = `${GRAY}·${RESET}`;
 const STALE_TEAM_MAX_AGE_SEC = 3600;
+const DEFAULT_TMUX_CLEANUP_PREFIX = "tfx-*";
+const DEFAULT_TMUX_CLEANUP_AGE_MIN = 60;
 const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
 const HUB_DEFAULT_PORT = 27888;
 const DOCTOR_HUB_PID_FILE = join(CLAUDE_DIR, "cache", "tfx-hub", "hub.pid");
@@ -155,7 +157,7 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
   },
   doctor: {
     usage:
-      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--json]",
+      "tfx doctor [--fix] [--reset] [--audit] [--diagnose] [--purge-logs] [--dynamic-routing] [--cleanup-stale-hubs --dry-run|--apply] [--cleanup-stale-tmux --prefix tfx-* --age-min N --dry-run|--apply] [--json]",
     description: "설치 상태 진단 및 자동 복구",
     options: [
       {
@@ -198,16 +200,32 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
           "PPID=1 hub/server.mjs 후보를 보고하고 opt-in 정리 모드를 활성화",
       },
       {
+        name: "--cleanup-stale-tmux",
+        type: "boolean",
+        description:
+          "detached tmux session 후보를 보고하고 opt-in 정리 모드를 활성화",
+      },
+      {
+        name: "--prefix <glob>",
+        type: "string",
+        description: "--cleanup-stale-tmux 와 함께 사용. 기본 tfx-*",
+      },
+      {
+        name: "--age-min <minutes>",
+        type: "number",
+        description: "--cleanup-stale-tmux 와 함께 사용. 기본 60",
+      },
+      {
         name: "--dry-run",
         type: "boolean",
         description:
-          "--cleanup-stale-hubs 와 함께 사용. active healthy hub를 제외하고 정리 후보만 표시",
+          "--cleanup-stale-hubs/--cleanup-stale-tmux 와 함께 사용. 정리 후보만 표시",
       },
       {
         name: "--apply",
         type: "boolean",
         description:
-          "--cleanup-stale-hubs 와 함께 사용. active healthy hub 제외 후 stale hub 종료",
+          "--cleanup-stale-hubs/--cleanup-stale-tmux 와 함께 사용. stale 대상 종료",
       },
       {
         name: "--json",
@@ -823,14 +841,23 @@ export async function inspectDetachedHubProcesses({
       healthy = true;
       break;
     }
+    const activeByPidFile = activeHealthy?.pid === row.pid;
+    const activeByConnection = established >= 1;
+    const isActiveHealthy = activeByPidFile || activeByConnection;
     hubs.push({
       ...row,
       ports,
       established,
       version,
-      healthy,
-      activeHealthy: activeHealthy?.pid === row.pid,
-      staleCandidate: activeHealthy?.pid !== row.pid,
+      healthy: healthy || activeByConnection,
+      activeHealthy: isActiveHealthy,
+      activeReason: activeByPidFile
+        ? "pid-file-health"
+        : activeByConnection
+          ? "established-connection"
+          : null,
+      healthStatus: isActiveHealthy ? "healthy" : "stale",
+      staleCandidate: !isActiveHealthy,
     });
   }
 
@@ -891,12 +918,30 @@ export async function cleanupDetachedHubProcesses({
 } = {}) {
   const results = [];
   for (const hub of hubs || []) {
-    if (activeHealthy?.pid === hub.pid || hub.activeHealthy) {
-      results.push({ pid: hub.pid, action: "excluded-active", ok: true, hub });
+    const classification =
+      activeHealthy?.pid === hub.pid ||
+      hub.activeHealthy ||
+      Number(hub.established) >= 1
+        ? "healthy"
+        : "stale";
+    if (classification === "healthy") {
+      results.push({
+        pid: hub.pid,
+        classification,
+        action: "excluded-active",
+        ok: true,
+        hub,
+      });
       continue;
     }
     if (!apply || dryRun) {
-      results.push({ pid: hub.pid, action: "dry-run-skip", ok: true, hub });
+      results.push({
+        pid: hub.pid,
+        classification,
+        action: "dry-run-skip",
+        ok: true,
+        hub,
+      });
       continue;
     }
     const retired = await retireDetachedHubPid(hub.pid, {
@@ -906,6 +951,7 @@ export async function cleanupDetachedHubProcesses({
     });
     results.push({
       pid: hub.pid,
+      classification,
       action: retired.ok ? "retired" : "failed",
       ok: retired.ok,
       reason: retired.reason,
@@ -1108,6 +1154,240 @@ function formatElapsedAge(ageSec) {
   if (ageSec < 3600) return `${Math.floor(ageSec / 60)}분`;
   if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}시간`;
   return `${Math.floor(ageSec / 86400)}일`;
+}
+
+function compileSimpleGlob(pattern) {
+  const source = String(pattern || DEFAULT_TMUX_CLEANUP_PREFIX)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${source}$`);
+}
+
+function parseDetachedTmuxSessionRows(output, nowSec) {
+  const sessions = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const [name, attachedText, createdText] = line.split("\t");
+    if (!name) continue;
+    const attached = Number.parseInt(attachedText || "0", 10);
+    const createdAt = parseSessionCreated(createdText);
+    sessions.push({
+      name,
+      attached: Number.isFinite(attached) ? attached : 0,
+      ageSec: createdAt == null ? null : Math.max(0, nowSec - createdAt),
+    });
+  }
+  return sessions;
+}
+
+function parseTmuxPaneRows(output) {
+  return String(output || "")
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => {
+      const [cwd, command, pidText] = line.split("\t");
+      const pid = Number.parseInt(pidText || "", 10);
+      return {
+        cwd: cwd || null,
+        command: command || null,
+        pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+      };
+    });
+}
+
+function queryTmuxPaneRows(sessionName, { execFile = execFileSync } = {}) {
+  try {
+    return parseTmuxPaneRows(
+      execFile(
+        "tmux",
+        [
+          "list-panes",
+          "-t",
+          sessionName,
+          "-F",
+          "#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}",
+        ],
+        {
+          encoding: "utf8",
+          timeout: 1000,
+          stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
+        },
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function queryProcessMemoryMb(pid, { execFile = execFileSync } = {}) {
+  const resolvedPid = Number(pid);
+  if (!Number.isFinite(resolvedPid) || resolvedPid <= 0) return null;
+  try {
+    const output = execFile("ps", ["-o", "rss=", "-p", String(resolvedPid)], {
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const rssKb = Number.parseInt(String(output || "").trim(), 10);
+    if (!Number.isFinite(rssKb) || rssKb < 0) return null;
+    return Math.round(rssKb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+function sumMemoryEstimateMb(panes, { execFile = execFileSync } = {}) {
+  let total = 0;
+  let seen = false;
+  for (const pane of panes) {
+    const memory = queryProcessMemoryMb(pane.pid, { execFile });
+    if (memory == null) continue;
+    total += memory;
+    seen = true;
+  }
+  return seen ? total : null;
+}
+
+export function inspectDetachedTmuxSessions({
+  prefix = DEFAULT_TMUX_CLEANUP_PREFIX,
+  ageMin = DEFAULT_TMUX_CLEANUP_AGE_MIN,
+  platform = process.platform,
+  execFile = execFileSync,
+  now = Date.now(),
+} = {}) {
+  if (platform === "win32") {
+    return {
+      available: false,
+      reason: "unsupported-platform",
+      prefix,
+      ageMin,
+      sessions: [],
+      staleCandidates: [],
+    };
+  }
+
+  let output = "";
+  try {
+    output = execFile(
+      "tmux",
+      [
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}\t#{session_created}",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 1000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+  } catch (error) {
+    return {
+      available: false,
+      reason: error?.code === "ENOENT" ? "tmux-missing" : "tmux-unavailable",
+      prefix,
+      ageMin,
+      sessions: [],
+      staleCandidates: [],
+    };
+  }
+
+  const nowSec = Math.floor(now / 1000);
+  const matcher = compileSimpleGlob(prefix);
+  const minAgeSec = Math.max(0, Number(ageMin) || 0) * 60;
+  const sessions = parseDetachedTmuxSessionRows(output, nowSec)
+    .filter((session) => session.attached === 0 && matcher.test(session.name))
+    .map((session) => {
+      const panes = queryTmuxPaneRows(session.name, { execFile });
+      const commands = [
+        ...new Set(panes.map((pane) => pane.command).filter(Boolean)),
+      ];
+      const cwd = panes.find((pane) => pane.cwd)?.cwd || null;
+      const staleCandidate =
+        session.ageSec != null && session.ageSec >= minAgeSec;
+      return {
+        name: session.name,
+        age: formatElapsedAge(session.ageSec),
+        ageSec: session.ageSec,
+        cwd,
+        command: commands.length > 0 ? commands.join(",") : null,
+        memoryEstimateMb: sumMemoryEstimateMb(panes, { execFile }),
+        staleCandidate,
+      };
+    });
+
+  return {
+    available: true,
+    reason: null,
+    prefix,
+    ageMin,
+    sessions,
+    staleCandidates: sessions.filter((session) => session.staleCandidate),
+  };
+}
+
+export async function cleanupDetachedTmuxSessions({
+  sessions,
+  dryRun = true,
+  apply = false,
+  execFile = execFileSync,
+} = {}) {
+  const results = [];
+  for (const session of sessions || []) {
+    if (!session.staleCandidate) {
+      results.push({
+        name: session.name,
+        action: "excluded-fresh",
+        ok: true,
+        session,
+      });
+      continue;
+    }
+    if (!apply || dryRun) {
+      results.push({
+        name: session.name,
+        action: "dry-run-skip",
+        ok: true,
+        session,
+      });
+      continue;
+    }
+    try {
+      execFile("tmux", ["kill-session", "-t", session.name], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      results.push({
+        name: session.name,
+        action: "retired",
+        ok: true,
+        session,
+      });
+    } catch (error) {
+      results.push({
+        name: session.name,
+        action: "failed",
+        ok: false,
+        error,
+        session,
+      });
+    }
+  }
+
+  return {
+    dryRun: !apply || dryRun,
+    results,
+    failed: results.filter((result) => result.ok === false).length,
+    retired: results.filter((result) => result.action === "retired").length,
+    skipped: results.filter((result) => result.action === "dry-run-skip")
+      .length,
+    excluded: results.filter((result) => result.action === "excluded-fresh")
+      .length,
+  };
 }
 
 function readTeamSessionCreatedMap() {
@@ -2286,6 +2566,11 @@ async function cmdDoctor(options = {}) {
     cleanupStaleHubs = false,
     cleanupStaleHubsDryRun = true,
     cleanupStaleHubsApply = false,
+    cleanupStaleTmux = false,
+    cleanupStaleTmuxDryRun = true,
+    cleanupStaleTmuxApply = false,
+    cleanupStaleTmuxPrefix = DEFAULT_TMUX_CLEANUP_PREFIX,
+    cleanupStaleTmuxAgeMin = DEFAULT_TMUX_CLEANUP_AGE_MIN,
     json = false,
   } = options;
   const report = {
@@ -2296,6 +2581,13 @@ async function cmdDoctor(options = {}) {
     hook_coverage: { total: 0, registered: 0, missing: [] },
     fsmonitorDaemons: { stale: 0, killed: 0 },
     hubServers: { detached: 0, stale: 0, activeHealthy: null },
+    tmuxSessions: {
+      detached: 0,
+      stale: 0,
+      prefix: cleanupStaleTmuxPrefix,
+      ageMin: cleanupStaleTmuxAgeMin,
+      sessions: [],
+    },
     issue_count: 0,
   };
 
@@ -3583,6 +3875,106 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // 12.5. detached tmux session report and opt-in cleanup
+    section("Detached Tmux Sessions");
+    const detachedTmuxReport = inspectDetachedTmuxSessions({
+      prefix: cleanupStaleTmuxPrefix,
+      ageMin: cleanupStaleTmuxAgeMin,
+    });
+    report.tmuxSessions = {
+      detached: detachedTmuxReport.sessions.length,
+      stale: detachedTmuxReport.staleCandidates.length,
+      prefix: detachedTmuxReport.prefix,
+      ageMin: detachedTmuxReport.ageMin,
+      available: detachedTmuxReport.available,
+      reason: detachedTmuxReport.reason,
+      sessions: detachedTmuxReport.sessions.map((session) => ({
+        name: session.name,
+        age: session.age,
+        age_sec: session.ageSec,
+        cwd: session.cwd,
+        command: session.command,
+        memory_estimate_mb: session.memoryEstimateMb,
+        stale: session.staleCandidate,
+      })),
+    };
+    addDoctorCheck(report, {
+      name: "detached-tmux-sessions",
+      status: !detachedTmuxReport.available
+        ? "skipped"
+        : detachedTmuxReport.staleCandidates.length > 0
+          ? "warning"
+          : "ok",
+      prefix: detachedTmuxReport.prefix,
+      age_min: detachedTmuxReport.ageMin,
+      detached: detachedTmuxReport.sessions.length,
+      stale: detachedTmuxReport.staleCandidates.length,
+      reason: detachedTmuxReport.reason,
+    });
+
+    if (!detachedTmuxReport.available) {
+      info(
+        `tmux 미감지 또는 서버 없음 — detached tmux 검사 건너뜀 (${detachedTmuxReport.reason})`,
+      );
+    } else if (detachedTmuxReport.sessions.length === 0) {
+      ok(`detached tmux session 없음 (prefix=${detachedTmuxReport.prefix})`);
+    } else {
+      info(
+        `prefix=${detachedTmuxReport.prefix} age-min=${detachedTmuxReport.ageMin}분`,
+      );
+      for (const session of detachedTmuxReport.sessions) {
+        const memoryLabel =
+          session.memoryEstimateMb == null
+            ? "?"
+            : `${session.memoryEstimateMb}MB`;
+        const cwdLabel = session.cwd || "?";
+        const commandLabel = session.command || "?";
+        const line = `${session.name}: age=${session.age} cwd=${cwdLabel} command=${commandLabel} memory=${memoryLabel}`;
+        if (session.staleCandidate) warn(`${line} stale`);
+        else ok(`${line} fresh`);
+      }
+    }
+
+    if (cleanupStaleTmux) {
+      const cleanupResult = await cleanupDetachedTmuxSessions({
+        sessions: detachedTmuxReport.sessions,
+        dryRun: cleanupStaleTmuxDryRun,
+        apply: cleanupStaleTmuxApply,
+      });
+      report.actions.push({
+        type: "cleanup-stale-tmux",
+        status: cleanupResult.failed > 0 ? "failed" : "ok",
+        dryRun: cleanupResult.dryRun,
+        retired: cleanupResult.retired,
+        skipped: cleanupResult.skipped,
+        excluded: cleanupResult.excluded,
+        failed: cleanupResult.failed,
+      });
+      for (const result of cleanupResult.results) {
+        if (result.action === "excluded-fresh") {
+          ok(`fresh detached tmux excluded: ${result.name}`);
+        } else if (result.action === "dry-run-skip") {
+          info(`dry-run stale tmux target: ${result.name}`);
+        } else if (result.action === "retired") {
+          ok(`stale tmux session killed: ${result.name}`);
+        } else {
+          fail(`stale tmux cleanup failed: ${result.name}`);
+        }
+      }
+      issues += cleanupResult.failed;
+      if (
+        cleanupResult.dryRun &&
+        detachedTmuxReport.staleCandidates.length > 0
+      ) {
+        issues += detachedTmuxReport.staleCandidates.length;
+      }
+    } else if (detachedTmuxReport.staleCandidates.length > 0) {
+      info(
+        "정리: tfx doctor --cleanup-stale-tmux --prefix tfx-* --dry-run|--apply",
+      );
+      issues += detachedTmuxReport.staleCandidates.length;
+    }
+
     // 13. OMC stale team 상태
     section("OMC Stale Teams");
     const omcTeamReport = inspectStaleOmcTeams({
@@ -3673,6 +4065,8 @@ async function cmdDoctor(options = {}) {
           established: hub.established,
           rssKb: hub.rssKb,
           activeHealthy: hub.activeHealthy,
+          activeReason: hub.activeReason,
+          healthStatus: hub.healthStatus,
           staleCandidate: hub.staleCandidate,
         })),
       };
@@ -3692,9 +4086,9 @@ async function cmdDoctor(options = {}) {
           const versionLabel = hub.version || "unknown";
           const rssLabel = hub.rssKb == null ? "?" : `${hub.rssKb}KB`;
           const activeLabel = hub.activeHealthy
-            ? " active healthy excluded"
+            ? ` healthy excluded${hub.activeReason ? ` (${hub.activeReason})` : ""}`
             : " stale candidate";
-          const line = `PID=${hub.pid} PPID=${hub.ppid} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
+          const line = `PID=${hub.pid} PPID=${hub.ppid} status=${hub.healthStatus} version=${versionLabel} uptime=${hub.uptime} port=${portLabel} ESTABLISHED=${hub.established} RSS=${rssLabel}${activeLabel}`;
           if (hub.activeHealthy) ok(line);
           else warn(line);
         }
@@ -3718,9 +4112,9 @@ async function cmdDoctor(options = {}) {
         });
         for (const result of cleanupResult.results) {
           if (result.action === "excluded-active") {
-            ok(`active healthy hub excluded: PID=${result.pid}`);
+            ok(`dry-run healthy hub excluded: PID=${result.pid}`);
           } else if (result.action === "dry-run-skip") {
-            info(`dry-run skip stale hub: PID=${result.pid}`);
+            info(`dry-run stale hub target: PID=${result.pid}`);
           } else if (result.action === "retired") {
             ok(`stale hub retired: PID=${result.pid} (${result.reason})`);
           } else {
@@ -6430,6 +6824,28 @@ async function cmdHub(args = [], options = {}) {
 
 // ── 메인 ──
 
+function readCliOptionValue(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) return null;
+  return value;
+}
+
+function parsePositiveIntegerOption(args, name, fallback) {
+  const value = readCliOptionValue(args, name);
+  if (value == null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw createCliError(`${name} 값은 0 이상의 정수여야 합니다`, {
+      exitCode: EXIT_ARG_ERROR,
+      reason: "argError",
+      fix: `${name} ${fallback}`,
+    });
+  }
+  return parsed;
+}
+
 async function main() {
   const cmd = NORMALIZED_ARGS[0] || "help";
   const cmdArgs = NORMALIZED_ARGS.slice(1);
@@ -6526,18 +6942,30 @@ async function main() {
       const reset = cmdArgs.includes("--reset");
       const purgeLogs = cmdArgs.includes("--purge-logs");
       const cleanupStaleHubs = cmdArgs.includes("--cleanup-stale-hubs");
+      const cleanupStaleTmux = cmdArgs.includes("--cleanup-stale-tmux");
       const cleanupApply = cmdArgs.includes("--apply");
       const cleanupDryRun = cmdArgs.includes("--dry-run") || !cleanupApply;
-      if (cleanupStaleHubs && cleanupApply && cmdArgs.includes("--dry-run")) {
+      if (
+        (cleanupStaleHubs || cleanupStaleTmux) &&
+        cleanupApply &&
+        cmdArgs.includes("--dry-run")
+      ) {
         throw createCliError(
-          "--cleanup-stale-hubs 에서는 --dry-run 과 --apply 중 하나만 지정하세요",
+          "cleanup 옵션에서는 --dry-run 과 --apply 중 하나만 지정하세요",
           {
             exitCode: EXIT_ARG_ERROR,
             reason: "argError",
-            fix: "tfx doctor --cleanup-stale-hubs --dry-run",
+            fix: "tfx doctor --cleanup-stale-tmux --dry-run",
           },
         );
       }
+      const cleanupStaleTmuxPrefix =
+        readCliOptionValue(cmdArgs, "--prefix") || DEFAULT_TMUX_CLEANUP_PREFIX;
+      const cleanupStaleTmuxAgeMin = parsePositiveIntegerOption(
+        cmdArgs,
+        "--age-min",
+        DEFAULT_TMUX_CLEANUP_AGE_MIN,
+      );
       await cmdDoctor({
         fix,
         reset,
@@ -6545,6 +6973,11 @@ async function main() {
         cleanupStaleHubs,
         cleanupStaleHubsDryRun: cleanupDryRun,
         cleanupStaleHubsApply: cleanupApply,
+        cleanupStaleTmux,
+        cleanupStaleTmuxDryRun: cleanupDryRun,
+        cleanupStaleTmuxApply: cleanupApply,
+        cleanupStaleTmuxPrefix,
+        cleanupStaleTmuxAgeMin,
         json: JSON_OUTPUT,
       });
       return;

--- a/packages/triflux/hooks/session-end-cleanup.mjs
+++ b/packages/triflux/hooks/session-end-cleanup.mjs
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
+
 // hooks/session-end-cleanup.mjs — SessionEnd lifecycle state reporter
 //
 // Report-only by default. Opt-in cleanup only removes the repo-local
 // .triflux/subagents/subagents.json file when stale running lifecycle state is
 // present. It never kills processes or touches external HOME/MCP configs.
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const MARKER = "[session-end-cleanup]";
 const STALE_MS = 30 * 60 * 1000;
 const MAX_OUTPUT_BYTES = 2 * 1024;
+const DEFAULT_TMUX_PREFIX = "tfx-*";
+const MAX_TMUX_REPORT_SESSIONS = 8;
 
 function readStdin() {
   try {
@@ -63,6 +67,140 @@ function agentEntries(state) {
   if (Array.isArray(agents)) return agents;
   if (agents && typeof agents === "object") return Object.values(agents);
   return [];
+}
+
+function compileSimpleGlob(pattern) {
+  const source = String(pattern || DEFAULT_TMUX_PREFIX)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${source}$`);
+}
+
+function formatAge(ageSec) {
+  if (!Number.isFinite(ageSec) || ageSec < 0) return "unknown";
+  if (ageSec < 60) return `${Math.floor(ageSec)}s`;
+  if (ageSec < 3600) return `${Math.floor(ageSec / 60)}m`;
+  if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}h`;
+  return `${Math.floor(ageSec / 86400)}d`;
+}
+
+function parseSessionCreated(rawValue) {
+  const parsed = Number.parseInt(String(rawValue || "").trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseTmuxListSessions(output, nowSec) {
+  const sessions = [];
+  for (const line of String(output || "").split(/\r?\n/)) {
+    const [name, attachedText, createdText] = line.split("\t");
+    if (!name) continue;
+    const attached = Number.parseInt(attachedText || "0", 10);
+    const created = parseSessionCreated(createdText);
+    sessions.push({
+      name,
+      attached: Number.isFinite(attached) ? attached : 0,
+      ageSec: created == null ? null : Math.max(0, nowSec - created),
+    });
+  }
+  return sessions;
+}
+
+function parseFirstPane(output) {
+  const first = String(output || "")
+    .split(/\r?\n/)
+    .find((line) => line.trim());
+  if (!first) return { cwd: null, command: null, pid: null };
+  const [cwd, command, pidText] = first.split("\t");
+  const pid = Number.parseInt(pidText || "", 10);
+  return {
+    cwd: cwd || null,
+    command: command || null,
+    pid: Number.isFinite(pid) && pid > 0 ? pid : null,
+  };
+}
+
+function queryMemoryEstimateMb(pid, execFile = execFileSync) {
+  if (!pid) return null;
+  try {
+    const output = execFile("ps", ["-o", "rss=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 400,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const rssKb = Number.parseInt(String(output || "").trim(), 10);
+    if (!Number.isFinite(rssKb) || rssKb < 0) return null;
+    return Math.round(rssKb / 1024);
+  } catch {
+    return null;
+  }
+}
+
+export function inspectDetachedTmuxSessions({
+  prefix = DEFAULT_TMUX_PREFIX,
+  now = Date.now(),
+  execFile = execFileSync,
+  limit = MAX_TMUX_REPORT_SESSIONS,
+} = {}) {
+  const nowSec = Math.floor(now / 1000);
+  const matcher = compileSimpleGlob(prefix);
+  let output = "";
+  try {
+    output = execFile(
+      "tmux",
+      [
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_attached}\t#{session_created}",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 500,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return { available: false, prefix, sessions: [] };
+  }
+
+  const sessions = [];
+  for (const session of parseTmuxListSessions(output, nowSec)) {
+    if (session.attached !== 0 || !matcher.test(session.name)) continue;
+    let pane = { cwd: null, command: null, pid: null };
+    try {
+      pane = parseFirstPane(
+        execFile(
+          "tmux",
+          [
+            "list-panes",
+            "-t",
+            session.name,
+            "-F",
+            "#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}",
+          ],
+          {
+            encoding: "utf8",
+            timeout: 500,
+            stdio: ["ignore", "pipe", "ignore"],
+            windowsHide: true,
+          },
+        ),
+      );
+    } catch {
+      pane = { cwd: null, command: null, pid: null };
+    }
+    sessions.push({
+      name: session.name,
+      age: formatAge(session.ageSec),
+      cwd: pane.cwd,
+      command: pane.command,
+      memory_estimate_mb: queryMemoryEstimateMb(pane.pid, execFile),
+    });
+    if (sessions.length >= limit) break;
+  }
+
+  return { available: true, prefix, sessions };
 }
 
 export function summarizeLifecycleState(state, now = Date.now()) {
@@ -121,28 +259,31 @@ function pruneStaleRunningAgents(state, now = Date.now()) {
   };
 }
 
-function buildOutput(summary, cleanup) {
-  const context =
+function buildContext(summary, cleanup, tmuxReport) {
+  let context =
     `${MARKER} subagent lifecycle: ` +
     `running=${summary.running} completed=${summary.completed} ` +
     `stale=${summary.stale} total=${summary.total} cleanup=${cleanup}`;
+
+  if (tmuxReport?.sessions?.length > 0) {
+    context += ` detached_tmux_sessions=${JSON.stringify(tmuxReport.sessions)}`;
+  }
+  return context;
+}
+
+function buildOutput(summary, cleanup, tmuxReport) {
+  const context = buildContext(summary, cleanup, tmuxReport);
   const output = {
     systemMessage: context,
-    hookSpecificOutput: {
-      hookEventName: "SessionEnd",
-      additionalContext: context,
-    },
   };
 
   let json = JSON.stringify(output);
   if (Buffer.byteLength(json, "utf8") >= MAX_OUTPUT_BYTES) {
-    const bounded = `${MARKER} subagent lifecycle: running=${summary.running} completed=${summary.completed} stale=${summary.stale} cleanup=${cleanup}`;
+    const bounded = buildContext(summary, cleanup, {
+      sessions: tmuxReport?.sessions?.slice(0, 2) || [],
+    });
     json = JSON.stringify({
       systemMessage: bounded,
-      hookSpecificOutput: {
-        hookEventName: "SessionEnd",
-        additionalContext: bounded,
-      },
     });
   }
   return json;
@@ -160,6 +301,9 @@ export function run(input, env = process.env) {
 
   const summary = summarizeLifecycleState(state);
   let cleanup = "report-only";
+  const tmuxReport = inspectDetachedTmuxSessions({
+    prefix: env.TFX_SESSION_END_TMUX_PREFIX || DEFAULT_TMUX_PREFIX,
+  });
 
   if (env.TFX_SESSION_END_CLEANUP === "1" && summary.stale > 0) {
     try {
@@ -184,7 +328,7 @@ export function run(input, env = process.env) {
     }
   }
 
-  return buildOutput(summary, cleanup);
+  return buildOutput(summary, cleanup, tmuxReport);
 }
 
 function main() {

--- a/packages/triflux/hub/team/session.mjs
+++ b/packages/triflux/hub/team/session.mjs
@@ -135,11 +135,11 @@ export function detectMultiplexer() {
     _cachedMux = "tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasGitBashTmux()) {
+  if (hasGitBashTmux()) {
     _cachedMux = "git-bash-tmux";
     return _cachedMux;
   }
-  if (process.platform === "win32" && hasWslTmux()) {
+  if (hasWslTmux()) {
     _cachedMux = "wsl-tmux";
     return _cachedMux;
   }

--- a/packages/triflux/hub/team/terminal-opener.mjs
+++ b/packages/triflux/hub/team/terminal-opener.mjs
@@ -1,4 +1,4 @@
-import { exec as defaultExec, execFileSync } from "node:child_process";
+import { exec as defaultExec, spawnSync } from "node:child_process";
 import { platform as osPlatform } from "node:os";
 import { psmuxExec as defaultPsmuxExec } from "./psmux.mjs";
 import { tmuxExec as defaultTmuxExec, detectMultiplexer } from "./session.mjs";
@@ -68,15 +68,27 @@ function shellCommandName(value) {
   return /^[A-Za-z0-9_./:-]+$/u.test(command) ? command : shellQuote(command);
 }
 
+function powershellCommandName(value) {
+  const command = String(value);
+  return /^[A-Za-z0-9_.:-]+$/u.test(command)
+    ? command
+    : `& ${powershellSingleQuote(command)}`;
+}
+
+function getCommandVersion(command) {
+  const r = spawnSync(command, ["-V"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if ((r.status ?? 1) !== 0) return null;
+  return `${r.stdout || ""}${r.stderr || ""}`.trim();
+}
+
 function defaultPsmuxBinaryExists(command) {
   try {
-    const output = execFileSync(command, ["-V"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 3000,
-      windowsHide: true,
-    });
-    return /\bpsmux\b/i.test(String(output || ""));
+    return /\bpsmux\b/i.test(getCommandVersion(command) || "");
   } catch {
     return false;
   }
@@ -139,12 +151,18 @@ export function createTerminalOpener(deps = {}) {
 
   async function openSession(sessionName, opts = {}) {
     if (platform === "win32") {
+      const command = process.env.PSMUX_BIN || "psmux";
+      const psmuxBinaryExists =
+        deps.psmuxBinaryExists || defaultPsmuxBinaryExists;
+      if (!psmuxBinaryExists(command)) return false;
       const wt = createWtManager();
       try {
         return wtResultSucceeded(
           await wt.createTab({
             title: sanitizeTerminalTitle(opts.title ?? sessionName),
-            command: `psmux attach-session -t ${powershellSingleQuote(sessionName)}`,
+            command: `${powershellCommandName(
+              command,
+            )} attach-session -t ${powershellSingleQuote(sessionName)}`,
             cwd: opts.cwd,
             profile: opts.profile ?? "triflux",
           }),

--- a/tests/unit/doctor-cleanup-stale-hubs.test.mjs
+++ b/tests/unit/doctor-cleanup-stale-hubs.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  cleanupDetachedHubProcesses,
+  inspectDetachedHubProcesses,
+} from "../../bin/triflux.mjs";
+
+function psRows(pids) {
+  return pids
+    .map(
+      (pid) =>
+        `${pid} 1 12000 01:00:00 node /repo/packages/triflux/hub/server.mjs`,
+    )
+    .join("\n");
+}
+
+function lsofEstablished(count) {
+  return [
+    "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME",
+    ...Array.from(
+      { length: count },
+      (_, index) =>
+        `node ${9000 + index} user 10u IPv4 0t0 TCP 127.0.0.1:27888->127.0.0.1:${50000 + index} (ESTABLISHED)`,
+    ),
+  ].join("\n");
+}
+
+function mockExecFile({ pids, establishedByPid }) {
+  return (file, args = []) => {
+    if (file === "ps" && args[0] === "-axo") return psRows(pids);
+    if (file === "lsof" && args.includes("-sTCP:ESTABLISHED")) {
+      const pid = Number(args[args.indexOf("-p") + 1]);
+      return lsofEstablished(establishedByPid[pid] || 0);
+    }
+    if (file === "lsof" && args.includes("-sTCP:LISTEN")) return "";
+    if (
+      file === "lsof" &&
+      args.some((arg) => String(arg).startsWith("-iTCP:"))
+    ) {
+      return "";
+    }
+    throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+  };
+}
+
+async function inspect({ pids, establishedByPid }) {
+  return inspectDetachedHubProcesses({
+    expectedVersion: "test-version",
+    exists: () => false,
+    platform: "darwin",
+    execFile: mockExecFile({ pids, establishedByPid }),
+    fetchImpl: async () => ({ ok: false }),
+  });
+}
+
+describe("doctor cleanup-stale-hubs active hub guard", () => {
+  it("marks stale hub only with ESTABLISHED=0 as a cleanup candidate", async () => {
+    const report = await inspect({
+      pids: [101],
+      establishedByPid: { 101: 0 },
+    });
+
+    assert.deepEqual(
+      report.staleCandidates.map((hub) => hub.pid),
+      [101],
+    );
+    assert.equal(report.hubs[0].activeHealthy, false);
+    assert.equal(report.hubs[0].healthStatus, "stale");
+  });
+
+  it("excludes active healthy hub with ESTABLISHED>=1 from cleanup candidates", async () => {
+    const report = await inspect({
+      pids: [84365],
+      establishedByPid: { 84365: 2 },
+    });
+
+    assert.deepEqual(report.staleCandidates, []);
+    assert.equal(report.hubs[0].activeHealthy, true);
+    assert.equal(report.hubs[0].healthStatus, "healthy");
+    assert.equal(report.hubs[0].activeReason, "established-connection");
+  });
+
+  it("cleans up only stale hubs and preserves healthy hubs in mixed reports", async () => {
+    const report = await inspect({
+      pids: [201, 202, 203],
+      establishedByPid: { 201: 0, 202: 1, 203: 0 },
+    });
+
+    assert.deepEqual(
+      report.staleCandidates.map((hub) => hub.pid),
+      [201, 203],
+    );
+
+    const signaled = [];
+    const alive = new Set([201, 203]);
+    const cleanup = await cleanupDetachedHubProcesses({
+      hubs: report.hubs,
+      dryRun: false,
+      apply: true,
+      graceMs: 0,
+      pollMs: 0,
+      killFn(pid, signal) {
+        if (signal === 0) {
+          if (alive.has(pid)) return;
+          const error = new Error("not alive");
+          error.code = "ESRCH";
+          throw error;
+        }
+        signaled.push([pid, signal]);
+        alive.delete(pid);
+      },
+    });
+
+    assert.equal(cleanup.excluded, 1);
+    assert.equal(cleanup.retired, 2);
+    assert.deepEqual(
+      cleanup.results.map((entry) => [
+        entry.pid,
+        entry.classification,
+        entry.action,
+      ]),
+      [
+        [201, "stale", "retired"],
+        [202, "healthy", "excluded-active"],
+        [203, "stale", "retired"],
+      ],
+    );
+    assert.deepEqual(signaled, [
+      [201, "SIGTERM"],
+      [203, "SIGTERM"],
+    ]);
+  });
+});

--- a/tests/unit/session-end-cleanup.test.mjs
+++ b/tests/unit/session-end-cleanup.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -35,6 +36,11 @@ function writeState(root, state) {
   );
 }
 
+function writeExecutable(path, content) {
+  writeFileSync(path, content, "utf8");
+  chmodSync(path, 0o755);
+}
+
 describe("session-end-cleanup hook", () => {
   let root;
 
@@ -64,7 +70,7 @@ describe("session-end-cleanup hook", () => {
     assert.equal(result.status, 0);
     assert.match(result.stdout, /\[session-end-cleanup\]/);
     const out = JSON.parse(result.stdout);
-    const context = out.hookSpecificOutput.additionalContext;
+    const context = out.systemMessage;
     assert.match(context, /running=1/);
     assert.match(context, /completed=1/);
     assert.match(context, /stale=1/);
@@ -73,6 +79,78 @@ describe("session-end-cleanup hook", () => {
       existsSync(join(root, ".triflux", "subagents", "subagents.json")),
       true,
     );
+  });
+
+  it("emits SessionEnd-compatible structured JSON without event-specific output", () => {
+    writeState(root, {
+      agents: {
+        running: { startedAt: new Date().toISOString() },
+      },
+    });
+
+    const result = run(
+      { hook_event_name: "SessionEnd", session_id: "s1", reason: "other" },
+      root,
+    );
+
+    assert.equal(result.status, 0);
+    const out = JSON.parse(result.stdout);
+    assert.equal(typeof out.systemMessage, "string");
+    assert.equal(out.hookSpecificOutput, undefined);
+    assert.equal(out.decision, undefined);
+    assert.equal(out.reason, undefined);
+  });
+
+  it("reports detached tmux session age, cwd, command, and memory estimate", () => {
+    writeState(root, {
+      agents: {
+        running: { startedAt: new Date().toISOString() },
+      },
+    });
+    const fakeBin = join(root, "fake-bin");
+    mkdirSync(fakeBin, { recursive: true });
+    writeExecutable(
+      join(fakeBin, "tmux"),
+      `#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  printf 'tfx-old\\t0\\t%d\\n' $(($(date +%s) - 7200))
+  exit 0
+fi
+if [ "$1" = "list-panes" ]; then
+  printf '%s\\tnode\\t4242\\n' '${root}'
+  exit 0
+fi
+exit 1
+`,
+    );
+    writeExecutable(
+      join(fakeBin, "ps"),
+      `#!/bin/sh
+if [ "$1" = "-o" ] && [ "$2" = "rss=" ]; then
+  printf '65536\\n'
+  exit 0
+fi
+exit 1
+`,
+    );
+
+    const result = run(
+      { hook_event_name: "SessionEnd", session_id: "s1", reason: "other" },
+      root,
+      { PATH: `${fakeBin}:${process.env.PATH}` },
+    );
+
+    assert.equal(result.status, 0);
+    const out = JSON.parse(result.stdout);
+    const match = out.systemMessage.match(/detached_tmux_sessions=(\[.*\])$/);
+    assert.ok(match, out.systemMessage);
+    const sessions = JSON.parse(match[1]);
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].name, "tfx-old");
+    assert.ok(sessions[0].age);
+    assert.equal(sessions[0].cwd, root);
+    assert.equal(sessions[0].command, "node");
+    assert.equal(sessions[0].memory_estimate_mb, 64);
   });
 
   it("deletes stale lifecycle files only when opt-in cleanup is enabled", () => {

--- a/tests/unit/terminal-opener.test.mjs
+++ b/tests/unit/terminal-opener.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
@@ -28,6 +31,85 @@ describe("terminal-opener helpers", () => {
 });
 
 describe("terminal-opener adapter", () => {
+  it("detects psmux when version output is written to stdout only", async () => {
+    const binDir = mkdtempSync(join(tmpdir(), "triflux-psmux-stdout-"));
+    const psmuxPath = join(binDir, "psmux");
+    writeFileSync(psmuxPath, "#!/bin/sh\nprintf 'psmux 1.2.3\\n'\n");
+    chmodSync(psmuxPath, 0o755);
+
+    const previousPath = process.env.PATH;
+    const previousPsmuxBin = process.env.PSMUX_BIN;
+    process.env.PATH = `${binDir}:${previousPath || ""}`;
+    delete process.env.PSMUX_BIN;
+
+    try {
+      const calls = [];
+      const opener = createTerminalOpener({
+        platform: "darwin",
+        mux: "psmux",
+        tmuxExec: (command) => calls.push(command),
+      });
+
+      assert.equal(await opener.openSession("demo"), true);
+      assert.match(calls[0], /psmux attach-session -t/);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousPsmuxBin === undefined) {
+        delete process.env.PSMUX_BIN;
+      } else {
+        process.env.PSMUX_BIN = previousPsmuxBin;
+      }
+    }
+  });
+
+  it("detects psmux when version output is written to stderr only", async () => {
+    const binDir = mkdtempSync(join(tmpdir(), "triflux-psmux-stderr-"));
+    const psmuxPath = join(binDir, "psmux");
+    writeFileSync(psmuxPath, "#!/bin/sh\nprintf 'psmux 1.2.3\\n' >&2\n");
+    chmodSync(psmuxPath, 0o755);
+
+    const previousPath = process.env.PATH;
+    const previousPsmuxBin = process.env.PSMUX_BIN;
+    process.env.PATH = `${binDir}:${previousPath || ""}`;
+    delete process.env.PSMUX_BIN;
+
+    try {
+      const calls = [];
+      const opener = createTerminalOpener({
+        platform: "darwin",
+        mux: "psmux",
+        tmuxExec: (command) => calls.push(command),
+      });
+
+      assert.equal(await opener.openSession("demo"), true);
+      assert.match(calls[0], /psmux attach-session -t/);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousPsmuxBin === undefined) {
+        delete process.env.PSMUX_BIN;
+      } else {
+        process.env.PSMUX_BIN = previousPsmuxBin;
+      }
+    }
+  });
+
+  it("session multiplexer detection removes redundant nested win32 guards only", () => {
+    const source = readFileSync("hub/team/session.mjs", "utf8");
+
+    assert.doesNotMatch(
+      source,
+      /process\.platform === "win32" && hasGitBashTmux\(\)/,
+    );
+    assert.doesNotMatch(
+      source,
+      /process\.platform === "win32" && hasWslTmux\(\)/,
+    );
+    assert.match(
+      source,
+      /return process\.platform === "win32" && !!process\.env\.WT_SESSION;/,
+    );
+  });
+
   it("Windows openCommand uses wt-manager createTab with original command and cwd", async () => {
     const calls = [];
     const opener = createTerminalOpener({
@@ -84,6 +166,7 @@ describe("terminal-opener adapter", () => {
     const calls = [];
     const opener = createTerminalOpener({
       platform: "win32",
+      psmuxBinaryExists: () => true,
       createWtManager: () => ({
         createTab: async (spec) => {
           calls.push(spec);
@@ -113,6 +196,7 @@ describe("terminal-opener adapter", () => {
   it("Windows openSession reports wt-manager failures", async () => {
     const opener = createTerminalOpener({
       platform: "win32",
+      psmuxBinaryExists: () => true,
       createWtManager: () => ({
         createTab: async () => ({ success: false, reason: "wt-not-installed" }),
       }),
@@ -124,6 +208,7 @@ describe("terminal-opener adapter", () => {
   it("Windows openSession reports thrown wt-manager failures", async () => {
     const opener = createTerminalOpener({
       platform: "win32",
+      psmuxBinaryExists: () => true,
       createWtManager: () => ({
         createTab: async () => {
           throw new Error("WT tab ready timeout: demo");
@@ -132,6 +217,22 @@ describe("terminal-opener adapter", () => {
     });
 
     assert.equal(await opener.openSession("demo"), false);
+  });
+
+  it("Windows openSession refuses to create a psmux attach tab when psmux is absent", async () => {
+    const calls = [];
+    const opener = createTerminalOpener({
+      platform: "win32",
+      psmuxBinaryExists: () => false,
+      createWtManager: () => ({
+        createTab: async (spec) => {
+          calls.push(spec);
+        },
+      }),
+    });
+
+    assert.equal(await opener.openSession("demo"), false);
+    assert.deepEqual(calls, []);
   });
 
   it("macOS tmux openCommand calls tmuxExec new-window and includes command", async () => {
@@ -304,6 +405,7 @@ describe("terminal-opener adapter", () => {
   it("Windows wt-manager null return is treated as success", async () => {
     const opener = createTerminalOpener({
       platform: "win32",
+      psmuxBinaryExists: () => true,
       createWtManager: () => ({
         createTab: async () => null,
       }),


### PR DESCRIPTION
## Summary

macos-lifecycle ultrareview verified follow-up 3건 통합 fix (tfx-swarm 격리 worker codex 작성).

### Issue #277 — dead win32 guards 제거

- `hub/team/session.mjs` 의 nested `process.platform === "win32" &&` redundant prefix 제거 (Windows-only branch 안에서 평가 의미 없음)
- platform-specific 실제 분기는 보존

### Issue #278 — defaultPsmuxBinaryExists stderr asymmetry

- `hub/team/terminal-opener.mjs::defaultPsmuxBinaryExists` 가 stderr-only 응답 누락 케이스 → `getCommandVersion` 패턴 (spawnSync + stdout+stderr concat 검사) 으로 통일

### Issue #279 — Windows openSession symmetric binary check

- `hub/team/terminal-opener.mjs` Windows openSession 분기에 symmetric `psmuxBinaryExists` 가드 추가 — wt-manager attach 전 psmux 존재 검증
- POSIX 분기와 동일 패턴

### Stacked PR 주의

이 PR 은 `fix/macos-s4-doctor-fix` (PR #284, dad8243a) 위에 stacked. PR #284 먼저 머지 → 이 PR 은 main 위 1 commit (47c24895 동등) 으로 자연 정렬.

### Files (4-layer mirror)

- `hub/team/session.mjs` + `packages/core` + `packages/triflux` byte-identical mirror, `packages/remote` Edit only (`@triflux/core` import 보존)
- `hub/team/terminal-opener.mjs` 동일 4-layer mirror
- `tests/unit/terminal-opener.test.mjs` 확장 (3 issue 회귀 가드)

## Test plan

- [x] `node --test tests/unit/terminal-opener.test.mjs` (회귀 가드 3 case)
- [x] `npm run release:check-mirror` (4-layer 정합)
- [x] `grep "@triflux/core/" packages/remote/hub/team/{session,terminal-opener}.mjs` non-empty (import 보존)
- [ ] CI: `npm test` + lint
- [ ] Windows test: 별도 (현재 macOS host 라 darwin 회귀 가드만 검증)

## Audit source

macos-lifecycle ultrareview verified follow-up 3건 (Issue #277/#278/#279) + tfx-swarm 격리 worker (codex 5.3-codex) 산출물. AI trailer / Co-Authored-By 없음.