### PR TITLE
ci(workflow): add npm trusted publishing (OIDC) workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+name: Publish to npm (Trusted Publishing OIDC)
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm to 11.5.1+
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci || npm install --no-audit --no-fund
+
+      - name: Publish triflux
+        working-directory: packages/triflux
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- 새 `.github/workflows/npm-publish.yml` 추가 — npm Trusted Publishing (OIDC) 전용
- 기존 `release.yml` 은 NPM_TOKEN 기반이라 [npm/cli#9268](https://github.com/npm/cli/issues/9268) (token bypass_2fa 무시 bug) + 2025-09 npm TOTP 차단 정책 결합으로 publish block 상태
- v10.24.0 부터 OIDC 로 전환. npm trusted publisher 등록 완료 (workflow filename = `npm-publish.yml`)

## 설계

- trigger: tag push (`v*`) + `workflow_dispatch`
- permissions: `id-token: write` (OIDC 필수)
- npm 11.5.1+ + node 22 (Trusted Publishing 요구 버전)
- \`cd packages/triflux && npm publish --provenance --access public\`

## v10.24.0 publish 계획

머지 후:
1. \`gh workflow run npm-publish.yml --ref main\` (수동 trigger, v10.24.0 tag 가 이미 push 됐기 때문)
2. \`gh run watch\` 로 실시간 확인
3. \`npm view triflux@10.24.0 version\` 으로 검증

v10.25.0+ 부터는 tag push 자동 trigger.

## Test plan

- [ ] PR merge 후 main HEAD 에 \`.github/workflows/npm-publish.yml\` 존재 확인
- [ ] \`gh workflow run\` 으로 trigger 가능 확인
- [ ] Actions OIDC token 발급 → npm publish 성공
- [ ] \`npm view triflux@10.24.0\` 가 10.24.0 반환

## 출처

- [docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers/)
- [github.blog GA 발표 (2025-07-31)](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- 진단 보고서: \`~/.gstack/projects/tellang-triflux/reports/research-npm-publish-2fa-trusted-publishing-20260520.md\`