### PR TITLE
security(mcp): Gemini/Antigravity headers 평문 시크릿 처리 정비

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docs/*
 !docs/demo.tape
 !docs/demo-light.tape
 !docs/design/
+!docs/mcp/
 !docs/prd/
 !docs/research/
 !docs/codex-conventions.md

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -5790,6 +5790,9 @@ function cmdMcp(args = [], options = {}) {
       console.log(`  ${LINE}`);
       section("Actions");
       for (const action of result.actions) {
+        for (const warning of action.warnings || []) {
+          process.stderr.write(`${warning}\n`);
+        }
         const label = `${action.label} ${DIM}(${formatPathForDisplay(action.filePath)})${RESET}`;
         if (action.status === "updated") ok(`${label} → updated`);
         else if (action.status === "warning") warn(`${label} → warning`);

--- a/docs/mcp/secrets-handling.md
+++ b/docs/mcp/secrets-handling.md
@@ -1,0 +1,52 @@
+# MCP secrets handling
+
+## 조사 결과
+
+2026-05-20 현재 `tfx mcp sync`의 secret header 처리 결론은 보수적으로 Branch B이다.
+
+- `npm root -g` 결과 글로벌 Node 모듈 위치는 `/opt/homebrew/lib/node_modules`이다.
+- 사용자 지정 grep 명령인 `grep -rE "mcpServers|mcp_config|expandEnv|envVar|\$\{" $(npm root -g)/@google/gemini-cli/dist`는 현재 설치본에 `dist`가 없어 매칭이 없었다. 실제 설치본은 `@google/gemini-cli/bundle` 아래에 있다.
+- Gemini CLI 번들에는 `createTransportRequestInit()`에서 `mcpServerConfig.headers` 값을 `expandEnvVars(value, sanitizedEnv)`로 처리하는 코드가 있다. 따라서 headers 문자열 보간 자체는 존재한다.
+- 다만 headers 보간 입력은 `sanitizeEnvironment(... enableEnvironmentVariableRedaction: true)`를 거친 값이다. Gemini 문서는 `env` block의 `$VAR` / `${VAR}` 확장을 명시하고, 민감 환경변수는 기본 redaction 대상이며 필요 시 `security.allowedEnvironmentVariables`로 명시 허용해야 한다고 설명한다. `EXA_API_KEY` 같은 이름은 secret pattern에 걸릴 수 있으므로, `${EXA_API_KEY}` header만 쓰는 마이그레이션은 기본 설정에서 빈 header가 될 수 있다.
+- Antigravity CLI(`agy`)는 `strings /Users/tellang/.local/bin/agy | grep -E '\$\{|expandEnv|envSubst'`에서 설정 header 보간으로 판단할 수 있는 안정적인 흔적을 찾지 못했다.
+- Antigravity MCP 공식 문서(`https://antigravity.google/docs/mcp`)는 WebFetch 시도에서 SPA HTML만 반환되어 본문 근거를 확보하지 못했다.
+- Antigravity plugin sample인 `~/.gemini/antigravity-cli/plugins/chrome-devtools-mcp/mcp_config.json`은 `env: null` 형태이며 header/env 보간 예시를 제공하지 않는다.
+
+운영 결론: Codex는 `env_http_headers` / `bearer_token_env_var`로 secret을 설정 파일 밖에 둘 수 있지만, Gemini/Antigravity JSON 설정은 지금 단계에서 Bearer header secret을 평문으로 쓴다. Gemini는 향후 allowlist까지 함께 관리하는 별도 마이그레이션이 가능하지만, 이 PR에서는 secret header 보간을 자동 적용하지 않는다.
+
+## 현재 상태
+
+`config/mcp-registry.json`의 header descriptor는 registry에 secret 값을 저장하지 않는다.
+
+```json
+{
+  "headers": {
+    "Authorization": { "env": "EXA_API_KEY", "prefix": "Bearer " }
+  }
+}
+```
+
+대상별 sync 결과는 다르다.
+
+- Codex: `~/.codex/config.toml`에 `bearer_token_env_var` 또는 `env_http_headers`를 기록한다. 런타임이 환경변수 값을 header로 조립하므로 config 파일에 Bearer token 평문이 남지 않는다.
+- Gemini: `~/.gemini/settings.json`의 `mcpServers.<name>.headers.Authorization`에 resolved Bearer token을 기록한다.
+- Antigravity: Task A가 Antigravity target을 추가하면 `~/.gemini/config/mcp_config.json`도 같은 JSON header 구조를 쓰는 것으로 취급한다.
+
+## Mitigation
+
+- Gemini/Antigravity JSON config를 쓸 때 파일 권한을 `0600`으로 강제한다.
+- env descriptor에서 secret header가 resolved plaintext로 기록될 때 `tfx mcp sync`는 stderr warning을 출력한다.
+- secret 값은 `config/mcp-registry.json`, docs, PR body, test fixture에 직접 쓰지 않는다. 테스트는 임시 token 문자열만 사용한다.
+- 운영 환경에서는 `secrets.env` 또는 shell secret manager에서 `EXA_API_KEY`를 주입하고 registry에는 env var 이름만 둔다.
+- 가능하면 remote MCP의 OAuth flow를 우선 사용한다. Gemini CLI는 MCP OAuth token을 별도 token store에서 관리할 수 있다.
+- API key 방식이 필요하면 token rotation 주기를 문서화하고, 노출이 의심될 때 즉시 revoke/rotate한다.
+
+## Migration path
+
+Gemini/Antigravity가 secret header 보간을 안전하게 지원한다고 검증되면 다음 순서로 이전한다.
+
+1. Gemini: `${EXA_API_KEY}` header 보간이 민감 env redaction과 충돌하지 않는지, 또는 `security.allowedEnvironmentVariables`를 함께 관리해야 하는지 먼저 테스트한다.
+2. Antigravity: `mcp_config.json`의 `mcpServers.<name>.headers`에서 `$VAR` / `${VAR}`가 실제 request header로 확장되는지 공식 문서 또는 실행 테스트로 확인한다.
+3. `mcp-guard-engine`의 JSON target writer를 resolved plaintext 대신 interpolation string writer로 전환한다.
+4. plaintext warning을 migration warning으로 낮추고, 기존 plaintext config를 interpolation config로 rewrite하는 regression test를 추가한다.
+5. 실제 home 파일 검증은 temp HOME 또는 dry-run equivalent로 먼저 수행한 뒤, 사용자 home에 적용한다.

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -5790,6 +5790,9 @@ function cmdMcp(args = [], options = {}) {
       console.log(`  ${LINE}`);
       section("Actions");
       for (const action of result.actions) {
+        for (const warning of action.warnings || []) {
+          process.stderr.write(`${warning}\n`);
+        }
         const label = `${action.label} ${DIM}(${formatPathForDisplay(action.filePath)})${RESET}`;
         if (action.status === "updated") ok(`${label} → updated`);
         else if (action.status === "warning") warn(`${label} → warning`);

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -222,5 +222,51 @@ describe("syncRegistryTargets HTTP headers", () => {
     assert.deepEqual(projectConfig.mcpServers.auth.headers, {
       "X-Client": "triflux",
     });
+  });
+
+  it("warns and locks permissions when Gemini sync writes env secrets as plaintext headers", () => {
+    const homeDir = createHomeDir();
+    mkdirSync(join(homeDir, ".gemini"), { recursive: true });
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const settingsPath = join(homeDir, ".gemini", "settings.json");
+    const result = syncRegistryTargets({
+      registry: {
+        version: 1,
+        defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+        servers: {
+          auth: {
+            safe: true,
+            transport: "http",
+            url: "https://example.com/mcp",
+            targets: ["gemini"],
+            headers: {
+              Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+            },
+          },
+        },
+        policies: {
+          stdio_action: "replace-with-hub",
+          watched_paths: [settingsPath],
+        },
+      },
+    });
+
+    const syncAction = result.actions.find(
+      (action) => action.filePath === settingsPath,
+    );
+    assert.equal(syncAction.status, "updated");
+    assert.deepEqual(syncAction.warnings, [
+      "[tfx mcp sync] warn: gemini server 'auth' headers contain plaintext secret resolved from $TFX_TEST_TOKEN. Ensure ~/.gemini/settings.json permissions stay 600.",
+    ]);
+
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    assert.equal(
+      settings.mcpServers.auth.headers.Authorization,
+      "Bearer sync-secret",
+    );
+    assert.equal(statSync(settingsPath).mode & 0o777, 0o600);
   });
 });

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -111,6 +112,7 @@ function isJsonMcpConfig(filePath) {
     isAntigravityConfig(filePath) ||
     name === "settings.json" ||
     name === "settings.local.json" ||
+    name === "mcp_config.json" ||
     name === ".mcp.json" ||
     isClaudeProjectMcpConfig(filePath)
   );
@@ -124,6 +126,31 @@ function isCodexConfig(filePath) {
 function isAntigravityConfig(filePath) {
   const normalized = normalizeForMatch(filePath);
   return normalized.endsWith("/.gemini/config/mcp_config.json");
+}
+
+function plaintextSecretHeaderClient(filePath) {
+  const client = detectClient(filePath);
+  return client === "gemini" || client === "antigravity" ? client : null;
+}
+
+function plaintextSecretPermissionHint(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/settings.json")) {
+    return "~/.gemini/settings.json";
+  }
+  if (normalized.endsWith("/.gemini/config/mcp_config.json")) {
+    return "~/.gemini/config/mcp_config.json";
+  }
+  return filePath;
+}
+
+function shouldLockJsonConfigPermissions(filePath) {
+  return Boolean(plaintextSecretHeaderClient(filePath));
+}
+
+function lockJsonConfigPermissions(filePath) {
+  if (!shouldLockJsonConfigPermissions(filePath)) return;
+  chmodSync(filePath, 0o600);
 }
 
 function isProtectedCodexConfigMutationEnv(env = process.env) {
@@ -159,6 +186,8 @@ function detectLabel(filePath) {
   if (normalized.endsWith("/.gemini/config/mcp_config.json"))
     return "Antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "Gemini";
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.codex/config.toml")) return "Codex";
   if (normalized.endsWith("/.claude/settings.json")) return "Claude User";
   if (normalized.endsWith("/.claude/settings.local.json"))
@@ -429,6 +458,13 @@ function resolveHeaderDescriptors(name, serverConfig, filePath) {
     }
 
     headers[headerName] = `${prefix}${envValue}`;
+
+    const plaintextClient = plaintextSecretHeaderClient(filePath);
+    if (plaintextClient) {
+      warnings.push(
+        `[tfx mcp sync] warn: ${plaintextClient} server '${name}' headers contain plaintext secret resolved from $${envName}. Ensure ${plaintextSecretPermissionHint(filePath)} permissions stay 600.`,
+      );
+    }
 
     if (!codexTarget) continue;
 
@@ -996,6 +1032,7 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
   }
 
   writeJsonFile(resolvedPath, parsed);
+  lockJsonConfigPermissions(resolvedPath);
   return { modified: true, filePath: resolvedPath };
 }
 

--- a/packages/triflux/scripts/mcp-safety-guard.mjs
+++ b/packages/triflux/scripts/mcp-safety-guard.mjs
@@ -31,6 +31,7 @@ export async function run(stdinData) {
 
   const stdioServers = scanForStdioServers(GEMINI_SETTINGS);
   const stdout = [];
+  const stderr = [];
 
   if (stdioServers.length > 0) {
     const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
@@ -61,6 +62,7 @@ export async function run(stdinData) {
 
   const syncResult = syncRegistryTargets({ registry });
   for (const action of syncResult.actions) {
+    stderr.push(...(action.warnings || []));
     if (action.status === "updated") {
       stdout.push(
         `[mcp-safety] registry sync: ${action.label} -> ${action.filePath}`,
@@ -77,7 +79,7 @@ export async function run(stdinData) {
   return {
     code: 0,
     stdout: stdout.length > 0 ? `${stdout.join("\n")}\n` : "",
-    stderr: "",
+    stderr: stderr.length > 0 ? `${stderr.join("\n")}\n` : "",
   };
 }
 

--- a/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -222,5 +222,51 @@ describe("syncRegistryTargets HTTP headers", () => {
     assert.deepEqual(projectConfig.mcpServers.auth.headers, {
       "X-Client": "triflux",
     });
+  });
+
+  it("warns and locks permissions when Gemini sync writes env secrets as plaintext headers", () => {
+    const homeDir = createHomeDir();
+    mkdirSync(join(homeDir, ".gemini"), { recursive: true });
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    process.env.TFX_TEST_TOKEN = "sync-secret";
+
+    const settingsPath = join(homeDir, ".gemini", "settings.json");
+    const result = syncRegistryTargets({
+      registry: {
+        version: 1,
+        defaults: { transport: "hub-url", hub_base: "http://127.0.0.1:27888" },
+        servers: {
+          auth: {
+            safe: true,
+            transport: "http",
+            url: "https://example.com/mcp",
+            targets: ["gemini"],
+            headers: {
+              Authorization: { env: "TFX_TEST_TOKEN", prefix: "Bearer " },
+            },
+          },
+        },
+        policies: {
+          stdio_action: "replace-with-hub",
+          watched_paths: [settingsPath],
+        },
+      },
+    });
+
+    const syncAction = result.actions.find(
+      (action) => action.filePath === settingsPath,
+    );
+    assert.equal(syncAction.status, "updated");
+    assert.deepEqual(syncAction.warnings, [
+      "[tfx mcp sync] warn: gemini server 'auth' headers contain plaintext secret resolved from $TFX_TEST_TOKEN. Ensure ~/.gemini/settings.json permissions stay 600.",
+    ]);
+
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    assert.equal(
+      settings.mcpServers.auth.headers.Authorization,
+      "Bearer sync-secret",
+    );
+    assert.equal(statSync(settingsPath).mode & 0o777, 0o600);
   });
 });

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -111,6 +112,7 @@ function isJsonMcpConfig(filePath) {
     isAntigravityConfig(filePath) ||
     name === "settings.json" ||
     name === "settings.local.json" ||
+    name === "mcp_config.json" ||
     name === ".mcp.json" ||
     isClaudeProjectMcpConfig(filePath)
   );
@@ -124,6 +126,31 @@ function isCodexConfig(filePath) {
 function isAntigravityConfig(filePath) {
   const normalized = normalizeForMatch(filePath);
   return normalized.endsWith("/.gemini/config/mcp_config.json");
+}
+
+function plaintextSecretHeaderClient(filePath) {
+  const client = detectClient(filePath);
+  return client === "gemini" || client === "antigravity" ? client : null;
+}
+
+function plaintextSecretPermissionHint(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/settings.json")) {
+    return "~/.gemini/settings.json";
+  }
+  if (normalized.endsWith("/.gemini/config/mcp_config.json")) {
+    return "~/.gemini/config/mcp_config.json";
+  }
+  return filePath;
+}
+
+function shouldLockJsonConfigPermissions(filePath) {
+  return Boolean(plaintextSecretHeaderClient(filePath));
+}
+
+function lockJsonConfigPermissions(filePath) {
+  if (!shouldLockJsonConfigPermissions(filePath)) return;
+  chmodSync(filePath, 0o600);
 }
 
 function isProtectedCodexConfigMutationEnv(env = process.env) {
@@ -159,6 +186,8 @@ function detectLabel(filePath) {
   if (normalized.endsWith("/.gemini/config/mcp_config.json"))
     return "Antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "Gemini";
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.codex/config.toml")) return "Codex";
   if (normalized.endsWith("/.claude/settings.json")) return "Claude User";
   if (normalized.endsWith("/.claude/settings.local.json"))
@@ -429,6 +458,13 @@ function resolveHeaderDescriptors(name, serverConfig, filePath) {
     }
 
     headers[headerName] = `${prefix}${envValue}`;
+
+    const plaintextClient = plaintextSecretHeaderClient(filePath);
+    if (plaintextClient) {
+      warnings.push(
+        `[tfx mcp sync] warn: ${plaintextClient} server '${name}' headers contain plaintext secret resolved from $${envName}. Ensure ${plaintextSecretPermissionHint(filePath)} permissions stay 600.`,
+      );
+    }
 
     if (!codexTarget) continue;
 
@@ -996,6 +1032,7 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
   }
 
   writeJsonFile(resolvedPath, parsed);
+  lockJsonConfigPermissions(resolvedPath);
   return { modified: true, filePath: resolvedPath };
 }
 

--- a/scripts/mcp-safety-guard.mjs
+++ b/scripts/mcp-safety-guard.mjs
@@ -31,6 +31,7 @@ export async function run(stdinData) {
 
   const stdioServers = scanForStdioServers(GEMINI_SETTINGS);
   const stdout = [];
+  const stderr = [];
 
   if (stdioServers.length > 0) {
     const result = remediate(GEMINI_SETTINGS, stdioServers, registry.policies);
@@ -61,6 +62,7 @@ export async function run(stdinData) {
 
   const syncResult = syncRegistryTargets({ registry });
   for (const action of syncResult.actions) {
+    stderr.push(...(action.warnings || []));
     if (action.status === "updated") {
       stdout.push(
         `[mcp-safety] registry sync: ${action.label} -> ${action.filePath}`,
@@ -77,7 +79,7 @@ export async function run(stdinData) {
   return {
     code: 0,
     stdout: stdout.length > 0 ? `${stdout.join("\n")}\n` : "",
-    stderr: "",
+    stderr: stderr.length > 0 ? `${stderr.join("\n")}\n` : "",
   };
 }
 


### PR DESCRIPTION
## Summary

`~/.gemini/settings.json` 과 (별도 PR 머지 후) `~/.gemini/config/mcp_config.json` 에 Bearer 토큰이 평문으로 박히는 현 상황을 정비한다. spike 조사 결과를 docs 로 남기고, mcp-guard-engine 에 평문 경고 + 파일 권한 600 강제를 추가한다.

## Spike 조사 결과

- `npm root -g`: `/opt/homebrew/lib/node_modules`
- 지정된 Gemini `dist` grep은 현재 설치본에 `dist`가 없어 매칭 없음. 실제 설치본은 `@google/gemini-cli/bundle` 아래에 있음.
- Gemini CLI bundle code: `mcpServerConfig.headers` 값에 `expandEnvVars(value, sanitizedEnv)`를 적용하므로 headers env interpolation 자체는 존재함.
- 단, headers interpolation 입력이 `sanitizeEnvironment(... enableEnvironmentVariableRedaction: true)`를 거치므로 `EXA_API_KEY` 같은 민감 env 이름은 기본 설정에서 빈 값으로 확장될 수 있음. 따라서 이번 PR에서는 Gemini headers를 interpolation string으로 자동 전환하지 않음.
- `agy` binary strings 검색에서는 header interpolation으로 볼 수 있는 안정적인 근거를 찾지 못함.
- `https://antigravity.google/docs/mcp` WebFetch 시도는 SPA HTML만 반환되어 본문 근거를 확보하지 못함.
- Antigravity plugin sample `~/.gemini/antigravity-cli/plugins/chrome-devtools-mcp/mcp_config.json`은 `env: null` 형태이며 header/env interpolation 예시가 없음.

## 변경

- `scripts/lib/mcp-guard-engine.mjs`: Gemini/Antigravity JSON target에서 env secret header가 resolved plaintext로 기록될 때 warning 생성, 출력 파일 권한 600 강제
- `bin/triflux.mjs`, `scripts/mcp-safety-guard.mjs`: sync warnings를 stderr로 출력
- `docs/mcp/secrets-handling.md`: 현 상황 + mitigation + 향후 migration path 문서화
- `packages/triflux/*`: root 변경 mirror 반영

## Test plan

- [x] `node --test scripts/__tests__/mcp-guard-engine.test.mjs`
- [x] `node --test scripts/__tests__/mcp-guard-engine-sync-http-headers.test.mjs`
- [x] `node --test scripts/__tests__/mcp-guard-engine*.test.mjs`
- [x] `node --check bin/triflux.mjs`
- [x] `node --check scripts/lib/mcp-guard-engine.mjs`
- [x] `npm run release:check-mirror`
- [x] `npm run release:check-sync`
- [x] temp HOME + temp registry `tfx mcp sync` smoke: stderr warning 확인, generated `settings.json` mode `600` 확인
- [x] 실제 home 파일은 직접 수정하지 않음. read-only stat 결과 현재 `~/.gemini/settings.json`은 `0644`라서, 다음 실제 sync/write 시 이 PR의 600 강제가 적용되어야 함.

## 관련

- Task A: feat/mcp-antigravity-target (먼저 머지되면 antigravity adapter 가 base 에 들어옴, 그 후 rebase 필요할 수 있음)