### PR TITLE
feat(mcp): exa/brave/tavily + antigravity client target 통합

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -2515,11 +2515,12 @@ function buildMcpStatusRows(statusInfo) {
     .filter((row) => row.type === "registry")
     .map((row) => {
       let detail = "";
-      if (row.status === "present") detail = row.actualUrl || row.expectedUrl;
+      if (row.status === "present")
+        detail = row.actualUrl || row.actualCommand || row.expectedUrl;
       else if (row.status === "missing") detail = "registry only";
       else if (row.status === "missing-file") detail = "config missing";
       else if (row.status === "mismatch")
-        detail = `expected ${row.expectedUrl}`;
+        detail = `expected ${row.expectedUrl || row.expectedCommand}`;
       else if (row.status === "invalid-config") detail = "parse error";
       else if (row.status === "stdio") detail = "configured as stdio";
       return [

--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -17,15 +17,45 @@
       "transport": "hub-url",
       "url": "http://127.0.0.1:27888/mcp",
       "safe": true,
-      "targets": ["claude", "gemini", "codex"],
+      "targets": ["claude", "gemini", "codex", "antigravity"],
       "description": "triflux Hub MCP 서버"
     },
     "context7": {
       "transport": "http",
       "url": "https://mcp.context7.com/mcp",
       "safe": true,
-      "targets": ["claude", "gemini", "codex"],
+      "targets": ["claude", "gemini", "codex", "antigravity"],
       "description": "Upstash Context7 — 라이브러리 문서/코드 컨텍스트 (HTTP MCP, API key 불필요)"
+    },
+    "exa": {
+      "transport": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "Authorization": { "env": "EXA_API_KEY", "prefix": "Bearer " }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Exa neural/semantic web search — 학술/기술 깊이. Key 발급: https://exa.ai/dashboard → secrets.env의 EXA_API_KEY"
+    },
+    "brave-search": {
+      "transport": "http",
+      "url": "https://mcp.brave.com/mcp",
+      "headers": {
+        "Authorization": { "env": "BRAVE_API_KEY", "prefix": "Bearer " }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Brave Search — 실용/뉴스/실시간. Key 발급: https://brave.com/search/api/ → secrets.env의 BRAVE_API_KEY"
+    },
+    "tavily": {
+      "transport": "http",
+      "url": "https://mcp.tavily.com/mcp",
+      "headers": {
+        "Authorization": { "env": "TAVILY_API_KEY", "prefix": "Bearer " }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Tavily research — 비용/운영/DX/일반 웹. Key 발급: https://app.tavily.com/home → secrets.env의 TAVILY_API_KEY"
     }
   },
   "policies": {
@@ -38,7 +68,8 @@
       "~/.claude/settings.json",
       "~/.claude/settings.local.json",
       ".claude/mcp.json",
-      ".mcp.json"
+      ".mcp.json",
+      "~/.gemini/config/mcp_config.json"
     ]
   }
 }

--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -7,7 +7,7 @@
     "hub_base": "http://127.0.0.1:27888"
   },
   "policy_notes": {
-    "transport": "Server transport accepts \"hub-url\" for the existing triflux Hub URL flow or \"http\" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.",
+    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers (rare; only for servers that have no hosted HTTP endpoint, e.g. brave-search). stdio servers require command, args, and may include env.",
     "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
     "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
     "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
@@ -38,14 +38,15 @@
       "description": "Exa neural/semantic web search — 학술/기술 깊이. Key 발급: https://exa.ai/dashboard → secrets.env의 EXA_API_KEY"
     },
     "brave-search": {
-      "transport": "http",
-      "url": "https://mcp.brave.com/mcp",
-      "headers": {
-        "Authorization": { "env": "BRAVE_API_KEY", "prefix": "Bearer " }
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": { "env": "BRAVE_API_KEY" }
       },
       "safe": true,
       "targets": ["claude", "gemini", "codex", "antigravity"],
-      "description": "Brave Search — 실용/뉴스/실시간. Key 발급: https://brave.com/search/api/ → secrets.env의 BRAVE_API_KEY"
+      "description": "Brave Search MCP — stdio 양식 (공식 hosted endpoint 없음, npx 로컬 실행). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
     },
     "tavily": {
       "transport": "http",

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -2515,11 +2515,12 @@ function buildMcpStatusRows(statusInfo) {
     .filter((row) => row.type === "registry")
     .map((row) => {
       let detail = "";
-      if (row.status === "present") detail = row.actualUrl || row.expectedUrl;
+      if (row.status === "present")
+        detail = row.actualUrl || row.actualCommand || row.expectedUrl;
       else if (row.status === "missing") detail = "registry only";
       else if (row.status === "missing-file") detail = "config missing";
       else if (row.status === "mismatch")
-        detail = `expected ${row.expectedUrl}`;
+        detail = `expected ${row.expectedUrl || row.expectedCommand}`;
       else if (row.status === "invalid-config") detail = "parse error";
       else if (row.status === "stdio") detail = "configured as stdio";
       return [

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
@@ -59,7 +59,28 @@ describe("mcp guard HTTP transport + headers schema", () => {
     }
   });
 
-  it("rejects malformed header descriptors and stdio-shaped registry servers", () => {
+  it("validates stdio transport with command, args, and env descriptors", () => {
+    assert.deepEqual(
+      validateRegistry(
+        registryWith({
+          transport: "stdio",
+          command: "npx",
+          args: [
+            "-y",
+            "@brave/brave-search-mcp-server",
+            "--transport",
+            "stdio",
+          ],
+          env: {
+            BRAVE_API_KEY: { env: "BRAVE_API_KEY" },
+          },
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("rejects malformed header descriptors and malformed stdio registry servers", () => {
     const invalidServers = [
       {
         transport: "http",
@@ -78,7 +99,8 @@ describe("mcp guard HTTP transport + headers schema", () => {
       },
       {
         transport: "stdio",
-        url: "https://example.com/mcp",
+        command: "npx",
+        args: [],
         headers: { "X-Client": { value: "triflux" } },
       },
       {
@@ -90,6 +112,28 @@ describe("mcp guard HTTP transport + headers schema", () => {
         transport: "http",
         url: "https://example.com/mcp",
         args: ["server.js"],
+      },
+      {
+        transport: "stdio",
+        url: "https://example.com/mcp",
+        command: "npx",
+        args: [],
+      },
+      {
+        transport: "stdio",
+        args: ["server.js"],
+      },
+      {
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { "bad-name": { env: "TOKEN" } },
+      },
+      {
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { TOKEN: { value: "literal" } },
       },
     ];
 

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-stdio-sync.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-stdio-sync.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_CODEX_CONFIG_SYNC: process.env.TFX_CODEX_CONFIG_SYNC,
+  BRAVE_API_KEY: process.env.BRAVE_API_KEY,
+  TFX_MISSING_BRAVE_API_KEY: process.env.TFX_MISSING_BRAVE_API_KEY,
+};
+
+function createHomeDir(prefix = "mcp-guard-stdio-sync-") {
+  const base = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(join(base, ".codex"), { recursive: true });
+  mkdirSync(join(base, ".gemini", "config"), { recursive: true });
+  mkdirSync(join(base, "repo", ".claude"), { recursive: true });
+  return base;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function registryFor(homeDir, envDescriptor = { env: "BRAVE_API_KEY" }) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: {
+      "brave-search": {
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+        env: {
+          BRAVE_API_KEY: envDescriptor,
+        },
+        safe: true,
+        targets: ["claude", "gemini", "codex", "antigravity"],
+      },
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      watched_paths: [
+        join(homeDir, "repo", ".mcp.json"),
+        join(homeDir, "repo", ".claude", "mcp.json"),
+        join(homeDir, ".gemini", "settings.json"),
+        join(homeDir, ".gemini", "config", "mcp_config.json"),
+        join(homeDir, ".codex", "config.toml"),
+      ],
+    },
+  };
+}
+
+afterEach(restoreEnv);
+
+describe("syncRegistryTargets stdio servers", () => {
+  it("writes stdio command, args, and resolved env to all primary clients", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+
+    for (const jsonPath of [
+      join(homeDir, "repo", ".mcp.json"),
+      join(homeDir, "repo", ".claude", "mcp.json"),
+      join(homeDir, ".gemini", "settings.json"),
+      join(homeDir, ".gemini", "config", "mcp_config.json"),
+    ]) {
+      writeFileSync(
+        jsonPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              "brave-search": {
+                type: "http",
+                url: "https://mcp.brave.com/mcp",
+                headers: { Authorization: "Bearer stale" },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    }
+
+    const result = syncRegistryTargets({ registry: registryFor(homeDir) });
+
+    assert.equal(
+      result.actions.every((action) => action.status === "updated"),
+      true,
+    );
+
+    for (const jsonPath of [
+      join(homeDir, "repo", ".mcp.json"),
+      join(homeDir, "repo", ".claude", "mcp.json"),
+      join(homeDir, ".gemini", "settings.json"),
+      join(homeDir, ".gemini", "config", "mcp_config.json"),
+    ]) {
+      const config = JSON.parse(readFileSync(jsonPath, "utf8"));
+      assert.deepEqual(config.mcpServers["brave-search"], {
+        command: "npx",
+        args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+        env: {
+          BRAVE_API_KEY: "test-brave-key",
+        },
+      });
+    }
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.match(codexToml, /\[mcp_servers\.brave-search\]/);
+    assert.match(codexToml, /command = "npx"/);
+    assert.match(
+      codexToml,
+      /args = \["-y", "@brave\/brave-search-mcp-server", "--transport", "stdio"\]/,
+    );
+    assert.match(codexToml, /env = \{ "BRAVE_API_KEY" = "test-brave-key" \}/);
+    assert.doesNotMatch(codexToml, /url = /);
+  });
+
+  it("warns on missing stdio env vars without writing empty env values", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    delete process.env.TFX_MISSING_BRAVE_API_KEY;
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, { env: "TFX_MISSING_BRAVE_API_KEY" }),
+    });
+
+    assert.ok(
+      result.actions.some((action) =>
+        (action.warnings || []).some((warning) =>
+          warning.includes("TFX_MISSING_BRAVE_API_KEY"),
+        ),
+      ),
+    );
+
+    const projectConfig = JSON.parse(
+      readFileSync(join(homeDir, "repo", ".mcp.json"), "utf8"),
+    );
+    assert.deepEqual(projectConfig.mcpServers["brave-search"], {
+      command: "npx",
+      args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+    });
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.doesNotMatch(codexToml, /TFX_MISSING_BRAVE_API_KEY/);
+    assert.doesNotMatch(codexToml, /env = /);
+    assert.doesNotMatch(codexToml, /""/);
+  });
+});

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
@@ -117,7 +117,7 @@ describe("watched MCP remediation with HTTP headers", () => {
     assert.match(JSON.stringify(result), /\*\*\*REDACTED\*\*\*/);
   });
 
-  it("keeps stdio-only registry entries unsupported", () => {
+  it("accepts stdio-only registry entries with command and args", () => {
     const errors = validateRegistry({
       version: 1,
       defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
@@ -131,8 +131,6 @@ describe("watched MCP remediation with HTTP headers", () => {
       policies: { watched_paths: [] },
     });
 
-    assert.ok(errors.some((error) => error.includes("transport")));
-    assert.ok(errors.some((error) => error.includes("command")));
-    assert.ok(errors.some((error) => error.includes("args")));
+    assert.deepEqual(errors, []);
   });
 });

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -11,6 +11,7 @@ import {
   remediate,
   resolveHubUrl,
   scanForStdioServers,
+  syncRegistryTargets,
 } from "../lib/mcp-guard-engine.mjs";
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
@@ -19,6 +20,7 @@ const originalHome = {
   HOME: process.env.HOME,
   USERPROFILE: process.env.USERPROFILE,
   TFX_HUB_PORT: process.env.TFX_HUB_PORT,
+  EXA_API_KEY: process.env.EXA_API_KEY,
 };
 
 function createHomeDir(prefix = "mcp-guard-") {
@@ -47,6 +49,9 @@ afterEach(() => {
 
   if (originalHome.TFX_HUB_PORT === undefined) delete process.env.TFX_HUB_PORT;
   else process.env.TFX_HUB_PORT = originalHome.TFX_HUB_PORT;
+
+  if (originalHome.EXA_API_KEY === undefined) delete process.env.EXA_API_KEY;
+  else process.env.EXA_API_KEY = originalHome.EXA_API_KEY;
 });
 
 describe("mcp guard engine", () => {
@@ -54,15 +59,19 @@ describe("mcp guard engine", () => {
     const registry = loadRegistry();
     assert.equal(registry.version, 1);
     assert.equal(registry.servers["tfx-hub"].url, "http://127.0.0.1:27888/mcp");
-    assert.equal(registry.policies.watched_paths.length, 6);
+    assert.equal(registry.policies.watched_paths.length, 7);
   });
 
-  it("matches watched paths for Gemini, Claude project MCP, and local .mcp.json", () => {
+  it("matches watched paths for Gemini, Antigravity, Claude project MCP, and local .mcp.json", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
 
     assert.equal(
       isWatchedPath(join(homeDir, ".gemini", "settings.json")),
+      true,
+    );
+    assert.equal(
+      isWatchedPath(join(homeDir, ".gemini", "config", "mcp_config.json")),
       true,
     );
     assert.equal(
@@ -205,5 +214,81 @@ describe("mcp guard engine", () => {
     // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
     // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
     assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
+  });
+
+  it("syncs antigravity MCP config with Gemini-style JSON and http type", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+    process.env.EXA_API_KEY = "test-exa-key";
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["gemini", "antigravity"],
+        },
+        context7: {
+          transport: "http",
+          url: "https://mcp.context7.com/mcp",
+          safe: true,
+          targets: ["gemini"],
+        },
+        exa: {
+          transport: "http",
+          url: "https://mcp.exa.ai/mcp",
+          headers: {
+            Authorization: { env: "EXA_API_KEY", prefix: "Bearer " },
+          },
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = syncRegistryTargets({ registry });
+    const updated = JSON.parse(readFileSync(antigravityPath, "utf8"));
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        serverCount: action.serverCount,
+      })),
+      [{ label: "Antigravity", status: "updated", serverCount: 2 }],
+    );
+    assert.deepEqual(updated, {
+      mcpServers: {
+        "tfx-hub": {
+          url: "http://127.0.0.1:27888/mcp",
+          type: "http",
+        },
+        exa: {
+          url: "https://mcp.exa.ai/mcp",
+          type: "http",
+          headers: {
+            Authorization: "Bearer test-exa-key",
+          },
+        },
+      },
+    });
   });
 });

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -23,7 +23,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   },
   policy_notes: {
     transport:
-      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+      'Server transport accepts "hub-url" for triflux Hub URL flow, "http" for direct Streamable HTTP MCP endpoints, or "stdio" for upstream-stdio-only MCP servers (rare; only for servers that have no hosted HTTP endpoint, e.g. brave-search). stdio servers require command, args, and may include env.',
     headers:
       'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
     secret_safety:
@@ -34,7 +34,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       transport: "hub-url",
       url: "http://127.0.0.1:27888/mcp",
       safe: true,
-      targets: ["claude", "gemini", "codex"],
+      targets: ["claude", "gemini", "codex", "antigravity"],
       description: "triflux Hub MCP 서버",
     },
   },
@@ -49,6 +49,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       "~/.claude/settings.local.json",
       ".claude/mcp.json",
       ".mcp.json",
+      "~/.gemini/config/mcp_config.json",
     ],
   },
 });
@@ -107,6 +108,7 @@ function ensureBackup(filePath) {
 function isJsonMcpConfig(filePath) {
   const name = pathBasename(filePath);
   return (
+    isAntigravityConfig(filePath) ||
     name === "settings.json" ||
     name === "settings.local.json" ||
     name === ".mcp.json" ||
@@ -117,6 +119,11 @@ function isJsonMcpConfig(filePath) {
 function isCodexConfig(filePath) {
   const normalized = normalizeForMatch(filePath);
   return normalized.endsWith("/.codex/config.toml");
+}
+
+function isAntigravityConfig(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
 function isProtectedCodexConfigMutationEnv(env = process.env) {
@@ -132,6 +139,8 @@ function shouldSkipCodexConfigMutation() {
 
 function detectClient(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "gemini";
   if (normalized.endsWith("/.codex/config.toml")) return "codex";
   if (
@@ -147,6 +156,8 @@ function detectClient(filePath) {
 
 function detectLabel(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "Gemini";
   if (normalized.endsWith("/.codex/config.toml")) return "Codex";
   if (normalized.endsWith("/.claude/settings.json")) return "Claude User";
@@ -161,6 +172,7 @@ function isPrimaryConfigTarget(filePath) {
   const normalized = normalizeForMatch(filePath);
   return (
     normalized.endsWith("/.gemini/settings.json") ||
+    normalized.endsWith("/.gemini/config/mcp_config.json") ||
     normalized.endsWith("/.codex/config.toml") ||
     normalized.endsWith("/.claude/mcp.json") ||
     normalized.endsWith("/.mcp.json")
@@ -190,6 +202,9 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return parseTomlArray(value);
+  }
   if (value.startsWith("{") && value.endsWith("}")) {
     return parseTomlInlineTable(value);
   }
@@ -197,6 +212,39 @@ function parseTomlScalar(rawValue) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlArray(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return [];
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  return parts.map((part) => parseTomlScalar(part));
 }
 
 function parseTomlInlineTable(rawValue) {
@@ -275,6 +323,10 @@ function isValidHeaderName(name) {
   return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
 }
 
+function isValidEnvName(name) {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(String(name || ""));
+}
+
 function normalizeHeaderDescriptors(headers = {}) {
   const normalized = {};
   if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
@@ -305,6 +357,47 @@ function normalizeHeaderDescriptors(headers = {}) {
     }
   }
   return normalized;
+}
+
+function normalizeEnvDescriptors(env = {}) {
+  const normalized = {};
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(env)) {
+    if (!isValidEnvName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor) &&
+      Object.hasOwn(descriptor, "env") &&
+      typeof descriptor.env === "string" &&
+      descriptor.env.trim()
+    ) {
+      normalized[name] = { env: descriptor.env.trim() };
+    }
+  }
+  return normalized;
+}
+
+function resolveEnvDescriptors(name, serverConfig) {
+  const descriptors = normalizeEnvDescriptors(serverConfig?.env || {});
+  const env = {};
+  const warnings = [];
+
+  for (const [envKey, descriptor] of Object.entries(descriptors)) {
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${envKey} env skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+    env[envKey] = envValue;
+  }
+
+  return { descriptors, env, warnings };
 }
 
 function resolveHeaderDescriptors(name, serverConfig, filePath) {
@@ -480,6 +573,10 @@ function formatTomlInlineTable(data = {}) {
     .join(", ")} }`;
 }
 
+function formatTomlArray(values = []) {
+  return `[${values.map((value) => formatTomlString(value)).join(", ")}]`;
+}
+
 function upsertTomlServer(raw, name, config, codex = {}) {
   const lines = String(raw || "").split(/\r?\n/);
   const header = `[mcp_servers.${name}]`;
@@ -490,8 +587,20 @@ function upsertTomlServer(raw, name, config, codex = {}) {
     "bearer_token_env_var",
     "http_headers",
     "env_http_headers",
+    "env",
   ]);
-  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  const nextManagedLines = [];
+  if (typeof config.url === "string") {
+    nextManagedLines.push(`url = ${formatTomlString(config.url)}`);
+  }
+  if (typeof config.command === "string") {
+    nextManagedLines.push(`command = ${formatTomlString(config.command)}`);
+  }
+  if (Array.isArray(config.args)) {
+    nextManagedLines.push(`args = ${formatTomlArray(config.args)}`);
+  }
+  const env = formatTomlInlineTable(config.env || {});
+  if (env) nextManagedLines.push(`env = ${env}`);
   if (codex.bearer_token_env_var) {
     nextManagedLines.push(
       `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
@@ -566,7 +675,7 @@ function serverTargets(serverConfig) {
       ),
     ];
   }
-  return ["claude", "gemini", "codex"];
+  return ["claude", "gemini", "codex", "antigravity"];
 }
 
 function serverAppliesToClient(serverConfig, client) {
@@ -595,6 +704,24 @@ function syncDenylistKey(client, serverName) {
 }
 
 export function buildDesiredServerRecord(name, serverConfig, filePath) {
+  if (serverConfig?.transport === "stdio") {
+    const resolvedEnv = resolveEnvDescriptors(name, serverConfig);
+    const envConfig = hasOwnEntries(resolvedEnv.env)
+      ? { env: resolvedEnv.env }
+      : {};
+    return {
+      name,
+      config: {
+        command: serverConfig.command,
+        args: Array.isArray(serverConfig.args) ? [...serverConfig.args] : [],
+        ...envConfig,
+      },
+      envDescriptors: resolvedEnv.descriptors,
+      codex: {},
+      warnings: resolvedEnv.warnings,
+    };
+  }
+
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
@@ -613,6 +740,16 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
     return {
       name,
       config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
+  }
+
+  if (isAntigravityConfig(filePath)) {
+    return {
+      name,
+      config: { url, type: "http", ...headerConfig },
       headerDescriptors: resolvedHeaders.descriptors,
       codex: resolvedHeaders.codex,
       warnings: resolvedHeaders.warnings,
@@ -669,6 +806,19 @@ function scanJsonConfig(filePath) {
               url:
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
+              args: Array.isArray(config.args)
+                ? config.args.filter((value) => typeof value === "string")
+                : [],
+              env:
+                config.env &&
+                typeof config.env === "object" &&
+                !Array.isArray(config.env)
+                  ? Object.fromEntries(
+                      Object.entries(config.env).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
               type: typeof config.type === "string" ? config.type : "",
               headers:
                 config.headers &&
@@ -732,6 +882,19 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      args: Array.isArray(config.args)
+        ? config.args.filter((value) => typeof value === "string")
+        : [],
+      env:
+        config.env &&
+        typeof config.env === "object" &&
+        !Array.isArray(config.env)
+          ? Object.fromEntries(
+              Object.entries(config.env).filter(
+                ([, value]) => typeof value === "string",
+              ),
+            )
+          : {},
       headers:
         config.http_headers && typeof config.http_headers === "object"
           ? config.http_headers
@@ -804,8 +967,21 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (Object.hasOwn(update.config, "command")) {
+      delete nextConfig.url;
+      delete nextConfig.type;
+      delete nextConfig.headers;
+    }
+    if (Object.hasOwn(update.config, "url")) {
+      delete nextConfig.command;
+      delete nextConfig.args;
+      delete nextConfig.env;
+    }
     if (!Object.hasOwn(update.config, "headers")) {
       delete nextConfig.headers;
+    }
+    if (!Object.hasOwn(update.config, "env")) {
+      delete nextConfig.env;
     }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
@@ -911,24 +1087,89 @@ export function validateRegistry(registry) {
         errors.push(`registry.servers.${name} must be an object`);
         continue;
       }
-      if (typeof server.url !== "string" || !server.url.trim()) {
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http", "stdio"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url, http, or stdio`,
+        );
+      }
+      if (
+        transport !== "stdio" &&
+        (typeof server.url !== "string" || !server.url.trim())
+      ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      const transport = server.transport || registry.defaults?.transport;
-      if (!["hub-url", "http"].includes(transport)) {
+      if (transport === "stdio" && server.url !== undefined) {
+        errors.push(`registry.servers.${name}.url is not used for stdio`);
+      }
+      if (transport === "stdio") {
+        if (typeof server.command !== "string" || !server.command.trim()) {
+          errors.push(
+            `registry.servers.${name}.command must be a non-empty string for stdio`,
+          );
+        }
+        if (
+          !Array.isArray(server.args) ||
+          server.args.some((arg) => typeof arg !== "string")
+        ) {
+          errors.push(
+            `registry.servers.${name}.args must be an array of strings for stdio`,
+          );
+        }
+      }
+      if (transport !== "stdio" && server.command !== undefined) {
         errors.push(
-          `registry.servers.${name}.transport must be hub-url or http`,
+          `registry.servers.${name}.command is allowed only for stdio transport`,
         );
       }
-      if (server.command !== undefined) {
+      if (transport !== "stdio" && server.args !== undefined) {
         errors.push(
-          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+          `registry.servers.${name}.args is allowed only for stdio transport`,
         );
       }
-      if (server.args !== undefined) {
-        errors.push(
-          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
-        );
+      if (server.env !== undefined) {
+        if (transport !== "stdio") {
+          errors.push(
+            `registry.servers.${name}.env is allowed only for stdio transport`,
+          );
+        }
+        if (
+          !server.env ||
+          typeof server.env !== "object" ||
+          Array.isArray(server.env)
+        ) {
+          errors.push(`registry.servers.${name}.env must be an object`);
+        } else {
+          for (const [envKey, descriptor] of Object.entries(server.env)) {
+            if (!isValidEnvName(envKey)) {
+              errors.push(
+                `registry.servers.${name}.env contains invalid env name ${envKey}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            if (
+              keys.length !== 1 ||
+              !Object.hasOwn(descriptor, "env") ||
+              typeof descriptor.env !== "string" ||
+              !descriptor.env.trim()
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey}.env must be a non-empty string`,
+              );
+            }
+          }
+        }
       }
       if (server.headers !== undefined) {
         if (!["hub-url", "http"].includes(transport)) {
@@ -1174,7 +1415,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         serverConfig,
         config.filePath,
       );
-      const expectedUrl = desired.config.url;
+      const expectedUrl = desired.config.url || "";
+      const expectedCommand = desired.config.command || "";
       const expectedHeaders = isCodexConfig(config.filePath)
         ? desired.headerDescriptors || {}
         : descriptorsFromJsonConfig(desired.config);
@@ -1190,6 +1432,13 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "invalid-config";
       } else if (!actual) {
         status = "missing";
+      } else if (expectedCommand) {
+        status =
+          actual.command === expectedCommand &&
+          JSON.stringify(actual.args || []) ===
+            JSON.stringify(desired.config.args || [])
+            ? "present"
+            : "mismatch";
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
@@ -1205,7 +1454,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         label: config.label,
         filePath: config.filePath,
         expectedUrl,
+        expectedCommand,
         actualUrl: actual?.url || "",
+        actualCommand: actual?.command || "",
         status,
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
@@ -1440,7 +1691,7 @@ export function addRegistryServer(name, url, options = {}) {
                 .filter(Boolean),
             ),
           ]
-        : ["claude", "gemini", "codex"],
+        : ["claude", "gemini", "codex", "antigravity"],
     description: options.description || `${trimmedName} MCP 서버`,
   };
 

--- a/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-http-headers.test.mjs
@@ -59,7 +59,28 @@ describe("mcp guard HTTP transport + headers schema", () => {
     }
   });
 
-  it("rejects malformed header descriptors and stdio-shaped registry servers", () => {
+  it("validates stdio transport with command, args, and env descriptors", () => {
+    assert.deepEqual(
+      validateRegistry(
+        registryWith({
+          transport: "stdio",
+          command: "npx",
+          args: [
+            "-y",
+            "@brave/brave-search-mcp-server",
+            "--transport",
+            "stdio",
+          ],
+          env: {
+            BRAVE_API_KEY: { env: "BRAVE_API_KEY" },
+          },
+        }),
+      ),
+      [],
+    );
+  });
+
+  it("rejects malformed header descriptors and malformed stdio registry servers", () => {
     const invalidServers = [
       {
         transport: "http",
@@ -78,7 +99,8 @@ describe("mcp guard HTTP transport + headers schema", () => {
       },
       {
         transport: "stdio",
-        url: "https://example.com/mcp",
+        command: "npx",
+        args: [],
         headers: { "X-Client": { value: "triflux" } },
       },
       {
@@ -90,6 +112,28 @@ describe("mcp guard HTTP transport + headers schema", () => {
         transport: "http",
         url: "https://example.com/mcp",
         args: ["server.js"],
+      },
+      {
+        transport: "stdio",
+        url: "https://example.com/mcp",
+        command: "npx",
+        args: [],
+      },
+      {
+        transport: "stdio",
+        args: ["server.js"],
+      },
+      {
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { "bad-name": { env: "TOKEN" } },
+      },
+      {
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { TOKEN: { value: "literal" } },
       },
     ];
 

--- a/scripts/__tests__/mcp-guard-engine-stdio-sync.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-stdio-sync.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { syncRegistryTargets } from "../lib/mcp-guard-engine.mjs";
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  TFX_CODEX_CONFIG_SYNC: process.env.TFX_CODEX_CONFIG_SYNC,
+  BRAVE_API_KEY: process.env.BRAVE_API_KEY,
+  TFX_MISSING_BRAVE_API_KEY: process.env.TFX_MISSING_BRAVE_API_KEY,
+};
+
+function createHomeDir(prefix = "mcp-guard-stdio-sync-") {
+  const base = join(
+    tmpdir(),
+    `${prefix}${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(join(base, ".codex"), { recursive: true });
+  mkdirSync(join(base, ".gemini", "config"), { recursive: true });
+  mkdirSync(join(base, "repo", ".claude"), { recursive: true });
+  return base;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function registryFor(homeDir, envDescriptor = { env: "BRAVE_API_KEY" }) {
+  return {
+    version: 1,
+    defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+    servers: {
+      "brave-search": {
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+        env: {
+          BRAVE_API_KEY: envDescriptor,
+        },
+        safe: true,
+        targets: ["claude", "gemini", "codex", "antigravity"],
+      },
+    },
+    policies: {
+      stdio_action: "replace-with-hub",
+      watched_paths: [
+        join(homeDir, "repo", ".mcp.json"),
+        join(homeDir, "repo", ".claude", "mcp.json"),
+        join(homeDir, ".gemini", "settings.json"),
+        join(homeDir, ".gemini", "config", "mcp_config.json"),
+        join(homeDir, ".codex", "config.toml"),
+      ],
+    },
+  };
+}
+
+afterEach(restoreEnv);
+
+describe("syncRegistryTargets stdio servers", () => {
+  it("writes stdio command, args, and resolved env to all primary clients", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+
+    for (const jsonPath of [
+      join(homeDir, "repo", ".mcp.json"),
+      join(homeDir, "repo", ".claude", "mcp.json"),
+      join(homeDir, ".gemini", "settings.json"),
+      join(homeDir, ".gemini", "config", "mcp_config.json"),
+    ]) {
+      writeFileSync(
+        jsonPath,
+        JSON.stringify(
+          {
+            mcpServers: {
+              "brave-search": {
+                type: "http",
+                url: "https://mcp.brave.com/mcp",
+                headers: { Authorization: "Bearer stale" },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+    }
+
+    const result = syncRegistryTargets({ registry: registryFor(homeDir) });
+
+    assert.equal(
+      result.actions.every((action) => action.status === "updated"),
+      true,
+    );
+
+    for (const jsonPath of [
+      join(homeDir, "repo", ".mcp.json"),
+      join(homeDir, "repo", ".claude", "mcp.json"),
+      join(homeDir, ".gemini", "settings.json"),
+      join(homeDir, ".gemini", "config", "mcp_config.json"),
+    ]) {
+      const config = JSON.parse(readFileSync(jsonPath, "utf8"));
+      assert.deepEqual(config.mcpServers["brave-search"], {
+        command: "npx",
+        args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+        env: {
+          BRAVE_API_KEY: "test-brave-key",
+        },
+      });
+    }
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.match(codexToml, /\[mcp_servers\.brave-search\]/);
+    assert.match(codexToml, /command = "npx"/);
+    assert.match(
+      codexToml,
+      /args = \["-y", "@brave\/brave-search-mcp-server", "--transport", "stdio"\]/,
+    );
+    assert.match(codexToml, /env = \{ "BRAVE_API_KEY" = "test-brave-key" \}/);
+    assert.doesNotMatch(codexToml, /url = /);
+  });
+
+  it("warns on missing stdio env vars without writing empty env values", () => {
+    const homeDir = createHomeDir();
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+    delete process.env.TFX_MISSING_BRAVE_API_KEY;
+
+    const result = syncRegistryTargets({
+      registry: registryFor(homeDir, { env: "TFX_MISSING_BRAVE_API_KEY" }),
+    });
+
+    assert.ok(
+      result.actions.some((action) =>
+        (action.warnings || []).some((warning) =>
+          warning.includes("TFX_MISSING_BRAVE_API_KEY"),
+        ),
+      ),
+    );
+
+    const projectConfig = JSON.parse(
+      readFileSync(join(homeDir, "repo", ".mcp.json"), "utf8"),
+    );
+    assert.deepEqual(projectConfig.mcpServers["brave-search"], {
+      command: "npx",
+      args: ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+    });
+
+    const codexToml = readFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      "utf8",
+    );
+    assert.doesNotMatch(codexToml, /TFX_MISSING_BRAVE_API_KEY/);
+    assert.doesNotMatch(codexToml, /env = /);
+    assert.doesNotMatch(codexToml, /""/);
+  });
+});

--- a/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-watch-http-headers.test.mjs
@@ -117,7 +117,7 @@ describe("watched MCP remediation with HTTP headers", () => {
     assert.match(JSON.stringify(result), /\*\*\*REDACTED\*\*\*/);
   });
 
-  it("keeps stdio-only registry entries unsupported", () => {
+  it("accepts stdio-only registry entries with command and args", () => {
     const errors = validateRegistry({
       version: 1,
       defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
@@ -131,8 +131,6 @@ describe("watched MCP remediation with HTTP headers", () => {
       policies: { watched_paths: [] },
     });
 
-    assert.ok(errors.some((error) => error.includes("transport")));
-    assert.ok(errors.some((error) => error.includes("command")));
-    assert.ok(errors.some((error) => error.includes("args")));
+    assert.deepEqual(errors, []);
   });
 });

--- a/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -11,6 +11,7 @@ import {
   remediate,
   resolveHubUrl,
   scanForStdioServers,
+  syncRegistryTargets,
 } from "../lib/mcp-guard-engine.mjs";
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
@@ -19,6 +20,7 @@ const originalHome = {
   HOME: process.env.HOME,
   USERPROFILE: process.env.USERPROFILE,
   TFX_HUB_PORT: process.env.TFX_HUB_PORT,
+  EXA_API_KEY: process.env.EXA_API_KEY,
 };
 
 function createHomeDir(prefix = "mcp-guard-") {
@@ -47,6 +49,9 @@ afterEach(() => {
 
   if (originalHome.TFX_HUB_PORT === undefined) delete process.env.TFX_HUB_PORT;
   else process.env.TFX_HUB_PORT = originalHome.TFX_HUB_PORT;
+
+  if (originalHome.EXA_API_KEY === undefined) delete process.env.EXA_API_KEY;
+  else process.env.EXA_API_KEY = originalHome.EXA_API_KEY;
 });
 
 describe("mcp guard engine", () => {
@@ -54,15 +59,19 @@ describe("mcp guard engine", () => {
     const registry = loadRegistry();
     assert.equal(registry.version, 1);
     assert.equal(registry.servers["tfx-hub"].url, "http://127.0.0.1:27888/mcp");
-    assert.equal(registry.policies.watched_paths.length, 6);
+    assert.equal(registry.policies.watched_paths.length, 7);
   });
 
-  it("matches watched paths for Gemini, Claude project MCP, and local .mcp.json", () => {
+  it("matches watched paths for Gemini, Antigravity, Claude project MCP, and local .mcp.json", () => {
     const homeDir = createHomeDir();
     withHome(homeDir);
 
     assert.equal(
       isWatchedPath(join(homeDir, ".gemini", "settings.json")),
+      true,
+    );
+    assert.equal(
+      isWatchedPath(join(homeDir, ".gemini", "config", "mcp_config.json")),
       true,
     );
     assert.equal(
@@ -205,5 +214,81 @@ describe("mcp guard engine", () => {
     // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
     // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
     assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
+  });
+
+  it("syncs antigravity MCP config with Gemini-style JSON and http type", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+    process.env.EXA_API_KEY = "test-exa-key";
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["gemini", "antigravity"],
+        },
+        context7: {
+          transport: "http",
+          url: "https://mcp.context7.com/mcp",
+          safe: true,
+          targets: ["gemini"],
+        },
+        exa: {
+          transport: "http",
+          url: "https://mcp.exa.ai/mcp",
+          headers: {
+            Authorization: { env: "EXA_API_KEY", prefix: "Bearer " },
+          },
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = syncRegistryTargets({ registry });
+    const updated = JSON.parse(readFileSync(antigravityPath, "utf8"));
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        serverCount: action.serverCount,
+      })),
+      [{ label: "Antigravity", status: "updated", serverCount: 2 }],
+    );
+    assert.deepEqual(updated, {
+      mcpServers: {
+        "tfx-hub": {
+          url: "http://127.0.0.1:27888/mcp",
+          type: "http",
+        },
+        exa: {
+          url: "https://mcp.exa.ai/mcp",
+          type: "http",
+          headers: {
+            Authorization: "Bearer test-exa-key",
+          },
+        },
+      },
+    });
   });
 });

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -34,7 +34,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       transport: "hub-url",
       url: "http://127.0.0.1:27888/mcp",
       safe: true,
-      targets: ["claude", "gemini", "codex"],
+      targets: ["claude", "gemini", "codex", "antigravity"],
       description: "triflux Hub MCP 서버",
     },
   },
@@ -49,6 +49,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       "~/.claude/settings.local.json",
       ".claude/mcp.json",
       ".mcp.json",
+      "~/.gemini/config/mcp_config.json",
     ],
   },
 });
@@ -107,6 +108,7 @@ function ensureBackup(filePath) {
 function isJsonMcpConfig(filePath) {
   const name = pathBasename(filePath);
   return (
+    isAntigravityConfig(filePath) ||
     name === "settings.json" ||
     name === "settings.local.json" ||
     name === ".mcp.json" ||
@@ -117,6 +119,11 @@ function isJsonMcpConfig(filePath) {
 function isCodexConfig(filePath) {
   const normalized = normalizeForMatch(filePath);
   return normalized.endsWith("/.codex/config.toml");
+}
+
+function isAntigravityConfig(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
 function isProtectedCodexConfigMutationEnv(env = process.env) {
@@ -132,6 +139,8 @@ function shouldSkipCodexConfigMutation() {
 
 function detectClient(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "gemini";
   if (normalized.endsWith("/.codex/config.toml")) return "codex";
   if (
@@ -147,6 +156,8 @@ function detectClient(filePath) {
 
 function detectLabel(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "Gemini";
   if (normalized.endsWith("/.codex/config.toml")) return "Codex";
   if (normalized.endsWith("/.claude/settings.json")) return "Claude User";
@@ -161,6 +172,7 @@ function isPrimaryConfigTarget(filePath) {
   const normalized = normalizeForMatch(filePath);
   return (
     normalized.endsWith("/.gemini/settings.json") ||
+    normalized.endsWith("/.gemini/config/mcp_config.json") ||
     normalized.endsWith("/.codex/config.toml") ||
     normalized.endsWith("/.claude/mcp.json") ||
     normalized.endsWith("/.mcp.json")
@@ -566,7 +578,7 @@ function serverTargets(serverConfig) {
       ),
     ];
   }
-  return ["claude", "gemini", "codex"];
+  return ["claude", "gemini", "codex", "antigravity"];
 }
 
 function serverAppliesToClient(serverConfig, client) {
@@ -613,6 +625,16 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
     return {
       name,
       config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
+  }
+
+  if (isAntigravityConfig(filePath)) {
+    return {
+      name,
+      config: { url, type: "http", ...headerConfig },
       headerDescriptors: resolvedHeaders.descriptors,
       codex: resolvedHeaders.codex,
       warnings: resolvedHeaders.warnings,
@@ -1440,7 +1462,7 @@ export function addRegistryServer(name, url, options = {}) {
                 .filter(Boolean),
             ),
           ]
-        : ["claude", "gemini", "codex"],
+        : ["claude", "gemini", "codex", "antigravity"],
     description: options.description || `${trimmedName} MCP 서버`,
   };
 

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -23,7 +23,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   },
   policy_notes: {
     transport:
-      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+      'Server transport accepts "hub-url" for triflux Hub URL flow, "http" for direct Streamable HTTP MCP endpoints, or "stdio" for upstream-stdio-only MCP servers (rare; only for servers that have no hosted HTTP endpoint, e.g. brave-search). stdio servers require command, args, and may include env.',
     headers:
       'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
     secret_safety:
@@ -202,6 +202,9 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return parseTomlArray(value);
+  }
   if (value.startsWith("{") && value.endsWith("}")) {
     return parseTomlInlineTable(value);
   }
@@ -209,6 +212,39 @@ function parseTomlScalar(rawValue) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlArray(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return [];
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  return parts.map((part) => parseTomlScalar(part));
 }
 
 function parseTomlInlineTable(rawValue) {
@@ -287,6 +323,10 @@ function isValidHeaderName(name) {
   return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
 }
 
+function isValidEnvName(name) {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(String(name || ""));
+}
+
 function normalizeHeaderDescriptors(headers = {}) {
   const normalized = {};
   if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
@@ -317,6 +357,47 @@ function normalizeHeaderDescriptors(headers = {}) {
     }
   }
   return normalized;
+}
+
+function normalizeEnvDescriptors(env = {}) {
+  const normalized = {};
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(env)) {
+    if (!isValidEnvName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor) &&
+      Object.hasOwn(descriptor, "env") &&
+      typeof descriptor.env === "string" &&
+      descriptor.env.trim()
+    ) {
+      normalized[name] = { env: descriptor.env.trim() };
+    }
+  }
+  return normalized;
+}
+
+function resolveEnvDescriptors(name, serverConfig) {
+  const descriptors = normalizeEnvDescriptors(serverConfig?.env || {});
+  const env = {};
+  const warnings = [];
+
+  for (const [envKey, descriptor] of Object.entries(descriptors)) {
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${envKey} env skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+    env[envKey] = envValue;
+  }
+
+  return { descriptors, env, warnings };
 }
 
 function resolveHeaderDescriptors(name, serverConfig, filePath) {
@@ -492,6 +573,10 @@ function formatTomlInlineTable(data = {}) {
     .join(", ")} }`;
 }
 
+function formatTomlArray(values = []) {
+  return `[${values.map((value) => formatTomlString(value)).join(", ")}]`;
+}
+
 function upsertTomlServer(raw, name, config, codex = {}) {
   const lines = String(raw || "").split(/\r?\n/);
   const header = `[mcp_servers.${name}]`;
@@ -502,8 +587,20 @@ function upsertTomlServer(raw, name, config, codex = {}) {
     "bearer_token_env_var",
     "http_headers",
     "env_http_headers",
+    "env",
   ]);
-  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  const nextManagedLines = [];
+  if (typeof config.url === "string") {
+    nextManagedLines.push(`url = ${formatTomlString(config.url)}`);
+  }
+  if (typeof config.command === "string") {
+    nextManagedLines.push(`command = ${formatTomlString(config.command)}`);
+  }
+  if (Array.isArray(config.args)) {
+    nextManagedLines.push(`args = ${formatTomlArray(config.args)}`);
+  }
+  const env = formatTomlInlineTable(config.env || {});
+  if (env) nextManagedLines.push(`env = ${env}`);
   if (codex.bearer_token_env_var) {
     nextManagedLines.push(
       `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
@@ -607,6 +704,24 @@ function syncDenylistKey(client, serverName) {
 }
 
 export function buildDesiredServerRecord(name, serverConfig, filePath) {
+  if (serverConfig?.transport === "stdio") {
+    const resolvedEnv = resolveEnvDescriptors(name, serverConfig);
+    const envConfig = hasOwnEntries(resolvedEnv.env)
+      ? { env: resolvedEnv.env }
+      : {};
+    return {
+      name,
+      config: {
+        command: serverConfig.command,
+        args: Array.isArray(serverConfig.args) ? [...serverConfig.args] : [],
+        ...envConfig,
+      },
+      envDescriptors: resolvedEnv.descriptors,
+      codex: {},
+      warnings: resolvedEnv.warnings,
+    };
+  }
+
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
@@ -691,6 +806,19 @@ function scanJsonConfig(filePath) {
               url:
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
+              args: Array.isArray(config.args)
+                ? config.args.filter((value) => typeof value === "string")
+                : [],
+              env:
+                config.env &&
+                typeof config.env === "object" &&
+                !Array.isArray(config.env)
+                  ? Object.fromEntries(
+                      Object.entries(config.env).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
               type: typeof config.type === "string" ? config.type : "",
               headers:
                 config.headers &&
@@ -754,6 +882,19 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      args: Array.isArray(config.args)
+        ? config.args.filter((value) => typeof value === "string")
+        : [],
+      env:
+        config.env &&
+        typeof config.env === "object" &&
+        !Array.isArray(config.env)
+          ? Object.fromEntries(
+              Object.entries(config.env).filter(
+                ([, value]) => typeof value === "string",
+              ),
+            )
+          : {},
       headers:
         config.http_headers && typeof config.http_headers === "object"
           ? config.http_headers
@@ -826,8 +967,21 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (Object.hasOwn(update.config, "command")) {
+      delete nextConfig.url;
+      delete nextConfig.type;
+      delete nextConfig.headers;
+    }
+    if (Object.hasOwn(update.config, "url")) {
+      delete nextConfig.command;
+      delete nextConfig.args;
+      delete nextConfig.env;
+    }
     if (!Object.hasOwn(update.config, "headers")) {
       delete nextConfig.headers;
+    }
+    if (!Object.hasOwn(update.config, "env")) {
+      delete nextConfig.env;
     }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
@@ -933,24 +1087,89 @@ export function validateRegistry(registry) {
         errors.push(`registry.servers.${name} must be an object`);
         continue;
       }
-      if (typeof server.url !== "string" || !server.url.trim()) {
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http", "stdio"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url, http, or stdio`,
+        );
+      }
+      if (
+        transport !== "stdio" &&
+        (typeof server.url !== "string" || !server.url.trim())
+      ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      const transport = server.transport || registry.defaults?.transport;
-      if (!["hub-url", "http"].includes(transport)) {
+      if (transport === "stdio" && server.url !== undefined) {
+        errors.push(`registry.servers.${name}.url is not used for stdio`);
+      }
+      if (transport === "stdio") {
+        if (typeof server.command !== "string" || !server.command.trim()) {
+          errors.push(
+            `registry.servers.${name}.command must be a non-empty string for stdio`,
+          );
+        }
+        if (
+          !Array.isArray(server.args) ||
+          server.args.some((arg) => typeof arg !== "string")
+        ) {
+          errors.push(
+            `registry.servers.${name}.args must be an array of strings for stdio`,
+          );
+        }
+      }
+      if (transport !== "stdio" && server.command !== undefined) {
         errors.push(
-          `registry.servers.${name}.transport must be hub-url or http`,
+          `registry.servers.${name}.command is allowed only for stdio transport`,
         );
       }
-      if (server.command !== undefined) {
+      if (transport !== "stdio" && server.args !== undefined) {
         errors.push(
-          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+          `registry.servers.${name}.args is allowed only for stdio transport`,
         );
       }
-      if (server.args !== undefined) {
-        errors.push(
-          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
-        );
+      if (server.env !== undefined) {
+        if (transport !== "stdio") {
+          errors.push(
+            `registry.servers.${name}.env is allowed only for stdio transport`,
+          );
+        }
+        if (
+          !server.env ||
+          typeof server.env !== "object" ||
+          Array.isArray(server.env)
+        ) {
+          errors.push(`registry.servers.${name}.env must be an object`);
+        } else {
+          for (const [envKey, descriptor] of Object.entries(server.env)) {
+            if (!isValidEnvName(envKey)) {
+              errors.push(
+                `registry.servers.${name}.env contains invalid env name ${envKey}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            if (
+              keys.length !== 1 ||
+              !Object.hasOwn(descriptor, "env") ||
+              typeof descriptor.env !== "string" ||
+              !descriptor.env.trim()
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey}.env must be a non-empty string`,
+              );
+            }
+          }
+        }
       }
       if (server.headers !== undefined) {
         if (!["hub-url", "http"].includes(transport)) {
@@ -1196,7 +1415,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         serverConfig,
         config.filePath,
       );
-      const expectedUrl = desired.config.url;
+      const expectedUrl = desired.config.url || "";
+      const expectedCommand = desired.config.command || "";
       const expectedHeaders = isCodexConfig(config.filePath)
         ? desired.headerDescriptors || {}
         : descriptorsFromJsonConfig(desired.config);
@@ -1212,6 +1432,13 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "invalid-config";
       } else if (!actual) {
         status = "missing";
+      } else if (expectedCommand) {
+        status =
+          actual.command === expectedCommand &&
+          JSON.stringify(actual.args || []) ===
+            JSON.stringify(desired.config.args || [])
+            ? "present"
+            : "mismatch";
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
@@ -1227,7 +1454,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         label: config.label,
         filePath: config.filePath,
         expectedUrl,
+        expectedCommand,
         actualUrl: actual?.url || "",
+        actualCommand: actual?.command || "",
         status,
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),


### PR DESCRIPTION
## Summary

triflux SSOT(config/mcp-registry.json)에 antigravity client target을 추가하고, dirty 상태였던 exa/brave-search/tavily server 등록을 함께 묶었다. 단일 `tfx mcp sync` 경로로 기존 4개 (claude/codex/gemini/.mcp.json) + antigravity까지 자동 전파되도록 했다.

## 변경

- registry: exa / brave-search / tavily server 추가 (HTTP, Authorization Bearer ${EXA_API_KEY} 등 env 디스크립터)
- registry: 5개 server targets에 antigravity 추가
- registry: watched_paths에 ~/.gemini/config/mcp_config.json 추가
- mcp-guard-engine: antigravity client adapter
- tests: antigravity sync 검증

## 배경 — agy MCP 설정

- agy v1.0.0 (2026-05-19 출시)는 ~/.gemini/config/mcp_config.json에서 MCP 설정을 읽는다 (agy 로그 discovery.go:335 확인).
- JSON 양식은 Gemini settings와 동일한 mcpServers 객체다.
- agy 자체 settings.json (~/.gemini/antigravity-cli/settings.json)은 UI 설정만 들어있고 mcpServers 키 없음.

## Test plan

- [x] node --test scripts/__tests__/mcp-guard-engine.test.mjs
- [x] tfx mcp list 출력에 antigravity 행 등장 (`node bin/triflux.mjs mcp list | grep -i antigravity`)
- [x] git diff --check
- [x] antigravity sync fixture가 ~/.gemini/config/mcp_config.json 형식의 temp-home 파일을 갱신하는지 검증
- [ ] tfx mcp sync 후 실제 ~/.gemini/config/mcp_config.json 갱신: 이번 작업 지시의 “워크트리 외부 파일 수정 금지” 때문에 실행하지 않음

## 후속 (별도 PR)

- Bearer 토큰 평문 박힘 분리 (Task B, security/mcp-bearer-secrets 브랜치)