### PR TITLE
test(integration): agy --print 5종 prompt-passing 회귀테스트

### DIFF
--- a/tests/integration/agy-stdout-pipe.test.mjs
+++ b/tests/integration/agy-stdout-pipe.test.mjs
@@ -1,0 +1,102 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+
+/**
+ * agy CLI 1.0.0 prompt 전달 패턴 회귀테스트.
+ *
+ * 정밀 sanity matrix (10종) 로 도출한 mechanism:
+ * - `--print` 는 string value-taking flag (Go flag library)
+ * - flag 순서 critical: `--print` 가 먼저 + 다른 flag 가 뒤면 value 흡수 사고 (timeout)
+ * - `--dangerously-skip-permissions` 가 먼저 + `--print` 가 뒤 = 정상 (T10)
+ * - `--print=VALUE` syntax = 정상 (T1, Go flag default)
+ *
+ * wrapper (scripts/tfx-route.sh L2031-2046) 의 antigravity case 가 사용해야 할
+ * 정답 패턴을 명시적으로 검증한다.
+ */
+
+function getAgyPath() {
+  const result = spawnSync("which", ["agy"], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+const AGY_PATH = getAgyPath();
+const TEST_PROMPT = "Reply with single word: hi";
+const WELCOME_KEYWORDS = [
+  "antigravity",
+  "scratch",
+  "how can i help",
+  "active workspace",
+  "timed out",
+  "flag needs an argument",
+];
+
+function hasHi(text) {
+  return text.toLowerCase().includes("hi");
+}
+
+function hasWelcomeOrFailure(text) {
+  const lower = text.toLowerCase();
+  return WELCOME_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+test("agy --print prompt-passing regression tests", { skip: !AGY_PATH ? "agy not in PATH" : false }, async (t) => {
+
+  await t.test("1. α commit 패턴 (현재): --print --dangerously + stdin pipe -> 정상", { timeout: 30000 }, () => {
+    const result = spawnSync(AGY_PATH, ["--print", "--dangerously-skip-permissions"], {
+      input: TEST_PROMPT,
+      encoding: "utf8",
+      timeout: 25000,
+      env: { ...process.env, PAGER: "cat" },
+    });
+    assert.strictEqual(result.status, 0, `Should exit 0. status=${result.status} signal=${result.signal} stderr=${result.stderr}`);
+    assert.ok(hasHi(result.stdout), `Should contain 'hi'. Got: ${result.stdout}`);
+  });
+
+  await t.test("2. Tier 1 broken 패턴 (regression guard): positional + stdin closed -> 실패", { timeout: 30000 }, () => {
+    const result = spawnSync(AGY_PATH, ["--print", "--dangerously-skip-permissions", "--", TEST_PROMPT], {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+      timeout: 25000,
+      env: { ...process.env, PAGER: "cat" },
+    });
+    const combined = (result.stdout || "") + (result.stderr || "");
+    assert.ok(
+      !hasHi(combined) || hasWelcomeOrFailure(combined),
+      `Broken pattern should NOT pass prompt. status=${result.status} signal=${result.signal} output: ${combined}`,
+    );
+  });
+
+  await t.test("3. 대안 (flag swap): --dangerously 먼저 + --print + positional -> 정상", { timeout: 30000 }, () => {
+    const result = spawnSync(AGY_PATH, ["--dangerously-skip-permissions", "--print", TEST_PROMPT], {
+      encoding: "utf8",
+      timeout: 25000,
+      env: { ...process.env, PAGER: "cat" },
+    });
+    assert.strictEqual(result.status, 0, `Should exit 0. status=${result.status}`);
+    assert.ok(hasHi(result.stdout), `Should contain 'hi'. Got: ${result.stdout}`);
+  });
+
+  await t.test("4. 대안 (= syntax): --print=VALUE + --dangerously -> 정상", { timeout: 30000 }, () => {
+    const result = spawnSync(AGY_PATH, [`--print=${TEST_PROMPT}`, "--dangerously-skip-permissions"], {
+      encoding: "utf8",
+      timeout: 25000,
+      env: { ...process.env, PAGER: "cat" },
+    });
+    assert.strictEqual(result.status, 0, `Should exit 0. status=${result.status}`);
+    assert.ok(hasHi(result.stdout), `Should contain 'hi'. Got: ${result.stdout}`);
+  });
+
+  await t.test("5. flag 흡수 사고 (regression guard): --print + --add-dir + positional -> timeout", { timeout: 30000 }, () => {
+    const result = spawnSync(AGY_PATH, ["--print", "--add-dir", "/tmp", TEST_PROMPT], {
+      encoding: "utf8",
+      timeout: 25000,
+      env: { ...process.env, PAGER: "cat" },
+    });
+    const combined = (result.stdout || "") + (result.stderr || "");
+    assert.ok(
+      !hasHi(combined) || hasWelcomeOrFailure(combined),
+      `--print + --add-dir + positional should NOT pass prompt cleanly. status=${result.status} signal=${result.signal} output: ${combined}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

agy CLI 1.0.0 의 `--print` headless 모드에서 prompt 전달이 어떻게 작동하는지 정밀 sanity matrix (10종 실측) 로 도출한 mechanism 을 lock-in 하는 회귀테스트.

**5 test cases** (`tests/integration/agy-stdout-pipe.test.mjs`, 102줄, agy PATH 부재 시 skip):

1. **α commit 패턴 (현재 wrapper)**: `--print --dangerously-skip-permissions` + stdin pipe → 정상 응답 (`hi`)
2. **Tier 1 broken 패턴 (regression guard)**: positional arg + stdin closed → 환영 메시지/timeout 폴백
3. **대안 (flag swap)**: `--dangerously` 먼저 + `--print` + positional → 정상 응답
4. **대안 (`=` syntax)**: `--print=VALUE` + `--dangerously` → 정상 응답
5. **flag 흡수 사고 (regression guard)**: `--print` + `--add-dir` + positional → timeout (Go flag library value 흡수)

## Background

PR #296 (Tier 2 wrapper fix) 의 evidence 역할 + 향후 회귀 방지. agy 의 정확한 flag parsing mechanism:

- `--print` 는 **string value-taking flag** (Go flag library 기본)
- flag 순서 critical: `--print` 가 먼저 + 다른 flag 가 뒤 = **value 흡수 → timeout**
- 3가지 safe pattern: stdin pipe (wrapper 채택), flag swap, `=` syntax

이번 PR 의 5 test 가 위 3가지 safe pattern 다 검증 + Tier 1 broken pattern + Go flag 흡수 사고 둘 다 regression guard 로 잡음.

## Test plan

- [x] `node --check tests/integration/agy-stdout-pipe.test.mjs` syntax PASS
- [x] `node --test tests/integration/agy-stdout-pipe.test.mjs` 5/5 PASS (72초, agy 실제 호출)
- [ ] CI 에서 agy 가 PATH 부재 → 전체 skip 확인 (테스트 자체 fail 안 됨)

## Mechanism evidence (정밀 sanity matrix 10종)

| Test | 패턴 | exit | 결과 |
|------|------|------|------|
| T1 | `--print=hi` (= syntax) | 0 | ✅ "hi" |
| T2 | `--print` alone | 2 | ❌ "flag needs an argument" (value-taking flag 증명) |
| T6 | `--print --add-dir /tmp 'prompt'` | 124 | 🔴 timeout (value 흡수) |
| T7 | `-p 'prompt'` | 0 | ✅ "hi" (short alias) |
| T10 | `--dangerously --print 'prompt'` | 0 | ✅ "hi" (flag swap) |

## Related

- 관련 wrapper fix: #296
- 정책 참조: `.claude/rules/tfx-update-logic.md` (Antigravity CLI 헤드리스 옵션 verbatim)