### PR TITLE
docs(plans): Issue #281 auto router swarm dispatch PRD bundle

### DIFF
--- a/.triflux/plans/issue-281-auto-router-swarm-dispatch.md
+++ b/.triflux/plans/issue-281-auto-router-swarm-dispatch.md
@@ -1,0 +1,76 @@
+# Issue #281 — auto router 코드 변경 자동 swarm dispatch (#87 격상)
+
+> Source: https://github.com/tellang/triflux/issues/281
+> Label: routing, tier:high
+> Audit origin: tfx-harness 라우팅 점검 (2026-05-19) D2 (High severity)
+> SSOT 갭 라인: `.claude/rules/tfx-execution-skill-map.md` L44/L49/L64
+> Closes: #87, #281
+> Worktree branch (per shard): `feat/issue-281-shard-{a,b,c}-*`
+
+## 목표
+
+`tfx-auto` 가 staged + unstaged + untracked 변경 파일 카운트로 코드 변경 자동 감지 → 2+ 태스크 + 코드 변경 ≥ 1건 시 자동 swarm dispatch 로 escalate. 사용자 명시 `--parallel N` override 시 warning 후 사용자 결정 존중.
+
+## 회귀 테스트 3 case (필수 — Issue #281 body 명시)
+
+| case | 입력 | 기대 dispatch |
+|------|------|--------------|
+| 1 | 코드 변경 0건 + 2+ 태스크 | multi |
+| 2 | 코드 변경 ≥ 1건 + 2+ 태스크 | swarm 자동 escalate |
+| 3 | `--parallel N` 명시 + 코드 변경 | warning + 사용자 결정 존중 |
+
+## Shard 분할
+
+| shard | 범위 | 의존 | worktree branch |
+|-------|------|------|-----------------|
+| A | `hub/lib/staged-file-detect.mjs` (helper) + `tests/unit/staged-file-detect.test.mjs` | — | `feat/issue-281-shard-a-staged-file-detect` |
+| B | `hub/lib/tfx-route-args.mjs` + `bin/triflux.mjs` + `scripts/tfx-route.sh` 자동 escalate 로직 | A | `feat/issue-281-shard-b-router-escalate` |
+| C | `tests/integration/tfx-auto-routing.test.mjs` (3 case) + SSOT docs (`.claude/rules/tfx-{routing,execution-skill-map}.md`) + 4-layer mirror 검증 | A, B | `feat/issue-281-shard-c-integration-ssot-mirror` |
+
+## 4-layer mirror 정책 (`.claude/rules/tfx-mirror-policy.md`)
+
+| 레이어 | 대상 | 방식 |
+|--------|------|------|
+| root | 위 모든 파일 (helper / route-args / triflux.mjs / tfx-route.sh / docs) | direct |
+| `packages/core/hub/lib/` | `staged-file-detect.mjs`, `tfx-route-args.mjs` | byte-identical cp |
+| `packages/triflux/hub/lib/`, `bin/`, `scripts/` | root 파일 mirror | byte-identical cp |
+| `packages/remote/` | 영향 없음 (auto router 는 `@triflux/core` 의존) | mirror 제외 |
+
+검증: `diff -q` exit 0 + `npm pack --dry-run` size ~1MB
+
+## 위치 매핑 (확정 — 2026-05-19 /tfx-find 결과)
+
+| 분류 | 파일 | 비고 |
+|------|------|------|
+| 수정 | `bin/triflux.mjs` (7272 lines) | tfx-auto JS 라우터 표면 |
+| 수정 | `hub/lib/tfx-route-args.mjs` | `--parallel` 인자 파싱 핵심 진입점 |
+| 수정 | `scripts/tfx-route.sh` (L789 `auto_reroute()`, L1209 `auto)` 분기) | shell 라우팅 layer |
+| 신규 | `hub/lib/staged-file-detect.mjs` | git diff/ls-files 카운트 helper |
+| 신규 | `tests/integration/tfx-auto-routing.test.mjs` | 3 case 회귀 가드 |
+| 수정 | `.claude/rules/tfx-execution-skill-map.md` L44/L49/L64 | MANDATORY 라인 → 자동 dispatch 정식화 톤 |
+
+참조 모델 (기존 git 감지 로직 위치): `hub/team/worktree-lifecycle.mjs`, `hub/team/swarm-hypervisor.mjs`, `hub/team/codex-review.mjs`, `hub/team/headless.mjs`, `scripts/lib/handoff.mjs`
+
+## Cross-review (`CLAUDE.md` 교차 검증)
+
+- Claude 작성 부분 → Codex 리뷰
+- Codex 작성 부분 → Claude 리뷰
+- 동일 모델 self-approve 금지
+- git commit 전 미검증 파일 감지 시 nudge
+
+## 영향
+
+- cwd 공유 race 사고 회피 (PR #72 패턴 재발 방지)
+- SSOT-구현 정합 회복 (현재 L44/L49/L64 갭 closed)
+- 사용자가 매번 명시 플래그 안 적어도 안전
+- Issue #87 + #281 close
+- v10.23.1 patch 또는 v10.24.0 release 진입 가능 (사용자 결정)
+
+## CLI 정책
+
+본 작업은 라우터 핵심 로직 변경 = code-touching lane → Codex default (`.claude/rules/tfx-routing.md` "CLI 우선순위 정책 — default = Codex"). 진입 명령:
+
+```
+/tfx-auto --parallel swarm --isolation worktree --cli codex --max-iterations 0 \
+  "Issue #281 — PRD: .triflux/plans/issue-281-auto-router-swarm-dispatch.md"
+```

--- a/.triflux/plans/issue-281-shard-a-staged-file-detect.md
+++ b/.triflux/plans/issue-281-shard-a-staged-file-detect.md
@@ -1,0 +1,106 @@
+# Shard A — staged-file-detect helper + 단위 테스트
+
+> Index: [issue-281-auto-router-swarm-dispatch.md](./issue-281-auto-router-swarm-dispatch.md)
+> Worktree branch: `feat/issue-281-shard-a-staged-file-detect`
+> CLI: Codex (default per `.claude/rules/tfx-routing.md`)
+> 의존: 없음 (가장 먼저 진입)
+
+## 신규 파일 1: `hub/lib/staged-file-detect.mjs`
+
+```javascript
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Detect code change files via git in cwd.
+ * Counts staged + unstaged + untracked separately and deduplicates.
+ * Gracefully returns 0 counts when cwd is not a git repo or git fails.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.cwd] - working directory (default: process.cwd())
+ * @param {boolean} [opts.includeStaged=true]
+ * @param {boolean} [opts.includeUnstaged=true]
+ * @param {boolean} [opts.includeUntracked=true]
+ * @returns {{
+ *   stagedCount: number,
+ *   unstagedCount: number,
+ *   untrackedCount: number,
+ *   totalChanged: number,
+ *   files: string[]
+ * }}
+ */
+export function detectChangedFiles({
+  cwd = process.cwd(),
+  includeStaged = true,
+  includeUnstaged = true,
+  includeUntracked = true,
+} = {}) {
+  const run = (args) => {
+    try {
+      return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+        .split('\n')
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+  const staged = includeStaged ? run(['diff', '--cached', '--name-only']) : [];
+  const unstaged = includeUnstaged ? run(['diff', '--name-only']) : [];
+  const untracked = includeUntracked ? run(['ls-files', '--others', '--exclude-standard']) : [];
+  const all = [...new Set([...staged, ...unstaged, ...untracked])];
+  return {
+    stagedCount: staged.length,
+    unstagedCount: unstaged.length,
+    untrackedCount: untracked.length,
+    totalChanged: all.length,
+    files: all,
+  };
+}
+
+/**
+ * Convenience: true when any tracked or untracked file changed in cwd.
+ */
+export function hasCodeChange(opts) {
+  return detectChangedFiles(opts).totalChanged > 0;
+}
+```
+
+## 신규 파일 2: `tests/unit/staged-file-detect.test.mjs`
+
+테스트 케이스 (각 case 는 mkdtemp + git init 으로 격리):
+
+1. **empty clean repo** → `totalChanged === 0`
+2. **staged file 1개** (write + `git add`) → `stagedCount === 1`, `totalChanged === 1`
+3. **unstaged + untracked 혼합** (tracked 파일 modify + new file) → `unstagedCount ≥ 1`, `untrackedCount ≥ 1`, `totalChanged === stagedCount + unstagedCount + untrackedCount` (중복 없을 때)
+4. **non-git cwd** (`/tmp` plain dir) → `totalChanged === 0` (graceful)
+5. **includeStaged: false** → staged 항목 카운트 제외
+6. **중복 파일** (같은 파일을 stage 후 또 modify) → 1번만 카운트 (Set 중복 제거)
+
+테스트 프레임워크: vitest (다른 `tests/unit/*.test.mjs` 참조)
+
+## 4-layer mirror (`.claude/rules/tfx-mirror-policy.md`)
+
+| 파일 | mirror 위치 | 방식 |
+|------|------------|------|
+| `hub/lib/staged-file-detect.mjs` | `packages/core/hub/lib/staged-file-detect.mjs` | byte-identical cp |
+| `hub/lib/staged-file-detect.mjs` | `packages/triflux/hub/lib/staged-file-detect.mjs` | byte-identical cp |
+| `tests/unit/staged-file-detect.test.mjs` | mirror 제외 (tests/ npm files 미포함) | — |
+
+검증:
+```bash
+diff -q hub/lib/staged-file-detect.mjs packages/core/hub/lib/staged-file-detect.mjs
+diff -q hub/lib/staged-file-detect.mjs packages/triflux/hub/lib/staged-file-detect.mjs
+```
+
+## Acceptance
+
+- [ ] `detectChangedFiles()` + `hasCodeChange()` 두 함수 export
+- [ ] 단위 테스트 6 case 통과 (`npm test -- staged-file-detect`)
+- [ ] packages/core + packages/triflux mirror byte-identical (diff -q exit 0)
+- [ ] non-git cwd 에서 graceful (throw 없음)
+- [ ] lint clean (`npm run lint`)
+
+## 안티패턴 회피
+
+- `git status --porcelain` 사용 금지 — staged/unstaged/untracked 구분이 모호 (XY 코드 파싱 필요)
+- 동기 execFileSync 사용 (router 진입점에서 호출, async overhead 회피)
+- shell injection 방지 — execFileSync(args[]) 형식 사용 (execSync(string) 금지)

--- a/.triflux/plans/issue-281-shard-b-router-escalate.md
+++ b/.triflux/plans/issue-281-shard-b-router-escalate.md
@@ -1,0 +1,194 @@
+# Shard B — router auto-escalate 로직
+
+> Index: [issue-281-auto-router-swarm-dispatch.md](./issue-281-auto-router-swarm-dispatch.md)
+> Worktree branch: `feat/issue-281-shard-b-router-escalate`
+> CLI: Codex
+> 의존: Shard A 의 `hub/lib/staged-file-detect.mjs` (import)
+
+## 진입 전 grep 필수
+
+shard 진입 첫 행위 — 기존 인자 파싱 구조 확인:
+
+```bash
+grep -n "parallel\|isolation\|tasks" hub/lib/tfx-route-args.mjs | head -30
+grep -n "tfx-auto\|--parallel\|dispatch" bin/triflux.mjs | head -30
+grep -n "auto_reroute\|auto)" scripts/tfx-route.sh | head -20
+```
+
+## 수정 파일 1: `hub/lib/tfx-route-args.mjs`
+
+신규 함수 `decideDispatchMode(args, opts)` 추가:
+
+```javascript
+import { hasCodeChange } from './staged-file-detect.mjs';
+
+/**
+ * Decide dispatch mode based on parsed args + cwd git state.
+ *
+ * Issue #281 — auto router 코드 변경 자동 swarm dispatch.
+ *
+ * @param {object} args - parseRouteArgs() result (existing shape)
+ *   - tasks: string[] (or count)
+ *   - parallel: number | 'swarm' | null
+ *   - isolation: 'worktree' | null
+ *   - cli: 'codex' | 'claude' | 'gemini' | null
+ * @param {object} [opts]
+ * @param {string} [opts.cwd]
+ * @param {Function} [opts.detector] - injectable hasCodeChange (test seam)
+ * @returns {{
+ *   mode: 'single' | 'multi' | 'swarm',
+ *   escalated: boolean,
+ *   warning: string | null,
+ *   reason: string,
+ * }}
+ */
+export function decideDispatchMode(args, { cwd = process.cwd(), detector = hasCodeChange } = {}) {
+  const tasksCount = Array.isArray(args.tasks) ? args.tasks.length : (args.tasks ?? 0);
+  const hasUserParallel = args.parallel != null && args.parallel !== 'swarm';
+  const hasUserSwarm = args.parallel === 'swarm' || args.isolation === 'worktree';
+  const codeChanged = detector({ cwd });
+
+  // 사용자 명시 swarm → 그대로
+  if (hasUserSwarm) {
+    return { mode: 'swarm', escalated: false, warning: null, reason: 'user-explicit-swarm' };
+  }
+
+  // case 3: 사용자 --parallel N 명시 + 코드 변경 → warning + 사용자 결정 존중
+  if (hasUserParallel && codeChanged) {
+    return {
+      mode: 'multi',
+      escalated: false,
+      warning: `[tfx-auto] WARNING: 코드 변경 감지 (cwd race 위험). --parallel swarm --isolation worktree 권장. 사용자 명시 --parallel=${args.parallel} 존중하여 multi 로 진행.`,
+      reason: 'user-explicit-multi-with-code-change',
+    };
+  }
+
+  // case 2: 2+ 태스크 + 코드 변경 → swarm 자동 escalate
+  if (tasksCount >= 2 && codeChanged) {
+    return {
+      mode: 'swarm',
+      escalated: true,
+      warning: `[tfx-auto] 코드 변경 ${tasksCount}건 태스크 + dirty cwd 감지. swarm dispatch 자동 escalate (--parallel swarm --isolation worktree). Issue #281.`,
+      reason: 'auto-escalate-code-change',
+    };
+  }
+
+  // case 1: 2+ 태스크 + 코드 변경 0건 → multi
+  if (tasksCount >= 2 || hasUserParallel) {
+    return { mode: 'multi', escalated: false, warning: null, reason: 'multi-no-code-change' };
+  }
+
+  // 1 task → single
+  return { mode: 'single', escalated: false, warning: null, reason: 'single-task' };
+}
+```
+
+기존 `parseRouteArgs()` 와 export 충돌 없는지 확인 후 추가.
+
+## 수정 파일 2: `bin/triflux.mjs`
+
+tfx-auto dispatch 분기 (정확 위치는 진입 후 grep `tfx-auto` 로 확인):
+
+```javascript
+import { decideDispatchMode } from '../hub/lib/tfx-route-args.mjs';
+
+// 기존 dispatch 분기 직전에 추가:
+const decision = decideDispatchMode(parsedArgs);
+if (decision.warning) {
+  process.stderr.write(`${decision.warning}\n`);
+}
+if (decision.escalated) {
+  // telemetry: .omc/state/auto-escalation.log append
+  const logLine = JSON.stringify({
+    at: new Date().toISOString(),
+    issue: 281,
+    from: 'multi',
+    to: 'swarm',
+    tasksCount: parsedArgs.tasks?.length,
+    reason: decision.reason,
+  }) + '\n';
+  try {
+    await fs.promises.appendFile('.omc/state/auto-escalation.log', logLine);
+  } catch { /* dir may not exist on fresh checkout; ignore */ }
+}
+// dispatch by decision.mode → single | multi | swarm
+```
+
+## 수정 파일 3: `scripts/tfx-route.sh`
+
+shell layer 의 `auto)` 분기 (L1209 근처) 와 `auto_reroute()` (L789 근처) 도 일관성 유지. node entry (`bin/triflux.mjs`) 가 최종 decision 을 내리므로 shell layer 는 인자 normalize 만 담당하고 escalation 은 JS 에 위임 (single source of truth).
+
+추가 변경: `auto)` 분기 docstring 갱신 — "Issue #281: auto router 가 코드 변경 감지 후 swarm escalate. shell layer 는 transparent passthrough."
+
+## 단위 테스트 확장: `tests/unit/tfx-route-args.test.mjs`
+
+`decideDispatchMode` 5 case (injectable detector 로 외부 git 의존 격리):
+
+```javascript
+import { decideDispatchMode } from '../../hub/lib/tfx-route-args.mjs';
+
+const noChange = () => false;
+const withChange = () => true;
+
+test('case 0: 1 task → single', () => {
+  expect(decideDispatchMode({ tasks: ['t1'] }, { detector: noChange }).mode).toBe('single');
+});
+
+test('case 1: 2+ tasks + 코드 변경 0건 → multi', () => {
+  const r = decideDispatchMode({ tasks: ['t1', 't2'] }, { detector: noChange });
+  expect(r.mode).toBe('multi');
+  expect(r.escalated).toBe(false);
+});
+
+test('case 2: 2+ tasks + 코드 변경 → swarm auto-escalate', () => {
+  const r = decideDispatchMode({ tasks: ['t1', 't2'] }, { detector: withChange });
+  expect(r.mode).toBe('swarm');
+  expect(r.escalated).toBe(true);
+  expect(r.warning).toMatch(/자동 escalate/);
+});
+
+test('case 3: --parallel N 명시 + 코드 변경 → multi + warning', () => {
+  const r = decideDispatchMode({ tasks: ['t1', 't2'], parallel: 3 }, { detector: withChange });
+  expect(r.mode).toBe('multi');
+  expect(r.escalated).toBe(false);
+  expect(r.warning).toMatch(/WARNING: 코드 변경/);
+});
+
+test('user-explicit swarm 그대로', () => {
+  const r = decideDispatchMode({ tasks: ['t1', 't2'], parallel: 'swarm', isolation: 'worktree' }, { detector: withChange });
+  expect(r.mode).toBe('swarm');
+  expect(r.escalated).toBe(false);
+});
+```
+
+## 4-layer mirror
+
+| 파일 | mirror 위치 | 방식 |
+|------|------------|------|
+| `hub/lib/tfx-route-args.mjs` | `packages/core/hub/lib/`, `packages/triflux/hub/lib/` | byte-identical cp |
+| `bin/triflux.mjs` | `packages/triflux/bin/` | byte-identical cp |
+| `scripts/tfx-route.sh` | `packages/triflux/scripts/` | byte-identical cp |
+| `tests/unit/tfx-route-args.test.mjs` | mirror 제외 | — |
+
+검증:
+```bash
+for f in hub/lib/tfx-route-args.mjs bin/triflux.mjs scripts/tfx-route.sh; do
+  diff -q "$f" "packages/triflux/$f" || echo "DRIFT: $f"
+done
+diff -q hub/lib/tfx-route-args.mjs packages/core/hub/lib/tfx-route-args.mjs
+```
+
+## Acceptance
+
+- [ ] `decideDispatchMode` 함수 export + 5 case 단위 테스트 통과
+- [ ] tfx-auto 진입 시 warning 메시지 stderr 출력
+- [ ] escalation 발생 시 `.omc/state/auto-escalation.log` append (디렉토리 없으면 graceful skip)
+- [ ] shell layer `auto)` 분기 docstring 갱신
+- [ ] 4-layer mirror byte-identical
+- [ ] lint clean
+
+## 안티패턴 회피
+
+- shell layer 에서 git 호출 금지 (JS layer 가 single source of truth)
+- decideDispatchMode 가 process.exit 호출 금지 (caller 가 dispatch 책임)
+- warning 메시지는 stderr 만 (stdout 은 dispatch 결과 전용)

--- a/.triflux/plans/issue-281-shard-c-integration-ssot-mirror.md
+++ b/.triflux/plans/issue-281-shard-c-integration-ssot-mirror.md
@@ -1,0 +1,123 @@
+# Shard C — integration test + SSOT docs + 4-layer mirror 검증
+
+> Index: [issue-281-auto-router-swarm-dispatch.md](./issue-281-auto-router-swarm-dispatch.md)
+> Worktree branch: `feat/issue-281-shard-c-integration-ssot-mirror`
+> CLI: Codex
+> 의존: Shard A, B 완료 후 통합 검증 (cherry-pick 또는 rebase 로 두 brunch 흡수)
+
+## 신규 파일: `tests/integration/tfx-auto-routing.test.mjs`
+
+Issue #281 회귀 가드 3 case (실제 git repo + decideDispatchMode 통합):
+
+```javascript
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { decideDispatchMode } from '../../hub/lib/tfx-route-args.mjs';
+
+describe('Issue #281 — auto router 코드 변경 자동 swarm dispatch', () => {
+  let cwd;
+
+  function setupRepo({ dirty = false }) {
+    cwd = mkdtempSync(join(tmpdir(), 'tfx-281-int-'));
+    execFileSync('git', ['init', '-q'], { cwd });
+    execFileSync('git', ['config', 'user.email', 'test@x'], { cwd });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd });
+    writeFileSync(join(cwd, 'seed.txt'), 'seed');
+    execFileSync('git', ['add', '.'], { cwd });
+    execFileSync('git', ['commit', '-m', 'init', '-q'], { cwd });
+    if (dirty) writeFileSync(join(cwd, 'change.txt'), 'x');
+    return cwd;
+  }
+
+  afterEach(() => {
+    if (cwd) rmSync(cwd, { recursive: true, force: true });
+    cwd = null;
+  });
+
+  test('case 1: 코드 변경 0건 + 2+ 태스크 → multi', () => {
+    setupRepo({ dirty: false });
+    const result = decideDispatchMode({ tasks: ['t1', 't2'] }, { cwd });
+    expect(result.mode).toBe('multi');
+    expect(result.escalated).toBe(false);
+    expect(result.warning).toBeNull();
+  });
+
+  test('case 2: 코드 변경 ≥ 1건 + 2+ 태스크 → swarm 자동 escalate', () => {
+    setupRepo({ dirty: true });
+    const result = decideDispatchMode({ tasks: ['t1', 't2'] }, { cwd });
+    expect(result.mode).toBe('swarm');
+    expect(result.escalated).toBe(true);
+    expect(result.warning).toMatch(/swarm dispatch 자동 escalate/);
+    expect(result.warning).toMatch(/Issue #281/);
+  });
+
+  test('case 3: --parallel 3 명시 + 코드 변경 → warning + 사용자 결정 존중 (multi)', () => {
+    setupRepo({ dirty: true });
+    const result = decideDispatchMode({ tasks: ['t1', 't2'], parallel: 3 }, { cwd });
+    expect(result.mode).toBe('multi');
+    expect(result.escalated).toBe(false);
+    expect(result.warning).toMatch(/WARNING: 코드 변경/);
+    expect(result.warning).toMatch(/사용자 명시.*존중/);
+  });
+});
+```
+
+## SSOT docs 정식화 톤 갱신
+
+### `.claude/rules/tfx-execution-skill-map.md`
+
+| 라인 | 현재 (드래프트 톤) | 갱신 (정식화 톤) |
+|------|------------------|----------------|
+| L44 안티패턴 행 | `tfx-auto --parallel 만 명시하고 코드 변경 포함 → Issue #87 미해결 갭으로 multi dispatch + cwd 공유 race` | `tfx-auto --parallel N 명시 + 코드 변경 → warning 후 사용자 결정 존중. swarm 권장이지만 사용자 명시 override 시 multi 진행 (Issue #281 closed).` |
+| L48-49 핵심 룰 | `MANDATORY: 코드 변경 포함 병렬은 사용자가 직접 --parallel swarm --isolation worktree 플래그 명시. tfx-auto 자동 swarm dispatch 는 Issue #87 미해결.` | `tfx-auto 는 2+ 태스크 + 코드 변경 자동 감지 시 swarm 으로 escalate (Issue #281 closed). 사용자 명시 --parallel N override 시 warning 후 사용자 결정 존중.` |
+| L57-59 알려진 한계 | `현재 tfx-auto 는 2+ 태스크를 만나면 multi 로만 dispatch 한다. 코드 변경 포함 시 자동 swarm dispatch 로직은 Issue #87 (auto 라우터 강화) 에서 추적.` | 섹션 자체 삭제 (또는 "## 해결됨" 으로 변경 후 Issue #87 + #281 close 링크) |
+
+### `.claude/rules/tfx-routing.md`
+
+- L21/L22 ladder 표: 변경 없음 (정책 자체는 동일, dispatch 자동화만 추가)
+- L90 Layer 2 예시: `tfx-auto --parallel swarm --mode consensus --isolation worktree` 유지 (사용자 명시 경로는 그대로)
+- L130 "충돌 해소" 섹션에 1줄 추가: `tfx-auto 자동 swarm escalate: 2+ 태스크 + 코드 변경 ≥ 1건 시 자동. 명시 --parallel N override 가능 (warning).`
+
+## 4-layer mirror 통합 검증
+
+PR 머지 직전 / Shard C 마무리 시 실행:
+
+```bash
+# packages/core mirror 검증 (Shard A + B 산출물)
+diff -q hub/lib/staged-file-detect.mjs packages/core/hub/lib/staged-file-detect.mjs
+diff -q hub/lib/tfx-route-args.mjs packages/core/hub/lib/tfx-route-args.mjs
+
+# packages/triflux mirror 검증 (root → publish 패키지)
+for f in hub/lib/staged-file-detect.mjs hub/lib/tfx-route-args.mjs bin/triflux.mjs scripts/tfx-route.sh; do
+  diff -q "$f" "packages/triflux/$f" || echo "DRIFT: $f"
+done
+
+# packages/remote 영향 없음 확인 (auto router 는 @triflux/core 의존)
+git diff --name-only origin/main..HEAD | grep '^packages/remote/' && echo "FAIL: remote 영향 있음" || echo "OK: remote 무영향"
+
+# tests/ mirror 제외 확인 (npm files 미포함이므로 packages/{core,triflux}/tests/ 에 untracked 신규 디렉토리 금지)
+ls packages/core/tests packages/triflux/tests 2>/dev/null && echo "FAIL: tests/ mirror 시도" || echo "OK: tests/ 미러 제외"
+
+# npm pack tarball size (binary 누수 회피)
+(cd packages/triflux && npm pack --dry-run 2>&1 | tail -3)
+```
+
+기대값 모두 OK + npm pack size ~1MB.
+
+## Acceptance
+
+- [ ] 3 case integration test 통과 (`npm test -- tfx-auto-routing`)
+- [ ] SSOT docs L44/L48-49/L57-59 정식화 톤 갱신 (Shard B + A 결과 반영)
+- [ ] `.claude/rules/tfx-routing.md` 충돌 해소 섹션 1줄 추가
+- [ ] 4-layer mirror 검증 스크립트 출력 모두 OK
+- [ ] npm pack size ~1MB
+- [ ] cross-review verdict: Claude 작성 코드는 Codex review, Codex 작성 코드는 Claude review
+
+## 안티패턴 회피
+
+- packages/{core,triflux}/tests/ 에 신규 디렉토리 생성 금지 (mirror 제외)
+- SSOT 라인 갱신 시 Issue #87 / #281 close 링크 보존
+- AI trailer / Co-Authored-By 금지 (release commit + PR body 모두)


### PR DESCRIPTION
## Summary

- Index + 3 shards PRD bundle for Issue #281 (auto router 코드 변경 자동 swarm dispatch, #87 격상)
- Shard 분할: A staged-file-detect helper, B router escalate logic, C integration test + SSOT docs + 4-layer mirror
- 회귀 테스트 3 case 명시 (Issue #281 body 그대로)

## 진입 명령 (PRD 머지 후)

```
/tfx-auto --parallel swarm --isolation worktree --cli codex --max-iterations 0 \\
  "Issue #281 — PRD: .triflux/plans/issue-281-auto-router-swarm-dispatch.md"
```

## Files added

- \`.triflux/plans/issue-281-auto-router-swarm-dispatch.md\` (76 lines, index)
- \`.triflux/plans/issue-281-shard-a-staged-file-detect.md\` (106 lines)
- \`.triflux/plans/issue-281-shard-b-router-escalate.md\` (194 lines)
- \`.triflux/plans/issue-281-shard-c-integration-ssot-mirror.md\` (123 lines)

## Related

- Issue #281 (이 PR 본체 — PRD 머지 후 swarm dispatch 진입)
- Issue #87 (원본, #281 로 격상)
- SSOT 갭 라인: \`.claude/rules/tfx-execution-skill-map.md\` L44/L49/L64

## Test plan

- [x] PRD 4파일 작성 완료, line counts: 76/106/194/123 = 499 total
- [ ] PRD 머지 후 swarm dispatch 진입 (별도 PR로 코드 구현)
- [ ] 회귀 테스트 3 case 통과 확인 (Shard C 완료 시)
- [ ] 4-layer mirror 검증 (PR 머지 직전)

## Notes

- PRD-only PR, CI 영향 없음
- \`.gitignore\` line 3 의 \`.triflux/\` 패턴 회피 위해 \`git add -f\` 사용 (macos-lifecycle PRD 와 동일 패턴)
- AI trailer / Co-Authored-By 금지 (commit + PR body 모두)