### PR TITLE
feat(routing): Issue #281 auto router 코드 변경 자동 swarm dispatch (#87 격상)

### DIFF
--- a/.claude/rules/tfx-execution-skill-map.md
+++ b/.claude/rules/tfx-execution-skill-map.md
@@ -41,12 +41,12 @@
 | PR conflict 해결을 `tfx-remote`로 실행 | WT 세션 `git checkout feat/X` → 메인 세션 working tree도 함께 전환 → race (2026-04-17 PR #72 사고) | `tfx-swarm` |
 | 단일 파일 수정을 `tfx-swarm`으로 실행 | PRD + worktree 오버헤드 과잉 | `tfx-autopilot` |
 | `tfx-multi`로 코드 수정 병렬 | cwd 공유 파일 race | `tfx-swarm` |
-| `tfx-auto --parallel` 만 명시하고 코드 변경 포함 | Issue #87 미해결 갭으로 multi dispatch + cwd 공유 race | 코드 변경 시 반드시 `--parallel swarm --isolation worktree` 명시 |
+| `tfx-auto --parallel N` 명시 + 코드 변경 | warning 후 사용자 결정 존중 | swarm 권장이지만 사용자 명시 override 시 multi 진행 (Issue #281 closed) |
 
 ## 핵심 룰
 
-> **코드 변경 = tfx-swarm만** (로컬/원격 동일). tfx-remote는 원격 대화형/탐색 전용. multi는 로컬 headless 병렬 (worktree 불필요 read-only 작업).
-> **MANDATORY**: 코드 변경 포함 병렬은 사용자가 직접 `--parallel swarm --isolation worktree` 플래그 명시. tfx-auto 자동 swarm dispatch 는 Issue #87 미해결.
+> **코드 변경 = tfx-swarm 우선** (로컬/원격 동일). tfx-remote는 원격 대화형/탐색 전용. multi는 로컬 headless 병렬 (worktree 불필요 read-only 작업).
+> **MANDATORY**: `tfx-auto` 는 2+ 태스크 + 코드 변경 자동 감지 시 swarm 으로 escalate (Issue #281 closed). 사용자 명시 `--parallel N` override 시 warning 후 사용자 결정 존중.
 
 ## Retry 정책 (Phase 3+)
 
@@ -59,6 +59,6 @@
 
 `ralph`/`auto-escalate` 는 `hub/team/retry-state-machine.mjs` 가 구동. state 는 `.omc/state/retry-<sessionId>.json` 에 저장 (compaction survive). Bridge: `node hub/bridge.mjs retry-run --snapshot X --event ...`.
 
-## 알려진 한계
+## 해결됨
 
-현재 `tfx-auto`는 2+ 태스크를 만나면 **multi로만 dispatch**한다. 코드 변경 포함 시 자동 swarm dispatch 로직은 Issue #87 (auto 라우터 강화)에서 추적.
+`tfx-auto` 자동 swarm dispatch 갭은 Issue #87 / #281 로 종료됐다. 2+ 태스크 + 코드 변경은 자동 swarm escalate, 명시 `--parallel N` override 는 warning 후 사용자 결정 존중.

--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -117,6 +117,7 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 - 복합 의도: "구현하고 리뷰까지" → tfx-auto → cross-review hook
 - "합의해서 비교해" 류 요청은 alias 대신 기본적으로 `tfx-auto --mode consensus --shape debate` 로 fold 한다
 - `ralph` 표기는 항상 `--retry ralph` mode 를 지칭. persist 스킬도 동일 의미. `--retry auto-escalate` 와 동시 사용 불가 (escalation-chain.md 규약).
+- `tfx-auto` 자동 swarm escalate: 2+ 태스크 + 코드 변경 ≥ 1건 시 자동. 명시 `--parallel N` override 가능 (warning).
 
 ## Q-Learning 동적 라우팅 (실험적)
 

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -3,6 +3,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { execFileSync, execSync, spawn } from "child_process";
 // triflux CLI — setup, doctor, version
 import {
+  appendFileSync,
   chmodSync,
   closeSync,
   copyFileSync,
@@ -26,6 +27,10 @@ import {
   checkNetworkAvailability,
   validateRuntimeCachePaths,
 } from "../hub/lib/cache-guard.mjs";
+import {
+  decideDispatchMode,
+  parseArgs as parseRouteArgs,
+} from "../hub/lib/tfx-route-args.mjs";
 import { getPipelineStateDbPath } from "../hub/pipeline/state.mjs";
 import { getVersionHash } from "../hub/state.mjs";
 import { forceCleanupTeam } from "../hub/team/nativeProxy.mjs";
@@ -6846,6 +6851,31 @@ function parsePositiveIntegerOption(args, name, fallback) {
   return parsed;
 }
 
+function applyAutoDispatchDecision(parsedArgs, decision = null) {
+  const resolved = decision || decideDispatchMode(parsedArgs);
+  if (resolved.warning) {
+    process.stderr.write(`${resolved.warning}\n`);
+  }
+  if (resolved.escalated) {
+    const logLine = `${JSON.stringify({
+      at: new Date().toISOString(),
+      issue: 281,
+      from: "multi",
+      to: "swarm",
+      tasksCount: Array.isArray(parsedArgs.tasks)
+        ? parsedArgs.tasks.length
+        : (parsedArgs.tasks ?? null),
+      reason: resolved.reason,
+    })}\n`;
+    try {
+      appendFileSync(".omc/state/auto-escalation.log", logLine, "utf8");
+    } catch {
+      // Fresh checkouts may not have .omc/state yet; dispatch should continue.
+    }
+  }
+  return resolved;
+}
+
 async function main() {
   const cmd = NORMALIZED_ARGS[0] || "help";
   const cmdArgs = NORMALIZED_ARGS.slice(1);
@@ -6855,6 +6885,16 @@ async function main() {
   }).catch(() => {});
 
   switch (cmd) {
+    case "auto": {
+      const parsedArgs = parseRouteArgs(cmdArgs);
+      const decision = applyAutoDispatchDecision(parsedArgs);
+      if (JSON_OUTPUT) {
+        printJson({ args: parsedArgs, dispatch: decision });
+      } else {
+        process.stdout.write(`${decision.mode}\n`);
+      }
+      return;
+    }
     case "setup":
       cmdSetup({
         dryRun: cmdArgs.includes("--dry-run"),

--- a/hub/lib/staged-file-detect.mjs
+++ b/hub/lib/staged-file-detect.mjs
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+
+export function detectChangedFiles({
+  cwd = process.cwd(),
+  includeStaged = true,
+  includeUnstaged = true,
+  includeUntracked = true,
+} = {}) {
+  const staged = includeStaged
+    ? runGit(cwd, ["diff", "--cached", "--name-only"])
+    : [];
+  const unstaged = includeUnstaged ? runGit(cwd, ["diff", "--name-only"]) : [];
+  const untracked = includeUntracked
+    ? runGit(cwd, ["ls-files", "--others", "--exclude-standard"])
+    : [];
+  const files = [...new Set([...staged, ...unstaged, ...untracked])];
+
+  return {
+    stagedCount: staged.length,
+    unstagedCount: unstaged.length,
+    untrackedCount: untracked.length,
+    totalChanged: files.length,
+    files,
+  };
+}
+
+export function hasCodeChange(opts) {
+  return detectChangedFiles(opts).totalChanged > 0;
+}
+
+function runGit(cwd, args) {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/hub/lib/tfx-route-args.mjs
+++ b/hub/lib/tfx-route-args.mjs
@@ -19,6 +19,8 @@
 //   --no-claude-native                (Claude native sub-agent 경로 disable)
 //   --max-iterations <N>              (ralph / auto-escalate 상한, 0=unlimited)
 
+import { hasCodeChange } from "./staged-file-detect.mjs";
+
 export const DEFAULT_OPTIONS = Object.freeze({
   cli: "auto",
   mode: "quick",
@@ -220,3 +222,88 @@ function validate(opts, warnings) {
 }
 
 export { VALID_VALUES };
+
+/**
+ * Decide dispatch mode based on parsed args and current git state.
+ *
+ * Issue #281: auto router code changes should use isolated swarm dispatch for
+ * multi-task work unless the user explicitly selected local parallel mode.
+ *
+ * @param {object} args
+ * @param {object} [opts]
+ * @param {string} [opts.cwd]
+ * @param {Function} [opts.detector]
+ * @returns {{
+ *   mode: "single" | "multi" | "swarm",
+ *   escalated: boolean,
+ *   warning: string | null,
+ *   reason: string,
+ * }}
+ */
+export function decideDispatchMode(
+  args = {},
+  { cwd = process.cwd(), detector = hasCodeChange } = {},
+) {
+  const tasksCount = countTasks(args);
+  const parallel = normalizeParallel(args.parallel);
+  const hasUserParallel = parallel !== null && parallel !== "1";
+  const hasUserSwarm = parallel === "swarm" || args.isolation === "worktree";
+  const codeChanged = Boolean(detector({ cwd }));
+
+  if (hasUserSwarm) {
+    return {
+      mode: "swarm",
+      escalated: false,
+      warning: null,
+      reason: "user-explicit-swarm",
+    };
+  }
+
+  if (hasUserParallel && codeChanged) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: `[tfx-auto] WARNING: 코드 변경 감지 (cwd race 위험). --parallel swarm --isolation worktree 권장. 사용자 명시 --parallel=${args.parallel} 존중하여 multi 로 진행.`,
+      reason: "user-explicit-multi-with-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 && codeChanged) {
+    return {
+      mode: "swarm",
+      escalated: true,
+      warning: `[tfx-auto] 코드 변경 ${tasksCount}건 태스크 + dirty cwd 감지. swarm dispatch 자동 escalate (--parallel swarm --isolation worktree). Issue #281.`,
+      reason: "auto-escalate-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 || hasUserParallel) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: null,
+      reason: "multi-no-code-change",
+    };
+  }
+
+  return {
+    mode: "single",
+    escalated: false,
+    warning: null,
+    reason: "single-task",
+  };
+}
+
+function countTasks(args) {
+  if (Array.isArray(args.tasks)) return args.tasks.length;
+  if (typeof args.tasks === "number") return args.tasks;
+  if (typeof args.tasks === "string") return args.tasks.trim() ? 1 : 0;
+  if (typeof args.task === "string") return args.task.trim() ? 1 : 0;
+  return args.tasks ?? 0;
+}
+
+function normalizeParallel(value) {
+  if (value == null) return null;
+  if (value === "swarm") return value;
+  return String(value);
+}

--- a/packages/core/hub/lib/staged-file-detect.mjs
+++ b/packages/core/hub/lib/staged-file-detect.mjs
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+
+export function detectChangedFiles({
+  cwd = process.cwd(),
+  includeStaged = true,
+  includeUnstaged = true,
+  includeUntracked = true,
+} = {}) {
+  const staged = includeStaged
+    ? runGit(cwd, ["diff", "--cached", "--name-only"])
+    : [];
+  const unstaged = includeUnstaged ? runGit(cwd, ["diff", "--name-only"]) : [];
+  const untracked = includeUntracked
+    ? runGit(cwd, ["ls-files", "--others", "--exclude-standard"])
+    : [];
+  const files = [...new Set([...staged, ...unstaged, ...untracked])];
+
+  return {
+    stagedCount: staged.length,
+    unstagedCount: unstaged.length,
+    untrackedCount: untracked.length,
+    totalChanged: files.length,
+    files,
+  };
+}
+
+export function hasCodeChange(opts) {
+  return detectChangedFiles(opts).totalChanged > 0;
+}
+
+function runGit(cwd, args) {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/packages/core/hub/lib/tfx-route-args.mjs
+++ b/packages/core/hub/lib/tfx-route-args.mjs
@@ -19,6 +19,8 @@
 //   --no-claude-native                (Claude native sub-agent 경로 disable)
 //   --max-iterations <N>              (ralph / auto-escalate 상한, 0=unlimited)
 
+import { hasCodeChange } from "./staged-file-detect.mjs";
+
 export const DEFAULT_OPTIONS = Object.freeze({
   cli: "auto",
   mode: "quick",
@@ -220,3 +222,88 @@ function validate(opts, warnings) {
 }
 
 export { VALID_VALUES };
+
+/**
+ * Decide dispatch mode based on parsed args and current git state.
+ *
+ * Issue #281: auto router code changes should use isolated swarm dispatch for
+ * multi-task work unless the user explicitly selected local parallel mode.
+ *
+ * @param {object} args
+ * @param {object} [opts]
+ * @param {string} [opts.cwd]
+ * @param {Function} [opts.detector]
+ * @returns {{
+ *   mode: "single" | "multi" | "swarm",
+ *   escalated: boolean,
+ *   warning: string | null,
+ *   reason: string,
+ * }}
+ */
+export function decideDispatchMode(
+  args = {},
+  { cwd = process.cwd(), detector = hasCodeChange } = {},
+) {
+  const tasksCount = countTasks(args);
+  const parallel = normalizeParallel(args.parallel);
+  const hasUserParallel = parallel !== null && parallel !== "1";
+  const hasUserSwarm = parallel === "swarm" || args.isolation === "worktree";
+  const codeChanged = Boolean(detector({ cwd }));
+
+  if (hasUserSwarm) {
+    return {
+      mode: "swarm",
+      escalated: false,
+      warning: null,
+      reason: "user-explicit-swarm",
+    };
+  }
+
+  if (hasUserParallel && codeChanged) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: `[tfx-auto] WARNING: 코드 변경 감지 (cwd race 위험). --parallel swarm --isolation worktree 권장. 사용자 명시 --parallel=${args.parallel} 존중하여 multi 로 진행.`,
+      reason: "user-explicit-multi-with-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 && codeChanged) {
+    return {
+      mode: "swarm",
+      escalated: true,
+      warning: `[tfx-auto] 코드 변경 ${tasksCount}건 태스크 + dirty cwd 감지. swarm dispatch 자동 escalate (--parallel swarm --isolation worktree). Issue #281.`,
+      reason: "auto-escalate-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 || hasUserParallel) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: null,
+      reason: "multi-no-code-change",
+    };
+  }
+
+  return {
+    mode: "single",
+    escalated: false,
+    warning: null,
+    reason: "single-task",
+  };
+}
+
+function countTasks(args) {
+  if (Array.isArray(args.tasks)) return args.tasks.length;
+  if (typeof args.tasks === "number") return args.tasks;
+  if (typeof args.tasks === "string") return args.tasks.trim() ? 1 : 0;
+  if (typeof args.task === "string") return args.task.trim() ? 1 : 0;
+  return args.tasks ?? 0;
+}
+
+function normalizeParallel(value) {
+  if (value == null) return null;
+  if (value === "swarm") return value;
+  return String(value);
+}

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -3,6 +3,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { execFileSync, execSync, spawn } from "child_process";
 // triflux CLI — setup, doctor, version
 import {
+  appendFileSync,
   chmodSync,
   closeSync,
   copyFileSync,
@@ -26,6 +27,10 @@ import {
   checkNetworkAvailability,
   validateRuntimeCachePaths,
 } from "../hub/lib/cache-guard.mjs";
+import {
+  decideDispatchMode,
+  parseArgs as parseRouteArgs,
+} from "../hub/lib/tfx-route-args.mjs";
 import { getPipelineStateDbPath } from "../hub/pipeline/state.mjs";
 import { getVersionHash } from "../hub/state.mjs";
 import { forceCleanupTeam } from "../hub/team/nativeProxy.mjs";
@@ -6846,6 +6851,31 @@ function parsePositiveIntegerOption(args, name, fallback) {
   return parsed;
 }
 
+function applyAutoDispatchDecision(parsedArgs, decision = null) {
+  const resolved = decision || decideDispatchMode(parsedArgs);
+  if (resolved.warning) {
+    process.stderr.write(`${resolved.warning}\n`);
+  }
+  if (resolved.escalated) {
+    const logLine = `${JSON.stringify({
+      at: new Date().toISOString(),
+      issue: 281,
+      from: "multi",
+      to: "swarm",
+      tasksCount: Array.isArray(parsedArgs.tasks)
+        ? parsedArgs.tasks.length
+        : (parsedArgs.tasks ?? null),
+      reason: resolved.reason,
+    })}\n`;
+    try {
+      appendFileSync(".omc/state/auto-escalation.log", logLine, "utf8");
+    } catch {
+      // Fresh checkouts may not have .omc/state yet; dispatch should continue.
+    }
+  }
+  return resolved;
+}
+
 async function main() {
   const cmd = NORMALIZED_ARGS[0] || "help";
   const cmdArgs = NORMALIZED_ARGS.slice(1);
@@ -6855,6 +6885,16 @@ async function main() {
   }).catch(() => {});
 
   switch (cmd) {
+    case "auto": {
+      const parsedArgs = parseRouteArgs(cmdArgs);
+      const decision = applyAutoDispatchDecision(parsedArgs);
+      if (JSON_OUTPUT) {
+        printJson({ args: parsedArgs, dispatch: decision });
+      } else {
+        process.stdout.write(`${decision.mode}\n`);
+      }
+      return;
+    }
     case "setup":
       cmdSetup({
         dryRun: cmdArgs.includes("--dry-run"),

--- a/packages/triflux/hub/lib/staged-file-detect.mjs
+++ b/packages/triflux/hub/lib/staged-file-detect.mjs
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+
+export function detectChangedFiles({
+  cwd = process.cwd(),
+  includeStaged = true,
+  includeUnstaged = true,
+  includeUntracked = true,
+} = {}) {
+  const staged = includeStaged
+    ? runGit(cwd, ["diff", "--cached", "--name-only"])
+    : [];
+  const unstaged = includeUnstaged ? runGit(cwd, ["diff", "--name-only"]) : [];
+  const untracked = includeUntracked
+    ? runGit(cwd, ["ls-files", "--others", "--exclude-standard"])
+    : [];
+  const files = [...new Set([...staged, ...unstaged, ...untracked])];
+
+  return {
+    stagedCount: staged.length,
+    unstagedCount: unstaged.length,
+    untrackedCount: untracked.length,
+    totalChanged: files.length,
+    files,
+  };
+}
+
+export function hasCodeChange(opts) {
+  return detectChangedFiles(opts).totalChanged > 0;
+}
+
+function runGit(cwd, args) {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .split(/\r?\n/)
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/packages/triflux/hub/lib/tfx-route-args.mjs
+++ b/packages/triflux/hub/lib/tfx-route-args.mjs
@@ -19,6 +19,8 @@
 //   --no-claude-native                (Claude native sub-agent 경로 disable)
 //   --max-iterations <N>              (ralph / auto-escalate 상한, 0=unlimited)
 
+import { hasCodeChange } from "./staged-file-detect.mjs";
+
 export const DEFAULT_OPTIONS = Object.freeze({
   cli: "auto",
   mode: "quick",
@@ -220,3 +222,88 @@ function validate(opts, warnings) {
 }
 
 export { VALID_VALUES };
+
+/**
+ * Decide dispatch mode based on parsed args and current git state.
+ *
+ * Issue #281: auto router code changes should use isolated swarm dispatch for
+ * multi-task work unless the user explicitly selected local parallel mode.
+ *
+ * @param {object} args
+ * @param {object} [opts]
+ * @param {string} [opts.cwd]
+ * @param {Function} [opts.detector]
+ * @returns {{
+ *   mode: "single" | "multi" | "swarm",
+ *   escalated: boolean,
+ *   warning: string | null,
+ *   reason: string,
+ * }}
+ */
+export function decideDispatchMode(
+  args = {},
+  { cwd = process.cwd(), detector = hasCodeChange } = {},
+) {
+  const tasksCount = countTasks(args);
+  const parallel = normalizeParallel(args.parallel);
+  const hasUserParallel = parallel !== null && parallel !== "1";
+  const hasUserSwarm = parallel === "swarm" || args.isolation === "worktree";
+  const codeChanged = Boolean(detector({ cwd }));
+
+  if (hasUserSwarm) {
+    return {
+      mode: "swarm",
+      escalated: false,
+      warning: null,
+      reason: "user-explicit-swarm",
+    };
+  }
+
+  if (hasUserParallel && codeChanged) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: `[tfx-auto] WARNING: 코드 변경 감지 (cwd race 위험). --parallel swarm --isolation worktree 권장. 사용자 명시 --parallel=${args.parallel} 존중하여 multi 로 진행.`,
+      reason: "user-explicit-multi-with-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 && codeChanged) {
+    return {
+      mode: "swarm",
+      escalated: true,
+      warning: `[tfx-auto] 코드 변경 ${tasksCount}건 태스크 + dirty cwd 감지. swarm dispatch 자동 escalate (--parallel swarm --isolation worktree). Issue #281.`,
+      reason: "auto-escalate-code-change",
+    };
+  }
+
+  if (tasksCount >= 2 || hasUserParallel) {
+    return {
+      mode: "multi",
+      escalated: false,
+      warning: null,
+      reason: "multi-no-code-change",
+    };
+  }
+
+  return {
+    mode: "single",
+    escalated: false,
+    warning: null,
+    reason: "single-task",
+  };
+}
+
+function countTasks(args) {
+  if (Array.isArray(args.tasks)) return args.tasks.length;
+  if (typeof args.tasks === "number") return args.tasks;
+  if (typeof args.tasks === "string") return args.tasks.trim() ? 1 : 0;
+  if (typeof args.task === "string") return args.task.trim() ? 1 : 0;
+  return args.tasks ?? 0;
+}
+
+function normalizeParallel(value) {
+  if (value == null) return null;
+  if (value === "swarm") return value;
+  return String(value);
+}

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -787,6 +787,9 @@ detect_quota_exceeded() {
 }
 
 auto_reroute() {
+  # Issue #281: code-change dispatch escalation is decided in the JS router
+  # (hub/lib/tfx-route-args.mjs). This shell function only handles quota-driven
+  # CLI fallback and must stay a transparent passthrough for dispatch mode.
   local failed_cli="$1"
   local target_cli=""
   case "$failed_cli" in
@@ -1207,6 +1210,9 @@ apply_cli_mode() {
         echo "[tfx-route] TFX_CLI_MODE=gemini: $AGENT_TYPE → gemini($gemini_tier)로 리매핑" >&2
       fi ;;
     auto)
+      # Issue #281: JS layer is the single source of truth for auto router
+      # single/multi/swarm dispatch. Shell auto mode only normalizes CLI
+      # availability and leaves code-change swarm escalation to JS.
       if [[ "$CLI_TYPE" == "codex" ]] && ! command -v "$CODEX_BIN" &>/dev/null; then
         if command -v "$GEMINI_BIN" &>/dev/null; then
           TFX_CLI_MODE="gemini"; apply_cli_mode; return

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -787,6 +787,9 @@ detect_quota_exceeded() {
 }
 
 auto_reroute() {
+  # Issue #281: code-change dispatch escalation is decided in the JS router
+  # (hub/lib/tfx-route-args.mjs). This shell function only handles quota-driven
+  # CLI fallback and must stay a transparent passthrough for dispatch mode.
   local failed_cli="$1"
   local target_cli=""
   case "$failed_cli" in
@@ -1207,6 +1210,9 @@ apply_cli_mode() {
         echo "[tfx-route] TFX_CLI_MODE=gemini: $AGENT_TYPE → gemini($gemini_tier)로 리매핑" >&2
       fi ;;
     auto)
+      # Issue #281: JS layer is the single source of truth for auto router
+      # single/multi/swarm dispatch. Shell auto mode only normalizes CLI
+      # availability and leaves code-change swarm escalation to JS.
       if [[ "$CLI_TYPE" == "codex" ]] && ! command -v "$CODEX_BIN" &>/dev/null; then
         if command -v "$GEMINI_BIN" &>/dev/null; then
           TFX_CLI_MODE="gemini"; apply_cli_mode; return

--- a/tests/integration/tfx-auto-routing.test.mjs
+++ b/tests/integration/tfx-auto-routing.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { decideDispatchMode } from "../../hub/lib/tfx-route-args.mjs";
+
+describe("Issue #281 - auto router code-change swarm dispatch", () => {
+  let cwd = null;
+
+  function setupRepo({ dirty = false }) {
+    cwd = mkdtempSync(join(tmpdir(), "tfx-281-int-"));
+    execFileSync("git", ["init", "-q"], { cwd });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd });
+    writeFileSync(join(cwd, "seed.txt"), "seed\n");
+    execFileSync("git", ["add", "."], { cwd });
+    execFileSync("git", ["commit", "-m", "init", "-q"], { cwd });
+    if (dirty) writeFileSync(join(cwd, "change.txt"), "x\n");
+    return cwd;
+  }
+
+  afterEach(() => {
+    if (cwd) rmSync(cwd, { recursive: true, force: true });
+    cwd = null;
+  });
+
+  it("case 1: clean repo + 2+ tasks -> multi", () => {
+    setupRepo({ dirty: false });
+
+    const result = decideDispatchMode({ tasks: ["t1", "t2"] }, { cwd });
+
+    assert.equal(result.mode, "multi");
+    assert.equal(result.escalated, false);
+    assert.equal(result.warning, null);
+  });
+
+  it("case 2: dirty repo + 2+ tasks -> swarm auto escalate", () => {
+    setupRepo({ dirty: true });
+
+    const result = decideDispatchMode({ tasks: ["t1", "t2"] }, { cwd });
+
+    assert.equal(result.mode, "swarm");
+    assert.equal(result.escalated, true);
+    assert.match(result.warning, /자동 escalate/);
+    assert.match(result.warning, /Issue #281/);
+  });
+
+  it("case 3: dirty repo + explicit --parallel 3 -> multi with warning", () => {
+    setupRepo({ dirty: true });
+
+    const result = decideDispatchMode(
+      { tasks: ["t1", "t2"], parallel: 3 },
+      { cwd },
+    );
+
+    assert.equal(result.mode, "multi");
+    assert.equal(result.escalated, false);
+    assert.match(result.warning, /WARNING: 코드 변경/);
+    assert.match(result.warning, /사용자 명시.*존중/);
+  });
+});

--- a/tests/unit/conductor-dynamic-routing.test.mjs
+++ b/tests/unit/conductor-dynamic-routing.test.mjs
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { resetSnapshotCache } from "../../hub/routing-snapshot.mjs";
-import { createConductor, STATES } from "../../hub/team/conductor.mjs";
+import { createConductor } from "../../hub/team/conductor.mjs";
 
 process.setMaxListeners(50);
 

--- a/tests/unit/staged-file-detect.test.mjs
+++ b/tests/unit/staged-file-detect.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  detectChangedFiles,
+  hasCodeChange,
+} from "../../hub/lib/staged-file-detect.mjs";
+
+const TEMP_DIRS = [];
+
+function makeRepo(prefix = "tfx-staged-file-detect-") {
+  const cwd = mkdtempSync(join(tmpdir(), prefix));
+  TEMP_DIRS.push(cwd);
+  git(cwd, ["init"]);
+  git(cwd, ["config", "user.email", "test@example.com"]);
+  git(cwd, ["config", "user.name", "Test User"]);
+  return cwd;
+}
+
+function makePlainDir(prefix = "tfx-staged-file-detect-plain-") {
+  const cwd = mkdtempSync(join(tmpdir(), prefix));
+  TEMP_DIRS.push(cwd);
+  return cwd;
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+function write(cwd, file, content) {
+  writeFileSync(join(cwd, file), content);
+}
+
+function commitSeed(cwd) {
+  write(cwd, "README.md", "# seed\n");
+  git(cwd, ["add", "README.md"]);
+  git(cwd, ["commit", "-m", "seed"]);
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("hub/lib/staged-file-detect.mjs", () => {
+  it("returns empty counts for a clean repo", () => {
+    const cwd = makeRepo();
+    commitSeed(cwd);
+
+    const result = detectChangedFiles({ cwd });
+
+    assert.deepEqual(result, {
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+      totalChanged: 0,
+      files: [],
+    });
+    assert.equal(hasCodeChange({ cwd }), false);
+  });
+
+  it("counts one staged file", () => {
+    const cwd = makeRepo();
+    write(cwd, "staged.txt", "staged\n");
+    git(cwd, ["add", "staged.txt"]);
+
+    const result = detectChangedFiles({ cwd });
+
+    assert.equal(result.stagedCount, 1);
+    assert.equal(result.unstagedCount, 0);
+    assert.equal(result.untrackedCount, 0);
+    assert.equal(result.totalChanged, 1);
+    assert.deepEqual(result.files, ["staged.txt"]);
+    assert.equal(hasCodeChange({ cwd }), true);
+  });
+
+  it("counts mixed unstaged and untracked files", () => {
+    const cwd = makeRepo();
+    commitSeed(cwd);
+    write(cwd, "README.md", "# changed\n");
+    write(cwd, "new.txt", "new\n");
+
+    const result = detectChangedFiles({ cwd });
+
+    assert.equal(result.stagedCount, 0);
+    assert.equal(result.unstagedCount, 1);
+    assert.equal(result.untrackedCount, 1);
+    assert.equal(result.totalChanged, 2);
+    assert.deepEqual(result.files, ["README.md", "new.txt"]);
+  });
+
+  it("returns empty counts for a non-git cwd", () => {
+    const cwd = makePlainDir();
+
+    const result = detectChangedFiles({ cwd });
+
+    assert.deepEqual(result, {
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+      totalChanged: 0,
+      files: [],
+    });
+    assert.equal(hasCodeChange({ cwd }), false);
+  });
+
+  it("excludes staged files when includeStaged is false", () => {
+    const cwd = makeRepo();
+    write(cwd, "staged.txt", "staged\n");
+    git(cwd, ["add", "staged.txt"]);
+
+    const result = detectChangedFiles({ cwd, includeStaged: false });
+
+    assert.equal(result.stagedCount, 0);
+    assert.equal(result.unstagedCount, 0);
+    assert.equal(result.untrackedCount, 0);
+    assert.equal(result.totalChanged, 0);
+    assert.deepEqual(result.files, []);
+  });
+
+  it("deduplicates a file that is staged and then modified again", () => {
+    const cwd = makeRepo();
+    commitSeed(cwd);
+    write(cwd, "README.md", "# staged\n");
+    git(cwd, ["add", "README.md"]);
+    write(cwd, "README.md", "# unstaged\n");
+
+    const result = detectChangedFiles({ cwd });
+
+    assert.equal(result.stagedCount, 1);
+    assert.equal(result.unstagedCount, 1);
+    assert.equal(result.untrackedCount, 0);
+    assert.equal(result.totalChanged, 1);
+    assert.deepEqual(result.files, ["README.md"]);
+  });
+});

--- a/tests/unit/tfx-route-args.test.mjs
+++ b/tests/unit/tfx-route-args.test.mjs
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 
 import {
   DEFAULT_OPTIONS,
+  decideDispatchMode,
   parseArgs,
   VALID_VALUES,
 } from "../../hub/lib/tfx-route-args.mjs";
@@ -131,5 +132,64 @@ describe("tfx-route-args — parseArgs", () => {
       const r = parseArgs(["--cli"]);
       assert.ok(r.warnings.some((w) => w.includes("--cli needs a value")));
     });
+  });
+});
+
+describe("tfx-route-args — decideDispatchMode", () => {
+  const noChange = () => false;
+  const withChange = () => true;
+
+  it("case 0: 1 task → single", () => {
+    const r = decideDispatchMode({ tasks: ["t1"] }, { detector: noChange });
+    assert.equal(r.mode, "single");
+    assert.equal(r.escalated, false);
+    assert.equal(r.warning, null);
+    assert.equal(r.reason, "single-task");
+  });
+
+  it("case 1: 2+ tasks + 코드 변경 0건 → multi", () => {
+    const r = decideDispatchMode(
+      { tasks: ["t1", "t2"] },
+      { detector: noChange },
+    );
+    assert.equal(r.mode, "multi");
+    assert.equal(r.escalated, false);
+    assert.equal(r.warning, null);
+    assert.equal(r.reason, "multi-no-code-change");
+  });
+
+  it("case 2: 2+ tasks + 코드 변경 → swarm auto-escalate", () => {
+    const r = decideDispatchMode(
+      { tasks: ["t1", "t2"] },
+      { detector: withChange },
+    );
+    assert.equal(r.mode, "swarm");
+    assert.equal(r.escalated, true);
+    assert.match(r.warning, /자동 escalate/);
+    assert.match(r.warning, /Issue #281/);
+    assert.equal(r.reason, "auto-escalate-code-change");
+  });
+
+  it("case 3: --parallel N 명시 + 코드 변경 → multi + warning", () => {
+    const r = decideDispatchMode(
+      { tasks: ["t1", "t2"], parallel: 3 },
+      { detector: withChange },
+    );
+    assert.equal(r.mode, "multi");
+    assert.equal(r.escalated, false);
+    assert.match(r.warning, /WARNING: 코드 변경/);
+    assert.match(r.warning, /사용자 명시.*존중/);
+    assert.equal(r.reason, "user-explicit-multi-with-code-change");
+  });
+
+  it("user-explicit swarm 그대로", () => {
+    const r = decideDispatchMode(
+      { tasks: ["t1", "t2"], parallel: "swarm", isolation: "worktree" },
+      { detector: withChange },
+    );
+    assert.equal(r.mode, "swarm");
+    assert.equal(r.escalated, false);
+    assert.equal(r.warning, null);
+    assert.equal(r.reason, "user-explicit-swarm");
   });
 });


### PR DESCRIPTION
## Summary

`tfx-auto` 가 2+ 태스크 + 코드 변경 (staged + unstaged + untracked) 자동 감지 시 swarm dispatch 로 escalate. 사용자 명시 `--parallel N` override 시 warning 후 사용자 결정 존중.

- **Closes #87** (원본: auto 라우터 강화)
- **Closes #281** (격상: 자동 swarm dispatch + 회귀 테스트 3 case)
- SSOT 갭 `.claude/rules/tfx-execution-skill-map.md` L44/L49/L64 정식화 톤 갱신
- 4-layer mirror byte-identical (root + packages/{core,triflux}, packages/remote 무영향)

## 변경 (16 files, +758 / -6)

**신규**:
- `hub/lib/staged-file-detect.mjs` — `detectChangedFiles()` + `hasCodeChange()` (CRLF 대응, graceful)
- `tests/unit/staged-file-detect.test.mjs` — 6 case (empty / staged / unstaged+untracked / non-git / includeStaged false / 중복)
- `tests/integration/tfx-auto-routing.test.mjs` — 3 case (코드변경 0 → multi / ≥1 → swarm escalate / `--parallel N` + 변경 → warning + multi)

**수정**:
- `hub/lib/tfx-route-args.mjs` — `decideDispatchMode()` + `countTasks()` + `normalizeParallel()`
- `bin/triflux.mjs` — `applyAutoDispatchDecision()` (stderr warning + `.omc/state/auto-escalation.log` JSON append)
- `scripts/tfx-route.sh` — auto 분기 docstring 갱신
- `.claude/rules/tfx-execution-skill-map.md` — L44 안티패턴 + L48-49 핵심 룰 + L57-59 "해결됨"
- `.claude/rules/tfx-routing.md` — 충돌 해소 섹션 +1줄
- `tests/unit/tfx-route-args.test.mjs` — `decideDispatchMode` 5 case 추가
- `tests/unit/conductor-dynamic-routing.test.mjs` — unused `STATES` import 정리 (lint 정합)

**4-layer mirror** (byte-identical 검증됨):
- `packages/core/hub/lib/{staged-file-detect,tfx-route-args}.mjs`
- `packages/triflux/{hub/lib/*,bin/triflux.mjs,scripts/tfx-route.sh}`
- `packages/remote/` 무영향

## Test plan

- [x] `tests/unit/staged-file-detect.test.mjs` — 6 case pass (435ms)
- [x] `tests/unit/tfx-route-args.test.mjs::decideDispatchMode` — 5 case pass
- [x] `tests/integration/tfx-auto-routing.test.mjs` — 3 case pass (227ms)
- [x] `npm run lint` clean (640 files, no fixes)
- [x] 4-layer mirror md5 identical (root = packages/core = packages/triflux)
- [x] Cross-review (Claude → Codex worker 산출물): APPROVE

## Generated by

`tfx-auto --parallel swarm --isolation worktree --cli codex --max-iterations 0` (Codex worker 3 shards, depends A → B → C, integration cherry-pick to swarm/swarm-1779180134733/merge → rename `feat/issue-281-auto-router-swarm-dispatch`).

## Notes

- Swarm 인프라 갭 (mcp manifest abstraction + redundancy default + CODEX_HOME preserve 강제) 은 별도 issue 로 추적 가능.
- `CODEX_HOME=$HOME/.codex` env preserve 가 worker auth 통과 핵심 (worker-sandbox.mjs line 5 주석 명시).
- `critical: false` 가 redundancy gemini auto-spawn 회피.
- Release: 본 PR 머지 후 v10.23.1 patch 또는 v10.24.0 minor 결정은 사용자.
- AI trailer / Co-Authored-By 금지 (commit + PR body 모두).