### PR TITLE
docs: Tier 2 follow-up — rules 정정 + agy subagents PRD + Node CLI PRD

### DIFF
--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -27,3 +27,30 @@
   - **IDE Cask (Antigravity 2.0) 경로** (Google Codelab 출처): 글로벌 skills `~/.gemini/antigravity/skills/` · 글로벌 workflows `~/.gemini/antigravity/global_workflows/` · 워크스페이스 `.agents/{rules,workflows,skills}/` (복수형 `s`).
   - **공통**: 글로벌 rules `~/.gemini/GEMINI.md` (Gemini CLI · Antigravity CLI · Antigravity IDE 가 모두 같은 path 공유).
   - **주의**: `~/.gemini/antigravity-cli/` (CLI 전용) 와 `~/.gemini/antigravity/` (IDE 전용) 는 **별개** path. third-party docs 의 `.agent/` (단수) 는 잘못된 경로.
+
+## Antigravity CLI 1.0.0 정밀 sanity matrix 발견 (2026-05-20)
+
+agy CLI 1.0.0 의 prompt 전달 mechanism 정밀 검증 결과 (정밀 sanity matrix 10종 + context7 3개 출처 + 공식 docs verbatim):
+
+- **`--print` 는 string value-taking flag** (Go flag library 기본): T1 `--print=hi` → "hi" ✅, T2 `--print` alone → "flag needs an argument" (exit 2). 즉 boolean flag 가 아님.
+- **flag 순서 critical**: `--print` 가 먼저 + 다른 flag 가 뒤 = **timeout** (T6 `--print --add-dir /tmp 'prompt'`, T9 `--print --sandbox 'prompt'` 둘 다 exit 124 timeout — `--print` value 로 다음 flag 흡수). 정상 패턴 3가지:
+  - `--dangerously-skip-permissions --print VALUE` (T10) — flag swap
+  - `--print=VALUE` (T1) — `=` syntax (Go flag default)
+  - `--print --dangerously-skip-permissions` + stdin pipe (T4/D) — wrapper Tier 2 (PR #296) 채택
+- **CLI TUI 모델 = account-dependent** (사용자 직접 확인 2026-05-20):
+  - **사내 계정 5개**: Gemini 3.1 Pro (High), Gemini 3.1 Pro (Low), **Gemini 3.5 Flash (default current)**, Gemini 3.5 Flash (Low), Gemini 3 Flash
+  - 개인 계정 4개 (이전 메모): Gemini 3.5 Flash High/Med, Gemini 3.1 Pro High/Low
+  - context7 `/llmstxt/sirius-red` 의 7개 (Gemini 3 Pro high/low/Flash, Claude Sonnet 4.5/thinking, Opus 4.5 thinking, GPT-OSS) 는 **IDE Antigravity 2.0 모델 리스트로 추정** (CLI TUI 와 별개)
+- **`/model` slash command** (CLI 안에서) = default 모델 변경 + **persists across sessions** (공식 docs verbatim). settings 저장 위치 미확정 (`~/.gemini/antigravity-cli/settings.json` 에 model 항목 부재, 추정 in-memory 또는 hidden state — 사용자 직접 검증 필요).
+- **모델 선택 sticky scope**: "The choice of reasoning model is sticky between user messages within a conversation" (공식 docs verbatim) — 새 conversation 시 default 적용.
+- **CLI launch flag override 가능 항목**: `--sandbox`, `--dangerously-skip-permissions` **2개만** (verbatim). `-m`/`--model` flag 부재 = wrapper 가 헤드리스 호출 시 model 통제 불가 (drop-down UI 만 가능).
+- **`/model` 외 주요 slash commands** (공식 docs verbatim): `/resume` (alias `/switch`), `/rewind` (alias `/undo`), `/rename <name>`, `/permissions`, `/keybindings`, `/statusline`, `/tasks`, `/skills`, `/mcp`, `/open <path>`, `/usage`, `/logout`.
+- **agy subagents framework** (공식 docs verbatim): `/tasks` panel (monitor/view-logs/terminate background tasks) + `/agents` panel (running subagents UI, ctrl+j teleport, ctrl+k fast-approve) + asynchronous subagents (parallel work, background research, system tests). triflux hub/team_mode 와 **중복/통합 가능 영역** — 별도 분석 PRD `.triflux/plans/agy-subagents-integration-eval.md`.
+- **MCP server config 위치 변경**: Gemini CLI 의 `~/.gemini/settings.json` (inline mcpServers) → Antigravity CLI 의 **`~/.gemini/antigravity-cli/mcp_config.json`** (별도 file) + workspace 는 `.agents/mcp_config.json`. **`serverUrl` field** (Gemini 의 `url`/`httpUrl` 대신).
+- **workspace context 호환**: GEMINI.md + AGENTS.md 둘 다 읽음. Global rules `~/.gemini/GEMINI.md` (Gemini CLI 와 공유).
+- **plugin import 명령 verbatim**: `agy plugin import gemini` — Gemini CLI extensions → Antigravity plugins 자동 변환 (`~/.gemini/antigravity-cli/plugins/<name>/skills/`).
+- **wrapper Tier 2 (PR #296)** 의 antigravity stdin pipe 분기 + no-op 승격 skip + auto_reroute tri-lane 확장 = 위 mechanism 의 운영 적용. 회귀테스트 (PR #297) 의 5 test 가 mechanism lock-in.
+
+후속 PRD:
+- `.triflux/plans/agy-subagents-integration-eval.md` — triflux hub vs agy subagents 책임 매트릭스 + 통합 시나리오 3가지
+- `.triflux/plans/node-cli-single-entry-migration.md` — wrapper 2609줄 Bash → Node 전환 plan (책임 16가지 매핑 + Phase 0~3)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # AI 설정
 .tfx/
-.triflux/
+.triflux/*
+!.triflux/plans/
+!.triflux/plans/**
 .omc/
 .omx/
 .claude/**

--- a/.triflux/plans/agy-subagents-integration-eval.md
+++ b/.triflux/plans/agy-subagents-integration-eval.md
@@ -1,0 +1,627 @@
+# PRD: agy subagents framework 통합 평가
+
+## 문서 목적
+
+이 문서는 triflux 의 기존 hub/team/headless 병렬 실행 인프라와 Antigravity CLI 1.0.0 의 subagents framework 를 어떤 관계로 둘지 평가한다.
+
+결론부터 쓰면, 현재 근거만으로 agy subagents 를 triflux 의 backend 로 흡수하는 것은 이르다.
+
+단기 권장은 **시나리오 B: 병렬 유지**다.
+
+중기 권장은 **시나리오 C: 책임 분리**를 PoC 로 검증하는 것이다.
+
+시나리오 A, 즉 triflux 가 agy subagents framework 를 직접 backend 로 호출하는 방식은 agy 의 외부 API, task channel, lifecycle 제어면이 확인되기 전까지 보류한다.
+
+## 범위
+
+- 신규/수정 파일: `.triflux/plans/agy-subagents-integration-eval.md`
+- 언어: 한국어 Markdown
+- 성격: 구현 PRD 가 아니라 통합 평가 PRD
+- 근거: user-provided 공식 docs verbatim + repo-local `git grep`/파일 확인
+- 추정 표기: agy 내부 구현 또는 외부 API 가 확인되지 않은 항목은 반드시 "추정" 또는 "조사 필요"로 표기
+
+## 비범위
+
+- agy CLI 설치/업데이트 절차 변경
+- `scripts/tfx-route.sh` 의 agy wrapper 구현 수정
+- `hub/team/backend.mjs` 에 AntigravityBackend 추가
+- AccountBroker 의 agy account lane 구현
+- 실제 agy `/agents` 또는 `/tasks` TUI 자동 조작 구현
+- 제품 결정 확정
+
+## 1차 agy 근거
+
+사용자 제공 공식 docs verbatim 기준으로만 확정한다.
+
+- agy CLI 는 asynchronous subagents framework 를 제공한다.
+- main agent 는 parallel work, background research, system tests 를 active conversation blocking 없이 위임할 수 있다.
+- `/tasks` 는 active background tasks 의 monitor, log view, terminate 를 제공한다.
+- `/agents` panel 은 running subagents 를 view/manage/approve 하는 interactive UI 이다.
+- subagents 는 code search, file editing, terminal commands, web searches 를 수행할 수 있다.
+- main agent 가 subagents 의 tools/permissions 를 결정한다.
+- `/agents` panel 에서 conversation log 전체를 확인할 수 있다.
+- `ctrl+j` 는 다음 subagent detail view 로 이동한다.
+- Fast Path Alerts 는 `ctrl+k` 로 prompt box 위에서 직접 approve 할 수 있다.
+
+## repo-local triflux 근거
+
+triflux 쪽 근거는 현재 worktree 에서 확인했다.
+
+- `hub/team/conductor.mjs:175` 는 Conductor 생성 함수이며, session map, state transition, restart, kill, broker lease 를 소유한다.
+- `hub/team/conductor.mjs:228` 는 session state transition 을 event log, emitter, Synapse registry 에 반영한다.
+- `hub/team/conductor.mjs:523` 은 child process 를 spawn 하고 stdout/stderr log, completion payload, restart 를 관리한다.
+- `hub/team/conductor.mjs:1036` 은 `spawnSession(config)` 로 worker session lifecycle 을 만든다.
+- `hub/team/conductor.mjs:1087` 은 AccountBroker lease 를 적용하고, `:1105` 이후 CODEX_HOME/auth env 를 session config 에 병합한다.
+- `hub/team/conductor.mjs:1189` 은 `killSession(id, reason)` 을 제공한다.
+- `hub/team/headless.mjs:87` 은 headless worker 를 hub bridge 에 register 한다.
+- `hub/team/headless.mjs:102` 은 headless result 를 `/bridge/publish` 로 publish 한다.
+- `hub/team/headless.mjs:596` 은 progressive psmux pane spawn 경로다.
+- `hub/team/headless.mjs:711` 은 batch dispatch 를 `Promise.all` 로 실행한다.
+- `hub/team/headless.mjs:792` 는 모든 pane completion 을 병렬 대기한다.
+- `hub/team/headless.mjs:1012` 는 `runHeadless(sessionName, assignments, opts)` 의 주 진입점이다.
+- `hub/server.mjs:971` 은 Delegator MCP resident service 를 초기화한다.
+- `hub/server.mjs:981` 은 Synapse registry, swarm locks, git preflight 를 초기화한다.
+- `hub/server.mjs:1075` 은 `tfx-hub` MCP server 를 생성하고 tools/list, tools/call 을 처리한다.
+- `hub/server.mjs:1425` 이후 `/bridge/register` 를 처리한다.
+- `hub/server.mjs:1527` 이후 `/bridge/publish` 를 처리한다.
+- `hub/server.mjs:1612` 이후 `/bridge/assign/async` 를 처리한다.
+- `hub/server.mjs:1718` 이후 `/bridge/team/task-list`, `/bridge/team/task-update`, `/bridge/team/send-message` 를 처리한다.
+- `hub/server.mjs:1775` 이후 `/bridge/delegator/*` endpoint 를 처리한다.
+- `hub/server.mjs:1857` 이후 `/mcp` Streamable HTTP MCP endpoint 를 처리한다.
+- `scripts/tfx-route.sh:952` 이후 agent routing table 이 CLI_TYPE, CLI_CMD, CLI_ARGS, effort, timeout 을 결정한다.
+- `scripts/tfx-route.sh:994` 는 `antigravity` CLI_TYPE 을 `agy` command 로 매핑한다.
+- `scripts/tfx-route.sh:1050` 이후 antigravity lane 은 `--print --dangerously-skip-permissions` 를 사용한다.
+- `scripts/tfx-route.sh:2018` 이후 codex exec path 는 prompt 를 argv 로 넘기고 tier fallback 을 수행한다.
+- `scripts/tfx-route.sh:2166` 이후 runtime route resolution, hub ensure, CLI execution, post-processing 이 실행된다.
+- `scripts/headless-guard.mjs:229` 이후 psmux send-keys/split-window 안의 `agy --print/--prompt` 직접 호출을 차단한다.
+- `scripts/headless-guard.mjs:336` 이후 direct tfx-route.sh 호출을 headless dispatch 로 auto-route 한다.
+- `scripts/headless-guard.mjs:396` 이후 Agent 래핑과 direct CLI wrapping 을 gate/nudge/deny 한다.
+- `hub/account-broker.mjs:258` 은 AccountBroker 가 codex/gemini account pool, lease, cooldown, circuit breaker 를 관리한다고 명시한다.
+- `hub/account-broker.mjs:843` 은 lease 를 선택하고, `:987` 은 release 를 처리한다.
+- `hub/team/agent-map.json:27` 은 `antigravity`, `:28` 은 `agy` 를 `antigravity` CLI_TYPE 으로 매핑한다.
+- `hub/team/backend.mjs:83` 의 backend registry 는 현재 `codex`, `gemini`, `claude` 만 포함한다. `antigravity` backend 는 없다.
+- `hub/workers/factory.mjs:83` 의 worker factory 도 `gemini`, `claude`, `codex`, `codex-app-server`, `delegator` 만 지원한다. `antigravity` worker type 은 없다.
+
+## 현재 전제
+
+triflux 는 이미 "외부 CLI 를 worker 로 실행하고 관측/통제하는 orchestrator" 이다.
+
+agy 는 "단일 CLI 내부에서 main agent 가 subagents 를 실행하고 관측/승인하는 runtime" 으로 보인다.
+
+두 시스템은 모두 병렬 작업, background task, permission, log visibility, termination 을 다룬다.
+
+다만 triflux 는 repo-local code 로 관측 가능한 API/bridge/state machine 을 갖고 있고, agy subagents 는 현재 docs verbatim 이외의 외부 machine-readable API 가 확인되지 않았다.
+
+따라서 이 PRD 는 agy 를 "잠재 backend" 로만 보며, 확정된 통합 대상으로 보지 않는다.
+
+## 성공 기준
+
+- 책임 매트릭스가 15개 이상 책임 영역을 비교한다.
+- agy 쪽 미확인 항목은 조사 필요로 남긴다.
+- 통합 시나리오 A/B/C 의 장단점과 일정 추정이 있다.
+- 권장 path 가 보수적이고 실행 가능한 다음 PR scope 로 이어진다.
+- 신규 PRD 외 파일은 변경하지 않는다.
+
+---
+
+# 1. 책임 매트릭스: triflux vs agy
+
+| 책임 | triflux 위치 | agy 위치 | 중복도 | 충돌 |
+|------|------------|---------|--------|------|
+| parallel worker spawn | `hub/team/conductor.mjs`, `hub/team/headless.mjs`, `scripts/tfx-route.sh`, `hub/team/cli/commands/start/*` | `/tasks` framework, `/agents` panel, async subagents | 높음 | 둘 다 worker/subagent spawn 주체가 되면 중복 spawn, 중복 timeout, 중복 kill 발생 가능 |
+| background task monitoring | `hub/team/headless.mjs` progress events, `hub/team/cli/commands/status.mjs`, `hub/team/cli/commands/tasks.mjs`, task-notification 운영 규칙 | `/tasks` panel | 높음 | 사용자가 어떤 panel 의 상태를 신뢰해야 하는지 혼란 가능 |
+| inter-agent message bus | `hub/server.mjs` bridge endpoints, `hub/bridge.mjs`, `hub/team-bridge.mjs`, `hub/team/conductor-mesh-bridge.mjs` | 조사 필요. docs 는 `/agents` conversation log UI 만 명시 | 중간 | agy subagent messages 가 외부 bridge 로 export 되지 않으면 triflux lead 가 상태를 모름 |
+| permission gate | `scripts/headless-guard.mjs`, hooks/safety gate, `hub/account-broker.mjs`, `tfx-route.sh` bypass flags | `/permissions`, Fast Path Alert, main agent tool permission decision | 높음 | 승인 정책이 두 곳에서 동시에 bypass/deny 되면 보안 모델이 불명확 |
+| file edit dispatch | `scripts/tfx-route.sh`, Codex/Gemini/Claude worker wrappers, headless result/handoff | agy subagents direct file edit | 높음 | triflux 는 worker ownership/worktree 를 가정하지만 agy 내부 subagents 는 같은 cwd 를 공유할 수 있음 |
+| CLI routing/model selection | `hub/team/agent-map.json`, `scripts/tfx-route.sh:952-1086`, profile/effort routing | agy 내부 `/model`, settings, main agent subagent tool decision | 중간 | triflux 가 model/role 을 지정해도 agy 내부 subagent model/permission 은 별도일 수 있음 |
+| account/auth lease | `hub/account-broker.mjs`, `conductor.mjs` lease/env/CODEX_HOME 적용 | 조사 필요. 현재 근거는 agy 가 Gemini OAuth creds 를 재사용한다는 운영 메모 수준 | 높음 | 다중 계정 lease 없이 agy 내부 subagents 가 같은 OAuth/account 를 동시 사용하면 quota/race 가능 |
+| session registry | Synapse registry in `hub/server.mjs`, `hub/team/headless.mjs` register/heartbeat | `/tasks` active task registry 로 추정 | 중간 | registry ID, heartbeat, stale cleanup semantics 가 다르면 상태 동기화가 깨짐 |
+| task lifecycle | `spawnSession`, state transition, `killSession`, `completed/dead` events | `/tasks` terminate, `/agents` manage 로 추정 | 높음 | start/pause/resume/kill semantics 미확인. 특히 pause/resume 은 triflux 에 직접 대응 없음 |
+| result handoff | sentinel completion payload, `extract-completion-payload.mjs`, `publishHeadlessResult()` | `/agents` conversation log, `/tasks` logs | 중간 | agy log 는 사람이 볼 수 있어도 machine-readable handoff 인지 미확인 |
+| log capture | psmux capture, result files under tmp, out/err logs in conductor | `/tasks` view logs, `/agents` conversation log | 높음 | 두 log source 가 불일치하면 debugging 비용 상승 |
+| health/stall detection | `hub/team/health-probe.mjs`, `headless.mjs` completion/stall timeout, Conductor restart | 조사 필요 | 중간 | agy 내부 stall 판단을 triflux 가 관측 못하면 parent timeout 만 남음 |
+| termination | `killSession`, psmux kill, runHeadless cleanup, stale cleanup | `/tasks` terminate | 높음 | triflux 가 parent agy 를 kill 해도 agy subagents 정리가 보장되는지 미확인 |
+| operator UI | triflux TUI/dashboard/status/notifications | `/tasks`, `/agents`, Fast Path Alerts | 높음 | 두 UI 가 서로 다른 truth 를 보여줄 수 있음 |
+| MCP exposure | `hub/server.mjs` Streamable HTTP `/mcp`, `DelegatorService`, `tfx-hub` tools | agy `/mcp`, `mcp_config.json` 로 추정 | 중간 | agy 가 tfx-hub MCP 를 client 로 쓸 수는 있어도 agy subagents task API 를 server 로 expose 하는지는 미확인 |
+| web search/research delegation | triflux 는 role/profile 로 외부 CLI capabilities 에 위임 | agy subagents 에 web searches capability 있음 | 중간 | researcher lane 을 agy 내부로 숨기면 triflux provenance 가 약해짐 |
+| workspace isolation | worktree, worker sandbox env, branch guard, psmux pane/session isolation | 조사 필요. 같은 agy conversation 내부 subagents 는 같은 workspace 를 공유할 가능성 있음(추정) | 높음 | 파일 edit race, branch guard 우회, dirty tree ownership 충돌 가능 |
+| prompt/profile config | `tfx-route.sh` CLI_ARGS, Codex profile, Gemini model flags, MCP profile hints | agy `--print`, `/model`, settings, permissions | 중간 | agy CLI top-level model flag 부재가 확인된 상태라 triflux role별 model forcing 어려움 |
+| notification | task-notification 운영 규칙, `hub/team/notify.mjs` bell/toast/webhook | Fast Path Alerts, `/agents` panel alert | 중간 | terminal notification 과 prompt-box approval alert 가 다른 UX 레벨에서 중복 |
+| audit/event log | `hub/team/event-log.mjs`, `conductor-events.jsonl`, bridge publish/result | `/agents` conversation log 전체 확인 | 중간 | agy log export format 이 없으면 audit 는 UI-only 가 됨 |
+| remote/terminal control | psmux, WT manager, tmux/macOS boundary, remote watcher | agy TUI 내부 panels | 낮음-중간 | agy TUI 를 psmux pane 안에서 돌릴 수는 있어도 panel navigation 자동화는 brittle |
+| task decomposition | `tfx-auto`, `tfx-multi`, team PRD/task model | main agent decides subagent work | 높음 | 두 decomposer 가 동시에 task split 을 수행하면 over-delegation 가능 |
+| approval provenance | safety hooks, permission-safe allow, bypass flags, Lore/test evidence | `/permissions`, Fast Path Alert approve | 높음 | 승인 주체, 승인 기록, replayability 가 분리됨 |
+| package/release mirror | root/package mirror checks, release gates | agy plugin/import surface 로 추정 | 낮음 | 직접 충돌은 적지만 agy plugin import 결과가 triflux package mirror 와 별개 |
+
+## 매트릭스 판정
+
+중복도가 높은 영역은 `parallel worker spawn`, `background task monitoring`, `permission gate`, `file edit dispatch`, `task lifecycle`, `operator UI` 다.
+
+중복도가 높으면서 agy 쪽 machine-readable API 가 미확인인 영역은 즉시 통합하면 안 된다.
+
+triflux 가 이미 구현한 책임은 대부분 "외부 worker 를 관측 가능한 프로세스/bridge/task 상태로 만들기"에 집중되어 있다.
+
+agy subagents 는 "한 CLI 대화 안에서 내부 subagent 를 돌리기"에 집중된 것으로 보인다.
+
+따라서 두 시스템을 같은 orchestration layer 로 겹치면 책임 충돌이 크다.
+
+---
+
+# 2. 통합 시나리오 3가지
+
+## 시나리오 A: triflux 가 agy subagents API 호출
+
+### 개념
+
+triflux hub/team_mode 가 worker 를 직접 spawn 하지 않고 agy 의 subagents framework 를 backend 로 호출한다.
+
+triflux 는 task decomposition, scheduling, AccountBroker, final reporting 을 유지한다.
+
+agy 는 실제 subagent spawn, `/tasks`, `/agents`, approval UI, logs 를 담당한다.
+
+### 필요 조건
+
+- agy subagents 를 외부에서 생성하는 API 또는 CLI command 가 있어야 한다.
+- subagent ID, status, logs, termination 을 machine-readable 로 조회할 수 있어야 한다.
+- agy task completion 을 JSON/event stream 으로 받을 수 있어야 한다.
+- agy permission approval 상태를 외부에서 관측하거나 callback 받을 수 있어야 한다.
+- agy subagents 의 cwd, allowed tools, file edit boundaries, auth account 를 지정할 수 있어야 한다.
+- agy 내부 task 가 `tfx-hub` MCP 또는 별도 bridge 로 publish 할 수 있어야 한다.
+
+### 장점
+
+- triflux 의 psmux/headless pane orchestration 일부를 줄일 수 있다.
+- agy `/agents` panel 의 conversation log, Fast Path Alerts, approval UI 를 활용할 수 있다.
+- background research/system tests 는 agy 가 native capability 로 처리할 수 있다.
+- agy 의 subagent UX 가 충분히 안정적이면 terminal/pane 구현 부담이 줄 수 있다.
+
+### 단점
+
+- agy 가 black-box 가 된다.
+- agy subagents lifecycle 이 UI 중심이면 자동화가 fragile 하다.
+- agy 내부 logs/export 가 machine-readable 이 아니면 triflux debugging 품질이 떨어진다.
+- vendor lock-in 이 크다.
+- triflux AccountBroker, worker sandbox, branch guard, completion payload 와 충돌한다.
+- agy permission 승인과 triflux permission gate 의 single source of truth 가 깨질 수 있다.
+- agy subagents 가 direct file edit 를 하면 worker ownership/worktree 격리가 약해질 수 있다.
+
+### 일정 추정
+
+- 외부 API 존재 여부 조사: 3-5일
+- 최소 PoC: 1-2주
+- task/log/kill/status adapter: 2-4주
+- permission/auth/workspace isolation hardening: 2-4주
+- production quality 전환: 총 4-8주 이상
+- 외부 API 가 없고 TUI 조작만 가능하면: production integration 은 비권장
+
+### 주요 리스크
+
+- `/agents` panel 이 interactive UI 로만 제공되면 bridge integration 이 불가능하거나 brittle 하다.
+- agy 가 subagent task 를 외부 hub 에 publish 할 수 없다면 triflux 는 parent process exit 밖에 볼 수 없다.
+- agy 내부 subagents 가 같은 cwd 를 공유하면 race 방지의 핵심 가치가 사라진다.
+- approval UX 는 좋아질 수 있지만 auditability 는 나빠질 수 있다.
+
+### 판정
+
+현재는 보류한다.
+
+단, agy 가 task channel API 또는 MCP server 역할을 공식 제공한다는 근거가 나오면 재평가한다.
+
+## 시나리오 B: 병렬 유지
+
+### 개념
+
+triflux hub/team/headless 는 그대로 유지한다.
+
+agy CLI 는 단일 worker lane 으로만 취급한다.
+
+agy 내부 subagents framework 는 agy worker 가 자체적으로 사용할 수 있지만, triflux 는 그 내부를 orchestration target 으로 삼지 않는다.
+
+### 현재 상태와 부합하는 근거
+
+- `hub/team/agent-map.json` 은 이미 `agy` 와 `antigravity` 를 `antigravity` CLI_TYPE 으로 매핑한다.
+- `scripts/tfx-route.sh` 는 `AGY_BIN` 과 `antigravity` lane 을 갖고 있다.
+- `scripts/headless-guard.mjs` 는 `agy --print/--prompt` direct call 을 직접 CLI 위험으로 취급한다.
+- 반면 `hub/team/backend.mjs` 와 `hub/workers/factory.mjs` 는 아직 antigravity backend/worker 를 지원하지 않는다.
+
+### 장점
+
+- 일정 0에 가깝다.
+- 기존 triflux worker lifecycle, AccountBroker, branch guard, handoff, task notification 규칙을 유지한다.
+- agy subagents 의 내부 구현 변화가 triflux core 를 흔들지 않는다.
+- 사용자는 agy 를 직접 사용할 때 `/tasks`/`/agents` 를 쓰고, triflux 를 쓸 때 `tfx multi/status/tasks` 를 쓰는 식으로 경계가 명확하다.
+- 디버깅 시 "triflux parent process" 와 "agy 내부 subagents" 를 분리해서 볼 수 있다.
+
+### 단점
+
+- 사용자 혼란 가능성이 있다.
+- agy worker 가 내부 subagents 를 다시 spawn 하면 nested parallelism 이 생긴다.
+- CPU, memory, token/quota 리소스 경합을 parent triflux 가 세밀하게 제어하지 못한다.
+- agy 내부 subagent failure 는 parent agy exit/log 로만 드러날 수 있다.
+- 같은 cwd 에서 triflux worker 병렬 + agy 내부 병렬이 동시에 file edit 하면 race 가능성이 있다.
+
+### 일정 추정
+
+- status quo: 0일
+- 문서/guard 보강: 1-3일
+- nested parallelism warning, no-op 승격, result parsing 회귀테스트: 2-5일
+
+### 운영 가드
+
+- agy lane 은 "single worker" 로 표시한다.
+- agy 내부 subagents 를 triflux task list 에 자동 펼치지 않는다.
+- agy parent worker 가 file edit 를 할 수 있는 경우 worktree isolation 을 우선한다.
+- agy worker 실행 중 `/agents` panel 내부 상태는 참고 UI 로만 본다.
+- triflux 완료 판정은 parent worker output/result/handoff 에 근거한다.
+
+### 판정
+
+단기 권장이다.
+
+현재 근거가 부족한 상태에서 가장 작은 변화로 risk 를 제한한다.
+
+## 시나리오 C: 책임 분리
+
+### 개념
+
+triflux 는 top-level orchestration 을 유지한다.
+
+agy subagents 는 agy single worker 내부 parallelism 으로만 허용한다.
+
+즉 "triflux = multi-CLI orchestration, account/worktree/session/reporting" 이고 "agy = 한 Antigravity CLI process 안의 internal subagents" 로 책임을 나눈다.
+
+### 권장 경계
+
+- triflux 가 task decomposition 과 worker ownership 을 가진다.
+- agy 는 `antigravity` role 의 단일 worker 로 실행된다.
+- agy 내부 subagents 는 parent agy process 의 implementation detail 로 간주한다.
+- triflux 는 agy 내부 subagents 를 직접 kill/status 하지 않는다.
+- 단, agy 가 machine-readable task export 를 제공하면 read-only telemetry adapter 를 붙인다.
+- agy subagent direct file edit 는 parent agy worker 의 file edit 로 귀속한다.
+- completion/handoff 은 agy parent output 에서만 수집한다.
+
+### 장점
+
+- 책임 경계가 명확하다.
+- vendor lock-in 을 줄인다.
+- agy subagents UX 를 활용하되 triflux core scheduler 를 black-box 로 교체하지 않는다.
+- AccountBroker, branch guard, worktree policy, bridge/handoff 를 보존한다.
+- 나중에 agy API 가 안정화되면 read-only telemetry 부터 점진 확장할 수 있다.
+
+### 단점
+
+- agy 내부 subagents 의 상세 상태가 triflux UI 에 바로 드러나지 않는다.
+- user-facing panel 이 두 개로 남는다.
+- nested parallelism resource cap 은 여전히 필요하다.
+- parent agy output 이 부실하면 triflux handoff 품질이 낮다.
+- agy 내부 approval 이 pending 일 때 triflux 는 "input wait" 를 정확히 판정하기 어렵다.
+
+### 일정 추정
+
+- 문서/UX 경계 명시: 1-2일
+- agy single-worker wrapper hardening: 3-5일
+- read-only `/tasks` telemetry 가능성 조사: 3-5일
+- PoC adapter: 1-2주
+- production hardening: 2-4주
+
+### 판정
+
+중기 권장이다.
+
+단기에는 B 로 유지하고, 조사 결과가 충분하면 C 의 read-only telemetry 부터 시작한다.
+
+---
+
+# 3. 핵심 unknowns: 조사 필요
+
+## U1. agy subagents 의 inter-process 통신 mechanism
+
+- 질문: agy subagents 는 IPC, shared memory, local files, embedded goroutine/process, MCP, 또는 internal RPC 중 무엇으로 통신하는가?
+- 필요한 근거: 공식 docs, verbose logs, process tree, file watch, network socket, strace/dtruss equivalent
+- triflux 영향: bridge adapter 가능 여부를 결정한다.
+- 현재 판정: 조사 필요.
+
+## U2. agy 가 외부 hub 와 통신 가능한가?
+
+- 질문: agy main agent 또는 subagent 가 `tfx-hub` MCP client 로 붙어 `/bridge/publish` 같은 event 를 보낼 수 있는가?
+- 필요한 근거: agy MCP config format, workspace `.agents/mcp_config.json`, `serverUrl` behavior, subagent tool inheritance
+- triflux 영향: 시나리오 C telemetry/handoff 개선 가능 여부를 결정한다.
+- 현재 판정: 부분 가능 추정. 단 subagent 별 MCP inheritance 는 조사 필요.
+
+## U3. agy 가 외부 hub 역할을 할 수 있는가?
+
+- 질문: agy `/tasks` channel 을 외부에서 query 하는 MCP server/API 가 있는가?
+- 필요한 근거: `agy --help`, docs, hidden commands, local socket/file endpoints
+- triflux 영향: 시나리오 A 의 필수 조건이다.
+- 현재 판정: 근거 없음. 조사 필요.
+
+## U4. subagents 의 OAuth account sharing
+
+- 질문: agy subagents 가 parent process 와 같은 OAuth/token/keyring 을 공유하는가?
+- 질문: 동시 subagent 실행이 quota/account lock/cooldown 을 어떻게 처리하는가?
+- 필요한 근거: auth files, keyring access pattern, error logs, parallel smoke test
+- triflux 영향: AccountBroker 통합 또는 별도 agy account lane 설계 여부를 결정한다.
+- 현재 판정: 조사 필요.
+
+## U5. agy `/agents` panel lifecycle
+
+- 질문: start, pause, resume, kill, approve, reject 가 CLI command 로 가능한가?
+- 질문: `ctrl+j`, `ctrl+k` 가 TUI-only 인가?
+- 필요한 근거: official docs detail, keybinding config, command palette, inspectable TUI state
+- triflux 영향: 시나리오 A 자동화 가능성과 operator UX 를 결정한다.
+- 현재 판정: 조사 필요.
+
+## U6. agy `/tasks` lifecycle
+
+- 질문: `/tasks` 는 task list/log/terminate 를 UI 로만 제공하는가, command/API 로도 제공하는가?
+- 질문: task ID 가 stable 한가?
+- 질문: task completion status 가 exit code 와 연결되는가?
+- 필요한 근거: `/tasks` command behavior transcript, logs, CLI flags
+- triflux 영향: bridge task-list/task-update 와 호환 가능성 판단.
+- 현재 판정: 조사 필요.
+
+## U7. triflux hub bridge 가 agy task channel 과 호환되는가?
+
+- 질문: agy task event 를 `register`, `publish`, `result`, `control`, `assign` 으로 normalize 할 수 있는가?
+- 필요한 근거: agy task payload schema
+- triflux 영향: C telemetry 또는 A backend adapter 의 구현 난이도.
+- 현재 판정: 조사 필요.
+
+## U8. agy 내부 subagents 의 cwd/workspace isolation
+
+- 질문: subagents 가 같은 working directory 를 공유하는가?
+- 질문: subagent 별 `--add-dir`, sandbox, readonly/edit permission 을 설정할 수 있는가?
+- 필요한 근거: parallel edit smoke test, file lock/logs
+- triflux 영향: file edit race 와 branch guard.
+- 현재 판정: 같은 cwd 공유 가능성이 있다고 추정. 확인 필요.
+
+## U9. agy parent output 과 subagent logs 의 관계
+
+- 질문: parent `agy --print` output 이 subagent 결과를 모두 포함하는가?
+- 질문: `/agents` conversation log 를 file/json 으로 export 할 수 있는가?
+- 필요한 근거: subagent 실행 transcript, local log files
+- triflux 영향: handoff 품질과 completion payload extraction.
+- 현재 판정: 조사 필요.
+
+## U10. agy approval pending 상태 감지
+
+- 질문: Fast Path Alert pending 상태가 parent CLI output/log/process status 에 드러나는가?
+- 질문: headless `--dangerously-skip-permissions` 에서도 subagents approval 이 완전히 bypass 되는가?
+- 필요한 근거: permission-required command smoke test
+- triflux 영향: headless stall/input_wait 판정.
+- 현재 판정: 조사 필요.
+
+## U11. nested parallelism resource caps
+
+- 질문: agy internal subagents 개수 제한이 있는가?
+- 질문: parent agy process 에서 subagent fan-out cap 을 설정할 수 있는가?
+- 필요한 근거: docs, settings, stress test
+- triflux 영향: tfx multi parallelism 과 중첩될 때 CPU/token/quota 폭증 가능성.
+- 현재 판정: 조사 필요.
+
+## U12. AntigravityBackend gap
+
+- 질문: `hub/team/backend.mjs` 와 `hub/workers/factory.mjs` 에 antigravity backend/worker 를 추가해야 하는가?
+- 근거: `agent-map.json` 은 agy 를 매핑하지만 backend registry/factory 는 antigravity 를 모른다.
+- triflux 영향: headless/team 경로에서 agy lane 이 모든 route 에서 동작하는지 검증 필요.
+- 현재 판정: 별도 wrapper Tier 2 PRD/PR 범위로 다루는 것이 맞다.
+
+---
+
+# 4. 권장 path
+
+## 권장 요약
+
+단기: **시나리오 B, 병렬 유지**.
+
+중기: **시나리오 C, 책임 분리 + read-only telemetry PoC**.
+
+보류: **시나리오 A, agy backend 위임**.
+
+## 이유
+
+1. agy subagents 는 공식 docs 상 강력한 병렬/approval/log UX 를 제공하지만, 외부 orchestration API 가 확인되지 않았다.
+
+2. triflux 는 이미 bridge, task model, Conductor state machine, AccountBroker, psmux/headless, MCP server 를 보유한다.
+
+3. 두 시스템의 책임이 가장 많이 겹치는 영역이 permission, lifecycle, file edit, monitoring 이다.
+
+4. 이 네 영역은 잘못 통합하면 사용자 혼란보다 더 큰 correctness/security 문제가 된다.
+
+5. agy 내부 subagents 를 black-box backend 로 쓰면 triflux 의 핵심 장점인 evidence, audit, worktree ownership, retry/kill control 이 약해진다.
+
+6. 반대로 agy 를 single worker 로 두면 현재 구조와 잘 맞고, agy 내부 subagents 는 점진적으로 관측만 추가할 수 있다.
+
+## 정책 문장
+
+agy 는 당분간 triflux worker backend 가 아니라 **Antigravity CLI lane** 이다.
+
+triflux 는 agy 내부 subagents 를 직접 orchestration unit 으로 취급하지 않는다.
+
+triflux 완료/실패 판정은 parent agy process 의 exit, stdout/stderr, handoff, workspace diff 에 근거한다.
+
+agy `/tasks`/`/agents` 는 단기에는 operator debug UI 로만 취급한다.
+
+machine-readable API 가 확인되면 read-only telemetry 부터 붙이고, write/control integration 은 별도 보안 review 후 결정한다.
+
+## 금지할 premature integration
+
+- TUI key sequence 로 `/agents` panel 을 자동 조작하는 통합.
+- agy subagent log 를 안정 schema 없이 regex 로 파싱해 task truth 로 삼는 통합.
+- agy 내부 subagents 를 triflux task list 에 가짜 worker 로 등록하는 통합.
+- agy permission approval 을 triflux permission gate 와 동등하게 간주하는 통합.
+- AccountBroker 없이 다중 agy subagents 를 production 병렬 lane 으로 열어두는 통합.
+
+## 허용할 작은 단계
+
+- agy parent worker 실행/종료/log capture 안정화.
+- agy `/tasks` output 을 사람이 읽는 debug artifact 로 저장.
+- agy 내부 subagents 사용 여부를 parent worker summary 에 표시.
+- agy 가 `tfx-hub` MCP 를 client 로 사용할 수 있는지 확인.
+- agy subagent logs 가 JSON/event 형태로 export 가능하면 read-only adapter PoC.
+
+---
+
+# 5. 다음 PR scope
+
+## PR 1: agy subagents API surface 정밀 조사
+
+### 목표
+
+agy subagents 가 외부에서 제어/관측 가능한지 확인한다.
+
+### 작업
+
+- `agy --help`, `agy help`, `/tasks`, `/agents`, `/permissions`, `/mcp` command detail 수집
+- `/tasks` list/log/terminate 의 machine-readable 출력 가능 여부 확인
+- `/agents` lifecycle command 또는 config/keybinding surface 확인
+- subagent 실행 중 process tree, local file/log, socket, mcp activity 샘플링
+- parent `agy --print` output 과 내부 subagent log 의 관계 확인
+- permission pending/approve/reject 상태가 headless 에서 어떻게 보이는지 확인
+
+### 산출물
+
+- `.triflux/plans/agy-subagents-api-surface-research.md`
+- transcript snippets
+- 가능/불가능 판정표
+- "A 가능", "C telemetry 가능", "B 유지" 중 하나의 후속 권장
+
+### Acceptance
+
+- UI-only 와 API-backed 기능을 분리한다.
+- 최소 3개 smoke transcript 를 남긴다.
+- 조사 불가 항목은 왜 불가인지 기록한다.
+
+## PR 2: triflux hub bridge 의 agy task channel 통합 PoC
+
+### 목표
+
+agy 내부 task 상태를 read-only 로 triflux 에 보여줄 수 있는지 확인한다.
+
+### 전제
+
+PR 1 에서 agy task/log/status 의 안정적인 외부 관측면이 발견된 경우에만 진행한다.
+
+### 작업
+
+- agy parent worker ID 와 agy internal task ID mapping 설계
+- `bridge/register` 는 parent agy process 만 등록
+- internal task 는 `metadata.agy_tasks` 또는 별도 read-only status 로 표시
+- `/bridge/publish` 는 parent worker event 로만 발행
+- kill/control 은 parent agy process 에만 허용
+- agy internal task terminate 는 PoC 에서 금지
+
+### 산출물
+
+- adapter PoC module
+- 샘플 JSON schema
+- status rendering screenshot 또는 text fixture
+- rollback plan
+
+### Acceptance
+
+- read-only telemetry 가 parent worker truth 를 덮어쓰지 않는다.
+- agy 내부 task 가 없어도 기존 worker status 는 정상이다.
+- agy API 가 없으면 PR 2 는 cancel 하고 B 유지 문서만 남긴다.
+
+## PR 3: AccountBroker 와 agy 인증 lane 호환성 평가
+
+### 목표
+
+agy subagents 병렬 실행이 현재 account/quota/auth lane 과 충돌하는지 평가한다.
+
+### 작업
+
+- agy CLI 가 쓰는 auth files/keyring path 확인
+- Gemini OAuth creds 재사용 여부 재검증
+- 다중 subagent 실행 시 quota/rate-limit/error category 수집
+- AccountBroker lease 개념을 agy parent process 에만 적용할지, internal subagents 까지 확장할지 비교
+- `TFX_DISABLE_ACCOUNT_BROKER`, `TFX_CODEX_HOME` 유사 env 가 agy 에 필요한지 검토
+
+### 산출물
+
+- `.triflux/plans/agy-accountbroker-compat.md`
+- auth path matrix
+- parallel quota smoke result
+- 권장 account policy
+
+### Acceptance
+
+- parent agy process 와 internal subagents 의 auth boundary 를 분리해서 설명한다.
+- account lease 를 agy 내부 subagents 단위로 적용할 수 없으면 명확히 "불가/비권장" 으로 표시한다.
+- 2026-06-18 Gemini OAuth lane 변화 리스크와 별도 agy enterprise lane 가능성을 분리한다.
+
+## PR 4: agy single-worker wrapper hardening
+
+### 목표
+
+시나리오 B/C 의 기반으로, agy 를 "triflux single worker lane" 으로 안정화한다.
+
+### 작업
+
+- `hub/team/backend.mjs` antigravity backend gap 검증
+- `hub/workers/factory.mjs` antigravity worker 필요 여부 검증
+- `tfx-route.sh` antigravity lane 의 stdin/argv/flag order 회귀테스트 추가
+- no-op success 승격이 agy output 에서 오탐 없는지 확인
+- `headless-guard.mjs` direct `agy --print/--prompt` 차단 테스트 추가
+
+### 산출물
+
+- 최소 단위 테스트
+- one-shot smoke command transcript
+- route/headless 경계 문서
+
+### Acceptance
+
+- agy lane 이 tfx-route 단일 실행에서 성공/실패/no-op 을 구분한다.
+- headless/team 경로에서 "지원 안 됨"이면 명확한 error 를 낸다.
+- backend/factory 미지원이 있으면 PR 4 에서 수정하거나 명시적으로 unsupported 로 guard 한다.
+
+---
+
+# 결정 기록
+
+## 결정 1: agy 를 즉시 orchestration backend 로 삼지 않는다
+
+근거는 external task API 부재다.
+
+triflux 는 backend 로 삼는 대상에 대해 spawn/status/log/kill/result 를 machine-readable 로 가져야 한다.
+
+현재 agy 공식 docs 근거는 `/tasks`/`/agents` UI 와 subagents capability 설명이지, 외부 API contract 가 아니다.
+
+## 결정 2: 단기에는 agy parent process 만 worker truth 로 본다
+
+triflux task truth 는 parent worker 의 exit/status/result/handoff 이다.
+
+agy 내부 subagent 는 implementation detail 이다.
+
+이 경계는 사용자 혼란과 audit 분산을 줄인다.
+
+## 결정 3: 중기 PoC 는 read-only telemetry 부터 시작한다
+
+write/control/terminate 는 permission, lifecycle, workspace ownership 위험이 크다.
+
+read-only telemetry 는 실패해도 parent worker truth 를 깨지 않는다.
+
+따라서 C 의 첫 단계는 read-only adapter 로 제한한다.
+
+## 결정 4: AccountBroker 호환성은 별도 PRD 로 분리한다
+
+agy 내부 subagents 의 OAuth/account sharing 은 핵심 unknown 이다.
+
+이 문제를 해결하지 않고 production 병렬 lane 으로 열면 quota/rate-limit/cooldown 이 불투명해진다.
+
+따라서 AccountBroker 호환성은 통합 PoC 와 별도 workstream 으로 둔다.
+
+---
+
+# Acceptance checklist
+
+- [ ] 이 PRD 는 신규 파일로 존재한다.
+- [ ] 책임 매트릭스가 15행 이상이다.
+- [ ] 시나리오 A/B/C 의 장점, 단점, 일정 추정이 있다.
+- [ ] 핵심 unknowns 가 조사 방법과 함께 적혀 있다.
+- [ ] 권장 path 가 단기/중기/보류로 분리되어 있다.
+- [ ] 다음 PR scope 가 조사, PoC, AccountBroker, wrapper hardening 으로 나뉜다.
+- [ ] 추정은 추정으로 표시되어 있다.
+- [ ] AI co-author footer 가 없다.

--- a/.triflux/plans/node-cli-single-entry-migration.md
+++ b/.triflux/plans/node-cli-single-entry-migration.md
@@ -1,0 +1,147 @@
+# [PRD] Node CLI 단일 진입점(Single Entry) 전환 및 Bash Wrapper 마이그레이션
+
+## 1. 개요 및 배경
+
+현재 `triflux` 시스템의 핵심 라우팅 및 환경 제어 로직은 `scripts/tfx-route.sh` (v2.7)에 작성되어 있으며, 그 분량은 2,609줄에 이르는 방대하고 복잡한 Bash 스크립트입니다. 
+
+해당 스크립트는 초기 인프라를 빠르게 조율하기 위해 작성되었으나, 다중 플랫폼(macOS, Linux, Windows) 지원 확장 과정에서 심각한 유지보수 비용을 초래하고 있습니다. 특히 **macOS 배포판의 기본 쉘인 Bash 3.2 버전 호환성 제약**으로 인해 연관 배열(Associative Array)이나 `mapfile` 같은 현대적인 Bash 문법을 사용하지 못해 간접 참조와 저수준 스트링 파싱 레이어로 복잡도가 가중되어 있습니다. 또한, Windows 개발 환경을 지원하기 위한 분기 코드가 스크립트 도처에 산재해 있어 잠재적인 버그의 온상이 되고 있습니다.
+
+본 PRD는 `triflux` 3자 합의(Claude + Codex + Agi) 결과 도출된 단순화 로드맵의 핵심인 **Node.js 기반 단일 진입점(Single Entry Point, `scripts/tfx-route.mjs`) 전환**을 달성하기 위한 구체적인 1차 마이그레이션 설계를 제시합니다. 이미 일부 사후 처리 로직이 `scripts/tfx-route-post.mjs`라는 Node.js 헬퍼로 위임되어 작동 중이므로, 이를 활용하여 점진적이고 안정적인 이관을 유도하고자 합니다.
+
+---
+
+## 2. 책임 16가지 매핑 (Bash → Node)
+
+`tfx-route.sh`가 담당해 온 16가지 시스템 관리적 책임을 Node.js 구조로 전면 매핑하여 이관 방안을 설계합니다.
+
+| # | 책임 | 현재 Bash 구현 위치 | Node.js 이전 대상 | OS 분기 Cost 감소 효과 |
+|---|------|-------------------|-------------------|---------------------|
+| 1 | **Timeout 호환** | `L32-44` <br> OS별 `gtimeout`/`timeout`/`TIMEOUT.exe` 체크 및 래핑 | `child_process.spawn()` 옵션의 `{ timeout }` 혹은 `AbortController` 활용 | Windows와 macOS 간의 외부 타임아웃 바이너리 유무 체크 코드 제거, 밀리초(ms) 단위의 단일 일관성 유지 |
+| 2 | **TMP 정규화** | `L46-62` <br> `TMPDIR`/`TEMP`/`TMP` 환경변수 순차 파싱 및 기본값 대입 | `os.tmpdir()` 표준 API 호출 | 각 OS별 환경변수 명명 방식 및 윈도우 백슬래시 경로 문제 완전 추상화 |
+| 3 | **Worker PID 추적 + Cleanup** | `L64-94` <br> 자식 프로세스 트리 추적 및 시그널 분할 전송 | `process.kill()` 표준 API 및 `tree-kill` npm 패키지 연동 | Windows의 `taskkill /T`와 POSIX `kill` 명령의 복잡한 쉘 결합 대체 |
+| 4 | **Preflight Env** | `L96-110` <br> 쉘 초기화 및 변수 존재 유무의 수동 `[[ -z ]]` 체크 | `process.env` 직접 읽기 및 유효성 검증 객체 캡슐화 | 쉘 세션별 스코프 전파 버그와 환경변수 익스포트 문법 차이 해소 |
+| 5 | **Codex config.toml MCP Auto-patch** | `L112-140` <br> `sed`, `awk` 등 정규식을 통한 강제 텍스트 주입 | `@iarna/toml` 파서/스트링파이어 활용한 구조적 패치 | macOS(BSD) `sed -i ''`와 Linux(GNU) `sed -i` 간 인자 호환성 문제 영구 제거 |
+| 6 | **--async Job 관리** | `L153-248` <br> 백그라운드 구동(`&`), PID 트래킹, 상태 파일 리디렉션 | `child_process.spawn(..., { detached: true })` + `crypto.randomUUID()` UUID 생성 + JSON 상태 제어 | 백그라운드 프로세스 데몬화 기법의 OS별 비호환성 차단, 구조화된 JSON 기반 비동기 상태 추적 구현 |
+| 7 | **Per-process Agent JSON 생성** | `L484-506` <br> heredoc(`cat <<EOF`)을 활용한 하드코딩 텍스트 파싱 및 파일 저장 | `fs.writeFileSync()` + `JSON.stringify()` 표준 흐름 | 특수 문자 이스케이프 오류, 개행 문자(`\r\n` vs `\n`) 문제를 Node.js 단에서 안전하게 차단 |
+| 8 | **Hub 자동 재시작** | `L620-680` <br> `curl` 요청을 통한 소켓 연결 감지 및 실패 시 재귀 백그라운드 구동 | Node native `fetch` API 기반 생존 확인 및 `child_process`를 통한 Hub 부트스트랩 | curl 설치 여부, 포트 대기 쉘 루프 차단 |
+| 9 | **Team Mode (Claim/Complete)** | `L600-768` <br> `node scripts/bridge.mjs` 서브프로세스를 매번 기동 및 결과 표준출력 파싱 | `import { claim, complete } from './bridge.mjs'` 직접 모듈 임포트 | 외부 Node.js 호출 오버헤드 100% 제거, 쉘 문자열 인터프리터 보안 위험 해소 |
+| 10 | **Quota 감지 + Auto Reroute** | `L771-821` <br> 서브프로세스 STDERR 캡처용 임시 파일 생성 및 정규식 Grep 감지 | STDERR 스트림 실시간 파이프 버퍼링 및 JS 정규식 연동 | 시스템 일시 디렉터리 내 누수되는 STDERR 로그 파일 제거, 에러 파싱 레이어 인메모리화 |
+| 11 | **Gemini Profile Resolution** | `L853-950` <br> 프로필 탐색 로직 및 외부 node helper/jq 기반 JSON 해석 파편화 | `tfx-route.mjs` 단일 진입점 내부 인라인 함수로 이관 및 제거 | 하위 프로세스 재생성 비용 소멸 및 환경에 따른 jq 누락 문제 대처 |
+| 12 | **Route Agent 결정** | `L955-1100+` <br> 거대한 Bash `case/esac` 구문과 제어 도중 에이전트 인덱싱 로직 | JS `switch-case` 매핑 구조 혹은 매핑 설정 객체 기반 라우터 아키텍처 | 문자열 가변 변수(`eval`)를 배제한 안전하고 확장 가능한 동적 라우팅 구현 |
+| 13 | **5 Override Hooks** | `L2167-2171` <br> 특정 쉘 환경변수에 등록된 훅 함수 탐색 및 `eval` 기동 | 이벤트 에미터(EventEmitter) 기반 라이프사이클 훅 또는 동적 ES 모듈 로딩 | 전역 쉘 네임스페이스 오염 방지 및 실행 흐름 제어의 타입 안정성 획득 |
+| 14 | **No-op 승격 판단** | `L2483-2486` <br> 파일 메타데이터 및 빈 줄 판별을 위한 `stat`, `wc -c` 실행 | `fs.statSync().size` 호출 | OS별 `stat` 파라미터 규격 격차 극복 및 무거웠던 서브프로세스 제거 |
+| 15 | **Antigravity Stdin Pipe 분기** | `L2036-2046` <br> TTY 테스트(`[ -t 0 ]`) 및 파이프 백업 세션 조율 | `process.stdin.isTTY` 및 스트림 `pipe` 연동 | 터미널 부착 여부에 따른 파일 디스크립터 상호작용의 OS 버그 우회 |
+| 16 | **Post-processing** | `tfx-route-post.mjs` 외부 Node 호출 | 동일 Node Engine 콘텍스트 내 직접 모듈 실행 | 추가적인 서브프로세스 스폰 비용 Zero 달성, 내부 데이터 교환 구조 단순화 |
+
+---
+
+## 3. 마이그레이션 단계 (점진적 전환 전략)
+
+대규모 쉘 스크립트를 한 번에 전환할 경우 가동 중단(Downtime)이나 숨겨진 예외 처리 유실로 장애가 발생할 수 있습니다. 3단계에 걸친 세밀한 점진적 전환을 통해 안정성을 극대화합니다.
+
+```mermaid
+graph TD
+    Phase0[Phase 0: 뼈대 구축 및 어댑터 분리] -->|TFX_ROUTE_NODE=1 병행 테스트| Phase1[Phase 1: 핵심 인프라 이관 #1~#10]
+    Phase1 --> Phase2[Phase 2: 라우팅/후처리 및 훅 이관 #11~#16]
+    Phase2 --> Phase3[Phase 3: 4주 모니터링 및 Bash 완전 삭제]
+```
+
+### Phase 0: 단일 진입점 및 에이전트 어댑터 설계 (준비 단계)
+* **목표**: 실행 프레임워크 구축 및 신구 진입점 병행 구동 환경 확보.
+* **상세 작업**:
+  1. 신규 단일 진입점 스크립트 `scripts/tfx-route.mjs` 생성.
+  2. 하위 도메인별 CLI 동작을 독립 캡슐화하는 어댑터 아키텍처 정의:
+     * `scripts/lib/cli-codex.mjs` (Codex 전용 파라미터 가공 및 기동)
+     * `scripts/lib/cli-gemini.mjs` (Gemini SDK/CLI 매핑)
+     * `scripts/lib/cli-claude.mjs` (Claude Code CLI 연계)
+     * `scripts/lib/cli-agy.mjs` (Antigravity Core 파이프 연동)
+  3. **병행 구동 게이트웨이**: `tfx-route.sh` 도입부에 `TFX_ROUTE_NODE` 플래그 체크 로직 추가.
+     ```bash
+     if [ "${TFX_ROUTE_NODE}" = "1" ]; then
+         exec node "$(dirname "$0")/tfx-route.mjs" "$@"
+     fi
+     ```
+     이 단계에서는 쉘 래퍼의 상단에 훅을 두어 개발 환경 및 특정 통합 테스트 파이프라인에서 점진적으로 Node로 가동을 우회해볼 수 있게 합니다.
+
+### Phase 1: 핵심 인프라 및 프로세스 제어 레이어 마이그레이션
+* **목표**: 쉘 스크립트 분량의 핵심(약 800줄)을 차지하는 시스템 크로스커팅 관심사(Cross-cutting Concerns) 이관.
+* **이관 대상 책임**: #1 (Timeout), #2 (TMP), #3 (PID 추적), #4 (Env), #5 (TOML 패치), #6 (Async), #7 (Agent JSON), #8 (Hub 재시작), #9 (Team Mode), #10 (Quota 감지).
+* **위험 및 대응**:
+  * 비동기 데몬 구동(`--async`) 시 Node 자식 프로세스가 유실되지 않도록 부모 프로세스 종료 후에도 안전하게 백그라운드에 남는 디태치(detached) 프로세스 처리와 파일 디스크립터 바인딩 분리가 철저히 검증되어야 합니다.
+* **추정 일정**: 5일 (검증 포함)
+
+### Phase 2: 라우팅, 에이전트 조율 및 후처리 마이그레이션
+* **목표**: 실질적인 라우팅 제어 흐름과 어댑터 통합을 완성하고, 분리 작동하던 포스트 프로세싱 레이어를 네이티브 수준으로 내재화(약 600줄 분량).
+* **이관 대상 책임**: #11 (Profile Resolution), #12 (Route Agent), #13 (Override Hooks), #14 (No-op 승격), #15 (Stdin Pipe), #16 (Post-processing 통합).
+* **상세 작업**:
+  * 기존의 개별 후처리 스크립트(`tfx-route-post.mjs`)를 새로 작성된 `tfx-route.mjs` 내부 라이브러리로 병합하여 인메모리 데이터를 직접 파이프 처리하도록 전환합니다.
+* **추정 일정**: 4일
+
+### Phase 3: 원격 측정(Telemetry) 기반 검증 및 쉘 배포 해제
+* **목표**: 구형 Bash 스크립트 실행 감시 후 영구 제거.
+* **상세 작업**:
+  1. 구형 `tfx-route.sh` 실행 시 경고 데퍼케이션 마커(Deprecation warning)를 표준 에러로 출력하되, 사내 모니터링 API에 실행 로깅(Telemetry)을 전송하는 훅 주입.
+  2. 약 4주간 운영 및 전체 CI/CD 환경 모니터링 수행.
+  3. 구형 `tfx-route.sh` 사용량이 0%에 도달했음을 검증한 즉시 레포지토리 내에서 완전 삭제하고 `scripts/tfx-route.mjs`를 표준 배포 사양의 단일 심볼릭 링크나 주 엔트리로 승격.
+* **추정 일정**: 2일 (모니터링 유지 기간 4주 별도 진행)
+
+---
+
+## 4. OS 분기 Cost 평가 (정량적)
+
+Bash에서 Node.js 플랫폼으로 전환됨에 따라 발생하는 실질적인 복잡도 및 유지관리 비용 감소를 수치화하여 증명합니다.
+
+| 평가 항목 | Bash (현재) | Node.js (이전 후) | 정량적 감소율 (추정) | 분석 근거 |
+|---|---|---|---|---|
+| **Windows 전용 코드 줄 수** | ~80 줄 | ~8 줄 | **90.0% 감소** | `cygpath`, OSTYPE 파싱, 경로 변환 매핑 로직이 Node `path` 내장 모듈 및 표준 경로 해석기로 대체됨에 따라 플랫폼 체크(process.platform) 조건문만 필요함. |
+| **macOS Bash 3.2 호환 비용** | 전체 코드 스타일에 무차별 지장 (보이지 않는 유지보수 장애) | 0 (비용 없음) | **100.0% 감소** | 쉘의 제한된 문법 제약이 완전히 제거되고 ES6+ 최신 자바스크립트 문법(Map, Set, Async/Await)을 제약 없이 사용함으로써 코딩 효율 급증. |
+| **OS 감지 분기 빈도** | ~12회 (파일 감지, 명령 확인, 개행 처리 등 곳곳에 산재) | 1회 (공통 유틸리티 헬퍼 또는 최초 진입 시 분기) | **91.6% 감소** | 각 함수 내부에서 개별적으로 구동 환경을 판단하지 않고 Node 플랫폼 자체 표준 명세 및 단일 헬퍼가 환경 격차를 흡수. |
+| **외부 플랫폼 종속 바이너리 의존성** | 3개 (`taskkill`, `cygpath`, `gtimeout`) | 0개 (순수 Node 모듈 대체) | **100.0% 감소** | `tree-kill` 라이브러리로 프로세스 제어 단일화, `path` 모듈로 경로 변환 일원화, Node 이벤트 루프의 자체 타이머를 통한 타임아웃 대체. |
+
+---
+
+## 5. 신규 위험 및 완화 방안
+
+1. **외부 npm 의존성 유입에 따른 취약성 전파 (Supply Chain Risk)**
+   * **위험**: `tree-kill`, `@iarna/toml` 등의 추가 외부 패키지 사용 시 소스코드 보안 검사 실패나 형상 불안정성 유입 가능.
+   * **완화**: 패키지 의존성을 최소화하는 것이 원칙입니다. 가급적 경량의 순수 구현이나 단일 목적의 유명 패키지만을 엄격한 버저닝(`package-lock.json` 고정) 하에 포함시키고, 정기적인 `npm audit` 또는 보안 스캔 도구를 활성화합니다.
+2. **Node.js 런타임 버전 비호환 및 호환성 파편화**
+   * **위험**: 개발자별 Node.js 버전 격차(예: v16 이하)나 ESM 구동 설정 차이로 발생할 수 있는 CLI 오동작.
+   * **완화**: 최저 요구 버전을 Node.js v18.0.0+ 이상(ESM 네이티브 안정화 버전)으로 못 박고, 스크립트 최초 진입(Preflight) 단계에서 `process.versions.node` 값을 검증하여 미달 시 동작을 거부하고 버전 일치를 강제합니다.
+3. **ESM 순환 참조 (Circular Import) 위험**
+   * **위험**: 어댑터와 라우팅 모듈 분리 과정에서 순환 참조 구조가 발생하여 런타임에 초기화되지 않은 참조 오류(Uninitialized reference error) 유발.
+   * **완화**: 모듈 역할을 단방향 계층 구조로 명확히 나눕니다. 설정 및 상태는 전역 인스턴스가 아닌 `tfx-route.mjs` 진입 영역에서 어댑터 함수로 파라미터를 통해 주입하는 단방향 의존 방식을 따릅니다.
+4. **Hub 백그라운드 구동 프로세스 간의 IPC 변화**
+   * **위험**: Bash 쉘 환경에서 파일 디스크립터 리디렉션을 통한 Hub 감시/제어 방식과 Node.js 서브프로세스 표준 출력 핸들링 간의 비정상 좀비 프로세스 유발 가능성.
+   * **완화**: 자식 프로세스를 기동할 때 `{ stdio: 'ignore', detached: true }`를 완전하게 설정한 뒤, 반드시 `child.unref()` 처리를 실행하여 부모 Node CLI가 종료되더라도 백그라운드 Hub가 안정적으로 상주하고 오펀(Orphan) 상태가 되지 않도록 방어합니다.
+
+---
+
+## 6. 일정 및 인력 계획
+
+단계별 검증 방안과 분담 계획을 세밀히 설계합니다.
+
+| Phase | 목표 및 마일스톤 | 소요 기간 (공수) | 담당 에이전트 | 주요 검증 체계 (Validation) |
+|---|---|---|---|---|
+| **Phase 0** | 진입점 PoC 및 ESM 기반 어댑터 뼈대(`cli-*.mjs`) 수립, TFX_ROUTE_NODE 병행 모드 활성화 | 2일 | **Claude** | 단위 테스트(Unit Test)를 기동하여 Node CLI 파라미터가 어댑터까지 전달 및 분기되는지 에이전트별 모의 구동 테스트 수행 |
+| **Phase 1** | 주요 인프라 제어(Timeout, TMP, TOML 파싱, Async 상태 관리 등) 10대 핵심 기능 구현 | 5일 | **Codex** | 통합 테스트(Integration Test)를 구성하여 비동기 프로세스 차단, TOML 패치 정밀도, tree-kill 활용 자식 청소 무결성 확보 |
+| **Phase 2** | 라우팅 제어 전체 통합, 훅 실행 체계 및 후처리 프로세스 합병 | 4일 | **Codex** | E2E(End-to-End) 시나리오 기반 전체 빌드 테스트 및 임의 고부하 시 상황 제어 모의 훈령(Smoke Test) 수행 |
+| **Phase 3** | 원격 분석 추적, 사용자 로그 감시 및 4주 경과 후 기존 Bash 래퍼 완전 소멸 | 2일 (안정성 모니터링 4주 기간 소요) | **Claude** | 텔레메트리 실행량 지표 분석(Telemetry analysis)을 확인해 구형 쉘 호출 이력 완전 차단 검증 후 파일 클린업 진행 |
+
+---
+
+## 7. 핵심 Unknowns 및 가이드
+
+1. **ESM 전환 시 기존 `.mjs` 외부 모듈과의 유기적 상호 호환성 검증**
+   * *영역*: `scripts/bridge.mjs` 등 이미 작성된 서브 컴포넌트와의 병합 과정에서 명시적 확장자 규칙, 모듈 중복 로드 유발 가능성.
+   * *가이드*: 로컬 테스트 단계에서 Node.js 표준 Resolution을 엄격하게 확인하며, 동일 프로젝트 루트 내 의존성이 이중 로딩되어 데이터 불일치가 일어나는지 모니터링합니다.
+2. **다양한 Windows 환경 경로 표준화의 실효성**
+   * *영역*: Git Bash, WSL, PowerShell 등 다양한 환경에 따라 Unix 형태와 Windows 형태(`C:\...` vs `/mnt/c/...` vs `/c/...`)로 상호 운용되는 경로의 `path.win32` 및 `path.posix` 분할 해석 정확도 파악.
+   * *가이드*: 어댑터 레벨에서 유일한 고유 경로 기준점을 정하기 위해 파일시스템 가상 마운트 지점의 유무를 감지하는 경로 직렬화 전용 검증 스위트를 구성하여 사전 테스트합니다.
+3. **`tree-kill` 라이브러리의 Windows 플랫폼 작동 신뢰성 확보**
+   * *영역*: `taskkill /T /F`로 타격되던 윈도우 프로세스 트리 하위 좀비 자식들이 Node 기반 외부 모듈로 제어 시 완벽히 소거되는지에 대한 실증 여부.
+   * *가이드*: Windows Runner 상에서 자식 프로세스가 다중 스폰되는 복합 상황을 구성하고, 타임아웃 종료를 강제 유발하여 시스템 프로세스 목록 상에 고아가 완전히 소멸하는지 가상 머신 테스트를 진행합니다.
+4. **Async Job 600s 타임아웃 우회 제어와 Claude Code Bash 도구 제약 사항의 간섭 유무**
+   * *영역*: 외부 Claude Code 도구 내부에서 스크립트를 기동하는 경우, 백그라운드 프로세스가 Node.js `spawn` 탈착(detached) 모드에서도 가상 호스트 샌드박스의 자체 제약으로 인해 종료 여부가 간섭되는지 조사 필요.
+   * *가이드*: 단일 엔트리 마이그레이션이 완료된 즉시 Claude Code 터미널 제어 상황을 가상으로 시뮬레이션하여 세션 행(Hang) 현상이 일어나는지, 샌드박스 경계를 넘어 정상적으로 비동기 태스크 상태가 보존 및 제어되는지 확인해야 합니다.
+


### PR DESCRIPTION
## Summary

Tier 2 wrapper fix (#296) + 회귀테스트 (#297) 의 follow-up doc PR. 3 변경 단일 commit (`bcfbd6a9`, 801 insertions, doc-only).

- **A** `.claude/rules/tfx-update-logic.md` — Antigravity CLI 1.0.0 정밀 sanity matrix 발견 section 30줄 append:
  - `--print` 가 string value-taking flag (Go flag library) — `--print=hi` ✅ / `--print` alone → "flag needs an argument"
  - flag 순서 critical: `--print` 가 먼저 + 다른 flag = timeout (T6 `--add-dir`, T9 `--sandbox` 둘 다 124)
  - safe pattern 3가지: stdin pipe / flag swap (`--dangerously` 먼저) / `--print=VALUE`
  - `/model` slash command + **persist across sessions** (공식 docs verbatim)
  - 모델 리스트 account-dependent: **사내 5** (Gemini 3.1 Pro High/Low, 3.5 Flash default current, 3.5 Flash Low, 3 Flash) / 개인 4 / IDE 7 (context7 sirius-red)
  - `agy subagents framework` (`/tasks` + `/agents` panel)
  - CLI launch flag override = `--sandbox`, `--dangerously-skip-permissions` **2개만**
  - MCP server config: `~/.gemini/antigravity-cli/mcp_config.json` + `serverUrl` field (Gemini 의 `url` 대신)
  - plugin import: `agy plugin import gemini`

- **D** `.triflux/plans/agy-subagents-integration-eval.md` (627줄, codex 직접 작성):
  - triflux hub/team_mode vs agy subagents framework 책임 매트릭스
  - 통합 시나리오 3가지: A backend 위임 / B 병렬 유지 / C 책임 분리
  - **단기 권장 = 시나리오 B** (병렬 유지)
  - **중기 권장 = 시나리오 C** (책임 분리 + read-only telemetry PoC)
  - 시나리오 A 보류 (agy 외부 API surface 근거 확보 후 재평가)

- **E** `.triflux/plans/node-cli-single-entry-migration.md` (147줄, agy stdin pipe 작성):
  - wrapper 2609줄 Bash → Node 단일 entry 전환 plan
  - 책임 16가지 Bash → Node 매핑 표
  - Phase 0~3 (총 13일 + 4주 모니터링)
  - **Phase 0 PoC scope**: `TFX_ROUTE_NODE` flag + `tfx-route.mjs` 진입점 + `cli-{codex,gemini,claude,agy}.mjs` 어댑터 스켈레톤
  - 핵심 risk: `--async` 데몬 프로세스 OS별 detach lifecycle + 고아 위험

## Test plan

- [x] markdown syntax 정상 (3 file)
- [x] commit message HEREDOC 정상 (AI co-author footer 없음)
- [x] `.gitignore` 의 `.triflux/` 통째 ignore 패턴 우회 (`git add -f`) — 기존 `issue-281-*.md` 와 같은 grandfathered 패턴
- [ ] 사용자 review: PRD D 의 단기 권장 (시나리오 B) + PRD E 의 Phase 0 PoC scope 합리성

## Related

- #296 — Tier 2 wrapper fix (antigravity stdin pipe + tri-lane fallback)
- #297 — agy --print 5종 prompt-passing 회귀테스트
- 3자 합의 simplify 결정 (이전 turn)

## Follow-up (별도 issue 후보)

- `.gitignore` 의 `.triflux/` 패턴 정정 — `!.triflux/plans/*.md` exception 추가 (force add 없이 PRD 추가 가능하게)
- Phase 0 PoC 실행 (PRD E 의 첫 단계, 2일 추정, claude 담당)
- agy subagents API 정밀 조사 (PRD D 의 unknowns 해소, codex 담당)