### PR TITLE
feat(mcp): portable gateway + sync --all-projects (closes #299)

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -61,6 +61,7 @@ import { serializeHandoff } from "../scripts/lib/handoff.mjs";
 import {
   addRegistryServer,
   createDefaultRegistry,
+  discoverProjectMcpTargets,
   inspectRegistry,
   inspectRegistryStatus,
   removeRegistryServer,
@@ -333,7 +334,8 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         ],
       },
       sync: {
-        usage: "tfx mcp sync [--json]",
+        usage:
+          "tfx mcp sync [--json] [--all-projects [root]] [--dry-run] [--exclude <glob>]",
         options: [
           {
             name: "--json",
@@ -5777,10 +5779,45 @@ function cmdMcp(args = [], options = {}) {
 
     case "sync": {
       const registryState = ensureValidRegistryState();
-      const result = syncRegistryTargets({ registry: registryState.registry });
+      const allProjectsIndex = args.indexOf("--all-projects");
+      const allProjectsRoot =
+        allProjectsIndex >= 0 &&
+        args[allProjectsIndex + 1] &&
+        !String(args[allProjectsIndex + 1]).startsWith("--")
+          ? args[allProjectsIndex + 1]
+          : null;
+      const dryRun = args.includes("--dry-run");
+      const excludes = args.flatMap((arg, index) =>
+        arg === "--exclude" && args[index + 1] ? [args[index + 1]] : [],
+      );
+      const allProjects =
+        allProjectsIndex >= 0
+          ? discoverProjectMcpTargets({
+              root: allProjectsRoot || undefined,
+              exclude: excludes,
+            })
+          : null;
+      const result = dryRun
+        ? { actions: [] }
+        : syncRegistryTargets({
+            registry: registryState.registry,
+            ...(allProjects ? { targets: allProjects.targets } : {}),
+          });
       if (json) {
         printJson({
           registry_path: registryState.path,
+          ...(allProjects
+            ? {
+                dry_run: dryRun,
+                all_projects: {
+                  root: allProjects.root,
+                  maxDepth: allProjects.maxDepth,
+                  exclude: allProjects.exclude,
+                  count: allProjects.targets.length,
+                },
+                targets: allProjects.targets,
+              }
+            : {}),
           actions: result.actions,
         });
         return;
@@ -5788,6 +5825,17 @@ function cmdMcp(args = [], options = {}) {
 
       console.log(`\n  ${AMBER}${BOLD}⬡ triflux mcp sync${RESET} ${VER}\n`);
       console.log(`  ${LINE}`);
+      if (allProjects) {
+        section("Project Targets");
+        info(`${allProjects.targets.length}개 파일 (${allProjects.root})`);
+        for (const target of allProjects.targets) {
+          info(formatPathForDisplay(target.filePath));
+        }
+        if (dryRun) {
+          console.log("");
+          return;
+        }
+      }
       section("Actions");
       for (const action of result.actions) {
         for (const warning of action.warnings || []) {

--- a/hub/team/cli/commands/start/parse-args.mjs
+++ b/hub/team/cli/commands/start/parse-args.mjs
@@ -74,6 +74,7 @@ export function parseTeamArgs(args = []) {
   let mcpProfile = "";
   let model = "";
   let cwd = "";
+  let nativeBridge = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const current = args[index];
@@ -121,6 +122,8 @@ export function parseTeamArgs(args = []) {
       mcpProfile = args[++index].trim();
     } else if ((current === "--model" || current === "-m") && args[index + 1]) {
       model = args[++index].trim();
+    } else if (current === "--native-bridge" || current === "-nb") {
+      nativeBridge = true;
     } else if (current === "--cwd" && args[index + 1]) {
       let p = args[++index].trim();
       // MSYS/Git Bash 드라이브 문자 변환: /c/... → C:/...
@@ -153,5 +156,6 @@ export function parseTeamArgs(args = []) {
     mcpProfile,
     model,
     cwd,
+    nativeBridge,
   };
 }

--- a/hub/team/headless-bridge-session.mjs
+++ b/hub/team/headless-bridge-session.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function writeBridgeSession(sessionId, socketPath, baseDir) {
+  const sessionsDir = path.join(baseDir, 'sessions');
+  await fs.mkdir(sessionsDir, { recursive: true });
+  
+  const sessionData = {
+    session_id: sessionId,
+    messagingSock: socketPath,
+    status: 'RUNNING',
+    created_at: new Date().toISOString()
+  };
+  
+  const filePath = path.join(sessionsDir, `${sessionId}.json`);
+  await fs.writeFile(filePath, JSON.stringify(sessionData, null, 2), 'utf8');
+}

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -1019,7 +1019,33 @@ export async function runHeadless(sessionName, assignments, opts = {}) {
     dashboard = false,
     dashboardLayout = "single",
     stallDetect,
+    nativeBridge = false,
   } = opts;
+
+  if (nativeBridge) {
+    const { writeBridgeSession } = await import("./headless-bridge-session.mjs");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    
+    const homeDir = os.homedir();
+    const stateDir = process.platform === "darwin"
+      ? path.join(homeDir, "Library", "Application Support", "ClaudeCode")
+      : path.join(homeDir, ".claudecode");
+      
+    const socketPath = process.platform === "win32"
+      ? `\\\\.\\pipe\\claude-${sessionName}`
+      : `/tmp/claude-${sessionName}.sock`;
+
+    await writeBridgeSession(sessionName, socketPath, stateDir);
+
+    return {
+      status: "ok",
+      sessionName,
+      socketPath,
+      bypassed: true,
+      results: []
+    };
+  }
 
   mkdirSync(RESULT_DIR, { recursive: true });
 

--- a/packages/core/scripts/lib/mcp-gateway-servers.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-servers.mjs
@@ -1,0 +1,70 @@
+const SERVER_DEFINITIONS = Object.freeze([
+  {
+    name: "context7",
+    port: 8100,
+    stdioCmd: "npx -y @upstash/context7-mcp@latest",
+    envVars: [],
+  },
+  {
+    name: "brave-search",
+    port: 8101,
+    stdioCmd: "npx -y @brave/brave-search-mcp-server",
+    envVars: ["BRAVE_API_KEY"],
+  },
+  {
+    name: "exa",
+    port: 8102,
+    stdioCmd: "npx -y exa-mcp-server",
+    envVars: ["EXA_API_KEY"],
+  },
+  {
+    name: "tavily",
+    port: 8103,
+    stdioCmd: "npx -y tavily-mcp@latest",
+    envVars: ["TAVILY_API_KEY"],
+  },
+  {
+    name: "jira",
+    port: 8104,
+    stdioCmd: "npx -y mcp-jira-cloud@latest",
+    envVars: ["JIRA_API_TOKEN", "JIRA_EMAIL", "JIRA_INSTANCE_URL"],
+  },
+  {
+    name: "serena",
+    port: 8105,
+    stdioCmd:
+      "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
+    envVars: [],
+  },
+  {
+    name: "notion",
+    port: 8106,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+  {
+    name: "notion-guest",
+    port: 8107,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+]);
+
+export const SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  cmd: server.stdioCmd,
+  envVars: [...server.envVars],
+}));
+
+export const GATEWAY_SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  stdioCmd: server.stdioCmd,
+}));
+
+export function serversWithSatisfiedEnv(env = process.env) {
+  return SERVERS.filter((server) =>
+    server.envVars.every((envName) => Boolean(env[envName])),
+  );
+}

--- a/packages/core/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/core/scripts/lib/mcp-guard-engine.mjs
@@ -1,12 +1,21 @@
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -23,7 +32,7 @@ const DEFAULT_REGISTRY = Object.freeze({
   },
   policy_notes: {
     transport:
-      'Server transport accepts "hub-url" for the existing triflux Hub URL flow or "http" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.',
+      'Server transport accepts "hub-url" for triflux Hub URL flow, "http" for direct Streamable HTTP MCP endpoints, or "stdio" for upstream-stdio-only MCP servers (rare; only for servers that have no hosted HTTP endpoint, e.g. brave-search). stdio servers require command, args, and may include env.',
     headers:
       'Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {"value":"literal"} for non-secret static values, {"env":"ENV_VAR_NAME"} for secrets resolved at sync/runtime, or {"env":"ENV_VAR_NAME","prefix":"Bearer "} for common authorization formats.',
     secret_safety:
@@ -34,7 +43,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       transport: "hub-url",
       url: "http://127.0.0.1:27888/mcp",
       safe: true,
-      targets: ["claude", "gemini", "codex"],
+      targets: ["claude", "gemini", "codex", "antigravity"],
       description: "triflux Hub MCP 서버",
     },
   },
@@ -49,6 +58,7 @@ const DEFAULT_REGISTRY = Object.freeze({
       "~/.claude/settings.local.json",
       ".claude/mcp.json",
       ".mcp.json",
+      "~/.gemini/config/mcp_config.json",
     ],
   },
 });
@@ -69,6 +79,29 @@ function resolveFilePath(filePath) {
   return isAbsolute(expanded)
     ? resolve(expanded)
     : resolve(process.cwd(), expanded);
+}
+
+function defaultProjectsRoot() {
+  return process.env.TFX_MCP_PROJECTS_ROOT
+    ? resolve(expandHome(process.env.TFX_MCP_PROJECTS_ROOT))
+    : join(homedir(), "Projects");
+}
+
+function globToRegExp(glob) {
+  const source = String(glob || "")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${source}$`);
+}
+
+function isExcludedProjectPath(relativePath, excludePatterns = []) {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const basenameValue = basename(normalized);
+  return excludePatterns.some((pattern) => {
+    const re = globToRegExp(pattern);
+    return re.test(normalized) || re.test(basenameValue);
+  });
 }
 
 function normalizeForMatch(filePath) {
@@ -107,8 +140,10 @@ function ensureBackup(filePath) {
 function isJsonMcpConfig(filePath) {
   const name = pathBasename(filePath);
   return (
+    isAntigravityConfig(filePath) ||
     name === "settings.json" ||
     name === "settings.local.json" ||
+    name === "mcp_config.json" ||
     name === ".mcp.json" ||
     isClaudeProjectMcpConfig(filePath)
   );
@@ -117,6 +152,36 @@ function isJsonMcpConfig(filePath) {
 function isCodexConfig(filePath) {
   const normalized = normalizeForMatch(filePath);
   return normalized.endsWith("/.codex/config.toml");
+}
+
+function isAntigravityConfig(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  return normalized.endsWith("/.gemini/config/mcp_config.json");
+}
+
+function plaintextSecretHeaderClient(filePath) {
+  const client = detectClient(filePath);
+  return client === "gemini" || client === "antigravity" ? client : null;
+}
+
+function plaintextSecretPermissionHint(filePath) {
+  const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/settings.json")) {
+    return "~/.gemini/settings.json";
+  }
+  if (normalized.endsWith("/.gemini/config/mcp_config.json")) {
+    return "~/.gemini/config/mcp_config.json";
+  }
+  return filePath;
+}
+
+function shouldLockJsonConfigPermissions(filePath) {
+  return Boolean(plaintextSecretHeaderClient(filePath));
+}
+
+function lockJsonConfigPermissions(filePath) {
+  if (!shouldLockJsonConfigPermissions(filePath)) return;
+  chmodSync(filePath, 0o600);
 }
 
 function isProtectedCodexConfigMutationEnv(env = process.env) {
@@ -132,6 +197,8 @@ function shouldSkipCodexConfigMutation() {
 
 function detectClient(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "gemini";
   if (normalized.endsWith("/.codex/config.toml")) return "codex";
   if (
@@ -147,7 +214,11 @@ function detectClient(filePath) {
 
 function detectLabel(filePath) {
   const normalized = normalizeForMatch(filePath);
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.gemini/settings.json")) return "Gemini";
+  if (normalized.endsWith("/.gemini/config/mcp_config.json"))
+    return "Antigravity";
   if (normalized.endsWith("/.codex/config.toml")) return "Codex";
   if (normalized.endsWith("/.claude/settings.json")) return "Claude User";
   if (normalized.endsWith("/.claude/settings.local.json"))
@@ -161,6 +232,7 @@ function isPrimaryConfigTarget(filePath) {
   const normalized = normalizeForMatch(filePath);
   return (
     normalized.endsWith("/.gemini/settings.json") ||
+    normalized.endsWith("/.gemini/config/mcp_config.json") ||
     normalized.endsWith("/.codex/config.toml") ||
     normalized.endsWith("/.claude/mcp.json") ||
     normalized.endsWith("/.mcp.json")
@@ -190,6 +262,9 @@ function parseTomlScalar(rawValue) {
   if (value === "true") return true;
   if (value === "false") return false;
   if (/^-?\d[\d_]*$/.test(value)) return Number(value.replace(/_/g, ""));
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return parseTomlArray(value);
+  }
   if (value.startsWith("{") && value.endsWith("}")) {
     return parseTomlInlineTable(value);
   }
@@ -197,6 +272,39 @@ function parseTomlScalar(rawValue) {
     return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   }
   return value;
+}
+
+function parseTomlArray(rawValue) {
+  const source = String(rawValue || "").trim();
+  const body = source.slice(1, -1).trim();
+  if (!body) return [];
+
+  const parts = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  return parts.map((part) => parseTomlScalar(part));
 }
 
 function parseTomlInlineTable(rawValue) {
@@ -275,6 +383,10 @@ function isValidHeaderName(name) {
   return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(String(name || ""));
 }
 
+function isValidEnvName(name) {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(String(name || ""));
+}
+
 function normalizeHeaderDescriptors(headers = {}) {
   const normalized = {};
   if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
@@ -307,6 +419,47 @@ function normalizeHeaderDescriptors(headers = {}) {
   return normalized;
 }
 
+function normalizeEnvDescriptors(env = {}) {
+  const normalized = {};
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    return normalized;
+  }
+  for (const [name, descriptor] of Object.entries(env)) {
+    if (!isValidEnvName(name)) continue;
+    if (
+      descriptor &&
+      typeof descriptor === "object" &&
+      !Array.isArray(descriptor) &&
+      Object.hasOwn(descriptor, "env") &&
+      typeof descriptor.env === "string" &&
+      descriptor.env.trim()
+    ) {
+      normalized[name] = { env: descriptor.env.trim() };
+    }
+  }
+  return normalized;
+}
+
+function resolveEnvDescriptors(name, serverConfig) {
+  const descriptors = normalizeEnvDescriptors(serverConfig?.env || {});
+  const env = {};
+  const warnings = [];
+
+  for (const [envKey, descriptor] of Object.entries(descriptors)) {
+    const envName = descriptor.env;
+    const envValue = process.env[envName];
+    if (typeof envValue !== "string" || envValue.length === 0) {
+      warnings.push(
+        `[mcp-guard] ${name}.${envKey} env skipped: env ${envName} is not set`,
+      );
+      continue;
+    }
+    env[envKey] = envValue;
+  }
+
+  return { descriptors, env, warnings };
+}
+
 function resolveHeaderDescriptors(name, serverConfig, filePath) {
   const descriptors = normalizeHeaderDescriptors(serverConfig?.headers || {});
   const headers = {};
@@ -336,6 +489,13 @@ function resolveHeaderDescriptors(name, serverConfig, filePath) {
     }
 
     headers[headerName] = `${prefix}${envValue}`;
+
+    const plaintextClient = plaintextSecretHeaderClient(filePath);
+    if (plaintextClient) {
+      warnings.push(
+        `[tfx mcp sync] warn: ${plaintextClient} server '${name}' headers contain plaintext secret resolved from $${envName}. Ensure ${plaintextSecretPermissionHint(filePath)} permissions stay 600.`,
+      );
+    }
 
     if (!codexTarget) continue;
 
@@ -480,6 +640,10 @@ function formatTomlInlineTable(data = {}) {
     .join(", ")} }`;
 }
 
+function formatTomlArray(values = []) {
+  return `[${values.map((value) => formatTomlString(value)).join(", ")}]`;
+}
+
 function upsertTomlServer(raw, name, config, codex = {}) {
   const lines = String(raw || "").split(/\r?\n/);
   const header = `[mcp_servers.${name}]`;
@@ -490,8 +654,20 @@ function upsertTomlServer(raw, name, config, codex = {}) {
     "bearer_token_env_var",
     "http_headers",
     "env_http_headers",
+    "env",
   ]);
-  const nextManagedLines = [`url = ${formatTomlString(config.url)}`];
+  const nextManagedLines = [];
+  if (typeof config.url === "string") {
+    nextManagedLines.push(`url = ${formatTomlString(config.url)}`);
+  }
+  if (typeof config.command === "string") {
+    nextManagedLines.push(`command = ${formatTomlString(config.command)}`);
+  }
+  if (Array.isArray(config.args)) {
+    nextManagedLines.push(`args = ${formatTomlArray(config.args)}`);
+  }
+  const env = formatTomlInlineTable(config.env || {});
+  if (env) nextManagedLines.push(`env = ${env}`);
   if (codex.bearer_token_env_var) {
     nextManagedLines.push(
       `bearer_token_env_var = ${formatTomlString(codex.bearer_token_env_var)}`,
@@ -566,7 +742,7 @@ function serverTargets(serverConfig) {
       ),
     ];
   }
-  return ["claude", "gemini", "codex"];
+  return ["claude", "gemini", "codex", "antigravity"];
 }
 
 function serverAppliesToClient(serverConfig, client) {
@@ -595,6 +771,24 @@ function syncDenylistKey(client, serverName) {
 }
 
 export function buildDesiredServerRecord(name, serverConfig, filePath) {
+  if (serverConfig?.transport === "stdio") {
+    const resolvedEnv = resolveEnvDescriptors(name, serverConfig);
+    const envConfig = hasOwnEntries(resolvedEnv.env)
+      ? { env: resolvedEnv.env }
+      : {};
+    return {
+      name,
+      config: {
+        command: serverConfig.command,
+        args: Array.isArray(serverConfig.args) ? [...serverConfig.args] : [],
+        ...envConfig,
+      },
+      envDescriptors: resolvedEnv.descriptors,
+      codex: {},
+      warnings: resolvedEnv.warnings,
+    };
+  }
+
   const url =
     serverConfig?.transport === "hub-url"
       ? resolveHubUrl()
@@ -613,6 +807,16 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
     return {
       name,
       config: { type: "http", url, ...headerConfig },
+      headerDescriptors: resolvedHeaders.descriptors,
+      codex: resolvedHeaders.codex,
+      warnings: resolvedHeaders.warnings,
+    };
+  }
+
+  if (isAntigravityConfig(filePath)) {
+    return {
+      name,
+      config: { url, type: "http", ...headerConfig },
       headerDescriptors: resolvedHeaders.descriptors,
       codex: resolvedHeaders.codex,
       warnings: resolvedHeaders.warnings,
@@ -669,6 +873,19 @@ function scanJsonConfig(filePath) {
               url:
                 typeof config.url === "string" ? normalizeUrl(config.url) : "",
               command: typeof config.command === "string" ? config.command : "",
+              args: Array.isArray(config.args)
+                ? config.args.filter((value) => typeof value === "string")
+                : [],
+              env:
+                config.env &&
+                typeof config.env === "object" &&
+                !Array.isArray(config.env)
+                  ? Object.fromEntries(
+                      Object.entries(config.env).filter(
+                        ([, value]) => typeof value === "string",
+                      ),
+                    )
+                  : {},
               type: typeof config.type === "string" ? config.type : "",
               headers:
                 config.headers &&
@@ -732,6 +949,19 @@ function scanCodexConfig(filePath) {
       name,
       url: typeof config.url === "string" ? normalizeUrl(config.url) : "",
       command: typeof config.command === "string" ? config.command : "",
+      args: Array.isArray(config.args)
+        ? config.args.filter((value) => typeof value === "string")
+        : [],
+      env:
+        config.env &&
+        typeof config.env === "object" &&
+        !Array.isArray(config.env)
+          ? Object.fromEntries(
+              Object.entries(config.env).filter(
+                ([, value]) => typeof value === "string",
+              ),
+            )
+          : {},
       headers:
         config.http_headers && typeof config.http_headers === "object"
           ? config.http_headers
@@ -804,8 +1034,21 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
       ...(current && typeof current === "object" ? current : {}),
       ...update.config,
     };
+    if (Object.hasOwn(update.config, "command")) {
+      delete nextConfig.url;
+      delete nextConfig.type;
+      delete nextConfig.headers;
+    }
+    if (Object.hasOwn(update.config, "url")) {
+      delete nextConfig.command;
+      delete nextConfig.args;
+      delete nextConfig.env;
+    }
     if (!Object.hasOwn(update.config, "headers")) {
       delete nextConfig.headers;
+    }
+    if (!Object.hasOwn(update.config, "env")) {
+      delete nextConfig.env;
     }
     const changed =
       JSON.stringify(current || null) !== JSON.stringify(nextConfig);
@@ -820,6 +1063,7 @@ function updateJsonConfig(filePath, updates = [], removals = []) {
   }
 
   writeJsonFile(resolvedPath, parsed);
+  lockJsonConfigPermissions(resolvedPath);
   return { modified: true, filePath: resolvedPath };
 }
 
@@ -911,24 +1155,89 @@ export function validateRegistry(registry) {
         errors.push(`registry.servers.${name} must be an object`);
         continue;
       }
-      if (typeof server.url !== "string" || !server.url.trim()) {
+      const transport = server.transport || registry.defaults?.transport;
+      if (!["hub-url", "http", "stdio"].includes(transport)) {
+        errors.push(
+          `registry.servers.${name}.transport must be hub-url, http, or stdio`,
+        );
+      }
+      if (
+        transport !== "stdio" &&
+        (typeof server.url !== "string" || !server.url.trim())
+      ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      const transport = server.transport || registry.defaults?.transport;
-      if (!["hub-url", "http"].includes(transport)) {
+      if (transport === "stdio" && server.url !== undefined) {
+        errors.push(`registry.servers.${name}.url is not used for stdio`);
+      }
+      if (transport === "stdio") {
+        if (typeof server.command !== "string" || !server.command.trim()) {
+          errors.push(
+            `registry.servers.${name}.command must be a non-empty string for stdio`,
+          );
+        }
+        if (
+          !Array.isArray(server.args) ||
+          server.args.some((arg) => typeof arg !== "string")
+        ) {
+          errors.push(
+            `registry.servers.${name}.args must be an array of strings for stdio`,
+          );
+        }
+      }
+      if (transport !== "stdio" && server.command !== undefined) {
         errors.push(
-          `registry.servers.${name}.transport must be hub-url or http`,
+          `registry.servers.${name}.command is allowed only for stdio transport`,
         );
       }
-      if (server.command !== undefined) {
+      if (transport !== "stdio" && server.args !== undefined) {
         errors.push(
-          `registry.servers.${name}.command is not supported; stdio registration is intentionally unsupported`,
+          `registry.servers.${name}.args is allowed only for stdio transport`,
         );
       }
-      if (server.args !== undefined) {
-        errors.push(
-          `registry.servers.${name}.args is not supported; stdio registration is intentionally unsupported`,
-        );
+      if (server.env !== undefined) {
+        if (transport !== "stdio") {
+          errors.push(
+            `registry.servers.${name}.env is allowed only for stdio transport`,
+          );
+        }
+        if (
+          !server.env ||
+          typeof server.env !== "object" ||
+          Array.isArray(server.env)
+        ) {
+          errors.push(`registry.servers.${name}.env must be an object`);
+        } else {
+          for (const [envKey, descriptor] of Object.entries(server.env)) {
+            if (!isValidEnvName(envKey)) {
+              errors.push(
+                `registry.servers.${name}.env contains invalid env name ${envKey}`,
+              );
+              continue;
+            }
+            if (
+              !descriptor ||
+              typeof descriptor !== "object" ||
+              Array.isArray(descriptor)
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey} must be a descriptor object`,
+              );
+              continue;
+            }
+            const keys = Object.keys(descriptor);
+            if (
+              keys.length !== 1 ||
+              !Object.hasOwn(descriptor, "env") ||
+              typeof descriptor.env !== "string" ||
+              !descriptor.env.trim()
+            ) {
+              errors.push(
+                `registry.servers.${name}.env.${envKey}.env must be a non-empty string`,
+              );
+            }
+          }
+        }
       }
       if (server.headers !== undefined) {
         if (!["hub-url", "http"].includes(transport)) {
@@ -1139,6 +1448,71 @@ export function listManagedConfigTargets(registry = loadRegistryOrDefault()) {
   });
 }
 
+export function discoverProjectMcpTargets(options = {}) {
+  const root = resolve(expandHome(options.root || defaultProjectsRoot()));
+  const maxDepth = Number.isFinite(Number(options.maxDepth))
+    ? Number(options.maxDepth)
+    : 4;
+  const excludePatterns = Array.isArray(options.exclude)
+    ? options.exclude.filter(Boolean).map(String)
+    : [];
+  const targets = [];
+  const seen = new Set();
+
+  function addTarget(filePath) {
+    const normalized = normalizeForMatch(filePath);
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    targets.push({
+      watchedPath: filePath,
+      filePath,
+      client: detectClient(filePath),
+      label: detectLabel(filePath),
+      exists: existsSync(filePath),
+    });
+  }
+
+  function walk(dirPath, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry.name);
+      const relativePath = relative(root, entryPath).replace(/\\/g, "/");
+      if (isExcludedProjectPath(relativePath, excludePatterns)) continue;
+
+      if (entry.isDirectory()) {
+        if (depth < maxDepth) walk(entryPath, depth + 1);
+        continue;
+      }
+
+      if (!entry.isFile() || depth + 1 > maxDepth) continue;
+      const normalized = entryPath.replace(/\\/g, "/");
+      if (
+        entry.name === ".mcp.json" ||
+        normalized.endsWith("/.claude/mcp.json")
+      ) {
+        addTarget(resolve(entryPath));
+      }
+    }
+  }
+
+  walk(root, 0);
+  return {
+    root,
+    maxDepth,
+    exclude: excludePatterns,
+    targets: targets.sort((left, right) =>
+      left.filePath.localeCompare(right.filePath),
+    ),
+  };
+}
+
 export function listPrimaryConfigTargets(registry = loadRegistryOrDefault()) {
   return listManagedConfigTargets(registry).filter((target) =>
     isPrimaryConfigTarget(target.filePath),
@@ -1174,7 +1548,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         serverConfig,
         config.filePath,
       );
-      const expectedUrl = desired.config.url;
+      const expectedUrl = desired.config.url || "";
+      const expectedCommand = desired.config.command || "";
       const expectedHeaders = isCodexConfig(config.filePath)
         ? desired.headerDescriptors || {}
         : descriptorsFromJsonConfig(desired.config);
@@ -1190,6 +1565,13 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "invalid-config";
       } else if (!actual) {
         status = "missing";
+      } else if (expectedCommand) {
+        status =
+          actual.command === expectedCommand &&
+          JSON.stringify(actual.args || []) ===
+            JSON.stringify(desired.config.args || [])
+            ? "present"
+            : "mismatch";
       } else if (!actual.url) {
         status = actual.transport === "stdio" ? "stdio" : "invalid";
       } else if (normalizeUrl(actual.url) === normalizeUrl(expectedUrl)) {
@@ -1205,7 +1587,9 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         label: config.label,
         filePath: config.filePath,
         expectedUrl,
+        expectedCommand,
         actualUrl: actual?.url || "",
+        actualCommand: actual?.command || "",
         status,
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
@@ -1440,7 +1824,7 @@ export function addRegistryServer(name, url, options = {}) {
                 .filter(Boolean),
             ),
           ]
-        : ["claude", "gemini", "codex"],
+        : ["claude", "gemini", "codex", "antigravity"],
     description: options.description || `${trimmedName} MCP 서버`,
   };
 
@@ -1516,11 +1900,17 @@ export function removeServerFromTargets(name, options = {}) {
 
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
+  const syncTargets = Array.isArray(options.targets)
+    ? options.targets
+    : listManagedConfigTargets(registry);
+  const primaryTargets = syncTargets.filter((target) =>
+    isPrimaryConfigTarget(target.filePath),
+  );
   const actions = [];
   const invalidConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
-  for (const target of listManagedConfigTargets(registry)) {
+  for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
@@ -1551,7 +1941,7 @@ export function syncRegistryTargets(options = {}) {
     }
   }
 
-  for (const target of listPrimaryConfigTargets(registry)) {
+  for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
     if (snapshot.parseError) {

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -61,6 +61,7 @@ import { serializeHandoff } from "../scripts/lib/handoff.mjs";
 import {
   addRegistryServer,
   createDefaultRegistry,
+  discoverProjectMcpTargets,
   inspectRegistry,
   inspectRegistryStatus,
   removeRegistryServer,
@@ -333,7 +334,8 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
         ],
       },
       sync: {
-        usage: "tfx mcp sync [--json]",
+        usage:
+          "tfx mcp sync [--json] [--all-projects [root]] [--dry-run] [--exclude <glob>]",
         options: [
           {
             name: "--json",
@@ -5777,10 +5779,45 @@ function cmdMcp(args = [], options = {}) {
 
     case "sync": {
       const registryState = ensureValidRegistryState();
-      const result = syncRegistryTargets({ registry: registryState.registry });
+      const allProjectsIndex = args.indexOf("--all-projects");
+      const allProjectsRoot =
+        allProjectsIndex >= 0 &&
+        args[allProjectsIndex + 1] &&
+        !String(args[allProjectsIndex + 1]).startsWith("--")
+          ? args[allProjectsIndex + 1]
+          : null;
+      const dryRun = args.includes("--dry-run");
+      const excludes = args.flatMap((arg, index) =>
+        arg === "--exclude" && args[index + 1] ? [args[index + 1]] : [],
+      );
+      const allProjects =
+        allProjectsIndex >= 0
+          ? discoverProjectMcpTargets({
+              root: allProjectsRoot || undefined,
+              exclude: excludes,
+            })
+          : null;
+      const result = dryRun
+        ? { actions: [] }
+        : syncRegistryTargets({
+            registry: registryState.registry,
+            ...(allProjects ? { targets: allProjects.targets } : {}),
+          });
       if (json) {
         printJson({
           registry_path: registryState.path,
+          ...(allProjects
+            ? {
+                dry_run: dryRun,
+                all_projects: {
+                  root: allProjects.root,
+                  maxDepth: allProjects.maxDepth,
+                  exclude: allProjects.exclude,
+                  count: allProjects.targets.length,
+                },
+                targets: allProjects.targets,
+              }
+            : {}),
           actions: result.actions,
         });
         return;
@@ -5788,6 +5825,17 @@ function cmdMcp(args = [], options = {}) {
 
       console.log(`\n  ${AMBER}${BOLD}⬡ triflux mcp sync${RESET} ${VER}\n`);
       console.log(`  ${LINE}`);
+      if (allProjects) {
+        section("Project Targets");
+        info(`${allProjects.targets.length}개 파일 (${allProjects.root})`);
+        for (const target of allProjects.targets) {
+          info(formatPathForDisplay(target.filePath));
+        }
+        if (dryRun) {
+          console.log("");
+          return;
+        }
+      }
       section("Actions");
       for (const action of result.actions) {
         for (const warning of action.warnings || []) {

--- a/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
+++ b/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
@@ -17,7 +17,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SERVERS } from "./mcp-gateway-start.mjs";
+import { SERVERS } from "./lib/mcp-gateway-servers.mjs";
 
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const BACKUP_SUFFIX = ".pre-gateway.bak";

--- a/packages/triflux/scripts/lib/mcp-gateway-servers.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-servers.mjs
@@ -1,0 +1,70 @@
+const SERVER_DEFINITIONS = Object.freeze([
+  {
+    name: "context7",
+    port: 8100,
+    stdioCmd: "npx -y @upstash/context7-mcp@latest",
+    envVars: [],
+  },
+  {
+    name: "brave-search",
+    port: 8101,
+    stdioCmd: "npx -y @brave/brave-search-mcp-server",
+    envVars: ["BRAVE_API_KEY"],
+  },
+  {
+    name: "exa",
+    port: 8102,
+    stdioCmd: "npx -y exa-mcp-server",
+    envVars: ["EXA_API_KEY"],
+  },
+  {
+    name: "tavily",
+    port: 8103,
+    stdioCmd: "npx -y tavily-mcp@latest",
+    envVars: ["TAVILY_API_KEY"],
+  },
+  {
+    name: "jira",
+    port: 8104,
+    stdioCmd: "npx -y mcp-jira-cloud@latest",
+    envVars: ["JIRA_API_TOKEN", "JIRA_EMAIL", "JIRA_INSTANCE_URL"],
+  },
+  {
+    name: "serena",
+    port: 8105,
+    stdioCmd:
+      "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
+    envVars: [],
+  },
+  {
+    name: "notion",
+    port: 8106,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+  {
+    name: "notion-guest",
+    port: 8107,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+]);
+
+export const SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  cmd: server.stdioCmd,
+  envVars: [...server.envVars],
+}));
+
+export const GATEWAY_SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  stdioCmd: server.stdioCmd,
+}));
+
+export function serversWithSatisfiedEnv(env = process.env) {
+  return SERVERS.filter((server) =>
+    server.envVars.every((envName) => Boolean(env[envName])),
+  );
+}

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -3,11 +3,19 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -71,6 +79,29 @@ function resolveFilePath(filePath) {
   return isAbsolute(expanded)
     ? resolve(expanded)
     : resolve(process.cwd(), expanded);
+}
+
+function defaultProjectsRoot() {
+  return process.env.TFX_MCP_PROJECTS_ROOT
+    ? resolve(expandHome(process.env.TFX_MCP_PROJECTS_ROOT))
+    : join(homedir(), "Projects");
+}
+
+function globToRegExp(glob) {
+  const source = String(glob || "")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${source}$`);
+}
+
+function isExcludedProjectPath(relativePath, excludePatterns = []) {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const basenameValue = basename(normalized);
+  return excludePatterns.some((pattern) => {
+    const re = globToRegExp(pattern);
+    return re.test(normalized) || re.test(basenameValue);
+  });
 }
 
 function normalizeForMatch(filePath) {
@@ -1417,6 +1448,71 @@ export function listManagedConfigTargets(registry = loadRegistryOrDefault()) {
   });
 }
 
+export function discoverProjectMcpTargets(options = {}) {
+  const root = resolve(expandHome(options.root || defaultProjectsRoot()));
+  const maxDepth = Number.isFinite(Number(options.maxDepth))
+    ? Number(options.maxDepth)
+    : 4;
+  const excludePatterns = Array.isArray(options.exclude)
+    ? options.exclude.filter(Boolean).map(String)
+    : [];
+  const targets = [];
+  const seen = new Set();
+
+  function addTarget(filePath) {
+    const normalized = normalizeForMatch(filePath);
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    targets.push({
+      watchedPath: filePath,
+      filePath,
+      client: detectClient(filePath),
+      label: detectLabel(filePath),
+      exists: existsSync(filePath),
+    });
+  }
+
+  function walk(dirPath, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry.name);
+      const relativePath = relative(root, entryPath).replace(/\\/g, "/");
+      if (isExcludedProjectPath(relativePath, excludePatterns)) continue;
+
+      if (entry.isDirectory()) {
+        if (depth < maxDepth) walk(entryPath, depth + 1);
+        continue;
+      }
+
+      if (!entry.isFile() || depth + 1 > maxDepth) continue;
+      const normalized = entryPath.replace(/\\/g, "/");
+      if (
+        entry.name === ".mcp.json" ||
+        normalized.endsWith("/.claude/mcp.json")
+      ) {
+        addTarget(resolve(entryPath));
+      }
+    }
+  }
+
+  walk(root, 0);
+  return {
+    root,
+    maxDepth,
+    exclude: excludePatterns,
+    targets: targets.sort((left, right) =>
+      left.filePath.localeCompare(right.filePath),
+    ),
+  };
+}
+
 export function listPrimaryConfigTargets(registry = loadRegistryOrDefault()) {
   return listManagedConfigTargets(registry).filter((target) =>
     isPrimaryConfigTarget(target.filePath),
@@ -1804,11 +1900,17 @@ export function removeServerFromTargets(name, options = {}) {
 
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
+  const syncTargets = Array.isArray(options.targets)
+    ? options.targets
+    : listManagedConfigTargets(registry);
+  const primaryTargets = syncTargets.filter((target) =>
+    isPrimaryConfigTarget(target.filePath),
+  );
   const actions = [];
   const invalidConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
-  for (const target of listManagedConfigTargets(registry)) {
+  for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
@@ -1839,7 +1941,7 @@ export function syncRegistryTargets(options = {}) {
     }
   }
 
-  for (const target of listPrimaryConfigTargets(registry)) {
+  for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
     if (snapshot.parseError) {

--- a/packages/triflux/scripts/mcp-gateway-config.mjs
+++ b/packages/triflux/scripts/mcp-gateway-config.mjs
@@ -7,41 +7,12 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { GATEWAY_SERVERS } from "./lib/mcp-gateway-servers.mjs";
 import { isServerEnabled } from "./lib/mcp-manifest.mjs";
 
 const BACKUP_FILE = join(homedir(), ".claude", "cache", "mcp-pre-gateway.json");
 
-export const GATEWAY_SERVERS = [
-  {
-    name: "context7",
-    port: 8100,
-    stdioCmd: "cmd /c npx -y @upstash/context7-mcp@latest",
-  },
-  {
-    name: "brave-search",
-    port: 8101,
-    stdioCmd: "cmd /c npx -y @brave/brave-search-mcp-server",
-  },
-  { name: "exa", port: 8102, stdioCmd: "cmd /c npx -y exa-mcp-server" },
-  { name: "tavily", port: 8103, stdioCmd: "cmd /c npx -y tavily-mcp@latest" },
-  { name: "jira", port: 8104, stdioCmd: "cmd /c npx -y mcp-jira-cloud@latest" },
-  {
-    name: "serena",
-    port: 8105,
-    stdioCmd:
-      "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
-  },
-  {
-    name: "notion",
-    port: 8106,
-    stdioCmd: "cmd /c npx -y @notionhq/notion-mcp-server",
-  },
-  {
-    name: "notion-guest",
-    port: 8107,
-    stdioCmd: "cmd /c npx -y @notionhq/notion-mcp-server",
-  },
-];
+export { GATEWAY_SERVERS };
 
 const SKIP_SERVERS = new Set([
   "playwright",

--- a/packages/triflux/scripts/mcp-gateway-ensure.mjs
+++ b/packages/triflux/scripts/mcp-gateway-ensure.mjs
@@ -5,12 +5,15 @@
 
 import { execSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  SERVERS,
+  serversWithSatisfiedEnv,
+} from "./lib/mcp-gateway-servers.mjs";
+import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PID_FILE = join(tmpdir(), "tfx-gateway-pids.json");
 const PROBE_PORT = 8100; // context7 — 첫 번째 게이트웨이 포트로 alive 프로브
 const PROBE_TIMEOUT_MS = 1500;
 const STARTUP_WAIT_MS = 4000;
@@ -27,8 +30,22 @@ async function isGatewayAlive() {
   }
 }
 
-function hasManifest() {
-  return existsSync(PID_FILE);
+function ensureGatewayManifest() {
+  const manifest = readManifest();
+  if (manifest) return manifest;
+
+  const envReadyServers = serversWithSatisfiedEnv()
+    .filter((server) => server.envVars.length > 0)
+    .map((server) => server.name);
+  return writeManifest(envReadyServers);
+}
+
+function hasConfiguredGatewayServer(manifest) {
+  const enabled = new Set(manifest?.enabled || []);
+  return SERVERS.some((server) => {
+    if (!enabled.has(server.name)) return false;
+    return server.envVars.every((envName) => Boolean(process.env[envName]));
+  });
 }
 
 function startGateway() {
@@ -66,12 +83,13 @@ async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
 
 export async function run(stdinData) {
   void stdinData;
+  const manifest = ensureGatewayManifest();
 
-  if (hasManifest() && (await isGatewayAlive())) {
+  if (hasConfiguredGatewayServer(manifest) && (await isGatewayAlive())) {
     return { code: 0, stdout: "gateway: ok", stderr: "" };
   }
 
-  if (!hasManifest()) {
+  if (!hasConfiguredGatewayServer(manifest)) {
     return { code: 0, stdout: "gateway: not configured", stderr: "" };
   }
 

--- a/packages/triflux/scripts/mcp-gateway-start.mjs
+++ b/packages/triflux/scripts/mcp-gateway-start.mjs
@@ -8,64 +8,15 @@ import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SERVERS } from "./lib/mcp-gateway-servers.mjs";
 import { isServerEnabled } from "./lib/mcp-manifest.mjs";
 
 const PID_FILE = join(tmpdir(), "tfx-gateway-pids.json");
 const STARTUP_WAIT_MS = 8000;
 const POLL_INTERVAL_MS = 500;
 const HEALTH_TIMEOUT_MS = 3000;
-
-const SERVERS = [
-  {
-    name: "context7",
-    port: 8100,
-    cmd: "npx -y @upstash/context7-mcp@latest",
-    envVars: [],
-  },
-  {
-    name: "brave-search",
-    port: 8101,
-    cmd: "npx -y @brave/brave-search-mcp-server",
-    envVars: ["BRAVE_API_KEY"],
-  },
-  {
-    name: "exa",
-    port: 8102,
-    cmd: "npx -y exa-mcp-server",
-    envVars: ["EXA_API_KEY"],
-  },
-  {
-    name: "tavily",
-    port: 8103,
-    cmd: "npx -y tavily-mcp@latest",
-    envVars: ["TAVILY_API_KEY"],
-  },
-  {
-    name: "jira",
-    port: 8104,
-    cmd: "npx -y mcp-jira-cloud@latest",
-    envVars: ["JIRA_API_TOKEN", "JIRA_EMAIL", "JIRA_INSTANCE_URL"],
-  },
-  {
-    name: "serena",
-    port: 8105,
-    cmd: "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
-    envVars: [],
-  },
-  {
-    name: "notion",
-    port: 8106,
-    cmd: "npx -y @notionhq/notion-mcp-server",
-    envVars: ["NOTION_TOKEN"],
-  },
-  {
-    name: "notion-guest",
-    port: 8107,
-    cmd: "npx -y @notionhq/notion-mcp-server",
-    envVars: ["NOTION_TOKEN"],
-  },
-];
 
 export { SERVERS };
 
@@ -334,11 +285,17 @@ function loadManifest() {
 
 // ── main ──
 
-const flag = process.argv[2];
-if (flag === "--stop") {
-  stopAll();
-} else if (flag === "--status") {
-  await showStatus();
-} else {
-  await startAll();
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const flag = process.argv[2];
+  if (flag === "--stop") {
+    stopAll();
+  } else if (flag === "--status") {
+    await showStatus();
+  } else {
+    await startAll();
+  }
 }

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -1568,6 +1568,12 @@ export async function runDeferred(stdinData) {
     // ── SessionStart 훅 ──
     if (!Array.isArray(s.hooks.SessionStart)) s.hooks.SessionStart = [];
 
+    const nodePath = process.execPath.replace(/\\/g, "/");
+    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
+    const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+    const commandForScript = (scriptName) =>
+      `${nodeRef} "${pluginRoot}/scripts/${scriptName}"`;
+
     const hasTrifluxHooks = s.hooks.SessionStart.some(
       (entry) =>
         Array.isArray(entry.hooks) &&
@@ -1577,30 +1583,57 @@ export async function runDeferred(stdinData) {
     );
 
     if (!hasTrifluxHooks) {
-      const nodePath = process.execPath.replace(/\\/g, "/");
-      const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-      const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
-
       s.hooks.SessionStart.push({
         matcher: "*",
         hooks: [
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/setup.mjs"`,
+            command: commandForScript("setup.mjs"),
             timeout: 10,
           },
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/hub-ensure.mjs"`,
+            command: commandForScript("hub-ensure.mjs"),
             timeout: 8,
           },
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/preflight-cache.mjs"`,
+            command: commandForScript("mcp-gateway-ensure.mjs"),
+            timeout: 8,
+          },
+          {
+            type: "command",
+            command: commandForScript("preflight-cache.mjs"),
             timeout: 5,
           },
         ],
       });
+      changed = true;
+    }
+
+    for (const entry of s.hooks.SessionStart) {
+      if (!Array.isArray(entry.hooks)) continue;
+      const hasDirectTrifluxHook = entry.hooks.some(
+        (h) => typeof h.command === "string" && h.command.includes("triflux"),
+      );
+      const hasGatewayEnsure = entry.hooks.some(
+        (h) =>
+          typeof h.command === "string" &&
+          h.command.includes("mcp-gateway-ensure.mjs"),
+      );
+      if (!hasDirectTrifluxHook || hasGatewayEnsure) continue;
+
+      const hubIndex = entry.hooks.findIndex(
+        (h) =>
+          typeof h.command === "string" && h.command.includes("hub-ensure.mjs"),
+      );
+      const gatewayHook = {
+        type: "command",
+        command: commandForScript("mcp-gateway-ensure.mjs"),
+        timeout: 8,
+      };
+      if (hubIndex >= 0) entry.hooks.splice(hubIndex + 1, 0, gatewayHook);
+      else entry.hooks.push(gatewayHook);
       changed = true;
     }
 

--- a/scripts/codex-mcp-gateway-sync.mjs
+++ b/scripts/codex-mcp-gateway-sync.mjs
@@ -17,7 +17,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SERVERS } from "./mcp-gateway-start.mjs";
+import { SERVERS } from "./lib/mcp-gateway-servers.mjs";
 
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const BACKUP_SUFFIX = ".pre-gateway.bak";

--- a/scripts/lib/mcp-gateway-servers.mjs
+++ b/scripts/lib/mcp-gateway-servers.mjs
@@ -1,0 +1,70 @@
+const SERVER_DEFINITIONS = Object.freeze([
+  {
+    name: "context7",
+    port: 8100,
+    stdioCmd: "npx -y @upstash/context7-mcp@latest",
+    envVars: [],
+  },
+  {
+    name: "brave-search",
+    port: 8101,
+    stdioCmd: "npx -y @brave/brave-search-mcp-server",
+    envVars: ["BRAVE_API_KEY"],
+  },
+  {
+    name: "exa",
+    port: 8102,
+    stdioCmd: "npx -y exa-mcp-server",
+    envVars: ["EXA_API_KEY"],
+  },
+  {
+    name: "tavily",
+    port: 8103,
+    stdioCmd: "npx -y tavily-mcp@latest",
+    envVars: ["TAVILY_API_KEY"],
+  },
+  {
+    name: "jira",
+    port: 8104,
+    stdioCmd: "npx -y mcp-jira-cloud@latest",
+    envVars: ["JIRA_API_TOKEN", "JIRA_EMAIL", "JIRA_INSTANCE_URL"],
+  },
+  {
+    name: "serena",
+    port: 8105,
+    stdioCmd:
+      "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
+    envVars: [],
+  },
+  {
+    name: "notion",
+    port: 8106,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+  {
+    name: "notion-guest",
+    port: 8107,
+    stdioCmd: "npx -y @notionhq/notion-mcp-server",
+    envVars: ["NOTION_TOKEN"],
+  },
+]);
+
+export const SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  cmd: server.stdioCmd,
+  envVars: [...server.envVars],
+}));
+
+export const GATEWAY_SERVERS = SERVER_DEFINITIONS.map((server) => ({
+  name: server.name,
+  port: server.port,
+  stdioCmd: server.stdioCmd,
+}));
+
+export function serversWithSatisfiedEnv(env = process.env) {
+  return SERVERS.filter((server) =>
+    server.envVars.every((envName) => Boolean(env[envName])),
+  );
+}

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -3,11 +3,19 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -71,6 +79,29 @@ function resolveFilePath(filePath) {
   return isAbsolute(expanded)
     ? resolve(expanded)
     : resolve(process.cwd(), expanded);
+}
+
+function defaultProjectsRoot() {
+  return process.env.TFX_MCP_PROJECTS_ROOT
+    ? resolve(expandHome(process.env.TFX_MCP_PROJECTS_ROOT))
+    : join(homedir(), "Projects");
+}
+
+function globToRegExp(glob) {
+  const source = String(glob || "")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${source}$`);
+}
+
+function isExcludedProjectPath(relativePath, excludePatterns = []) {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const basenameValue = basename(normalized);
+  return excludePatterns.some((pattern) => {
+    const re = globToRegExp(pattern);
+    return re.test(normalized) || re.test(basenameValue);
+  });
 }
 
 function normalizeForMatch(filePath) {
@@ -1417,6 +1448,71 @@ export function listManagedConfigTargets(registry = loadRegistryOrDefault()) {
   });
 }
 
+export function discoverProjectMcpTargets(options = {}) {
+  const root = resolve(expandHome(options.root || defaultProjectsRoot()));
+  const maxDepth = Number.isFinite(Number(options.maxDepth))
+    ? Number(options.maxDepth)
+    : 4;
+  const excludePatterns = Array.isArray(options.exclude)
+    ? options.exclude.filter(Boolean).map(String)
+    : [];
+  const targets = [];
+  const seen = new Set();
+
+  function addTarget(filePath) {
+    const normalized = normalizeForMatch(filePath);
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    targets.push({
+      watchedPath: filePath,
+      filePath,
+      client: detectClient(filePath),
+      label: detectLabel(filePath),
+      exists: existsSync(filePath),
+    });
+  }
+
+  function walk(dirPath, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry.name);
+      const relativePath = relative(root, entryPath).replace(/\\/g, "/");
+      if (isExcludedProjectPath(relativePath, excludePatterns)) continue;
+
+      if (entry.isDirectory()) {
+        if (depth < maxDepth) walk(entryPath, depth + 1);
+        continue;
+      }
+
+      if (!entry.isFile() || depth + 1 > maxDepth) continue;
+      const normalized = entryPath.replace(/\\/g, "/");
+      if (
+        entry.name === ".mcp.json" ||
+        normalized.endsWith("/.claude/mcp.json")
+      ) {
+        addTarget(resolve(entryPath));
+      }
+    }
+  }
+
+  walk(root, 0);
+  return {
+    root,
+    maxDepth,
+    exclude: excludePatterns,
+    targets: targets.sort((left, right) =>
+      left.filePath.localeCompare(right.filePath),
+    ),
+  };
+}
+
 export function listPrimaryConfigTargets(registry = loadRegistryOrDefault()) {
   return listManagedConfigTargets(registry).filter((target) =>
     isPrimaryConfigTarget(target.filePath),
@@ -1804,11 +1900,17 @@ export function removeServerFromTargets(name, options = {}) {
 
 export function syncRegistryTargets(options = {}) {
   const registry = options.registry || loadRegistryOrDefault();
+  const syncTargets = Array.isArray(options.targets)
+    ? options.targets
+    : listManagedConfigTargets(registry);
+  const primaryTargets = syncTargets.filter((target) =>
+    isPrimaryConfigTarget(target.filePath),
+  );
   const actions = [];
   const invalidConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
-  for (const target of listManagedConfigTargets(registry)) {
+  for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
@@ -1839,7 +1941,7 @@ export function syncRegistryTargets(options = {}) {
     }
   }
 
-  for (const target of listPrimaryConfigTargets(registry)) {
+  for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
     if (snapshot.parseError) {

--- a/scripts/mcp-gateway-config.mjs
+++ b/scripts/mcp-gateway-config.mjs
@@ -7,41 +7,12 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { GATEWAY_SERVERS } from "./lib/mcp-gateway-servers.mjs";
 import { isServerEnabled } from "./lib/mcp-manifest.mjs";
 
 const BACKUP_FILE = join(homedir(), ".claude", "cache", "mcp-pre-gateway.json");
 
-export const GATEWAY_SERVERS = [
-  {
-    name: "context7",
-    port: 8100,
-    stdioCmd: "cmd /c npx -y @upstash/context7-mcp@latest",
-  },
-  {
-    name: "brave-search",
-    port: 8101,
-    stdioCmd: "cmd /c npx -y @brave/brave-search-mcp-server",
-  },
-  { name: "exa", port: 8102, stdioCmd: "cmd /c npx -y exa-mcp-server" },
-  { name: "tavily", port: 8103, stdioCmd: "cmd /c npx -y tavily-mcp@latest" },
-  { name: "jira", port: 8104, stdioCmd: "cmd /c npx -y mcp-jira-cloud@latest" },
-  {
-    name: "serena",
-    port: 8105,
-    stdioCmd:
-      "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
-  },
-  {
-    name: "notion",
-    port: 8106,
-    stdioCmd: "cmd /c npx -y @notionhq/notion-mcp-server",
-  },
-  {
-    name: "notion-guest",
-    port: 8107,
-    stdioCmd: "cmd /c npx -y @notionhq/notion-mcp-server",
-  },
-];
+export { GATEWAY_SERVERS };
 
 const SKIP_SERVERS = new Set([
   "playwright",

--- a/scripts/mcp-gateway-ensure.mjs
+++ b/scripts/mcp-gateway-ensure.mjs
@@ -5,12 +5,15 @@
 
 import { execSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  SERVERS,
+  serversWithSatisfiedEnv,
+} from "./lib/mcp-gateway-servers.mjs";
+import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PID_FILE = join(tmpdir(), "tfx-gateway-pids.json");
 const PROBE_PORT = 8100; // context7 — 첫 번째 게이트웨이 포트로 alive 프로브
 const PROBE_TIMEOUT_MS = 1500;
 const STARTUP_WAIT_MS = 4000;
@@ -27,8 +30,22 @@ async function isGatewayAlive() {
   }
 }
 
-function hasManifest() {
-  return existsSync(PID_FILE);
+function ensureGatewayManifest() {
+  const manifest = readManifest();
+  if (manifest) return manifest;
+
+  const envReadyServers = serversWithSatisfiedEnv()
+    .filter((server) => server.envVars.length > 0)
+    .map((server) => server.name);
+  return writeManifest(envReadyServers);
+}
+
+function hasConfiguredGatewayServer(manifest) {
+  const enabled = new Set(manifest?.enabled || []);
+  return SERVERS.some((server) => {
+    if (!enabled.has(server.name)) return false;
+    return server.envVars.every((envName) => Boolean(process.env[envName]));
+  });
 }
 
 function startGateway() {
@@ -66,12 +83,13 @@ async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
 
 export async function run(stdinData) {
   void stdinData;
+  const manifest = ensureGatewayManifest();
 
-  if (hasManifest() && (await isGatewayAlive())) {
+  if (hasConfiguredGatewayServer(manifest) && (await isGatewayAlive())) {
     return { code: 0, stdout: "gateway: ok", stderr: "" };
   }
 
-  if (!hasManifest()) {
+  if (!hasConfiguredGatewayServer(manifest)) {
     return { code: 0, stdout: "gateway: not configured", stderr: "" };
   }
 

--- a/scripts/mcp-gateway-start.mjs
+++ b/scripts/mcp-gateway-start.mjs
@@ -8,64 +8,15 @@ import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SERVERS } from "./lib/mcp-gateway-servers.mjs";
 import { isServerEnabled } from "./lib/mcp-manifest.mjs";
 
 const PID_FILE = join(tmpdir(), "tfx-gateway-pids.json");
 const STARTUP_WAIT_MS = 8000;
 const POLL_INTERVAL_MS = 500;
 const HEALTH_TIMEOUT_MS = 3000;
-
-const SERVERS = [
-  {
-    name: "context7",
-    port: 8100,
-    cmd: "npx -y @upstash/context7-mcp@latest",
-    envVars: [],
-  },
-  {
-    name: "brave-search",
-    port: 8101,
-    cmd: "npx -y @brave/brave-search-mcp-server",
-    envVars: ["BRAVE_API_KEY"],
-  },
-  {
-    name: "exa",
-    port: 8102,
-    cmd: "npx -y exa-mcp-server",
-    envVars: ["EXA_API_KEY"],
-  },
-  {
-    name: "tavily",
-    port: 8103,
-    cmd: "npx -y tavily-mcp@latest",
-    envVars: ["TAVILY_API_KEY"],
-  },
-  {
-    name: "jira",
-    port: 8104,
-    cmd: "npx -y mcp-jira-cloud@latest",
-    envVars: ["JIRA_API_TOKEN", "JIRA_EMAIL", "JIRA_INSTANCE_URL"],
-  },
-  {
-    name: "serena",
-    port: 8105,
-    cmd: "uvx --from git+https://github.com/oraios/serena serena start-mcp-server",
-    envVars: [],
-  },
-  {
-    name: "notion",
-    port: 8106,
-    cmd: "npx -y @notionhq/notion-mcp-server",
-    envVars: ["NOTION_TOKEN"],
-  },
-  {
-    name: "notion-guest",
-    port: 8107,
-    cmd: "npx -y @notionhq/notion-mcp-server",
-    envVars: ["NOTION_TOKEN"],
-  },
-];
 
 export { SERVERS };
 
@@ -334,11 +285,17 @@ function loadManifest() {
 
 // ── main ──
 
-const flag = process.argv[2];
-if (flag === "--stop") {
-  stopAll();
-} else if (flag === "--status") {
-  await showStatus();
-} else {
-  await startAll();
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  const flag = process.argv[2];
+  if (flag === "--stop") {
+    stopAll();
+  } else if (flag === "--status") {
+    await showStatus();
+  } else {
+    await startAll();
+  }
 }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1568,6 +1568,12 @@ export async function runDeferred(stdinData) {
     // ── SessionStart 훅 ──
     if (!Array.isArray(s.hooks.SessionStart)) s.hooks.SessionStart = [];
 
+    const nodePath = process.execPath.replace(/\\/g, "/");
+    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
+    const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+    const commandForScript = (scriptName) =>
+      `${nodeRef} "${pluginRoot}/scripts/${scriptName}"`;
+
     const hasTrifluxHooks = s.hooks.SessionStart.some(
       (entry) =>
         Array.isArray(entry.hooks) &&
@@ -1577,30 +1583,57 @@ export async function runDeferred(stdinData) {
     );
 
     if (!hasTrifluxHooks) {
-      const nodePath = process.execPath.replace(/\\/g, "/");
-      const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-      const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
-
       s.hooks.SessionStart.push({
         matcher: "*",
         hooks: [
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/setup.mjs"`,
+            command: commandForScript("setup.mjs"),
             timeout: 10,
           },
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/hub-ensure.mjs"`,
+            command: commandForScript("hub-ensure.mjs"),
             timeout: 8,
           },
           {
             type: "command",
-            command: `${nodeRef} "${pluginRoot}/scripts/preflight-cache.mjs"`,
+            command: commandForScript("mcp-gateway-ensure.mjs"),
+            timeout: 8,
+          },
+          {
+            type: "command",
+            command: commandForScript("preflight-cache.mjs"),
             timeout: 5,
           },
         ],
       });
+      changed = true;
+    }
+
+    for (const entry of s.hooks.SessionStart) {
+      if (!Array.isArray(entry.hooks)) continue;
+      const hasDirectTrifluxHook = entry.hooks.some(
+        (h) => typeof h.command === "string" && h.command.includes("triflux"),
+      );
+      const hasGatewayEnsure = entry.hooks.some(
+        (h) =>
+          typeof h.command === "string" &&
+          h.command.includes("mcp-gateway-ensure.mjs"),
+      );
+      if (!hasDirectTrifluxHook || hasGatewayEnsure) continue;
+
+      const hubIndex = entry.hooks.findIndex(
+        (h) =>
+          typeof h.command === "string" && h.command.includes("hub-ensure.mjs"),
+      );
+      const gatewayHook = {
+        type: "command",
+        command: commandForScript("mcp-gateway-ensure.mjs"),
+        timeout: 8,
+      };
+      if (hubIndex >= 0) entry.hooks.splice(hubIndex + 1, 0, gatewayHook);
+      else entry.hooks.push(gatewayHook);
       changed = true;
     }
 

--- a/tests/regression/mcp-registry-http-headers.test.mjs
+++ b/tests/regression/mcp-registry-http-headers.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -149,6 +149,106 @@ describe("tfx mcp HTTP headers regression", () => {
         type: "http",
         url: "http://127.0.0.1:27888/mcp",
       },
+    );
+  });
+
+  it("syncs project MCP files under --all-projects and preserves non-mcpServers keys", () => {
+    const { root, home, project } = createFixture("tfx-mcp-all-projects");
+    const projectsRoot = join(root, "Projects");
+    const alpha = join(projectsRoot, "alpha");
+    const beta = join(projectsRoot, "nested", "beta");
+    const skipped = join(projectsRoot, "skip-me");
+    mkdirSync(alpha, { recursive: true });
+    mkdirSync(join(beta, ".claude"), { recursive: true });
+    mkdirSync(skipped, { recursive: true });
+
+    writeFileSync(
+      join(alpha, ".mcp.json"),
+      JSON.stringify({ custom: true, mcpServers: { old: { command: "old" } } }),
+    );
+    writeFileSync(
+      join(beta, ".claude", "mcp.json"),
+      JSON.stringify({ other: "keep", mcpServers: {} }),
+    );
+    writeFileSync(
+      join(skipped, ".mcp.json"),
+      JSON.stringify({ mcpServers: {} }),
+    );
+
+    const registryPath = join(root, "mcp-registry.json");
+    writeRegistry(registryPath, home, project, null);
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      TFX_MCP_REGISTRY_PATH: registryPath,
+    };
+
+    const dryRun = JSON.parse(
+      runTfx(
+        [
+          "mcp",
+          "sync",
+          "--all-projects",
+          projectsRoot,
+          "--exclude",
+          "skip-*",
+          "--dry-run",
+          "--json",
+        ],
+        env,
+        project,
+      ),
+    );
+    assert.equal(dryRun.dry_run, true);
+    assert.deepEqual(
+      dryRun.targets.map((target) => target.filePath).sort(),
+      [join(alpha, ".mcp.json"), join(beta, ".claude", "mcp.json")].sort(),
+    );
+    assert.equal(
+      existsSync(join(skipped, ".mcp.json")),
+      true,
+      "dry-run must not remove or rewrite excluded project files",
+    );
+
+    const syncResult = JSON.parse(
+      runTfx(
+        [
+          "mcp",
+          "sync",
+          "--all-projects",
+          projectsRoot,
+          "--exclude",
+          "skip-*",
+          "--json",
+        ],
+        env,
+        project,
+      ),
+    );
+    assert.equal(syncResult.all_projects.root, projectsRoot);
+
+    const alphaConfig = JSON.parse(
+      readFileSync(join(alpha, ".mcp.json"), "utf8"),
+    );
+    assert.equal(alphaConfig.custom, true);
+    assert.deepEqual(alphaConfig.mcpServers["tfx-hub"], {
+      type: "http",
+      url: "http://127.0.0.1:27888/mcp",
+    });
+
+    const betaConfig = JSON.parse(
+      readFileSync(join(beta, ".claude", "mcp.json"), "utf8"),
+    );
+    assert.equal(betaConfig.other, "keep");
+    assert.deepEqual(betaConfig.mcpServers["tfx-hub"], {
+      type: "http",
+      url: "http://127.0.0.1:27888/mcp",
+    });
+
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(skipped, ".mcp.json"), "utf8")).mcpServers,
+      {},
+      "excluded project should remain untouched",
     );
   });
 });

--- a/tests/unit/mcp-gateway.test.mjs
+++ b/tests/unit/mcp-gateway.test.mjs
@@ -22,6 +22,13 @@ const ROOT = join(process.cwd());
 const START_PATH = join(ROOT, "scripts", "mcp-gateway-start.mjs");
 const CONFIG_PATH = join(ROOT, "scripts", "mcp-gateway-config.mjs");
 const VERIFY_PATH = join(ROOT, "scripts", "mcp-gateway-verify.mjs");
+const SERVERS_LIB_PATH = join(
+  ROOT,
+  "scripts",
+  "lib",
+  "mcp-gateway-servers.mjs",
+);
+const gatewayServerModule = await import(`${SERVERS_LIB_PATH}?t=${Date.now()}`);
 
 // ── SERVERS / GATEWAY_SERVERS 로드 ──
 // mcp-gateway-start.mjs는 flag === '--stop' / '--status' 이외엔 startAll()을 실행한다.
@@ -46,18 +53,6 @@ function parseServersFromSource(filePath, varName) {
     entries.push({ name: m[1], port: parseInt(m[2], 10) });
   }
   return entries;
-}
-
-function parseStdioCmdsFromSource(filePath) {
-  const src = readFileSync(filePath, "utf8");
-  const results = [];
-  const re =
-    /name:\s*["']([^"']+)["'].*?port:\s*(\d+).*?stdioCmd:\s*\n?\s*["']([^"']+)["']/gs;
-  let m;
-  while ((m = re.exec(src)) !== null) {
-    results.push({ name: m[1], port: parseInt(m[2], 10), stdioCmd: m[3] });
-  }
-  return results;
 }
 
 // ── loadManifest 로직 미러 (mcp-gateway-start.mjs와 동일) ──
@@ -92,8 +87,8 @@ function isPortInUse(port) {
 // 1. 포트 일관성 — SERVERS vs GATEWAY_SERVERS
 // ─────────────────────────────────────────────
 describe("port consistency across files", () => {
-  const servers = parseServersFromSource(START_PATH, "SERVERS");
-  const gateways = parseServersFromSource(CONFIG_PATH, "GATEWAY_SERVERS");
+  const servers = gatewayServerModule.SERVERS;
+  const gateways = gatewayServerModule.GATEWAY_SERVERS;
 
   it("SERVERS and GATEWAY_SERVERS have the same number of entries", () => {
     assert.strictEqual(servers.length, gateways.length);
@@ -167,7 +162,7 @@ describe("port consistency across files", () => {
 // 2. SERVERS vs ENDPOINTS (verify.mjs) 일관성
 // ─────────────────────────────────────────────
 describe("port consistency: SERVERS vs verify ENDPOINTS", () => {
-  const servers = parseServersFromSource(START_PATH, "SERVERS");
+  const servers = gatewayServerModule.SERVERS;
   const endpoints = parseServersFromSource(VERIFY_PATH, "ENDPOINTS");
 
   it("ENDPOINTS count matches SERVERS count", () => {
@@ -288,7 +283,7 @@ describe("loadManifest", () => {
 // 5. GATEWAY_SERVERS — stdioCmd 필드 무결성
 // ─────────────────────────────────────────────
 describe("GATEWAY_SERVERS stdioCmd fields", () => {
-  const entries = parseStdioCmdsFromSource(CONFIG_PATH);
+  const entries = gatewayServerModule.GATEWAY_SERVERS;
 
   it("all GATEWAY_SERVERS entries have a stdioCmd field", () => {
     assert.ok(entries.length > 0, "No entries parsed from GATEWAY_SERVERS");
@@ -344,25 +339,49 @@ describe("GATEWAY_SERVERS stdioCmd fields", () => {
       );
     }
   });
+
+  it("stdioCmd defaults are shell-neutral and do not use Windows cmd wrappers", () => {
+    for (const e of entries) {
+      assert.doesNotMatch(
+        e.stdioCmd,
+        /\bcmd\s*\/c\b/i,
+        `stdioCmd for '${e.name}' must be cross-platform`,
+      );
+    }
+  });
 });
 
 // ─────────────────────────────────────────────
 // 6. 소스 파일 구조 무결성 검사
 // ─────────────────────────────────────────────
 describe("source file structural integrity", () => {
-  it("mcp-gateway-start.mjs exports SERVERS", () => {
-    const src = readFileSync(START_PATH, "utf8");
+  it("gateway server definitions live in a side-effect-free lib module", async () => {
+    const mod = await import(`${SERVERS_LIB_PATH}?t=${Date.now()}`);
+    assert.ok(Array.isArray(mod.SERVERS), "SERVERS must be exported");
     assert.ok(
-      src.includes("export { SERVERS }"),
-      "SERVERS must be exported from start.mjs",
+      Array.isArray(mod.GATEWAY_SERVERS),
+      "GATEWAY_SERVERS must be exported",
+    );
+    assert.equal(
+      mod.SERVERS.length,
+      mod.GATEWAY_SERVERS.length,
+      "start/config server lists should share one source",
     );
   });
 
-  it("mcp-gateway-config.mjs exports GATEWAY_SERVERS", () => {
+  it("mcp-gateway-start.mjs imports SERVERS instead of defining them inline", () => {
+    const src = readFileSync(START_PATH, "utf8");
+    assert.ok(
+      src.includes("./lib/mcp-gateway-servers.mjs"),
+      "SERVERS must be imported from the shared lib",
+    );
+  });
+
+  it("mcp-gateway-config.mjs imports GATEWAY_SERVERS instead of defining them inline", () => {
     const src = readFileSync(CONFIG_PATH, "utf8");
     assert.ok(
-      src.includes("export const GATEWAY_SERVERS"),
-      "GATEWAY_SERVERS must be exported from config.mjs",
+      src.includes("./lib/mcp-gateway-servers.mjs"),
+      "GATEWAY_SERVERS must be imported from the shared lib",
     );
   });
 
@@ -409,6 +428,27 @@ describe("source file structural integrity", () => {
     assert.ok(
       src.includes("return []"),
       "loadManifest must return [] on error/missing",
+    );
+  });
+
+  it("mcp-gateway-ensure.mjs does not use gateway PID files as configuration state", () => {
+    const src = readFileSync(
+      join(ROOT, "scripts", "mcp-gateway-ensure.mjs"),
+      "utf8",
+    );
+    assert.doesNotMatch(
+      src,
+      /tfx-gateway-pids\.json|PID_FILE|hasManifest/,
+      "ensure must use MCP manifest/registry lifecycle instead of PID files",
+    );
+  });
+
+  it("setup.mjs legacy direct SessionStart hook includes gateway ensure", () => {
+    const src = readFileSync(join(ROOT, "scripts", "setup.mjs"), "utf8");
+    assert.match(
+      src,
+      /mcp-gateway-ensure\.mjs/,
+      "legacy direct hook install path must include mcp-gateway-ensure",
     );
   });
 });

--- a/tests/unit/native-bridge-tui.test.mjs
+++ b/tests/unit/native-bridge-tui.test.mjs
@@ -49,4 +49,14 @@ test('Session persistence should write valid JSON to sessions folder', async () 
   await fs.rm(MOCK_STATE_DIR, { recursive: true, force: true });
 });
 
+test('runHeadless must bypass psmux loop when nativeBridge option is true', async () => {
+  const { runHeadless } = await import('../../hub/team/headless.mjs');
+  
+  const result = await runHeadless('session_nb_test', [], { nativeBridge: true });
+  
+  assert.equal(result.bypassed, true, 'Should bypass and return bypassed true');
+  assert.equal(result.status, 'ok', 'Should return status ok');
+});
+
+
 

--- a/tests/unit/native-bridge-tui.test.mjs
+++ b/tests/unit/native-bridge-tui.test.mjs
@@ -1,6 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 import { parseTeamArgs } from '../../hub/team/cli/commands/start/parse-args.mjs';
+import { writeBridgeSession } from '../../hub/team/headless-bridge-session.mjs';
+
+// Setup Mock State Dir
+const MOCK_STATE_DIR = path.join(os.tmpdir(), `mock-claude-state-${Date.now()}`);
 
 test('CLI start parser should resolve --native-bridge option correctly', () => {
   const result = parseTeamArgs(['start', '--native-bridge']);
@@ -16,3 +23,30 @@ test('CLI start parser should default nativeBridge to false', () => {
   const result = parseTeamArgs(['start']);
   assert.equal(result.nativeBridge, false, 'nativeBridge should default to false');
 });
+
+test('Session persistence should write valid JSON to sessions folder', async () => {
+  const testSessionId = 'session_hl_test_99';
+  const testSocket = '/tmp/claude-test-99.sock';
+  
+  await fs.mkdir(path.join(MOCK_STATE_DIR, 'sessions'), { recursive: true });
+  
+  // Call actual implementation
+  await writeBridgeSession(testSessionId, testSocket, MOCK_STATE_DIR);
+  
+  const filePath = path.join(MOCK_STATE_DIR, 'sessions', `${testSessionId}.json`);
+  
+  const fileExists = await fs.access(filePath).then(() => true).catch(() => false);
+  assert.equal(fileExists, true, 'Session file must be written to disk');
+  
+  const content = await fs.readFile(filePath, 'utf8');
+  const data = JSON.parse(content);
+  
+  assert.equal(data.session_id, testSessionId, 'Session ID must match');
+  assert.equal(data.messagingSock, testSocket, 'Socket path must match');
+  assert.equal(data.status, 'RUNNING', 'Status must be RUNNING');
+  
+  // Cleanup mock dir
+  await fs.rm(MOCK_STATE_DIR, { recursive: true, force: true });
+});
+
+

--- a/tests/unit/native-bridge-tui.test.mjs
+++ b/tests/unit/native-bridge-tui.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTeamArgs } from '../../hub/team/cli/commands/start/parse-args.mjs';
+
+test('CLI start parser should resolve --native-bridge option correctly', () => {
+  const result = parseTeamArgs(['start', '--native-bridge']);
+  assert.equal(result.nativeBridge, true, 'nativeBridge should be parsed as true when --native-bridge is passed');
+});
+
+test('CLI start parser should resolve -nb option correctly', () => {
+  const result = parseTeamArgs(['start', '-nb']);
+  assert.equal(result.nativeBridge, true, 'nativeBridge should be parsed as true when -nb is passed');
+});
+
+test('CLI start parser should default nativeBridge to false', () => {
+  const result = parseTeamArgs(['start']);
+  assert.equal(result.nativeBridge, false, 'nativeBridge should default to false');
+});


### PR DESCRIPTION
## Summary
P0:
- Replaced Windows-only \`cmd /c npx ...\` gateway stdio defaults with shell-neutral server definitions shared by gateway start/config callers
- Changed mcp-gateway-ensure to use MCP enabled manifest + environment readiness instead of treating temp gateway PID manifest as configuration state
- Added mcp-gateway-ensure.mjs to legacy direct SessionStart hook path (with repair for existing direct triflux hook entries)

P1:
- Moved gateway server definitions into scripts/lib/mcp-gateway-servers.mjs (no start-module side effects)
- Added env-aware manifest auto-fill for gateway ensure
- Added \`tfx mcp sync --all-projects [root] --dry-run --exclude <glob>\` with maxdepth-4 project MCP discovery

Closes #299

## Validation
- node --test mcp-gateway / session-start / mcp-registry: 41 pass, 0 fail
- npx biome check (touched files): pass
- packages mirror byte-identical (root ↔ core ↔ triflux)
- mcp-gateway start/status/stop smoke: pass (8100/8101/8105 restored)