### PR TITLE
feat(routing): tfx-route Node single entry (Phase 0 PoC + Phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
         "packages/triflux"
       ],
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "systray2": "^2.1.4",
+        "tree-kill": "^1.2.2",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -251,6 +253,12 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -3105,6 +3113,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/triflux": {
       "resolved": "packages/triflux",
       "link": true
@@ -3256,8 +3273,10 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "tree-kill": "^1.2.2",
         "zod": "^4.0.0"
       },
       "engines": {
@@ -3284,8 +3303,10 @@
       "version": "10.24.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@triflux/core": "10.0.1",
-        "@triflux/remote": "^10.0.0-alpha.1"
+        "@triflux/remote": "^10.0.0-alpha.1",
+        "tree-kill": "^1.2.2"
       },
       "bin": {
         "tfl": "bin/triflux.mjs",

--- a/package.json
+++ b/package.json
@@ -77,11 +77,13 @@
   "author": "tellang",
   "license": "MIT",
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.10.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "systray2": "^2.1.4",
+    "tree-kill": "^1.2.2",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,8 +13,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "tree-kill": "^1.2.2",
     "zod": "^4.0.0"
   },
   "files": [

--- a/packages/core/scripts/lib/agent-json.mjs
+++ b/packages/core/scripts/lib/agent-json.mjs
@@ -1,0 +1,27 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function agentJsonPath({ tmpDir, pid = process.pid }) {
+  return join(tmpDir, `tfx-agent-${pid}.json`);
+}
+
+export function registerAgent({
+  tmpDir,
+  pid = process.pid,
+  cli = "",
+  agent = "",
+  started = Math.floor(Date.now() / 1000),
+}) {
+  mkdirSync(tmpDir, { recursive: true });
+  const file = agentJsonPath({ tmpDir, pid });
+  writeFileSync(
+    file,
+    `${JSON.stringify({ pid, cli, agent, started })}\n`,
+    "utf8",
+  );
+  return file;
+}
+
+export function removeAgent({ tmpDir, pid = process.pid }) {
+  rmSync(agentJsonPath({ tmpDir, pid }), { force: true });
+}

--- a/packages/core/scripts/lib/async.mjs
+++ b/packages/core/scripts/lib/async.mjs
@@ -1,0 +1,174 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+function jobDir(jobsDir, jobId) {
+  return join(jobsDir, jobId);
+}
+
+function readState(dir) {
+  const path = join(dir, "state.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeState(dir, state) {
+  writeFileSync(join(dir, "state.json"), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function fileSize(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function isAlive(pid) {
+  if (!pid || pid === "starting") return false;
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createJob({
+  jobsDir,
+  command,
+  args = [],
+  env = process.env,
+  cwd = process.cwd(),
+  timeoutMs = 0,
+}) {
+  mkdirSync(jobsDir, { recursive: true });
+  const id = randomUUID();
+  const dir = jobDir(jobsDir, id);
+  mkdirSync(dir, { recursive: true });
+  const startedAt = Date.now();
+  const stdoutPath = join(dir, "result.log");
+  const stderrPath = join(dir, "stderr.log");
+  writeState(dir, {
+    id,
+    state: "starting",
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  writeFileSync(join(dir, "pid"), "starting");
+  writeFileSync(join(dir, "start_time"), String(Math.floor(startedAt / 1000)));
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.unref?.();
+  writeFileSync(join(dir, "pid"), String(child.pid));
+  writeState(dir, {
+    id,
+    state: "running",
+    pid: child.pid,
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  child.stdout?.on("data", (chunk) => {
+    writeFileSync(stdoutPath, chunk, { flag: "a" });
+  });
+  child.stderr?.on("data", (chunk) => {
+    writeFileSync(stderrPath, chunk, { flag: "a" });
+  });
+  let timer = null;
+  let timedOut = false;
+  if (timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // Process already exited.
+      }
+    }, timeoutMs);
+    timer.unref?.();
+  }
+  child.on("exit", (code) => {
+    if (timer) clearTimeout(timer);
+    const exitCode = timedOut ? 124 : (code ?? 1);
+    writeFileSync(join(dir, "exit_code"), String(exitCode));
+    writeFileSync(join(dir, "done"), "");
+    writeState(dir, {
+      id,
+      state: exitCode === 0 ? "done" : exitCode === 124 ? "timeout" : "failed",
+      pid: child.pid,
+      startedAt,
+      finishedAt: Date.now(),
+      exitCode,
+      command,
+      args,
+      timeoutMs,
+    });
+  });
+
+  return { id, dir, pid: child.pid };
+}
+
+export function getJobStatus(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir))
+    return { state: "error", text: "error: job not found", exitCode: 1 };
+  const state = readState(dir);
+  if (state?.state === "done") return { ...state, text: "done" };
+  if (state?.state === "timeout") return { ...state, text: "timeout" };
+  if (state?.state === "failed") return { ...state, text: "failed" };
+  const pidText = existsSync(join(dir, "pid"))
+    ? readFileSync(join(dir, "pid"), "utf8").trim()
+    : "";
+  if (pidText === "starting")
+    return { ...(state ?? {}), state: "starting", text: "starting" };
+  if (isAlive(pidText)) {
+    const start =
+      Number(readFileSync(join(dir, "start_time"), "utf8")) ||
+      Math.floor(Date.now() / 1000);
+    const elapsed = Math.max(0, Math.floor(Date.now() / 1000) - start);
+    const bytes = fileSize(join(dir, "result.log"));
+    return {
+      ...(state ?? {}),
+      state: "running",
+      text: `running elapsed=${elapsed}s output=${bytes}B`,
+    };
+  }
+  return { ...(state ?? {}), state: "failed", text: "failed" };
+}
+
+export function getJobResult(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir)) throw new Error("job not found");
+  const status = getJobStatus(jobId, { jobsDir });
+  if (!["done", "timeout", "failed"].includes(status.state)) {
+    throw new Error("job still running");
+  }
+  const stdout = existsSync(join(dir, "result.log"))
+    ? readFileSync(join(dir, "result.log"), "utf8")
+    : "";
+  const stderr = existsSync(join(dir, "stderr.log"))
+    ? readFileSync(join(dir, "stderr.log"), "utf8")
+    : "";
+  return {
+    state: status.state,
+    exitCode: status.exitCode ?? 1,
+    stdout: stdout || stderr,
+    stderr,
+  };
+}

--- a/packages/core/scripts/lib/cli-agy.mjs
+++ b/packages/core/scripts/lib/cli-agy.mjs
@@ -1,0 +1,62 @@
+// cli-agy.mjs — Antigravity (agy) CLI adapter (Phase 0 PoC).
+//
+// 책임: agy --print 는 stdin-only 이므로 plan() 에서 stdinMode="pipe" 시그널을 반환한다.
+// positional prompt 패턴은 환영 메시지 폴백을 유발하므로 사용 금지.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1052-L1059, run_codex_exec() L2036-L2046.
+//        .claude/rules/tfx-update-logic.md Antigravity CLI 1.0.0 정밀 sanity matrix.
+
+export const id = "agy";
+export const cliType = "antigravity";
+export const command = "agy";
+
+const AGENT_PROFILES = {
+  antigravity: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  agy: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.antigravity;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-agy] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["--print", "--dangerously-skip-permissions"],
+    stdinMode: "pipe",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/core/scripts/lib/cli-claude.mjs
+++ b/packages/core/scripts/lib/cli-claude.mjs
@@ -1,0 +1,78 @@
+// cli-claude.mjs — Claude native adapter (Phase 0 PoC).
+//
+// 책임: Claude 는 외부 CLI 가 아닌 Claude Code Agent 도구로 dispatch 된다. plan() 은
+// command=null 을 반환하고 호출자가 Agent() 로 라우팅하도록 신호한다.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1062-L1063 (explore|claude),
+//        L1196-L1203 (TFX_CLI_MODE=gemini fallback), TFX_VERIFIER_OVERRIDE=claude.
+
+export const id = "claude";
+export const cliType = "claude-native";
+export const command = null;
+
+const AGENT_PROFILES = {
+  explore: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  claude: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  "test-engineer": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  "qa-tester": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  verifier: {
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.explore;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-claude] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: "claude-native",
+    effort: "n/a",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    model: cfg.model,
+    mcpProfile: mcpProfile === "auto" ? null : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+    note: "Claude native — dispatched via Claude Code Agent tool, not CLI",
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/core/scripts/lib/cli-codex.mjs
+++ b/packages/core/scripts/lib/cli-codex.mjs
@@ -1,0 +1,199 @@
+// cli-codex.mjs — Codex CLI adapter (Phase 0 PoC).
+//
+// 책임: agent 이름과 입력 파라미터를 받아 Codex 실행 계획(profile/effort/timeout/runMode)을
+// 산출한다. 실제 spawn 은 Phase 1 에서 이관된다 (현재는 tfx-route.sh 가 수행).
+//
+// 진입점: tfx-route.mjs → selectAdapter("codex") → plan({...}).
+// 출처: scripts/tfx-route.sh route_agent() L1001-L1079 case 문 미러.
+
+export const id = "codex";
+export const cliType = "codex";
+export const command = "codex";
+
+const AGENT_PROFILES = {
+  executor: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  codex: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "build-fixer": {
+    profile: "gpt55_low",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  cleanup: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  deslop: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  debugger: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "deep-executor": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "implement",
+  },
+  architect: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  critic: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  planner: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  analyst: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  "code-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "quality-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "security-reviewer": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  scientist: {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "document-specialist": {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "scientist-deep": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  verifier: {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "test-engineer": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "qa-tester": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  spark: {
+    profile: "spark53_low",
+    timeoutSec: 180,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.executor;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-codex] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    subcommand: cfg.subcommand ?? "exec",
+    profile: cfg.profile,
+    effort: cfg.profile,
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/core/scripts/lib/cli-gemini.mjs
+++ b/packages/core/scripts/lib/cli-gemini.mjs
@@ -1,0 +1,67 @@
+// cli-gemini.mjs — Gemini CLI adapter (Phase 0 PoC).
+//
+// 책임: Gemini 프로파일/모델/timeout 매핑. resolve_gemini_profile() 의 결과는 Phase 1 에서
+// 통합한다 (Phase 0 은 라벨만 전달).
+//
+// 출처: scripts/tfx-route.sh route_agent() L1045-L1050.
+
+export const id = "gemini";
+export const cliType = "gemini";
+export const command = "gemini";
+
+const AGENT_PROFILES = {
+  designer: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  gemini: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  writer: {
+    profile: "flash3",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.gemini;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-gemini] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["-m", cfg.profile, "-y", "--prompt"],
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/core/scripts/lib/env.mjs
+++ b/packages/core/scripts/lib/env.mjs
@@ -1,0 +1,14 @@
+export function buildPreflightEnv(env = process.env) {
+  return {
+    ...env,
+    GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT ?? "0",
+    GIT_ASKPASS: env.GIT_ASKPASS ?? "false",
+    npm_config_yes: env.npm_config_yes ?? "true",
+  };
+}
+
+export function shouldWarnGhAuth(env = process.env, checks = {}) {
+  if (!checks.ghExists) return false;
+  if (env.GH_TOKEN || env.GITHUB_TOKEN) return false;
+  return checks.ghAuthenticated === false;
+}

--- a/packages/core/scripts/lib/hub.mjs
+++ b/packages/core/scripts/lib/hub.mjs
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+
+export function parseHubPort(hubUrl = "") {
+  try {
+    const parsed = new URL(hubUrl);
+    return parsed.port || "27888";
+  } catch {
+    return "27888";
+  }
+}
+
+export async function restartHub({
+  hubUrl = process.env.TFX_HUB_URL || "http://127.0.0.1:27888",
+  hubServer,
+  nodeBin = process.execPath,
+  spawnFn = spawn,
+  fetchFn = globalThis.fetch,
+  sleepMs = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  attempts = 8,
+} = {}) {
+  if (!hubServer) return { ok: false, error: "hub_server_missing" };
+  const port = parseHubPort(hubUrl);
+  const child = spawnFn(nodeBin, [hubServer], {
+    env: { ...process.env, TFX_HUB_PORT: port },
+    stdio: "ignore",
+    detached: true,
+  });
+  child.unref?.();
+
+  for (let i = 0; i < attempts; i += 1) {
+    await sleepMs(500);
+    try {
+      const response = await fetchFn(`${hubUrl.replace(/\/$/, "")}/status`);
+      if (response?.ok) return { ok: true, pid: child.pid };
+    } catch {
+      // Keep polling until attempts are exhausted.
+    }
+  }
+  return { ok: false, pid: child.pid };
+}
+
+export async function withHubRestart({ action, restart }) {
+  const first = await action();
+  if (first?.ok) return first;
+  const restarted = await restart();
+  if (!restarted?.ok) return first;
+  return action();
+}

--- a/packages/core/scripts/lib/pid.mjs
+++ b/packages/core/scripts/lib/pid.mjs
@@ -1,0 +1,63 @@
+import { appendFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let treeKill = null;
+try {
+  treeKill = require("tree-kill");
+} catch {
+  treeKill = null;
+}
+
+function defaultIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultKillTree(pid) {
+  return new Promise((resolve) => {
+    if (treeKill) {
+      treeKill(pid, "SIGTERM", () => resolve());
+      return;
+    }
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Process already exited.
+    }
+    resolve();
+  });
+}
+
+export class PidTracker {
+  constructor(path, options = {}) {
+    this.path = path;
+    this.isAlive = options.isAlive ?? defaultIsAlive;
+    this.killTree = options.killTree ?? defaultKillTree;
+  }
+
+  track(pid) {
+    if (!pid) return;
+    appendFileSync(this.path, `${pid}\n`);
+  }
+
+  list() {
+    if (!existsSync(this.path)) return [];
+    return readFileSync(this.path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  }
+
+  async cleanup() {
+    for (const pid of this.list()) {
+      if (!this.isAlive(pid)) continue;
+      await this.killTree(pid);
+    }
+    rmSync(this.path, { force: true });
+  }
+}

--- a/packages/core/scripts/lib/quota.mjs
+++ b/packages/core/scripts/lib/quota.mjs
@@ -1,0 +1,47 @@
+export const QUOTA_PATTERNS = [
+  /usage limit exceeded/i,
+  /rate limit exceeded/i,
+  /rate limit reached/i,
+  /try again at/i,
+  /purchase more credits/i,
+  /quota exceeded/i,
+  /RESOURCE_EXHAUSTED/i,
+  /rateLimitExceeded/i,
+  /Too Many Requests/i,
+  /rate_limit_error/i,
+  /overloaded_error/i,
+  /insufficient_quota/i,
+];
+
+export class QuotaStreamBuffer {
+  constructor({ maxBytes = 65536 } = {}) {
+    this.maxBytes = maxBytes;
+    this.text = "";
+  }
+
+  push(chunk) {
+    this.text += Buffer.isBuffer(chunk)
+      ? chunk.toString("utf8")
+      : String(chunk);
+    if (this.text.length > this.maxBytes) {
+      this.text = this.text.slice(-this.maxBytes);
+    }
+    return detectQuotaText(this.text);
+  }
+}
+
+export function detectQuotaText(text = "") {
+  return QUOTA_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function getRerouteTarget(cliType) {
+  switch (cliType) {
+    case "codex":
+    case "gemini":
+      return "antigravity";
+    case "antigravity":
+      return "codex";
+    default:
+      return null;
+  }
+}

--- a/packages/core/scripts/lib/team.mjs
+++ b/packages/core/scripts/lib/team.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function teamContext(env) {
+  const team = env.TFX_TEAM_NAME || "";
+  const taskId = env.TFX_TEAM_TASK_ID || "";
+  if (!team || !taskId) return null;
+  return {
+    team,
+    taskId,
+    agent: env.TFX_TEAM_AGENT_NAME || "agent",
+    lead: env.TFX_TEAM_LEAD_NAME || "team-lead",
+  };
+}
+
+export async function claimTask({ env = process.env, bridge } = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const response = await bridge.claim({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    owner: ctx.agent,
+    status: "in_progress",
+  });
+  if (response?.ok) return { claimed: true };
+  const code = response?.error?.code;
+  const before = response?.error?.details?.task_before ?? {};
+  if (
+    code === "CLAIM_CONFLICT" &&
+    before.owner === ctx.agent &&
+    before.status === "in_progress"
+  ) {
+    return { claimed: true, alreadyClaimed: true };
+  }
+  if (code === "CLAIM_CONFLICT") {
+    return { claimed: false, conflict: true, owner: before.owner ?? null };
+  }
+  return { claimed: false, error: response?.error ?? null };
+}
+
+export async function completeTask({
+  env = process.env,
+  bridge,
+  result = "success",
+  summary = "작업 완료",
+  now = () => new Date().toISOString(),
+} = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const trimmed = String(summary).slice(0, 4096);
+  const response = await bridge.complete({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    agent: ctx.agent,
+    result,
+    summary: trimmed,
+  });
+
+  const resultDir =
+    env.TFX_RESULT_DIR ||
+    join(process.env.HOME || ".", ".claude", "tfx-results", ctx.team);
+  mkdirSync(resultDir, { recursive: true });
+  writeFileSync(
+    join(resultDir, `${ctx.taskId}.json`),
+    `${JSON.stringify({
+      taskId: ctx.taskId,
+      agent: ctx.agent,
+      team: ctx.team,
+      result,
+      summary: trimmed,
+      timestamp: now(),
+    })}\n`,
+  );
+  return { completed: Boolean(response?.ok), response };
+}

--- a/packages/core/scripts/lib/timeout.mjs
+++ b/packages/core/scripts/lib/timeout.mjs
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+
+export function timeoutCodeForSignal(signal) {
+  return signal ? 124 : null;
+}
+
+export function runWithTimeout(command, args = [], options = {}) {
+  const {
+    cwd = process.cwd(),
+    env = process.env,
+    input,
+    timeoutMs = 0,
+    stdio = "pipe",
+    spawnFn = spawn,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    let timedOut = false;
+    const child = spawnFn(command, args, {
+      cwd,
+      env,
+      stdio,
+      signal: controller.signal,
+    });
+    const stdout = [];
+    const stderr = [];
+    let timer = null;
+
+    if (child.stdout) child.stdout.on("data", (chunk) => stdout.push(chunk));
+    if (child.stderr) child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", (err) => {
+      if (timedOut && err.name === "AbortError") return;
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        code: timedOut ? 124 : (code ?? timeoutCodeForSignal(signal) ?? 1),
+        signal,
+        timedOut,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        if (child.pid) {
+          try {
+            process.kill(child.pid, "SIGTERM");
+          } catch {
+            // Process already exited.
+          }
+        }
+      }, timeoutMs);
+      timer.unref?.();
+    }
+
+    if (input !== undefined && child.stdin) {
+      child.stdin.end(input);
+    }
+  });
+}

--- a/packages/core/scripts/lib/tmp.mjs
+++ b/packages/core/scripts/lib/tmp.mjs
@@ -1,0 +1,26 @@
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function resolveTmpDir({ env = process.env, cwd = process.cwd() } = {}) {
+  const candidate = env.TFX_TMP || tmpdir();
+  try {
+    mkdirSync(candidate, { recursive: true });
+    return candidate;
+  } catch {
+    const fallback = join(cwd, ".tfx-tmp");
+    try {
+      mkdirSync(fallback, { recursive: true });
+    } catch {
+      // Bash printed the fallback path even when mkdir failed.
+    }
+    return fallback;
+  }
+}
+
+export function resolveJobsDir({
+  env = process.env,
+  tmpDir = resolveTmpDir({ env }),
+} = {}) {
+  return env.TFX_JOBS_DIR || join(tmpDir, "tfx-jobs");
+}

--- a/packages/core/scripts/lib/toml.mjs
+++ b/packages/core/scripts/lib/toml.mjs
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let TOML = null;
+try {
+  TOML = require("@iarna/toml");
+} catch {
+  TOML = null;
+}
+
+function walk(value, visitor) {
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    visitor(value, key, child);
+    walk(child, visitor);
+  }
+}
+
+export function parseToml(source) {
+  if (!TOML) return parseTomlFallback(source);
+  return TOML.parse(source || "");
+}
+
+export function stringifyToml(value) {
+  if (!TOML) return stringifyTomlFallback(value);
+  return TOML.stringify(value);
+}
+
+function parseTomlFallback(source = "") {
+  const root = {};
+  let current = root;
+  for (const rawLine of String(source).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const section = line.match(/^\[([^\]]+)\]$/);
+    if (section) {
+      current = root;
+      for (const part of section[1].split(".")) {
+        current[part] ??= {};
+        current = current[part];
+      }
+      continue;
+    }
+    const assignment = line.match(/^([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"$/);
+    if (assignment) {
+      current[assignment[1]] = assignment[2];
+    }
+  }
+  return root;
+}
+
+function stringifyTomlFallback(value) {
+  const lines = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (child && typeof child === "object") continue;
+    lines.push(`${key} = "${String(child)}"`);
+  }
+  function writeSections(prefix, obj) {
+    for (const [key, child] of Object.entries(obj)) {
+      if (!child || typeof child !== "object") continue;
+      const section = [...prefix, key];
+      lines.push("", `[${section.join(".")}]`);
+      for (const [childKey, childValue] of Object.entries(child)) {
+        if (childValue && typeof childValue === "object") continue;
+        lines.push(`${childKey} = "${String(childValue)}"`);
+      }
+      writeSections(section, child);
+    }
+  }
+  writeSections([], value);
+  return `${lines.join("\n")}\n`;
+}
+
+export function detectTopLevelCodexConfig(source) {
+  const parsed = parseToml(source);
+  return {
+    hasTopLevelSandboxOrApproval:
+      Object.hasOwn(parsed, "sandbox") ||
+      Object.hasOwn(parsed, "approval_mode"),
+  };
+}
+
+export function patchMcpApprovalMode(source) {
+  const parsed = parseToml(source);
+  let count = 0;
+  walk(parsed.mcp_servers, (parent, key, value) => {
+    if (key === "approval_mode" && value === "approve") {
+      parent[key] = "full-auto";
+      count += 1;
+    }
+  });
+  return {
+    changed: count > 0,
+    count,
+    toml: count > 0 ? stringifyToml(parsed) : source,
+  };
+}
+
+export function patchCodexConfigFile(path, { now = () => new Date() } = {}) {
+  if (!path || !existsSync(path)) return { changed: false, count: 0 };
+  const source = readFileSync(path, "utf8");
+  const patched = patchMcpApprovalMode(source);
+  if (!patched.changed) return patched;
+  const stamp = now()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..*$/, "")
+    .replace("T", "-");
+  writeFileSync(`${path}.bak-${stamp}`, source);
+  writeFileSync(path, patched.toml);
+  return patched;
+}

--- a/packages/triflux/config/mcp-registry.json
+++ b/packages/triflux/config/mcp-registry.json
@@ -7,7 +7,7 @@
     "hub_base": "http://127.0.0.1:27888"
   },
   "policy_notes": {
-    "transport": "Server transport accepts \"hub-url\" for the existing triflux Hub URL flow or \"http\" for direct Streamable HTTP MCP endpoints. Direct stdio registration via command/args is intentionally unsupported.",
+    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers (rare; only for servers that have no hosted HTTP endpoint, e.g. brave-search). stdio servers require command, args, and may include env.",
     "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
     "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
     "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
@@ -17,15 +17,46 @@
       "transport": "hub-url",
       "url": "http://127.0.0.1:27888/mcp",
       "safe": true,
-      "targets": ["claude", "gemini", "codex"],
+      "targets": ["claude", "gemini", "codex", "antigravity"],
       "description": "triflux Hub MCP 서버"
     },
     "context7": {
       "transport": "http",
       "url": "https://mcp.context7.com/mcp",
       "safe": true,
-      "targets": ["claude", "gemini", "codex"],
+      "targets": ["claude", "gemini", "codex", "antigravity"],
       "description": "Upstash Context7 — 라이브러리 문서/코드 컨텍스트 (HTTP MCP, API key 불필요)"
+    },
+    "exa": {
+      "transport": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "Authorization": { "env": "EXA_API_KEY", "prefix": "Bearer " }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Exa neural/semantic web search — 학술/기술 깊이. Key 발급: https://exa.ai/dashboard → secrets.env의 EXA_API_KEY"
+    },
+    "brave-search": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": { "env": "BRAVE_API_KEY" }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Brave Search MCP — stdio 양식 (공식 hosted endpoint 없음, npx 로컬 실행). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
+    },
+    "tavily": {
+      "transport": "http",
+      "url": "https://mcp.tavily.com/mcp",
+      "headers": {
+        "Authorization": { "env": "TAVILY_API_KEY", "prefix": "Bearer " }
+      },
+      "safe": true,
+      "targets": ["claude", "gemini", "codex", "antigravity"],
+      "description": "Tavily research — 비용/운영/DX/일반 웹. Key 발급: https://app.tavily.com/home → secrets.env의 TAVILY_API_KEY"
     }
   },
   "policies": {
@@ -38,7 +69,8 @@
       "~/.claude/settings.json",
       "~/.claude/settings.local.json",
       ".claude/mcp.json",
-      ".mcp.json"
+      ".mcp.json",
+      "~/.gemini/config/mcp_config.json"
     ]
   }
 }

--- a/packages/triflux/package.json
+++ b/packages/triflux/package.json
@@ -17,8 +17,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@triflux/core": "10.0.1",
-    "@triflux/remote": "^10.0.0-alpha.1"
+    "@triflux/remote": "^10.0.0-alpha.1",
+    "tree-kill": "^1.2.2"
   },
   "files": [
     "bin",

--- a/packages/triflux/scripts/__tests__/tfx-route-bash-node-parity.test.mjs
+++ b/packages/triflux/scripts/__tests__/tfx-route-bash-node-parity.test.mjs
@@ -1,0 +1,169 @@
+// tfx-route — bash / node 두 lane 회귀가드.
+//
+// Phase 0 PoC 의 단일 진입점 약속:
+//   1. tfx-route.sh 가 TFX_ROUTE_NODE 게이트웨이 + BYPASS guard 를 보유한다
+//   2. Node 진입점은 tfx-route.sh 와 동일한 agent-map.json 을 단일 source of truth 로 쓴다
+//   3. node tfx-route.mjs --version / --route-print 가 외부 invocation 으로 동작한다
+//
+// 직접 CLI spawn (codex/gemini/agy) 은 Phase 1 까지 bash 가 소유하므로 여기서는 검증하지
+// 않는다. Phase 1 부터 plan → spawn 까지 Node 가 처리할 때 회귀가드를 확장한다.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+const BASH_SCRIPT = join(REPO_ROOT, "scripts/tfx-route.sh");
+const NODE_SCRIPT = join(REPO_ROOT, "scripts/tfx-route.mjs");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+describe("tfx-route bash/node parity — Phase 0 회귀가드", () => {
+  test("tfx-route.sh 에 TFX_ROUTE_NODE 게이트웨이 + bypass guard 존재", () => {
+    const sh = readFileSync(BASH_SCRIPT, "utf8");
+    assert.match(sh, /TFX_ROUTE_NODE:-0/, "TFX_ROUTE_NODE 플래그 체크 누락");
+    assert.match(sh, /exec node[^\n]*tfx-route\.mjs/, "Node 진입점 exec 누락");
+    assert.match(sh, /TFX_ROUTE_NODE_BYPASS/, "bypass guard 누락 (재귀 방지)");
+  });
+
+  test("Node 진입점이 agent-map.json 의 모든 agent 를 dispatch 한다", async () => {
+    const route = await import("../tfx-route.mjs");
+    const agentMap = JSON.parse(readFileSync(AGENT_MAP_PATH, "utf8"));
+
+    const EXPECTED_CLI = {
+      codex: "codex",
+      gemini: "gemini",
+      claude: "claude-native",
+      antigravity: "antigravity",
+    };
+
+    for (const [agent, mappedCli] of Object.entries(agentMap)) {
+      const expected = EXPECTED_CLI[mappedCli];
+      assert.ok(expected, `agent-map.json 의 CLI 타입 미지원: ${mappedCli}`);
+
+      const plan = route.buildRoutePlan(
+        { agent, prompt: "parity-smoke", mcpProfile: "auto" },
+        agentMap,
+      );
+      assert.equal(
+        plan.cliType,
+        expected,
+        `agent=${agent} expected cliType=${expected}, got ${plan.cliType}`,
+      );
+      assert.ok(plan.adapter, "adapter id 누락");
+    }
+  });
+
+  test("--version invocation: node lane 정상 출력", () => {
+    const out = execFileSync("node", [NODE_SCRIPT, "--version"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    assert.match(out, /tfx-route\.mjs/);
+  });
+
+  test("--route-print invocation: executor 의 JSON plan 추출", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "executor", "hello world"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.agent, "executor");
+    assert.equal(plan.cliType, "codex");
+    assert.equal(plan.adapter, "codex");
+    assert.equal(plan.effort, "gpt55_high");
+    assert.equal(plan.runMode, "fg");
+  });
+
+  test("--route-print invocation: designer → gemini", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "designer", "ui sketch"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "gemini");
+    assert.equal(plan.adapter, "gemini");
+    assert.equal(plan.effort, "pro31");
+  });
+
+  test("--route-print invocation: explore → claude-native (no CLI command)", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "explore", "search"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "claude-native");
+    assert.equal(plan.adapter, "claude");
+    assert.equal(plan.command, null);
+  });
+
+  test("--route-print invocation: antigravity → stdin-pipe", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "antigravity", "doc gen"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "antigravity");
+    assert.equal(plan.adapter, "agy");
+    assert.equal(plan.stdinMode, "pipe");
+    assert.deepEqual(plan.args, ["--print", "--dangerously-skip-permissions"]);
+  });
+
+  test("Unknown agent → exit 1 + stderr error", () => {
+    let threw = false;
+    try {
+      execFileSync(
+        "node",
+        [NODE_SCRIPT, "--route-print", "totally-nonexistent-agent", "x"],
+        { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      threw = true;
+      assert.equal(err.status, 1);
+      assert.match(String(err.stderr ?? ""), /Unknown agent type/);
+    }
+    assert.ok(threw, "unknown agent 인데 throw 안 함");
+  });
+
+  test("TFX_ROUTE_NODE=1 게이트웨이: bash → node 정확히 이관", () => {
+    const out = execFileSync(
+      "bash",
+      [BASH_SCRIPT, "--route-print", "executor", "via-gateway"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        env: { ...process.env, TFX_ROUTE_NODE: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.adapter, "codex");
+    assert.equal(plan.cliType, "codex");
+  });
+
+  test("TFX_ROUTE_NODE=0 (default): bash lane 그대로 (게이트웨이 무동작)", () => {
+    // bash 단독 호출은 정상 검증을 거쳐 unknown agent 라면 정확한 bash-side 에러를
+    // 반환해야 한다. node 진입점이면 메시지가 다름 — 게이트웨이가 동작 안 했다는
+    // 직접 증거.
+    let stderr = "";
+    try {
+      execFileSync("bash", [BASH_SCRIPT, "nope-nonexistent-agent", "x"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      stderr = String(err.stderr ?? "");
+    }
+    // bash 의 route_agent() L983 에러 메시지 ("알 수 없는 에이전트 타입") 가 나와야
+    // bash 가 직접 처리했다는 신호. node 진입점이면 "Unknown agent type" (영어) 가 남는다.
+    assert.match(stderr, /알 수 없는 에이전트 타입|Unknown agent type/);
+  });
+});

--- a/packages/triflux/scripts/__tests__/tfx-route-node-entry.test.mjs
+++ b/packages/triflux/scripts/__tests__/tfx-route-node-entry.test.mjs
@@ -1,0 +1,403 @@
+// tfx-route.mjs Phase 0 PoC — 단위 테스트.
+//
+// 검증 범위:
+//   1. 4개 CLI 어댑터의 {id, cliType, plan, describe} 계약
+//   2. parseArgs — positional + flag 처리, 거부 케이스
+//   3. selectAdapter — CLI 타입별 매핑
+//   4. buildRoutePlan — agent-map.json 의 모든 agent 가 분기에 도달
+//   5. 어댑터별 핵심 속성 (effort, timeout, runMode, stdinMode, opusOversight)
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+const route = await import("../tfx-route.mjs");
+const codexAdapter = await import("../lib/cli-codex.mjs");
+const geminiAdapter = await import("../lib/cli-gemini.mjs");
+const claudeAdapter = await import("../lib/cli-claude.mjs");
+const agyAdapter = await import("../lib/cli-agy.mjs");
+
+const AGENT_MAP = JSON.parse(readFileSync(AGENT_MAP_PATH, "utf8"));
+
+describe("tfx-route.mjs Phase 0 PoC — adapter contract", () => {
+  const adapters = [
+    ["codex", codexAdapter, "codex", "codex"],
+    ["gemini", geminiAdapter, "gemini", "gemini"],
+    ["claude", claudeAdapter, "claude", "claude-native"],
+    ["agy", agyAdapter, "agy", "antigravity"],
+  ];
+
+  for (const [name, adapter, expectedId, expectedCliType] of adapters) {
+    test(`cli-${name}.mjs exports {id, cliType, plan, describe}`, () => {
+      assert.equal(adapter.id, expectedId);
+      assert.equal(adapter.cliType, expectedCliType);
+      assert.equal(typeof adapter.plan, "function");
+      assert.equal(typeof adapter.describe, "function");
+      const desc = adapter.describe();
+      assert.equal(desc.id, expectedId);
+      assert.equal(desc.cliType, expectedCliType);
+      assert.ok(Array.isArray(desc.agents));
+      assert.ok(desc.agents.length > 0, "agents 배열이 비어있음");
+    });
+  }
+});
+
+describe("tfx-route.mjs — parseArgs", () => {
+  test("positional: agent + prompt only (mcpProfile=auto default)", () => {
+    const r = route.parseArgs(["executor", "implement X"]);
+    assert.equal(r.mode, "run");
+    assert.equal(r.agent, "executor");
+    assert.equal(r.prompt, "implement X");
+    assert.equal(r.mcpProfile, "auto");
+    assert.equal(r.timeoutSec, undefined);
+    assert.equal(r.contextFile, undefined);
+  });
+
+  test("positional: agent + prompt + mcp + timeout + context", () => {
+    const r = route.parseArgs([
+      "executor",
+      "implement X",
+      "implement",
+      "1080",
+      "/tmp/ctx.md",
+    ]);
+    assert.equal(r.agent, "executor");
+    assert.equal(r.prompt, "implement X");
+    assert.equal(r.mcpProfile, "implement");
+    assert.equal(r.timeoutSec, 1080);
+    assert.equal(r.contextFile, "/tmp/ctx.md");
+  });
+
+  test("--async flag → mode=async, positional 이어서 파싱", () => {
+    const r = route.parseArgs([
+      "--async",
+      "scientist",
+      "deep research",
+      "auto",
+      "1440",
+    ]);
+    assert.equal(r.mode, "async");
+    assert.equal(r.agent, "scientist");
+    assert.equal(r.prompt, "deep research");
+    assert.equal(r.timeoutSec, 1440);
+  });
+
+  test("--job-status <id> → 즉시 반환, agent/prompt 불필요", () => {
+    const r = route.parseArgs(["--job-status", "job-abc-123"]);
+    assert.equal(r.mode, "job-status");
+    assert.equal(r.jobId, "job-abc-123");
+    assert.equal(r.agent, undefined);
+  });
+
+  test("--job-result <id> → 즉시 반환", () => {
+    const r = route.parseArgs(["--job-result", "job-xyz"]);
+    assert.equal(r.mode, "job-result");
+    assert.equal(r.jobId, "job-xyz");
+  });
+
+  test("--version → mode=version, 다른 인자 무시", () => {
+    const r = route.parseArgs(["--version"]);
+    assert.equal(r.mode, "version");
+  });
+
+  test("--help / -h → mode=help", () => {
+    assert.equal(route.parseArgs(["--help"]).mode, "help");
+    assert.equal(route.parseArgs(["-h"]).mode, "help");
+  });
+
+  test("--route-print → dryRun=true, mode=route-print", () => {
+    const r = route.parseArgs(["--route-print", "executor", "go"]);
+    assert.equal(r.mode, "route-print");
+    assert.equal(r.dryRun, true);
+    assert.equal(r.agent, "executor");
+  });
+
+  test("거부: agent 누락", () => {
+    assert.throws(() => route.parseArgs([]), /Agent type required/);
+  });
+
+  test("거부: prompt 누락", () => {
+    assert.throws(() => route.parseArgs(["executor"]), /Prompt required/);
+  });
+
+  test("거부: 3번째 인자(MCP_PROFILE) 자리에 플래그", () => {
+    assert.throws(
+      () => route.parseArgs(["executor", "go", "--mode"]),
+      /cannot be a flag/,
+    );
+  });
+
+  test("거부: 알 수 없는 플래그", () => {
+    assert.throws(
+      () => route.parseArgs(["--bogus", "executor", "go"]),
+      /Unknown flag/,
+    );
+  });
+
+  test("거부: timeout_sec 가 숫자 아님", () => {
+    assert.throws(
+      () => route.parseArgs(["executor", "go", "auto", "abc"]),
+      /must be numeric/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — selectAdapter", () => {
+  test("codex → codex adapter", () => {
+    assert.equal(route.selectAdapter("codex").id, "codex");
+  });
+  test("gemini → gemini adapter", () => {
+    assert.equal(route.selectAdapter("gemini").id, "gemini");
+  });
+  test("claude-native → claude adapter", () => {
+    assert.equal(route.selectAdapter("claude-native").id, "claude");
+  });
+  test("claude (raw) → claude adapter (alias)", () => {
+    assert.equal(route.selectAdapter("claude").id, "claude");
+  });
+  test("antigravity → agy adapter", () => {
+    assert.equal(route.selectAdapter("antigravity").id, "agy");
+  });
+  test("agy → agy adapter (alias)", () => {
+    assert.equal(route.selectAdapter("agy").id, "agy");
+  });
+  test("unknown CLI type throws", () => {
+    assert.throws(
+      () => route.selectAdapter("totally-nonexistent"),
+      /No adapter registered/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — resolveCliTypeForAgent", () => {
+  test("claude raw → claude-native (parity with tfx-route.sh L990)", () => {
+    assert.equal(
+      route.resolveCliTypeForAgent("explore", AGENT_MAP),
+      "claude-native",
+    );
+    assert.equal(
+      route.resolveCliTypeForAgent("claude", AGENT_MAP),
+      "claude-native",
+    );
+  });
+  test("codex raw 그대로 유지", () => {
+    assert.equal(route.resolveCliTypeForAgent("executor", AGENT_MAP), "codex");
+  });
+  test("antigravity raw 그대로 유지", () => {
+    assert.equal(
+      route.resolveCliTypeForAgent("antigravity", AGENT_MAP),
+      "antigravity",
+    );
+    assert.equal(route.resolveCliTypeForAgent("agy", AGENT_MAP), "antigravity");
+  });
+  test("unknown agent throws", () => {
+    assert.throws(
+      () => route.resolveCliTypeForAgent("nope-not-real", AGENT_MAP),
+      /Unknown agent type/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — buildRoutePlan (agent-map.json 전수)", () => {
+  const EXPECTED_CLI = {
+    codex: "codex",
+    gemini: "gemini",
+    claude: "claude-native",
+    antigravity: "antigravity",
+  };
+
+  for (const [agent, mappedCli] of Object.entries(AGENT_MAP)) {
+    const expectedCliType = EXPECTED_CLI[mappedCli];
+    test(`agent=${agent} → cliType=${expectedCliType}`, () => {
+      const plan = route.buildRoutePlan(
+        { agent, prompt: "hello", mcpProfile: "auto" },
+        AGENT_MAP,
+      );
+      assert.equal(plan.agent, agent);
+      assert.equal(plan.cliType, expectedCliType);
+      assert.ok(
+        typeof plan.timeoutMs === "number" && plan.timeoutMs > 0,
+        `timeoutMs invalid: ${plan.timeoutMs}`,
+      );
+      assert.ok(
+        plan.runMode === "fg" || plan.runMode === "bg",
+        `runMode invalid: ${plan.runMode}`,
+      );
+    });
+  }
+});
+
+describe("cli-codex.mjs — 핵심 매핑", () => {
+  test("executor → gpt55_high / 1080s / fg / mcp=implement", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_high");
+    assert.equal(p.profile, "gpt55_high");
+    assert.equal(p.timeoutMs, 1_080_000);
+    assert.equal(p.runMode, "fg");
+    assert.equal(p.opusOversight, false);
+    assert.equal(p.mcpProfile, "implement");
+    assert.equal(p.subcommand, "exec");
+  });
+
+  test("architect → gpt55_xhigh / 3600s / bg / opus oversight", () => {
+    const p = codexAdapter.plan({
+      agent: "architect",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_xhigh");
+    assert.equal(p.timeoutMs, 3_600_000);
+    assert.equal(p.runMode, "bg");
+    assert.equal(p.opusOversight, true);
+    assert.equal(p.mcpProfile, "analyze");
+  });
+
+  test("security-reviewer → review 서브커맨드 + opus oversight", () => {
+    const p = codexAdapter.plan({
+      agent: "security-reviewer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.subcommand, "review");
+    assert.equal(p.mcpProfile, "review");
+    assert.equal(p.opusOversight, true);
+  });
+
+  test("명시 mcpProfile 는 agent hint 를 override", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "review",
+    });
+    assert.equal(p.mcpProfile, "review");
+  });
+
+  test("명시 timeoutSec 는 agent default 를 override", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "auto",
+      timeoutSec: 30,
+    });
+    assert.equal(p.timeoutMs, 30_000);
+  });
+
+  test("미등록 agent → executor default 로 폴백", () => {
+    const p = codexAdapter.plan({
+      agent: "unmapped-future-agent",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_high");
+    assert.equal(p.timeoutMs, 1_080_000);
+  });
+
+  test("agent 누락 시 throw", () => {
+    assert.throws(() => codexAdapter.plan({}), /agent required/);
+  });
+});
+
+describe("cli-gemini.mjs — 핵심 매핑", () => {
+  test("designer → pro31 / 900s / bg", () => {
+    const p = geminiAdapter.plan({
+      agent: "designer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "pro31");
+    assert.equal(p.timeoutMs, 900_000);
+    assert.equal(p.runMode, "bg");
+    assert.equal(p.mcpProfile, "docs");
+    assert.deepEqual(p.args, ["-m", "pro31", "-y", "--prompt"]);
+  });
+
+  test("writer → flash3", () => {
+    const p = geminiAdapter.plan({
+      agent: "writer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "flash3");
+    assert.deepEqual(p.args, ["-m", "flash3", "-y", "--prompt"]);
+  });
+});
+
+describe("cli-claude.mjs — native (no CLI command)", () => {
+  test("explore → command=null, model=haiku", () => {
+    const p = claudeAdapter.plan({
+      agent: "explore",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.command, null);
+    assert.equal(p.model, "haiku");
+    assert.equal(p.profile, "claude-native");
+    assert.equal(p.effort, "n/a");
+    assert.equal(p.mcpProfile, null);
+    assert.match(p.note, /Claude native/);
+  });
+
+  test("verifier (override 경로) → model=sonnet, fg", () => {
+    const p = claudeAdapter.plan({
+      agent: "verifier",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.model, "sonnet");
+    assert.equal(p.runMode, "fg");
+  });
+});
+
+describe("cli-agy.mjs — stdin-pipe 계약", () => {
+  test("antigravity → stdinMode=pipe + --print --dangerously-skip-permissions", () => {
+    const p = agyAdapter.plan({
+      agent: "antigravity",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.stdinMode, "pipe");
+    assert.deepEqual(p.args, ["--print", "--dangerously-skip-permissions"]);
+    assert.equal(p.command, "agy");
+    assert.equal(p.effort, "agy_v1");
+    assert.equal(p.mcpProfile, "docs");
+  });
+
+  test("agy (alias) → 동일한 plan", () => {
+    const p = agyAdapter.plan({
+      agent: "agy",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.stdinMode, "pipe");
+    assert.equal(p.command, "agy");
+  });
+});
+
+describe("preflightNodeVersion", () => {
+  test("v18+ 통과", () => {
+    assert.equal(route.preflightNodeVersion("18.0.0"), 18);
+    assert.equal(route.preflightNodeVersion("20.10.5"), 20);
+    assert.equal(route.preflightNodeVersion("26.0.0"), 26);
+  });
+
+  test("v16 거부", () => {
+    assert.throws(
+      () => route.preflightNodeVersion("16.20.0"),
+      /Node\.js v18\+/,
+    );
+  });
+
+  test("실행 환경 자체는 통과해야 함", () => {
+    assert.doesNotThrow(() => route.preflightNodeVersion());
+  });
+});

--- a/packages/triflux/scripts/__tests__/tfx-route-phase1-modules.test.mjs
+++ b/packages/triflux/scripts/__tests__/tfx-route-phase1-modules.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { registerAgent, removeAgent } from "../lib/agent-json.mjs";
+import { createJob, getJobResult, getJobStatus } from "../lib/async.mjs";
+import { buildPreflightEnv, shouldWarnGhAuth } from "../lib/env.mjs";
+import { restartHub, withHubRestart } from "../lib/hub.mjs";
+import { PidTracker } from "../lib/pid.mjs";
+import {
+  detectQuotaText,
+  getRerouteTarget,
+  QuotaStreamBuffer,
+} from "../lib/quota.mjs";
+import { claimTask, completeTask } from "../lib/team.mjs";
+import { runWithTimeout } from "../lib/timeout.mjs";
+import { resolveTmpDir } from "../lib/tmp.mjs";
+import {
+  detectTopLevelCodexConfig,
+  patchMcpApprovalMode,
+} from "../lib/toml.mjs";
+
+const SCRATCH = mkdtempSync(join(tmpdir(), "tfx-route-phase1-"));
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+
+after(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+});
+
+describe("Phase 1 timeout/tmp/pid/env/toml modules", () => {
+  test("runWithTimeout returns exit code 124 and aborts a long process", async () => {
+    const started = Date.now();
+    const result = await runWithTimeout(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 5000)"],
+      { timeoutMs: 100 },
+    );
+
+    assert.equal(result.timedOut, true);
+    assert.equal(result.code, 124);
+    assert.ok(Date.now() - started < 2000);
+  });
+
+  test("resolveTmpDir uses os.tmpdir as the standard default and creates it", () => {
+    const dir = resolveTmpDir({ env: {}, cwd: SCRATCH });
+    assert.equal(dir, tmpdir());
+    assert.ok(existsSync(dir));
+  });
+
+  test("PidTracker records pids and cleanup tree-kills live entries", async () => {
+    const killed = [];
+    const tracker = new PidTracker(join(SCRATCH, "pids"), {
+      isAlive: (pid) => pid === 12345,
+      killTree: async (pid) => killed.push(pid),
+    });
+
+    tracker.track(12345);
+    tracker.track(99999);
+    await tracker.cleanup();
+
+    assert.deepEqual(killed, [12345]);
+    assert.equal(existsSync(join(SCRATCH, "pids")), false);
+  });
+
+  test("buildPreflightEnv preserves caller values and fills noninteractive defaults", () => {
+    const env = buildPreflightEnv({
+      GIT_TERMINAL_PROMPT: "1",
+      GH_TOKEN: "token",
+    });
+
+    assert.equal(env.GIT_TERMINAL_PROMPT, "1");
+    assert.equal(env.GIT_ASKPASS, "false");
+    assert.equal(env.npm_config_yes, "true");
+    assert.equal(
+      shouldWarnGhAuth(env, { ghExists: true, ghAuthenticated: false }),
+      false,
+    );
+    assert.equal(
+      shouldWarnGhAuth({}, { ghExists: true, ghAuthenticated: false }),
+      true,
+    );
+  });
+
+  test("patchMcpApprovalMode structurally rewrites approve and detects top-level config only", () => {
+    const source = [
+      'approval_mode = "auto"',
+      'sandbox = "danger-full-access"',
+      "",
+      "[mcp_servers.demo.tools.lookup]",
+      'approval_mode = "approve"',
+    ].join("\n");
+
+    const detection = detectTopLevelCodexConfig(source);
+    const patched = patchMcpApprovalMode(source);
+
+    assert.equal(detection.hasTopLevelSandboxOrApproval, true);
+    assert.equal(patched.changed, true);
+    assert.equal(patched.count, 1);
+    assert.match(patched.toml, /approval_mode = "full-auto"/);
+  });
+});
+
+describe("Phase 1 async/agent-json/hub/team/quota modules", () => {
+  test("async jobs use JSON state, status mapping, and result fallback", async () => {
+    const jobsDir = join(SCRATCH, "jobs");
+    const job = createJob({
+      jobsDir,
+      command: process.execPath,
+      args: ["-e", "console.log('job-ok')"],
+      timeoutMs: 5000,
+    });
+
+    let status = getJobStatus(job.id, { jobsDir });
+    assert.match(status.text, /starting|running/);
+
+    for (let i = 0; i < 20; i += 1) {
+      status = getJobStatus(job.id, { jobsDir });
+      if (status.state === "done") break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    assert.equal(status.state, "done");
+    assert.equal(getJobResult(job.id, { jobsDir }).stdout.trim(), "job-ok");
+  });
+
+  test("registerAgent writes per-process JSON and removeAgent deletes it", () => {
+    const file = registerAgent({
+      tmpDir: SCRATCH,
+      pid: 42,
+      cli: "codex",
+      agent: "executor",
+      started: 123,
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), {
+      pid: 42,
+      cli: "codex",
+      agent: "executor",
+      started: 123,
+    });
+    removeAgent({ tmpDir: SCRATCH, pid: 42 });
+    assert.equal(existsSync(file), false);
+  });
+
+  test("restartHub spawns server and polls native fetch status", async () => {
+    const calls = [];
+    const status = [false, true];
+    const result = await restartHub({
+      hubUrl: "http://127.0.0.1:4567",
+      hubServer: join(SCRATCH, "server.mjs"),
+      spawnFn: (_cmd, _args, opts) => {
+        calls.push(opts.env.TFX_HUB_PORT);
+        return { pid: 777, unref() {} };
+      },
+      fetchFn: async () => ({ ok: status.shift() }),
+      sleepMs: async () => {},
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.pid, 777);
+    assert.deepEqual(calls, ["4567"]);
+  });
+
+  test("withHubRestart retries a failing bridge call after restart", async () => {
+    let attempts = 0;
+    const result = await withHubRestart({
+      action: async () => {
+        attempts += 1;
+        return attempts === 2 ? { ok: true } : { ok: false };
+      },
+      restart: async () => ({ ok: true }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  test("team claim/complete call native bridge functions and keep local backup", async () => {
+    const calls = [];
+    const env = {
+      TFX_TEAM_NAME: "alpha",
+      TFX_TEAM_TASK_ID: "task-1",
+      TFX_TEAM_AGENT_NAME: "executor-1",
+      TFX_RESULT_DIR: join(SCRATCH, "results"),
+    };
+    const bridge = {
+      claim: async (payload) => {
+        calls.push(["claim", payload]);
+        return { ok: true };
+      },
+      complete: async (payload) => {
+        calls.push(["complete", payload]);
+        return { ok: true };
+      },
+    };
+
+    assert.equal((await claimTask({ env, bridge })).claimed, true);
+    const completion = await completeTask({
+      env,
+      bridge,
+      result: "success",
+      summary: "finished",
+      now: () => "2026-05-20T00:00:00.000Z",
+    });
+
+    assert.equal(completion.completed, true);
+    assert.deepEqual(
+      calls.map(([name]) => name),
+      ["claim", "complete"],
+    );
+    assert.equal(
+      JSON.parse(readFileSync(join(env.TFX_RESULT_DIR, "task-1.json"), "utf8"))
+        .summary,
+      "finished",
+    );
+  });
+
+  test("quota detection buffers stderr text and maps allowed reroute targets", () => {
+    const buffer = new QuotaStreamBuffer();
+    buffer.push("normal prefix ");
+    buffer.push("RESOURCE_EXHAUSTED: quota exceeded");
+
+    assert.equal(detectQuotaText(buffer.text), true);
+    assert.equal(getRerouteTarget("codex"), "antigravity");
+    assert.equal(getRerouteTarget("gemini"), "antigravity");
+    assert.equal(getRerouteTarget("antigravity"), "codex");
+    assert.equal(getRerouteTarget("claude-native"), null);
+  });
+});
+
+describe("Phase 1 node invocation surface", () => {
+  test("TFX_ROUTE_NODE=1 handles --job-status in Node lane without bash delegation", () => {
+    const jobsDir = join(SCRATCH, "cli-jobs");
+    const jobDir = join(jobsDir, "known-job");
+    mkdirSync(jobDir, { recursive: true });
+    writeFileSync(
+      join(jobDir, "state.json"),
+      JSON.stringify({ state: "done", exitCode: 0 }),
+    );
+    writeFileSync(join(jobDir, "done"), "");
+    writeFileSync(join(jobDir, "exit_code"), "0");
+    writeFileSync(join(jobDir, "result.log"), "ok\n");
+
+    const out = execFileSync(
+      "bash",
+      ["scripts/tfx-route.sh", "--job-status", "known-job"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: { ...process.env, TFX_ROUTE_NODE: "1", TFX_JOBS_DIR: jobsDir },
+      },
+    );
+
+    assert.equal(out.trim(), "done");
+  });
+});

--- a/packages/triflux/scripts/lib/agent-json.mjs
+++ b/packages/triflux/scripts/lib/agent-json.mjs
@@ -1,0 +1,27 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function agentJsonPath({ tmpDir, pid = process.pid }) {
+  return join(tmpDir, `tfx-agent-${pid}.json`);
+}
+
+export function registerAgent({
+  tmpDir,
+  pid = process.pid,
+  cli = "",
+  agent = "",
+  started = Math.floor(Date.now() / 1000),
+}) {
+  mkdirSync(tmpDir, { recursive: true });
+  const file = agentJsonPath({ tmpDir, pid });
+  writeFileSync(
+    file,
+    `${JSON.stringify({ pid, cli, agent, started })}\n`,
+    "utf8",
+  );
+  return file;
+}
+
+export function removeAgent({ tmpDir, pid = process.pid }) {
+  rmSync(agentJsonPath({ tmpDir, pid }), { force: true });
+}

--- a/packages/triflux/scripts/lib/async.mjs
+++ b/packages/triflux/scripts/lib/async.mjs
@@ -1,0 +1,174 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+function jobDir(jobsDir, jobId) {
+  return join(jobsDir, jobId);
+}
+
+function readState(dir) {
+  const path = join(dir, "state.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeState(dir, state) {
+  writeFileSync(join(dir, "state.json"), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function fileSize(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function isAlive(pid) {
+  if (!pid || pid === "starting") return false;
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createJob({
+  jobsDir,
+  command,
+  args = [],
+  env = process.env,
+  cwd = process.cwd(),
+  timeoutMs = 0,
+}) {
+  mkdirSync(jobsDir, { recursive: true });
+  const id = randomUUID();
+  const dir = jobDir(jobsDir, id);
+  mkdirSync(dir, { recursive: true });
+  const startedAt = Date.now();
+  const stdoutPath = join(dir, "result.log");
+  const stderrPath = join(dir, "stderr.log");
+  writeState(dir, {
+    id,
+    state: "starting",
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  writeFileSync(join(dir, "pid"), "starting");
+  writeFileSync(join(dir, "start_time"), String(Math.floor(startedAt / 1000)));
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.unref?.();
+  writeFileSync(join(dir, "pid"), String(child.pid));
+  writeState(dir, {
+    id,
+    state: "running",
+    pid: child.pid,
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  child.stdout?.on("data", (chunk) => {
+    writeFileSync(stdoutPath, chunk, { flag: "a" });
+  });
+  child.stderr?.on("data", (chunk) => {
+    writeFileSync(stderrPath, chunk, { flag: "a" });
+  });
+  let timer = null;
+  let timedOut = false;
+  if (timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // Process already exited.
+      }
+    }, timeoutMs);
+    timer.unref?.();
+  }
+  child.on("exit", (code) => {
+    if (timer) clearTimeout(timer);
+    const exitCode = timedOut ? 124 : (code ?? 1);
+    writeFileSync(join(dir, "exit_code"), String(exitCode));
+    writeFileSync(join(dir, "done"), "");
+    writeState(dir, {
+      id,
+      state: exitCode === 0 ? "done" : exitCode === 124 ? "timeout" : "failed",
+      pid: child.pid,
+      startedAt,
+      finishedAt: Date.now(),
+      exitCode,
+      command,
+      args,
+      timeoutMs,
+    });
+  });
+
+  return { id, dir, pid: child.pid };
+}
+
+export function getJobStatus(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir))
+    return { state: "error", text: "error: job not found", exitCode: 1 };
+  const state = readState(dir);
+  if (state?.state === "done") return { ...state, text: "done" };
+  if (state?.state === "timeout") return { ...state, text: "timeout" };
+  if (state?.state === "failed") return { ...state, text: "failed" };
+  const pidText = existsSync(join(dir, "pid"))
+    ? readFileSync(join(dir, "pid"), "utf8").trim()
+    : "";
+  if (pidText === "starting")
+    return { ...(state ?? {}), state: "starting", text: "starting" };
+  if (isAlive(pidText)) {
+    const start =
+      Number(readFileSync(join(dir, "start_time"), "utf8")) ||
+      Math.floor(Date.now() / 1000);
+    const elapsed = Math.max(0, Math.floor(Date.now() / 1000) - start);
+    const bytes = fileSize(join(dir, "result.log"));
+    return {
+      ...(state ?? {}),
+      state: "running",
+      text: `running elapsed=${elapsed}s output=${bytes}B`,
+    };
+  }
+  return { ...(state ?? {}), state: "failed", text: "failed" };
+}
+
+export function getJobResult(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir)) throw new Error("job not found");
+  const status = getJobStatus(jobId, { jobsDir });
+  if (!["done", "timeout", "failed"].includes(status.state)) {
+    throw new Error("job still running");
+  }
+  const stdout = existsSync(join(dir, "result.log"))
+    ? readFileSync(join(dir, "result.log"), "utf8")
+    : "";
+  const stderr = existsSync(join(dir, "stderr.log"))
+    ? readFileSync(join(dir, "stderr.log"), "utf8")
+    : "";
+  return {
+    state: status.state,
+    exitCode: status.exitCode ?? 1,
+    stdout: stdout || stderr,
+    stderr,
+  };
+}

--- a/packages/triflux/scripts/lib/cli-agy.mjs
+++ b/packages/triflux/scripts/lib/cli-agy.mjs
@@ -1,0 +1,62 @@
+// cli-agy.mjs — Antigravity (agy) CLI adapter (Phase 0 PoC).
+//
+// 책임: agy --print 는 stdin-only 이므로 plan() 에서 stdinMode="pipe" 시그널을 반환한다.
+// positional prompt 패턴은 환영 메시지 폴백을 유발하므로 사용 금지.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1052-L1059, run_codex_exec() L2036-L2046.
+//        .claude/rules/tfx-update-logic.md Antigravity CLI 1.0.0 정밀 sanity matrix.
+
+export const id = "agy";
+export const cliType = "antigravity";
+export const command = "agy";
+
+const AGENT_PROFILES = {
+  antigravity: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  agy: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.antigravity;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-agy] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["--print", "--dangerously-skip-permissions"],
+    stdinMode: "pipe",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/triflux/scripts/lib/cli-claude.mjs
+++ b/packages/triflux/scripts/lib/cli-claude.mjs
@@ -1,0 +1,78 @@
+// cli-claude.mjs — Claude native adapter (Phase 0 PoC).
+//
+// 책임: Claude 는 외부 CLI 가 아닌 Claude Code Agent 도구로 dispatch 된다. plan() 은
+// command=null 을 반환하고 호출자가 Agent() 로 라우팅하도록 신호한다.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1062-L1063 (explore|claude),
+//        L1196-L1203 (TFX_CLI_MODE=gemini fallback), TFX_VERIFIER_OVERRIDE=claude.
+
+export const id = "claude";
+export const cliType = "claude-native";
+export const command = null;
+
+const AGENT_PROFILES = {
+  explore: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  claude: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  "test-engineer": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  "qa-tester": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  verifier: {
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.explore;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-claude] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: "claude-native",
+    effort: "n/a",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    model: cfg.model,
+    mcpProfile: mcpProfile === "auto" ? null : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+    note: "Claude native — dispatched via Claude Code Agent tool, not CLI",
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/triflux/scripts/lib/cli-codex.mjs
+++ b/packages/triflux/scripts/lib/cli-codex.mjs
@@ -1,0 +1,199 @@
+// cli-codex.mjs — Codex CLI adapter (Phase 0 PoC).
+//
+// 책임: agent 이름과 입력 파라미터를 받아 Codex 실행 계획(profile/effort/timeout/runMode)을
+// 산출한다. 실제 spawn 은 Phase 1 에서 이관된다 (현재는 tfx-route.sh 가 수행).
+//
+// 진입점: tfx-route.mjs → selectAdapter("codex") → plan({...}).
+// 출처: scripts/tfx-route.sh route_agent() L1001-L1079 case 문 미러.
+
+export const id = "codex";
+export const cliType = "codex";
+export const command = "codex";
+
+const AGENT_PROFILES = {
+  executor: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  codex: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "build-fixer": {
+    profile: "gpt55_low",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  cleanup: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  deslop: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  debugger: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "deep-executor": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "implement",
+  },
+  architect: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  critic: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  planner: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  analyst: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  "code-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "quality-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "security-reviewer": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  scientist: {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "document-specialist": {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "scientist-deep": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  verifier: {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "test-engineer": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "qa-tester": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  spark: {
+    profile: "spark53_low",
+    timeoutSec: 180,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.executor;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-codex] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    subcommand: cfg.subcommand ?? "exec",
+    profile: cfg.profile,
+    effort: cfg.profile,
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/triflux/scripts/lib/cli-gemini.mjs
+++ b/packages/triflux/scripts/lib/cli-gemini.mjs
@@ -1,0 +1,67 @@
+// cli-gemini.mjs — Gemini CLI adapter (Phase 0 PoC).
+//
+// 책임: Gemini 프로파일/모델/timeout 매핑. resolve_gemini_profile() 의 결과는 Phase 1 에서
+// 통합한다 (Phase 0 은 라벨만 전달).
+//
+// 출처: scripts/tfx-route.sh route_agent() L1045-L1050.
+
+export const id = "gemini";
+export const cliType = "gemini";
+export const command = "gemini";
+
+const AGENT_PROFILES = {
+  designer: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  gemini: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  writer: {
+    profile: "flash3",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.gemini;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-gemini] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["-m", cfg.profile, "-y", "--prompt"],
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/packages/triflux/scripts/lib/env.mjs
+++ b/packages/triflux/scripts/lib/env.mjs
@@ -1,0 +1,14 @@
+export function buildPreflightEnv(env = process.env) {
+  return {
+    ...env,
+    GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT ?? "0",
+    GIT_ASKPASS: env.GIT_ASKPASS ?? "false",
+    npm_config_yes: env.npm_config_yes ?? "true",
+  };
+}
+
+export function shouldWarnGhAuth(env = process.env, checks = {}) {
+  if (!checks.ghExists) return false;
+  if (env.GH_TOKEN || env.GITHUB_TOKEN) return false;
+  return checks.ghAuthenticated === false;
+}

--- a/packages/triflux/scripts/lib/hub.mjs
+++ b/packages/triflux/scripts/lib/hub.mjs
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+
+export function parseHubPort(hubUrl = "") {
+  try {
+    const parsed = new URL(hubUrl);
+    return parsed.port || "27888";
+  } catch {
+    return "27888";
+  }
+}
+
+export async function restartHub({
+  hubUrl = process.env.TFX_HUB_URL || "http://127.0.0.1:27888",
+  hubServer,
+  nodeBin = process.execPath,
+  spawnFn = spawn,
+  fetchFn = globalThis.fetch,
+  sleepMs = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  attempts = 8,
+} = {}) {
+  if (!hubServer) return { ok: false, error: "hub_server_missing" };
+  const port = parseHubPort(hubUrl);
+  const child = spawnFn(nodeBin, [hubServer], {
+    env: { ...process.env, TFX_HUB_PORT: port },
+    stdio: "ignore",
+    detached: true,
+  });
+  child.unref?.();
+
+  for (let i = 0; i < attempts; i += 1) {
+    await sleepMs(500);
+    try {
+      const response = await fetchFn(`${hubUrl.replace(/\/$/, "")}/status`);
+      if (response?.ok) return { ok: true, pid: child.pid };
+    } catch {
+      // Keep polling until attempts are exhausted.
+    }
+  }
+  return { ok: false, pid: child.pid };
+}
+
+export async function withHubRestart({ action, restart }) {
+  const first = await action();
+  if (first?.ok) return first;
+  const restarted = await restart();
+  if (!restarted?.ok) return first;
+  return action();
+}

--- a/packages/triflux/scripts/lib/pid.mjs
+++ b/packages/triflux/scripts/lib/pid.mjs
@@ -1,0 +1,63 @@
+import { appendFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let treeKill = null;
+try {
+  treeKill = require("tree-kill");
+} catch {
+  treeKill = null;
+}
+
+function defaultIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultKillTree(pid) {
+  return new Promise((resolve) => {
+    if (treeKill) {
+      treeKill(pid, "SIGTERM", () => resolve());
+      return;
+    }
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Process already exited.
+    }
+    resolve();
+  });
+}
+
+export class PidTracker {
+  constructor(path, options = {}) {
+    this.path = path;
+    this.isAlive = options.isAlive ?? defaultIsAlive;
+    this.killTree = options.killTree ?? defaultKillTree;
+  }
+
+  track(pid) {
+    if (!pid) return;
+    appendFileSync(this.path, `${pid}\n`);
+  }
+
+  list() {
+    if (!existsSync(this.path)) return [];
+    return readFileSync(this.path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  }
+
+  async cleanup() {
+    for (const pid of this.list()) {
+      if (!this.isAlive(pid)) continue;
+      await this.killTree(pid);
+    }
+    rmSync(this.path, { force: true });
+  }
+}

--- a/packages/triflux/scripts/lib/quota.mjs
+++ b/packages/triflux/scripts/lib/quota.mjs
@@ -1,0 +1,47 @@
+export const QUOTA_PATTERNS = [
+  /usage limit exceeded/i,
+  /rate limit exceeded/i,
+  /rate limit reached/i,
+  /try again at/i,
+  /purchase more credits/i,
+  /quota exceeded/i,
+  /RESOURCE_EXHAUSTED/i,
+  /rateLimitExceeded/i,
+  /Too Many Requests/i,
+  /rate_limit_error/i,
+  /overloaded_error/i,
+  /insufficient_quota/i,
+];
+
+export class QuotaStreamBuffer {
+  constructor({ maxBytes = 65536 } = {}) {
+    this.maxBytes = maxBytes;
+    this.text = "";
+  }
+
+  push(chunk) {
+    this.text += Buffer.isBuffer(chunk)
+      ? chunk.toString("utf8")
+      : String(chunk);
+    if (this.text.length > this.maxBytes) {
+      this.text = this.text.slice(-this.maxBytes);
+    }
+    return detectQuotaText(this.text);
+  }
+}
+
+export function detectQuotaText(text = "") {
+  return QUOTA_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function getRerouteTarget(cliType) {
+  switch (cliType) {
+    case "codex":
+    case "gemini":
+      return "antigravity";
+    case "antigravity":
+      return "codex";
+    default:
+      return null;
+  }
+}

--- a/packages/triflux/scripts/lib/team.mjs
+++ b/packages/triflux/scripts/lib/team.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function teamContext(env) {
+  const team = env.TFX_TEAM_NAME || "";
+  const taskId = env.TFX_TEAM_TASK_ID || "";
+  if (!team || !taskId) return null;
+  return {
+    team,
+    taskId,
+    agent: env.TFX_TEAM_AGENT_NAME || "agent",
+    lead: env.TFX_TEAM_LEAD_NAME || "team-lead",
+  };
+}
+
+export async function claimTask({ env = process.env, bridge } = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const response = await bridge.claim({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    owner: ctx.agent,
+    status: "in_progress",
+  });
+  if (response?.ok) return { claimed: true };
+  const code = response?.error?.code;
+  const before = response?.error?.details?.task_before ?? {};
+  if (
+    code === "CLAIM_CONFLICT" &&
+    before.owner === ctx.agent &&
+    before.status === "in_progress"
+  ) {
+    return { claimed: true, alreadyClaimed: true };
+  }
+  if (code === "CLAIM_CONFLICT") {
+    return { claimed: false, conflict: true, owner: before.owner ?? null };
+  }
+  return { claimed: false, error: response?.error ?? null };
+}
+
+export async function completeTask({
+  env = process.env,
+  bridge,
+  result = "success",
+  summary = "작업 완료",
+  now = () => new Date().toISOString(),
+} = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const trimmed = String(summary).slice(0, 4096);
+  const response = await bridge.complete({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    agent: ctx.agent,
+    result,
+    summary: trimmed,
+  });
+
+  const resultDir =
+    env.TFX_RESULT_DIR ||
+    join(process.env.HOME || ".", ".claude", "tfx-results", ctx.team);
+  mkdirSync(resultDir, { recursive: true });
+  writeFileSync(
+    join(resultDir, `${ctx.taskId}.json`),
+    `${JSON.stringify({
+      taskId: ctx.taskId,
+      agent: ctx.agent,
+      team: ctx.team,
+      result,
+      summary: trimmed,
+      timestamp: now(),
+    })}\n`,
+  );
+  return { completed: Boolean(response?.ok), response };
+}

--- a/packages/triflux/scripts/lib/timeout.mjs
+++ b/packages/triflux/scripts/lib/timeout.mjs
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+
+export function timeoutCodeForSignal(signal) {
+  return signal ? 124 : null;
+}
+
+export function runWithTimeout(command, args = [], options = {}) {
+  const {
+    cwd = process.cwd(),
+    env = process.env,
+    input,
+    timeoutMs = 0,
+    stdio = "pipe",
+    spawnFn = spawn,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    let timedOut = false;
+    const child = spawnFn(command, args, {
+      cwd,
+      env,
+      stdio,
+      signal: controller.signal,
+    });
+    const stdout = [];
+    const stderr = [];
+    let timer = null;
+
+    if (child.stdout) child.stdout.on("data", (chunk) => stdout.push(chunk));
+    if (child.stderr) child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", (err) => {
+      if (timedOut && err.name === "AbortError") return;
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        code: timedOut ? 124 : (code ?? timeoutCodeForSignal(signal) ?? 1),
+        signal,
+        timedOut,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        if (child.pid) {
+          try {
+            process.kill(child.pid, "SIGTERM");
+          } catch {
+            // Process already exited.
+          }
+        }
+      }, timeoutMs);
+      timer.unref?.();
+    }
+
+    if (input !== undefined && child.stdin) {
+      child.stdin.end(input);
+    }
+  });
+}

--- a/packages/triflux/scripts/lib/tmp.mjs
+++ b/packages/triflux/scripts/lib/tmp.mjs
@@ -1,0 +1,26 @@
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function resolveTmpDir({ env = process.env, cwd = process.cwd() } = {}) {
+  const candidate = env.TFX_TMP || tmpdir();
+  try {
+    mkdirSync(candidate, { recursive: true });
+    return candidate;
+  } catch {
+    const fallback = join(cwd, ".tfx-tmp");
+    try {
+      mkdirSync(fallback, { recursive: true });
+    } catch {
+      // Bash printed the fallback path even when mkdir failed.
+    }
+    return fallback;
+  }
+}
+
+export function resolveJobsDir({
+  env = process.env,
+  tmpDir = resolveTmpDir({ env }),
+} = {}) {
+  return env.TFX_JOBS_DIR || join(tmpDir, "tfx-jobs");
+}

--- a/packages/triflux/scripts/lib/toml.mjs
+++ b/packages/triflux/scripts/lib/toml.mjs
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let TOML = null;
+try {
+  TOML = require("@iarna/toml");
+} catch {
+  TOML = null;
+}
+
+function walk(value, visitor) {
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    visitor(value, key, child);
+    walk(child, visitor);
+  }
+}
+
+export function parseToml(source) {
+  if (!TOML) return parseTomlFallback(source);
+  return TOML.parse(source || "");
+}
+
+export function stringifyToml(value) {
+  if (!TOML) return stringifyTomlFallback(value);
+  return TOML.stringify(value);
+}
+
+function parseTomlFallback(source = "") {
+  const root = {};
+  let current = root;
+  for (const rawLine of String(source).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const section = line.match(/^\[([^\]]+)\]$/);
+    if (section) {
+      current = root;
+      for (const part of section[1].split(".")) {
+        current[part] ??= {};
+        current = current[part];
+      }
+      continue;
+    }
+    const assignment = line.match(/^([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"$/);
+    if (assignment) {
+      current[assignment[1]] = assignment[2];
+    }
+  }
+  return root;
+}
+
+function stringifyTomlFallback(value) {
+  const lines = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (child && typeof child === "object") continue;
+    lines.push(`${key} = "${String(child)}"`);
+  }
+  function writeSections(prefix, obj) {
+    for (const [key, child] of Object.entries(obj)) {
+      if (!child || typeof child !== "object") continue;
+      const section = [...prefix, key];
+      lines.push("", `[${section.join(".")}]`);
+      for (const [childKey, childValue] of Object.entries(child)) {
+        if (childValue && typeof childValue === "object") continue;
+        lines.push(`${childKey} = "${String(childValue)}"`);
+      }
+      writeSections(section, child);
+    }
+  }
+  writeSections([], value);
+  return `${lines.join("\n")}\n`;
+}
+
+export function detectTopLevelCodexConfig(source) {
+  const parsed = parseToml(source);
+  return {
+    hasTopLevelSandboxOrApproval:
+      Object.hasOwn(parsed, "sandbox") ||
+      Object.hasOwn(parsed, "approval_mode"),
+  };
+}
+
+export function patchMcpApprovalMode(source) {
+  const parsed = parseToml(source);
+  let count = 0;
+  walk(parsed.mcp_servers, (parent, key, value) => {
+    if (key === "approval_mode" && value === "approve") {
+      parent[key] = "full-auto";
+      count += 1;
+    }
+  });
+  return {
+    changed: count > 0,
+    count,
+    toml: count > 0 ? stringifyToml(parsed) : source,
+  };
+}
+
+export function patchCodexConfigFile(path, { now = () => new Date() } = {}) {
+  if (!path || !existsSync(path)) return { changed: false, count: 0 };
+  const source = readFileSync(path, "utf8");
+  const patched = patchMcpApprovalMode(source);
+  if (!patched.changed) return patched;
+  const stamp = now()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..*$/, "")
+    .replace("T", "-");
+  writeFileSync(`${path}.bak-${stamp}`, source);
+  writeFileSync(path, patched.toml);
+  return patched;
+}

--- a/packages/triflux/scripts/tfx-route.mjs
+++ b/packages/triflux/scripts/tfx-route.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+// tfx-route.mjs — Node 단일 진입점 (Phase 1).
+//
+// 외부 인터페이스는 tfx-route.sh 와 동일한 positional 인자 (agent, prompt, [mcp], [timeout],
+// [context]) + 동일한 플래그 (--async, --job-status, --job-result, --version). Phase 0 는
+// 라우팅 결정 (agent → CLI 타입 → adapter plan) 만 Node 에서 수행하고, 실제 spawn 은
+// TFX_ROUTE_NODE_BYPASS=1 로 tfx-route.sh 를 재호출하여 위임한다.
+//
+// 활성화: TFX_ROUTE_NODE=1 환경변수가 설정되면 tfx-route.sh 의 게이트웨이가 이 파일로
+// exec 한다 (.triflux/plans/node-cli-single-entry-migration.md Phase 0).
+//
+// Phase 1 부터 timeout/TMP/PID/Async/Quota 등 16개 책임을 직접 흡수한다.
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createJob, getJobResult, getJobStatus } from "./lib/async.mjs";
+import * as agyAdapter from "./lib/cli-agy.mjs";
+import * as claudeAdapter from "./lib/cli-claude.mjs";
+import * as codexAdapter from "./lib/cli-codex.mjs";
+import * as geminiAdapter from "./lib/cli-gemini.mjs";
+import { buildPreflightEnv } from "./lib/env.mjs";
+import { resolveJobsDir, resolveTmpDir } from "./lib/tmp.mjs";
+import { patchCodexConfigFile } from "./lib/toml.mjs";
+
+export const MJS_VERSION = "0.2.0-phase1";
+const MIN_NODE_MAJOR = 18;
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+const ADAPTERS = {
+  codex: codexAdapter,
+  gemini: geminiAdapter,
+  claude: claudeAdapter,
+  "claude-native": claudeAdapter,
+  antigravity: agyAdapter,
+  agy: agyAdapter,
+};
+
+export function preflightNodeVersion(versionString = process.versions.node) {
+  const major = Number(versionString.split(".")[0]);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    throw new Error(
+      `Node.js v${MIN_NODE_MAJOR}+ required (current: v${versionString})`,
+    );
+  }
+  return major;
+}
+
+export function loadAgentMap(path = AGENT_MAP_PATH) {
+  if (!existsSync(path)) {
+    throw new Error(`agent-map.json not found at ${path}`);
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function resolveCliTypeForAgent(agent, agentMap) {
+  const raw = agentMap[agent];
+  if (!raw) {
+    throw new Error(`Unknown agent type: ${agent}`);
+  }
+  return raw === "claude" ? "claude-native" : raw;
+}
+
+export function selectAdapter(cliType) {
+  const adapter = ADAPTERS[cliType];
+  if (!adapter) {
+    throw new Error(`No adapter registered for CLI type: ${cliType}`);
+  }
+  return adapter;
+}
+
+export function parseArgs(argv) {
+  const args = [...argv];
+  const result = { mode: "run", dryRun: false };
+
+  // -h shorthand 는 short-flag 라 아래 `--` while 루프에 안 잡힌다.
+  if (args[0] === "-h") {
+    return { ...result, mode: "help" };
+  }
+
+  while (args.length > 0 && args[0].startsWith("--")) {
+    const flag = args.shift();
+    switch (flag) {
+      case "--version":
+        return { ...result, mode: "version" };
+      case "--help":
+        return { ...result, mode: "help" };
+      case "--async":
+        result.mode = "async";
+        break;
+      case "--job-status":
+        return { ...result, mode: "job-status", jobId: args.shift() };
+      case "--job-result":
+        return { ...result, mode: "job-result", jobId: args.shift() };
+      case "--route-print":
+        result.mode = "route-print";
+        result.dryRun = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  if (result.mode === "version" || result.mode === "help") {
+    return result;
+  }
+
+  const [
+    agent,
+    prompt,
+    mcpProfile = "auto",
+    timeoutRaw = "",
+    contextFile = "",
+  ] = args;
+
+  if (!agent) {
+    throw new Error("Agent type required (executor, debugger, designer, ...)");
+  }
+  if (prompt === undefined || prompt === null) {
+    throw new Error("Prompt required");
+  }
+  if (mcpProfile.startsWith("--")) {
+    throw new Error(`MCP profile (3rd arg) cannot be a flag: ${mcpProfile}`);
+  }
+
+  const timeoutSec = timeoutRaw === "" ? undefined : Number(timeoutRaw);
+  if (timeoutRaw !== "" && !Number.isFinite(timeoutSec)) {
+    throw new Error(`timeout_sec must be numeric, got: ${timeoutRaw}`);
+  }
+
+  return {
+    ...result,
+    agent,
+    prompt,
+    mcpProfile,
+    timeoutSec,
+    contextFile: contextFile || undefined,
+  };
+}
+
+export function buildRoutePlan(request, agentMap) {
+  const cliType = resolveCliTypeForAgent(request.agent, agentMap);
+  const adapter = selectAdapter(cliType);
+  const adapterPlan = adapter.plan({
+    agent: request.agent,
+    prompt: request.prompt ?? "",
+    mcpProfile: request.mcpProfile ?? "auto",
+    timeoutSec: request.timeoutSec,
+    contextFile: request.contextFile,
+  });
+  return {
+    agent: request.agent,
+    cliType,
+    adapter: adapter.id,
+    ...adapterPlan,
+  };
+}
+
+function helpText() {
+  return [
+    `tfx-route.mjs ${MJS_VERSION} — Phase 0 PoC (Node single entry)`,
+    "",
+    "Usage:",
+    "  tfx-route.mjs <agent_type> <prompt> [mcp_profile] [timeout_sec] [context_file]",
+    "  tfx-route.mjs --async <agent_type> <prompt> [mcp_profile] [timeout_sec] [context_file]",
+    "  tfx-route.mjs --job-status <job_id>",
+    "  tfx-route.mjs --job-result <job_id>",
+    "  tfx-route.mjs --route-print <agent_type> <prompt> ...   (dry-run, prints JSON plan)",
+    "  tfx-route.mjs --version",
+    "",
+    "Phase 1: cross-cutting process concerns live in Node; detailed CLI dispatch",
+    "is still delegated to tfx-route.sh until Phase 2.",
+    "",
+  ].join("\n");
+}
+
+function delegateToBash(argv) {
+  const bashScript = join(SCRIPT_DIR, "tfx-route.sh");
+  if (!existsSync(bashScript)) {
+    process.stderr.write(
+      `[tfx-route.mjs] bash entry not found at ${bashScript}\n`,
+    );
+    process.exit(2);
+  }
+  const env = { ...process.env, TFX_ROUTE_NODE_BYPASS: "1" };
+  const child = spawn("bash", [bashScript, ...argv], {
+    stdio: "inherit",
+    env,
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      try {
+        process.kill(process.pid, signal);
+      } catch {
+        process.exit(1);
+      }
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+  child.on("error", (err) => {
+    process.stderr.write(
+      `[tfx-route.mjs] bash delegate failed: ${err.message}\n`,
+    );
+    process.exit(1);
+  });
+}
+
+async function main(argv) {
+  preflightNodeVersion();
+  const request = parseArgs(argv);
+
+  if (request.mode === "version") {
+    process.stdout.write(`tfx-route.mjs ${MJS_VERSION}\n`);
+    return;
+  }
+  if (request.mode === "help") {
+    process.stdout.write(helpText());
+    return;
+  }
+
+  if (request.mode === "job-status" || request.mode === "job-result") {
+    const tmpDir = resolveTmpDir();
+    const jobsDir = resolveJobsDir({ tmpDir });
+    if (!request.jobId) {
+      throw new Error("job_id required");
+    }
+    if (request.mode === "job-status") {
+      const status = getJobStatus(request.jobId, { jobsDir });
+      process.stdout.write(`${status.text}\n`);
+      if (status.state === "error") process.exit(1);
+      return;
+    }
+    const result = getJobResult(request.jobId, { jobsDir });
+    process.stdout.write(result.stdout);
+    process.exitCode = result.exitCode;
+    return;
+  }
+
+  if (request.mode === "async") {
+    const tmpDir = resolveTmpDir();
+    const jobsDir = resolveJobsDir({ tmpDir });
+    const childArgv = argv.filter((arg) => arg !== "--async");
+    const job = createJob({
+      jobsDir,
+      command: process.execPath,
+      args: [fileURLToPath(import.meta.url), ...childArgv],
+      env: { ...buildPreflightEnv(process.env), TFX_ROUTE_NODE: "1" },
+      cwd: process.cwd(),
+      timeoutMs: request.timeoutSec ? request.timeoutSec * 1000 : 0,
+    });
+    process.stdout.write(`${job.id}\n`);
+    return;
+  }
+
+  const agentMap = loadAgentMap();
+  const plan = buildRoutePlan(request, agentMap);
+
+  if (request.mode === "route-print") {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  patchCodexConfigFile(join(homedir(), ".codex", "config.toml"));
+
+  process.stderr.write(
+    `[tfx-route.mjs] Phase 1: agent=${plan.agent} cli=${plan.cliType} effort=${plan.effort} — bash lane retained for CLI dispatch\n`,
+  );
+  delegateToBash(argv);
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[tfx-route.mjs] ${err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -27,6 +27,14 @@ VERSION="2.7"
 #   tfx-route.sh --job-status 1742400000-12345-9876
 #   tfx-route.sh --job-result 1742400000-12345-9876
 
+# ── Phase 0 PoC: Node single-entry gateway ──
+# TFX_ROUTE_NODE=1 일 때 scripts/tfx-route.mjs 로 exec. Node 진입점이 다시 이 스크립트를
+# 호출할 때는 TFX_ROUTE_NODE_BYPASS=1 을 세팅해 무한 루프를 방지한다.
+# PRD: .triflux/plans/node-cli-single-entry-migration.md (Phase 0).
+if [ "${TFX_ROUTE_NODE:-0}" = "1" ] && [ "${TFX_ROUTE_NODE_BYPASS:-0}" != "1" ]; then
+  exec node "$(dirname "$0")/tfx-route.mjs" "$@"
+fi
+
 set -euo pipefail
 
 # ── timeout 명령 호환성 — Windows에서 TIMEOUT.exe 대신 Git Bash coreutils timeout 사용 ──

--- a/scripts/__tests__/tfx-route-bash-node-parity.test.mjs
+++ b/scripts/__tests__/tfx-route-bash-node-parity.test.mjs
@@ -1,0 +1,169 @@
+// tfx-route — bash / node 두 lane 회귀가드.
+//
+// Phase 0 PoC 의 단일 진입점 약속:
+//   1. tfx-route.sh 가 TFX_ROUTE_NODE 게이트웨이 + BYPASS guard 를 보유한다
+//   2. Node 진입점은 tfx-route.sh 와 동일한 agent-map.json 을 단일 source of truth 로 쓴다
+//   3. node tfx-route.mjs --version / --route-print 가 외부 invocation 으로 동작한다
+//
+// 직접 CLI spawn (codex/gemini/agy) 은 Phase 1 까지 bash 가 소유하므로 여기서는 검증하지
+// 않는다. Phase 1 부터 plan → spawn 까지 Node 가 처리할 때 회귀가드를 확장한다.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+const BASH_SCRIPT = join(REPO_ROOT, "scripts/tfx-route.sh");
+const NODE_SCRIPT = join(REPO_ROOT, "scripts/tfx-route.mjs");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+describe("tfx-route bash/node parity — Phase 0 회귀가드", () => {
+  test("tfx-route.sh 에 TFX_ROUTE_NODE 게이트웨이 + bypass guard 존재", () => {
+    const sh = readFileSync(BASH_SCRIPT, "utf8");
+    assert.match(sh, /TFX_ROUTE_NODE:-0/, "TFX_ROUTE_NODE 플래그 체크 누락");
+    assert.match(sh, /exec node[^\n]*tfx-route\.mjs/, "Node 진입점 exec 누락");
+    assert.match(sh, /TFX_ROUTE_NODE_BYPASS/, "bypass guard 누락 (재귀 방지)");
+  });
+
+  test("Node 진입점이 agent-map.json 의 모든 agent 를 dispatch 한다", async () => {
+    const route = await import("../tfx-route.mjs");
+    const agentMap = JSON.parse(readFileSync(AGENT_MAP_PATH, "utf8"));
+
+    const EXPECTED_CLI = {
+      codex: "codex",
+      gemini: "gemini",
+      claude: "claude-native",
+      antigravity: "antigravity",
+    };
+
+    for (const [agent, mappedCli] of Object.entries(agentMap)) {
+      const expected = EXPECTED_CLI[mappedCli];
+      assert.ok(expected, `agent-map.json 의 CLI 타입 미지원: ${mappedCli}`);
+
+      const plan = route.buildRoutePlan(
+        { agent, prompt: "parity-smoke", mcpProfile: "auto" },
+        agentMap,
+      );
+      assert.equal(
+        plan.cliType,
+        expected,
+        `agent=${agent} expected cliType=${expected}, got ${plan.cliType}`,
+      );
+      assert.ok(plan.adapter, "adapter id 누락");
+    }
+  });
+
+  test("--version invocation: node lane 정상 출력", () => {
+    const out = execFileSync("node", [NODE_SCRIPT, "--version"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    assert.match(out, /tfx-route\.mjs/);
+  });
+
+  test("--route-print invocation: executor 의 JSON plan 추출", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "executor", "hello world"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.agent, "executor");
+    assert.equal(plan.cliType, "codex");
+    assert.equal(plan.adapter, "codex");
+    assert.equal(plan.effort, "gpt55_high");
+    assert.equal(plan.runMode, "fg");
+  });
+
+  test("--route-print invocation: designer → gemini", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "designer", "ui sketch"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "gemini");
+    assert.equal(plan.adapter, "gemini");
+    assert.equal(plan.effort, "pro31");
+  });
+
+  test("--route-print invocation: explore → claude-native (no CLI command)", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "explore", "search"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "claude-native");
+    assert.equal(plan.adapter, "claude");
+    assert.equal(plan.command, null);
+  });
+
+  test("--route-print invocation: antigravity → stdin-pipe", () => {
+    const out = execFileSync(
+      "node",
+      [NODE_SCRIPT, "--route-print", "antigravity", "doc gen"],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.cliType, "antigravity");
+    assert.equal(plan.adapter, "agy");
+    assert.equal(plan.stdinMode, "pipe");
+    assert.deepEqual(plan.args, ["--print", "--dangerously-skip-permissions"]);
+  });
+
+  test("Unknown agent → exit 1 + stderr error", () => {
+    let threw = false;
+    try {
+      execFileSync(
+        "node",
+        [NODE_SCRIPT, "--route-print", "totally-nonexistent-agent", "x"],
+        { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      threw = true;
+      assert.equal(err.status, 1);
+      assert.match(String(err.stderr ?? ""), /Unknown agent type/);
+    }
+    assert.ok(threw, "unknown agent 인데 throw 안 함");
+  });
+
+  test("TFX_ROUTE_NODE=1 게이트웨이: bash → node 정확히 이관", () => {
+    const out = execFileSync(
+      "bash",
+      [BASH_SCRIPT, "--route-print", "executor", "via-gateway"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+        env: { ...process.env, TFX_ROUTE_NODE: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const plan = JSON.parse(out);
+    assert.equal(plan.adapter, "codex");
+    assert.equal(plan.cliType, "codex");
+  });
+
+  test("TFX_ROUTE_NODE=0 (default): bash lane 그대로 (게이트웨이 무동작)", () => {
+    // bash 단독 호출은 정상 검증을 거쳐 unknown agent 라면 정확한 bash-side 에러를
+    // 반환해야 한다. node 진입점이면 메시지가 다름 — 게이트웨이가 동작 안 했다는
+    // 직접 증거.
+    let stderr = "";
+    try {
+      execFileSync("bash", [BASH_SCRIPT, "nope-nonexistent-agent", "x"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      stderr = String(err.stderr ?? "");
+    }
+    // bash 의 route_agent() L983 에러 메시지 ("알 수 없는 에이전트 타입") 가 나와야
+    // bash 가 직접 처리했다는 신호. node 진입점이면 "Unknown agent type" (영어) 가 남는다.
+    assert.match(stderr, /알 수 없는 에이전트 타입|Unknown agent type/);
+  });
+});

--- a/scripts/__tests__/tfx-route-node-entry.test.mjs
+++ b/scripts/__tests__/tfx-route-node-entry.test.mjs
@@ -1,0 +1,403 @@
+// tfx-route.mjs Phase 0 PoC — 단위 테스트.
+//
+// 검증 범위:
+//   1. 4개 CLI 어댑터의 {id, cliType, plan, describe} 계약
+//   2. parseArgs — positional + flag 처리, 거부 케이스
+//   3. selectAdapter — CLI 타입별 매핑
+//   4. buildRoutePlan — agent-map.json 의 모든 agent 가 분기에 도달
+//   5. 어댑터별 핵심 속성 (effort, timeout, runMode, stdinMode, opusOversight)
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+const route = await import("../tfx-route.mjs");
+const codexAdapter = await import("../lib/cli-codex.mjs");
+const geminiAdapter = await import("../lib/cli-gemini.mjs");
+const claudeAdapter = await import("../lib/cli-claude.mjs");
+const agyAdapter = await import("../lib/cli-agy.mjs");
+
+const AGENT_MAP = JSON.parse(readFileSync(AGENT_MAP_PATH, "utf8"));
+
+describe("tfx-route.mjs Phase 0 PoC — adapter contract", () => {
+  const adapters = [
+    ["codex", codexAdapter, "codex", "codex"],
+    ["gemini", geminiAdapter, "gemini", "gemini"],
+    ["claude", claudeAdapter, "claude", "claude-native"],
+    ["agy", agyAdapter, "agy", "antigravity"],
+  ];
+
+  for (const [name, adapter, expectedId, expectedCliType] of adapters) {
+    test(`cli-${name}.mjs exports {id, cliType, plan, describe}`, () => {
+      assert.equal(adapter.id, expectedId);
+      assert.equal(adapter.cliType, expectedCliType);
+      assert.equal(typeof adapter.plan, "function");
+      assert.equal(typeof adapter.describe, "function");
+      const desc = adapter.describe();
+      assert.equal(desc.id, expectedId);
+      assert.equal(desc.cliType, expectedCliType);
+      assert.ok(Array.isArray(desc.agents));
+      assert.ok(desc.agents.length > 0, "agents 배열이 비어있음");
+    });
+  }
+});
+
+describe("tfx-route.mjs — parseArgs", () => {
+  test("positional: agent + prompt only (mcpProfile=auto default)", () => {
+    const r = route.parseArgs(["executor", "implement X"]);
+    assert.equal(r.mode, "run");
+    assert.equal(r.agent, "executor");
+    assert.equal(r.prompt, "implement X");
+    assert.equal(r.mcpProfile, "auto");
+    assert.equal(r.timeoutSec, undefined);
+    assert.equal(r.contextFile, undefined);
+  });
+
+  test("positional: agent + prompt + mcp + timeout + context", () => {
+    const r = route.parseArgs([
+      "executor",
+      "implement X",
+      "implement",
+      "1080",
+      "/tmp/ctx.md",
+    ]);
+    assert.equal(r.agent, "executor");
+    assert.equal(r.prompt, "implement X");
+    assert.equal(r.mcpProfile, "implement");
+    assert.equal(r.timeoutSec, 1080);
+    assert.equal(r.contextFile, "/tmp/ctx.md");
+  });
+
+  test("--async flag → mode=async, positional 이어서 파싱", () => {
+    const r = route.parseArgs([
+      "--async",
+      "scientist",
+      "deep research",
+      "auto",
+      "1440",
+    ]);
+    assert.equal(r.mode, "async");
+    assert.equal(r.agent, "scientist");
+    assert.equal(r.prompt, "deep research");
+    assert.equal(r.timeoutSec, 1440);
+  });
+
+  test("--job-status <id> → 즉시 반환, agent/prompt 불필요", () => {
+    const r = route.parseArgs(["--job-status", "job-abc-123"]);
+    assert.equal(r.mode, "job-status");
+    assert.equal(r.jobId, "job-abc-123");
+    assert.equal(r.agent, undefined);
+  });
+
+  test("--job-result <id> → 즉시 반환", () => {
+    const r = route.parseArgs(["--job-result", "job-xyz"]);
+    assert.equal(r.mode, "job-result");
+    assert.equal(r.jobId, "job-xyz");
+  });
+
+  test("--version → mode=version, 다른 인자 무시", () => {
+    const r = route.parseArgs(["--version"]);
+    assert.equal(r.mode, "version");
+  });
+
+  test("--help / -h → mode=help", () => {
+    assert.equal(route.parseArgs(["--help"]).mode, "help");
+    assert.equal(route.parseArgs(["-h"]).mode, "help");
+  });
+
+  test("--route-print → dryRun=true, mode=route-print", () => {
+    const r = route.parseArgs(["--route-print", "executor", "go"]);
+    assert.equal(r.mode, "route-print");
+    assert.equal(r.dryRun, true);
+    assert.equal(r.agent, "executor");
+  });
+
+  test("거부: agent 누락", () => {
+    assert.throws(() => route.parseArgs([]), /Agent type required/);
+  });
+
+  test("거부: prompt 누락", () => {
+    assert.throws(() => route.parseArgs(["executor"]), /Prompt required/);
+  });
+
+  test("거부: 3번째 인자(MCP_PROFILE) 자리에 플래그", () => {
+    assert.throws(
+      () => route.parseArgs(["executor", "go", "--mode"]),
+      /cannot be a flag/,
+    );
+  });
+
+  test("거부: 알 수 없는 플래그", () => {
+    assert.throws(
+      () => route.parseArgs(["--bogus", "executor", "go"]),
+      /Unknown flag/,
+    );
+  });
+
+  test("거부: timeout_sec 가 숫자 아님", () => {
+    assert.throws(
+      () => route.parseArgs(["executor", "go", "auto", "abc"]),
+      /must be numeric/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — selectAdapter", () => {
+  test("codex → codex adapter", () => {
+    assert.equal(route.selectAdapter("codex").id, "codex");
+  });
+  test("gemini → gemini adapter", () => {
+    assert.equal(route.selectAdapter("gemini").id, "gemini");
+  });
+  test("claude-native → claude adapter", () => {
+    assert.equal(route.selectAdapter("claude-native").id, "claude");
+  });
+  test("claude (raw) → claude adapter (alias)", () => {
+    assert.equal(route.selectAdapter("claude").id, "claude");
+  });
+  test("antigravity → agy adapter", () => {
+    assert.equal(route.selectAdapter("antigravity").id, "agy");
+  });
+  test("agy → agy adapter (alias)", () => {
+    assert.equal(route.selectAdapter("agy").id, "agy");
+  });
+  test("unknown CLI type throws", () => {
+    assert.throws(
+      () => route.selectAdapter("totally-nonexistent"),
+      /No adapter registered/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — resolveCliTypeForAgent", () => {
+  test("claude raw → claude-native (parity with tfx-route.sh L990)", () => {
+    assert.equal(
+      route.resolveCliTypeForAgent("explore", AGENT_MAP),
+      "claude-native",
+    );
+    assert.equal(
+      route.resolveCliTypeForAgent("claude", AGENT_MAP),
+      "claude-native",
+    );
+  });
+  test("codex raw 그대로 유지", () => {
+    assert.equal(route.resolveCliTypeForAgent("executor", AGENT_MAP), "codex");
+  });
+  test("antigravity raw 그대로 유지", () => {
+    assert.equal(
+      route.resolveCliTypeForAgent("antigravity", AGENT_MAP),
+      "antigravity",
+    );
+    assert.equal(route.resolveCliTypeForAgent("agy", AGENT_MAP), "antigravity");
+  });
+  test("unknown agent throws", () => {
+    assert.throws(
+      () => route.resolveCliTypeForAgent("nope-not-real", AGENT_MAP),
+      /Unknown agent type/,
+    );
+  });
+});
+
+describe("tfx-route.mjs — buildRoutePlan (agent-map.json 전수)", () => {
+  const EXPECTED_CLI = {
+    codex: "codex",
+    gemini: "gemini",
+    claude: "claude-native",
+    antigravity: "antigravity",
+  };
+
+  for (const [agent, mappedCli] of Object.entries(AGENT_MAP)) {
+    const expectedCliType = EXPECTED_CLI[mappedCli];
+    test(`agent=${agent} → cliType=${expectedCliType}`, () => {
+      const plan = route.buildRoutePlan(
+        { agent, prompt: "hello", mcpProfile: "auto" },
+        AGENT_MAP,
+      );
+      assert.equal(plan.agent, agent);
+      assert.equal(plan.cliType, expectedCliType);
+      assert.ok(
+        typeof plan.timeoutMs === "number" && plan.timeoutMs > 0,
+        `timeoutMs invalid: ${plan.timeoutMs}`,
+      );
+      assert.ok(
+        plan.runMode === "fg" || plan.runMode === "bg",
+        `runMode invalid: ${plan.runMode}`,
+      );
+    });
+  }
+});
+
+describe("cli-codex.mjs — 핵심 매핑", () => {
+  test("executor → gpt55_high / 1080s / fg / mcp=implement", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_high");
+    assert.equal(p.profile, "gpt55_high");
+    assert.equal(p.timeoutMs, 1_080_000);
+    assert.equal(p.runMode, "fg");
+    assert.equal(p.opusOversight, false);
+    assert.equal(p.mcpProfile, "implement");
+    assert.equal(p.subcommand, "exec");
+  });
+
+  test("architect → gpt55_xhigh / 3600s / bg / opus oversight", () => {
+    const p = codexAdapter.plan({
+      agent: "architect",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_xhigh");
+    assert.equal(p.timeoutMs, 3_600_000);
+    assert.equal(p.runMode, "bg");
+    assert.equal(p.opusOversight, true);
+    assert.equal(p.mcpProfile, "analyze");
+  });
+
+  test("security-reviewer → review 서브커맨드 + opus oversight", () => {
+    const p = codexAdapter.plan({
+      agent: "security-reviewer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.subcommand, "review");
+    assert.equal(p.mcpProfile, "review");
+    assert.equal(p.opusOversight, true);
+  });
+
+  test("명시 mcpProfile 는 agent hint 를 override", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "review",
+    });
+    assert.equal(p.mcpProfile, "review");
+  });
+
+  test("명시 timeoutSec 는 agent default 를 override", () => {
+    const p = codexAdapter.plan({
+      agent: "executor",
+      prompt: "x",
+      mcpProfile: "auto",
+      timeoutSec: 30,
+    });
+    assert.equal(p.timeoutMs, 30_000);
+  });
+
+  test("미등록 agent → executor default 로 폴백", () => {
+    const p = codexAdapter.plan({
+      agent: "unmapped-future-agent",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "gpt55_high");
+    assert.equal(p.timeoutMs, 1_080_000);
+  });
+
+  test("agent 누락 시 throw", () => {
+    assert.throws(() => codexAdapter.plan({}), /agent required/);
+  });
+});
+
+describe("cli-gemini.mjs — 핵심 매핑", () => {
+  test("designer → pro31 / 900s / bg", () => {
+    const p = geminiAdapter.plan({
+      agent: "designer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "pro31");
+    assert.equal(p.timeoutMs, 900_000);
+    assert.equal(p.runMode, "bg");
+    assert.equal(p.mcpProfile, "docs");
+    assert.deepEqual(p.args, ["-m", "pro31", "-y", "--prompt"]);
+  });
+
+  test("writer → flash3", () => {
+    const p = geminiAdapter.plan({
+      agent: "writer",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.effort, "flash3");
+    assert.deepEqual(p.args, ["-m", "flash3", "-y", "--prompt"]);
+  });
+});
+
+describe("cli-claude.mjs — native (no CLI command)", () => {
+  test("explore → command=null, model=haiku", () => {
+    const p = claudeAdapter.plan({
+      agent: "explore",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.command, null);
+    assert.equal(p.model, "haiku");
+    assert.equal(p.profile, "claude-native");
+    assert.equal(p.effort, "n/a");
+    assert.equal(p.mcpProfile, null);
+    assert.match(p.note, /Claude native/);
+  });
+
+  test("verifier (override 경로) → model=sonnet, fg", () => {
+    const p = claudeAdapter.plan({
+      agent: "verifier",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.model, "sonnet");
+    assert.equal(p.runMode, "fg");
+  });
+});
+
+describe("cli-agy.mjs — stdin-pipe 계약", () => {
+  test("antigravity → stdinMode=pipe + --print --dangerously-skip-permissions", () => {
+    const p = agyAdapter.plan({
+      agent: "antigravity",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.stdinMode, "pipe");
+    assert.deepEqual(p.args, ["--print", "--dangerously-skip-permissions"]);
+    assert.equal(p.command, "agy");
+    assert.equal(p.effort, "agy_v1");
+    assert.equal(p.mcpProfile, "docs");
+  });
+
+  test("agy (alias) → 동일한 plan", () => {
+    const p = agyAdapter.plan({
+      agent: "agy",
+      prompt: "x",
+      mcpProfile: "auto",
+    });
+    assert.equal(p.stdinMode, "pipe");
+    assert.equal(p.command, "agy");
+  });
+});
+
+describe("preflightNodeVersion", () => {
+  test("v18+ 통과", () => {
+    assert.equal(route.preflightNodeVersion("18.0.0"), 18);
+    assert.equal(route.preflightNodeVersion("20.10.5"), 20);
+    assert.equal(route.preflightNodeVersion("26.0.0"), 26);
+  });
+
+  test("v16 거부", () => {
+    assert.throws(
+      () => route.preflightNodeVersion("16.20.0"),
+      /Node\.js v18\+/,
+    );
+  });
+
+  test("실행 환경 자체는 통과해야 함", () => {
+    assert.doesNotThrow(() => route.preflightNodeVersion());
+  });
+});

--- a/scripts/__tests__/tfx-route-phase1-modules.test.mjs
+++ b/scripts/__tests__/tfx-route-phase1-modules.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { registerAgent, removeAgent } from "../lib/agent-json.mjs";
+import { createJob, getJobResult, getJobStatus } from "../lib/async.mjs";
+import { buildPreflightEnv, shouldWarnGhAuth } from "../lib/env.mjs";
+import { restartHub, withHubRestart } from "../lib/hub.mjs";
+import { PidTracker } from "../lib/pid.mjs";
+import {
+  detectQuotaText,
+  getRerouteTarget,
+  QuotaStreamBuffer,
+} from "../lib/quota.mjs";
+import { claimTask, completeTask } from "../lib/team.mjs";
+import { runWithTimeout } from "../lib/timeout.mjs";
+import { resolveTmpDir } from "../lib/tmp.mjs";
+import {
+  detectTopLevelCodexConfig,
+  patchMcpApprovalMode,
+} from "../lib/toml.mjs";
+
+const SCRATCH = mkdtempSync(join(tmpdir(), "tfx-route-phase1-"));
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "../..");
+
+after(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+});
+
+describe("Phase 1 timeout/tmp/pid/env/toml modules", () => {
+  test("runWithTimeout returns exit code 124 and aborts a long process", async () => {
+    const started = Date.now();
+    const result = await runWithTimeout(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 5000)"],
+      { timeoutMs: 100 },
+    );
+
+    assert.equal(result.timedOut, true);
+    assert.equal(result.code, 124);
+    assert.ok(Date.now() - started < 2000);
+  });
+
+  test("resolveTmpDir uses os.tmpdir as the standard default and creates it", () => {
+    const dir = resolveTmpDir({ env: {}, cwd: SCRATCH });
+    assert.equal(dir, tmpdir());
+    assert.ok(existsSync(dir));
+  });
+
+  test("PidTracker records pids and cleanup tree-kills live entries", async () => {
+    const killed = [];
+    const tracker = new PidTracker(join(SCRATCH, "pids"), {
+      isAlive: (pid) => pid === 12345,
+      killTree: async (pid) => killed.push(pid),
+    });
+
+    tracker.track(12345);
+    tracker.track(99999);
+    await tracker.cleanup();
+
+    assert.deepEqual(killed, [12345]);
+    assert.equal(existsSync(join(SCRATCH, "pids")), false);
+  });
+
+  test("buildPreflightEnv preserves caller values and fills noninteractive defaults", () => {
+    const env = buildPreflightEnv({
+      GIT_TERMINAL_PROMPT: "1",
+      GH_TOKEN: "token",
+    });
+
+    assert.equal(env.GIT_TERMINAL_PROMPT, "1");
+    assert.equal(env.GIT_ASKPASS, "false");
+    assert.equal(env.npm_config_yes, "true");
+    assert.equal(
+      shouldWarnGhAuth(env, { ghExists: true, ghAuthenticated: false }),
+      false,
+    );
+    assert.equal(
+      shouldWarnGhAuth({}, { ghExists: true, ghAuthenticated: false }),
+      true,
+    );
+  });
+
+  test("patchMcpApprovalMode structurally rewrites approve and detects top-level config only", () => {
+    const source = [
+      'approval_mode = "auto"',
+      'sandbox = "danger-full-access"',
+      "",
+      "[mcp_servers.demo.tools.lookup]",
+      'approval_mode = "approve"',
+    ].join("\n");
+
+    const detection = detectTopLevelCodexConfig(source);
+    const patched = patchMcpApprovalMode(source);
+
+    assert.equal(detection.hasTopLevelSandboxOrApproval, true);
+    assert.equal(patched.changed, true);
+    assert.equal(patched.count, 1);
+    assert.match(patched.toml, /approval_mode = "full-auto"/);
+  });
+});
+
+describe("Phase 1 async/agent-json/hub/team/quota modules", () => {
+  test("async jobs use JSON state, status mapping, and result fallback", async () => {
+    const jobsDir = join(SCRATCH, "jobs");
+    const job = createJob({
+      jobsDir,
+      command: process.execPath,
+      args: ["-e", "console.log('job-ok')"],
+      timeoutMs: 5000,
+    });
+
+    let status = getJobStatus(job.id, { jobsDir });
+    assert.match(status.text, /starting|running/);
+
+    for (let i = 0; i < 20; i += 1) {
+      status = getJobStatus(job.id, { jobsDir });
+      if (status.state === "done") break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    assert.equal(status.state, "done");
+    assert.equal(getJobResult(job.id, { jobsDir }).stdout.trim(), "job-ok");
+  });
+
+  test("registerAgent writes per-process JSON and removeAgent deletes it", () => {
+    const file = registerAgent({
+      tmpDir: SCRATCH,
+      pid: 42,
+      cli: "codex",
+      agent: "executor",
+      started: 123,
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), {
+      pid: 42,
+      cli: "codex",
+      agent: "executor",
+      started: 123,
+    });
+    removeAgent({ tmpDir: SCRATCH, pid: 42 });
+    assert.equal(existsSync(file), false);
+  });
+
+  test("restartHub spawns server and polls native fetch status", async () => {
+    const calls = [];
+    const status = [false, true];
+    const result = await restartHub({
+      hubUrl: "http://127.0.0.1:4567",
+      hubServer: join(SCRATCH, "server.mjs"),
+      spawnFn: (_cmd, _args, opts) => {
+        calls.push(opts.env.TFX_HUB_PORT);
+        return { pid: 777, unref() {} };
+      },
+      fetchFn: async () => ({ ok: status.shift() }),
+      sleepMs: async () => {},
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.pid, 777);
+    assert.deepEqual(calls, ["4567"]);
+  });
+
+  test("withHubRestart retries a failing bridge call after restart", async () => {
+    let attempts = 0;
+    const result = await withHubRestart({
+      action: async () => {
+        attempts += 1;
+        return attempts === 2 ? { ok: true } : { ok: false };
+      },
+      restart: async () => ({ ok: true }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  test("team claim/complete call native bridge functions and keep local backup", async () => {
+    const calls = [];
+    const env = {
+      TFX_TEAM_NAME: "alpha",
+      TFX_TEAM_TASK_ID: "task-1",
+      TFX_TEAM_AGENT_NAME: "executor-1",
+      TFX_RESULT_DIR: join(SCRATCH, "results"),
+    };
+    const bridge = {
+      claim: async (payload) => {
+        calls.push(["claim", payload]);
+        return { ok: true };
+      },
+      complete: async (payload) => {
+        calls.push(["complete", payload]);
+        return { ok: true };
+      },
+    };
+
+    assert.equal((await claimTask({ env, bridge })).claimed, true);
+    const completion = await completeTask({
+      env,
+      bridge,
+      result: "success",
+      summary: "finished",
+      now: () => "2026-05-20T00:00:00.000Z",
+    });
+
+    assert.equal(completion.completed, true);
+    assert.deepEqual(
+      calls.map(([name]) => name),
+      ["claim", "complete"],
+    );
+    assert.equal(
+      JSON.parse(readFileSync(join(env.TFX_RESULT_DIR, "task-1.json"), "utf8"))
+        .summary,
+      "finished",
+    );
+  });
+
+  test("quota detection buffers stderr text and maps allowed reroute targets", () => {
+    const buffer = new QuotaStreamBuffer();
+    buffer.push("normal prefix ");
+    buffer.push("RESOURCE_EXHAUSTED: quota exceeded");
+
+    assert.equal(detectQuotaText(buffer.text), true);
+    assert.equal(getRerouteTarget("codex"), "antigravity");
+    assert.equal(getRerouteTarget("gemini"), "antigravity");
+    assert.equal(getRerouteTarget("antigravity"), "codex");
+    assert.equal(getRerouteTarget("claude-native"), null);
+  });
+});
+
+describe("Phase 1 node invocation surface", () => {
+  test("TFX_ROUTE_NODE=1 handles --job-status in Node lane without bash delegation", () => {
+    const jobsDir = join(SCRATCH, "cli-jobs");
+    const jobDir = join(jobsDir, "known-job");
+    mkdirSync(jobDir, { recursive: true });
+    writeFileSync(
+      join(jobDir, "state.json"),
+      JSON.stringify({ state: "done", exitCode: 0 }),
+    );
+    writeFileSync(join(jobDir, "done"), "");
+    writeFileSync(join(jobDir, "exit_code"), "0");
+    writeFileSync(join(jobDir, "result.log"), "ok\n");
+
+    const out = execFileSync(
+      "bash",
+      ["scripts/tfx-route.sh", "--job-status", "known-job"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: { ...process.env, TFX_ROUTE_NODE: "1", TFX_JOBS_DIR: jobsDir },
+      },
+    );
+
+    assert.equal(out.trim(), "done");
+  });
+});

--- a/scripts/lib/agent-json.mjs
+++ b/scripts/lib/agent-json.mjs
@@ -1,0 +1,27 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function agentJsonPath({ tmpDir, pid = process.pid }) {
+  return join(tmpDir, `tfx-agent-${pid}.json`);
+}
+
+export function registerAgent({
+  tmpDir,
+  pid = process.pid,
+  cli = "",
+  agent = "",
+  started = Math.floor(Date.now() / 1000),
+}) {
+  mkdirSync(tmpDir, { recursive: true });
+  const file = agentJsonPath({ tmpDir, pid });
+  writeFileSync(
+    file,
+    `${JSON.stringify({ pid, cli, agent, started })}\n`,
+    "utf8",
+  );
+  return file;
+}
+
+export function removeAgent({ tmpDir, pid = process.pid }) {
+  rmSync(agentJsonPath({ tmpDir, pid }), { force: true });
+}

--- a/scripts/lib/async.mjs
+++ b/scripts/lib/async.mjs
@@ -1,0 +1,174 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+function jobDir(jobsDir, jobId) {
+  return join(jobsDir, jobId);
+}
+
+function readState(dir) {
+  const path = join(dir, "state.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeState(dir, state) {
+  writeFileSync(join(dir, "state.json"), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function fileSize(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function isAlive(pid) {
+  if (!pid || pid === "starting") return false;
+  try {
+    process.kill(Number(pid), 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createJob({
+  jobsDir,
+  command,
+  args = [],
+  env = process.env,
+  cwd = process.cwd(),
+  timeoutMs = 0,
+}) {
+  mkdirSync(jobsDir, { recursive: true });
+  const id = randomUUID();
+  const dir = jobDir(jobsDir, id);
+  mkdirSync(dir, { recursive: true });
+  const startedAt = Date.now();
+  const stdoutPath = join(dir, "result.log");
+  const stderrPath = join(dir, "stderr.log");
+  writeState(dir, {
+    id,
+    state: "starting",
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  writeFileSync(join(dir, "pid"), "starting");
+  writeFileSync(join(dir, "start_time"), String(Math.floor(startedAt / 1000)));
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.unref?.();
+  writeFileSync(join(dir, "pid"), String(child.pid));
+  writeState(dir, {
+    id,
+    state: "running",
+    pid: child.pid,
+    startedAt,
+    command,
+    args,
+    timeoutMs,
+  });
+  child.stdout?.on("data", (chunk) => {
+    writeFileSync(stdoutPath, chunk, { flag: "a" });
+  });
+  child.stderr?.on("data", (chunk) => {
+    writeFileSync(stderrPath, chunk, { flag: "a" });
+  });
+  let timer = null;
+  let timedOut = false;
+  if (timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // Process already exited.
+      }
+    }, timeoutMs);
+    timer.unref?.();
+  }
+  child.on("exit", (code) => {
+    if (timer) clearTimeout(timer);
+    const exitCode = timedOut ? 124 : (code ?? 1);
+    writeFileSync(join(dir, "exit_code"), String(exitCode));
+    writeFileSync(join(dir, "done"), "");
+    writeState(dir, {
+      id,
+      state: exitCode === 0 ? "done" : exitCode === 124 ? "timeout" : "failed",
+      pid: child.pid,
+      startedAt,
+      finishedAt: Date.now(),
+      exitCode,
+      command,
+      args,
+      timeoutMs,
+    });
+  });
+
+  return { id, dir, pid: child.pid };
+}
+
+export function getJobStatus(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir))
+    return { state: "error", text: "error: job not found", exitCode: 1 };
+  const state = readState(dir);
+  if (state?.state === "done") return { ...state, text: "done" };
+  if (state?.state === "timeout") return { ...state, text: "timeout" };
+  if (state?.state === "failed") return { ...state, text: "failed" };
+  const pidText = existsSync(join(dir, "pid"))
+    ? readFileSync(join(dir, "pid"), "utf8").trim()
+    : "";
+  if (pidText === "starting")
+    return { ...(state ?? {}), state: "starting", text: "starting" };
+  if (isAlive(pidText)) {
+    const start =
+      Number(readFileSync(join(dir, "start_time"), "utf8")) ||
+      Math.floor(Date.now() / 1000);
+    const elapsed = Math.max(0, Math.floor(Date.now() / 1000) - start);
+    const bytes = fileSize(join(dir, "result.log"));
+    return {
+      ...(state ?? {}),
+      state: "running",
+      text: `running elapsed=${elapsed}s output=${bytes}B`,
+    };
+  }
+  return { ...(state ?? {}), state: "failed", text: "failed" };
+}
+
+export function getJobResult(jobId, { jobsDir }) {
+  const dir = jobDir(jobsDir, jobId);
+  if (!existsSync(dir)) throw new Error("job not found");
+  const status = getJobStatus(jobId, { jobsDir });
+  if (!["done", "timeout", "failed"].includes(status.state)) {
+    throw new Error("job still running");
+  }
+  const stdout = existsSync(join(dir, "result.log"))
+    ? readFileSync(join(dir, "result.log"), "utf8")
+    : "";
+  const stderr = existsSync(join(dir, "stderr.log"))
+    ? readFileSync(join(dir, "stderr.log"), "utf8")
+    : "";
+  return {
+    state: status.state,
+    exitCode: status.exitCode ?? 1,
+    stdout: stdout || stderr,
+    stderr,
+  };
+}

--- a/scripts/lib/cli-agy.mjs
+++ b/scripts/lib/cli-agy.mjs
@@ -1,0 +1,62 @@
+// cli-agy.mjs — Antigravity (agy) CLI adapter (Phase 0 PoC).
+//
+// 책임: agy --print 는 stdin-only 이므로 plan() 에서 stdinMode="pipe" 시그널을 반환한다.
+// positional prompt 패턴은 환영 메시지 폴백을 유발하므로 사용 금지.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1052-L1059, run_codex_exec() L2036-L2046.
+//        .claude/rules/tfx-update-logic.md Antigravity CLI 1.0.0 정밀 sanity matrix.
+
+export const id = "agy";
+export const cliType = "antigravity";
+export const command = "agy";
+
+const AGENT_PROFILES = {
+  antigravity: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  agy: {
+    profile: "agy_v1",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.antigravity;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-agy] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["--print", "--dangerously-skip-permissions"],
+    stdinMode: "pipe",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/scripts/lib/cli-claude.mjs
+++ b/scripts/lib/cli-claude.mjs
@@ -1,0 +1,78 @@
+// cli-claude.mjs — Claude native adapter (Phase 0 PoC).
+//
+// 책임: Claude 는 외부 CLI 가 아닌 Claude Code Agent 도구로 dispatch 된다. plan() 은
+// command=null 을 반환하고 호출자가 Agent() 로 라우팅하도록 신호한다.
+//
+// 출처: scripts/tfx-route.sh route_agent() L1062-L1063 (explore|claude),
+//        L1196-L1203 (TFX_CLI_MODE=gemini fallback), TFX_VERIFIER_OVERRIDE=claude.
+
+export const id = "claude";
+export const cliType = "claude-native";
+export const command = null;
+
+const AGENT_PROFILES = {
+  explore: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  claude: {
+    timeoutSec: 600,
+    runMode: "fg",
+    opusOversight: false,
+    model: "haiku",
+  },
+  "test-engineer": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  "qa-tester": {
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+  verifier: {
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    model: "sonnet",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.explore;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-claude] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: "claude-native",
+    effort: "n/a",
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    model: cfg.model,
+    mcpProfile: mcpProfile === "auto" ? null : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+    note: "Claude native — dispatched via Claude Code Agent tool, not CLI",
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/scripts/lib/cli-codex.mjs
+++ b/scripts/lib/cli-codex.mjs
@@ -1,0 +1,199 @@
+// cli-codex.mjs — Codex CLI adapter (Phase 0 PoC).
+//
+// 책임: agent 이름과 입력 파라미터를 받아 Codex 실행 계획(profile/effort/timeout/runMode)을
+// 산출한다. 실제 spawn 은 Phase 1 에서 이관된다 (현재는 tfx-route.sh 가 수행).
+//
+// 진입점: tfx-route.mjs → selectAdapter("codex") → plan({...}).
+// 출처: scripts/tfx-route.sh route_agent() L1001-L1079 case 문 미러.
+
+export const id = "codex";
+export const cliType = "codex";
+export const command = "codex";
+
+const AGENT_PROFILES = {
+  executor: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  codex: {
+    profile: "gpt55_high",
+    timeoutSec: 1080,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "build-fixer": {
+    profile: "gpt55_low",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  cleanup: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  deslop: {
+    profile: "mini54_med",
+    timeoutSec: 540,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  debugger: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "deep-executor": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "implement",
+  },
+  architect: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  critic: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  planner: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  analyst: {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "fg",
+    opusOversight: true,
+    mcpHint: "analyze",
+  },
+  "code-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "quality-reviewer": {
+    profile: "gpt55_high",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "security-reviewer": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 1800,
+    runMode: "bg",
+    opusOversight: true,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  scientist: {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "document-specialist": {
+    profile: "gpt55_high",
+    timeoutSec: 1440,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  "scientist-deep": {
+    profile: "gpt55_xhigh",
+    timeoutSec: 3600,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "analyze",
+  },
+  verifier: {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  "test-engineer": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+  "qa-tester": {
+    profile: "gpt55_high",
+    timeoutSec: 1200,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "review",
+    subcommand: "review",
+  },
+  spark: {
+    profile: "spark53_low",
+    timeoutSec: 180,
+    runMode: "fg",
+    opusOversight: false,
+    mcpHint: "implement",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.executor;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-codex] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    subcommand: cfg.subcommand ?? "exec",
+    profile: cfg.profile,
+    effort: cfg.profile,
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/scripts/lib/cli-gemini.mjs
+++ b/scripts/lib/cli-gemini.mjs
@@ -1,0 +1,67 @@
+// cli-gemini.mjs — Gemini CLI adapter (Phase 0 PoC).
+//
+// 책임: Gemini 프로파일/모델/timeout 매핑. resolve_gemini_profile() 의 결과는 Phase 1 에서
+// 통합한다 (Phase 0 은 라벨만 전달).
+//
+// 출처: scripts/tfx-route.sh route_agent() L1045-L1050.
+
+export const id = "gemini";
+export const cliType = "gemini";
+export const command = "gemini";
+
+const AGENT_PROFILES = {
+  designer: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  gemini: {
+    profile: "pro31",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+  writer: {
+    profile: "flash3",
+    timeoutSec: 900,
+    runMode: "bg",
+    opusOversight: false,
+    mcpHint: "docs",
+  },
+};
+
+const DEFAULT_PROFILE = AGENT_PROFILES.gemini;
+
+export function plan({
+  agent,
+  prompt = "",
+  mcpProfile = "auto",
+  timeoutSec,
+  contextFile,
+} = {}) {
+  if (!agent) {
+    throw new Error("[cli-gemini] agent required");
+  }
+  const cfg = AGENT_PROFILES[agent] ?? DEFAULT_PROFILE;
+  const effectiveTimeoutSec =
+    Number.isFinite(timeoutSec) && timeoutSec > 0 ? timeoutSec : cfg.timeoutSec;
+  return {
+    command,
+    profile: cfg.profile,
+    effort: cfg.profile,
+    args: ["-m", cfg.profile, "-y", "--prompt"],
+    timeoutMs: effectiveTimeoutSec * 1000,
+    runMode: cfg.runMode,
+    opusOversight: cfg.opusOversight,
+    mcpProfile: mcpProfile === "auto" ? cfg.mcpHint : mcpProfile,
+    promptLength: prompt.length,
+    contextFile: contextFile || null,
+  };
+}
+
+export function describe() {
+  return { id, cliType, command, agents: Object.keys(AGENT_PROFILES) };
+}

--- a/scripts/lib/env.mjs
+++ b/scripts/lib/env.mjs
@@ -1,0 +1,14 @@
+export function buildPreflightEnv(env = process.env) {
+  return {
+    ...env,
+    GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT ?? "0",
+    GIT_ASKPASS: env.GIT_ASKPASS ?? "false",
+    npm_config_yes: env.npm_config_yes ?? "true",
+  };
+}
+
+export function shouldWarnGhAuth(env = process.env, checks = {}) {
+  if (!checks.ghExists) return false;
+  if (env.GH_TOKEN || env.GITHUB_TOKEN) return false;
+  return checks.ghAuthenticated === false;
+}

--- a/scripts/lib/hub.mjs
+++ b/scripts/lib/hub.mjs
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+
+export function parseHubPort(hubUrl = "") {
+  try {
+    const parsed = new URL(hubUrl);
+    return parsed.port || "27888";
+  } catch {
+    return "27888";
+  }
+}
+
+export async function restartHub({
+  hubUrl = process.env.TFX_HUB_URL || "http://127.0.0.1:27888",
+  hubServer,
+  nodeBin = process.execPath,
+  spawnFn = spawn,
+  fetchFn = globalThis.fetch,
+  sleepMs = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  attempts = 8,
+} = {}) {
+  if (!hubServer) return { ok: false, error: "hub_server_missing" };
+  const port = parseHubPort(hubUrl);
+  const child = spawnFn(nodeBin, [hubServer], {
+    env: { ...process.env, TFX_HUB_PORT: port },
+    stdio: "ignore",
+    detached: true,
+  });
+  child.unref?.();
+
+  for (let i = 0; i < attempts; i += 1) {
+    await sleepMs(500);
+    try {
+      const response = await fetchFn(`${hubUrl.replace(/\/$/, "")}/status`);
+      if (response?.ok) return { ok: true, pid: child.pid };
+    } catch {
+      // Keep polling until attempts are exhausted.
+    }
+  }
+  return { ok: false, pid: child.pid };
+}
+
+export async function withHubRestart({ action, restart }) {
+  const first = await action();
+  if (first?.ok) return first;
+  const restarted = await restart();
+  if (!restarted?.ok) return first;
+  return action();
+}

--- a/scripts/lib/pid.mjs
+++ b/scripts/lib/pid.mjs
@@ -1,0 +1,63 @@
+import { appendFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let treeKill = null;
+try {
+  treeKill = require("tree-kill");
+} catch {
+  treeKill = null;
+}
+
+function defaultIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultKillTree(pid) {
+  return new Promise((resolve) => {
+    if (treeKill) {
+      treeKill(pid, "SIGTERM", () => resolve());
+      return;
+    }
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Process already exited.
+    }
+    resolve();
+  });
+}
+
+export class PidTracker {
+  constructor(path, options = {}) {
+    this.path = path;
+    this.isAlive = options.isAlive ?? defaultIsAlive;
+    this.killTree = options.killTree ?? defaultKillTree;
+  }
+
+  track(pid) {
+    if (!pid) return;
+    appendFileSync(this.path, `${pid}\n`);
+  }
+
+  list() {
+    if (!existsSync(this.path)) return [];
+    return readFileSync(this.path, "utf8")
+      .split(/\r?\n/)
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  }
+
+  async cleanup() {
+    for (const pid of this.list()) {
+      if (!this.isAlive(pid)) continue;
+      await this.killTree(pid);
+    }
+    rmSync(this.path, { force: true });
+  }
+}

--- a/scripts/lib/quota.mjs
+++ b/scripts/lib/quota.mjs
@@ -1,0 +1,47 @@
+export const QUOTA_PATTERNS = [
+  /usage limit exceeded/i,
+  /rate limit exceeded/i,
+  /rate limit reached/i,
+  /try again at/i,
+  /purchase more credits/i,
+  /quota exceeded/i,
+  /RESOURCE_EXHAUSTED/i,
+  /rateLimitExceeded/i,
+  /Too Many Requests/i,
+  /rate_limit_error/i,
+  /overloaded_error/i,
+  /insufficient_quota/i,
+];
+
+export class QuotaStreamBuffer {
+  constructor({ maxBytes = 65536 } = {}) {
+    this.maxBytes = maxBytes;
+    this.text = "";
+  }
+
+  push(chunk) {
+    this.text += Buffer.isBuffer(chunk)
+      ? chunk.toString("utf8")
+      : String(chunk);
+    if (this.text.length > this.maxBytes) {
+      this.text = this.text.slice(-this.maxBytes);
+    }
+    return detectQuotaText(this.text);
+  }
+}
+
+export function detectQuotaText(text = "") {
+  return QUOTA_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function getRerouteTarget(cliType) {
+  switch (cliType) {
+    case "codex":
+    case "gemini":
+      return "antigravity";
+    case "antigravity":
+      return "codex";
+    default:
+      return null;
+  }
+}

--- a/scripts/lib/team.mjs
+++ b/scripts/lib/team.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function teamContext(env) {
+  const team = env.TFX_TEAM_NAME || "";
+  const taskId = env.TFX_TEAM_TASK_ID || "";
+  if (!team || !taskId) return null;
+  return {
+    team,
+    taskId,
+    agent: env.TFX_TEAM_AGENT_NAME || "agent",
+    lead: env.TFX_TEAM_LEAD_NAME || "team-lead",
+  };
+}
+
+export async function claimTask({ env = process.env, bridge } = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const response = await bridge.claim({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    owner: ctx.agent,
+    status: "in_progress",
+  });
+  if (response?.ok) return { claimed: true };
+  const code = response?.error?.code;
+  const before = response?.error?.details?.task_before ?? {};
+  if (
+    code === "CLAIM_CONFLICT" &&
+    before.owner === ctx.agent &&
+    before.status === "in_progress"
+  ) {
+    return { claimed: true, alreadyClaimed: true };
+  }
+  if (code === "CLAIM_CONFLICT") {
+    return { claimed: false, conflict: true, owner: before.owner ?? null };
+  }
+  return { claimed: false, error: response?.error ?? null };
+}
+
+export async function completeTask({
+  env = process.env,
+  bridge,
+  result = "success",
+  summary = "작업 완료",
+  now = () => new Date().toISOString(),
+} = {}) {
+  const ctx = teamContext(env);
+  if (!ctx) return { skipped: true };
+  const trimmed = String(summary).slice(0, 4096);
+  const response = await bridge.complete({
+    team: ctx.team,
+    taskId: ctx.taskId,
+    agent: ctx.agent,
+    result,
+    summary: trimmed,
+  });
+
+  const resultDir =
+    env.TFX_RESULT_DIR ||
+    join(process.env.HOME || ".", ".claude", "tfx-results", ctx.team);
+  mkdirSync(resultDir, { recursive: true });
+  writeFileSync(
+    join(resultDir, `${ctx.taskId}.json`),
+    `${JSON.stringify({
+      taskId: ctx.taskId,
+      agent: ctx.agent,
+      team: ctx.team,
+      result,
+      summary: trimmed,
+      timestamp: now(),
+    })}\n`,
+  );
+  return { completed: Boolean(response?.ok), response };
+}

--- a/scripts/lib/timeout.mjs
+++ b/scripts/lib/timeout.mjs
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+
+export function timeoutCodeForSignal(signal) {
+  return signal ? 124 : null;
+}
+
+export function runWithTimeout(command, args = [], options = {}) {
+  const {
+    cwd = process.cwd(),
+    env = process.env,
+    input,
+    timeoutMs = 0,
+    stdio = "pipe",
+    spawnFn = spawn,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    let timedOut = false;
+    const child = spawnFn(command, args, {
+      cwd,
+      env,
+      stdio,
+      signal: controller.signal,
+    });
+    const stdout = [];
+    const stderr = [];
+    let timer = null;
+
+    if (child.stdout) child.stdout.on("data", (chunk) => stdout.push(chunk));
+    if (child.stderr) child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", (err) => {
+      if (timedOut && err.name === "AbortError") return;
+      reject(err);
+    });
+    child.on("exit", (code, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        code: timedOut ? 124 : (code ?? timeoutCodeForSignal(signal) ?? 1),
+        signal,
+        timedOut,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        if (child.pid) {
+          try {
+            process.kill(child.pid, "SIGTERM");
+          } catch {
+            // Process already exited.
+          }
+        }
+      }, timeoutMs);
+      timer.unref?.();
+    }
+
+    if (input !== undefined && child.stdin) {
+      child.stdin.end(input);
+    }
+  });
+}

--- a/scripts/lib/tmp.mjs
+++ b/scripts/lib/tmp.mjs
@@ -1,0 +1,26 @@
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function resolveTmpDir({ env = process.env, cwd = process.cwd() } = {}) {
+  const candidate = env.TFX_TMP || tmpdir();
+  try {
+    mkdirSync(candidate, { recursive: true });
+    return candidate;
+  } catch {
+    const fallback = join(cwd, ".tfx-tmp");
+    try {
+      mkdirSync(fallback, { recursive: true });
+    } catch {
+      // Bash printed the fallback path even when mkdir failed.
+    }
+    return fallback;
+  }
+}
+
+export function resolveJobsDir({
+  env = process.env,
+  tmpDir = resolveTmpDir({ env }),
+} = {}) {
+  return env.TFX_JOBS_DIR || join(tmpDir, "tfx-jobs");
+}

--- a/scripts/lib/toml.mjs
+++ b/scripts/lib/toml.mjs
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let TOML = null;
+try {
+  TOML = require("@iarna/toml");
+} catch {
+  TOML = null;
+}
+
+function walk(value, visitor) {
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    visitor(value, key, child);
+    walk(child, visitor);
+  }
+}
+
+export function parseToml(source) {
+  if (!TOML) return parseTomlFallback(source);
+  return TOML.parse(source || "");
+}
+
+export function stringifyToml(value) {
+  if (!TOML) return stringifyTomlFallback(value);
+  return TOML.stringify(value);
+}
+
+function parseTomlFallback(source = "") {
+  const root = {};
+  let current = root;
+  for (const rawLine of String(source).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const section = line.match(/^\[([^\]]+)\]$/);
+    if (section) {
+      current = root;
+      for (const part of section[1].split(".")) {
+        current[part] ??= {};
+        current = current[part];
+      }
+      continue;
+    }
+    const assignment = line.match(/^([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"$/);
+    if (assignment) {
+      current[assignment[1]] = assignment[2];
+    }
+  }
+  return root;
+}
+
+function stringifyTomlFallback(value) {
+  const lines = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (child && typeof child === "object") continue;
+    lines.push(`${key} = "${String(child)}"`);
+  }
+  function writeSections(prefix, obj) {
+    for (const [key, child] of Object.entries(obj)) {
+      if (!child || typeof child !== "object") continue;
+      const section = [...prefix, key];
+      lines.push("", `[${section.join(".")}]`);
+      for (const [childKey, childValue] of Object.entries(child)) {
+        if (childValue && typeof childValue === "object") continue;
+        lines.push(`${childKey} = "${String(childValue)}"`);
+      }
+      writeSections(section, child);
+    }
+  }
+  writeSections([], value);
+  return `${lines.join("\n")}\n`;
+}
+
+export function detectTopLevelCodexConfig(source) {
+  const parsed = parseToml(source);
+  return {
+    hasTopLevelSandboxOrApproval:
+      Object.hasOwn(parsed, "sandbox") ||
+      Object.hasOwn(parsed, "approval_mode"),
+  };
+}
+
+export function patchMcpApprovalMode(source) {
+  const parsed = parseToml(source);
+  let count = 0;
+  walk(parsed.mcp_servers, (parent, key, value) => {
+    if (key === "approval_mode" && value === "approve") {
+      parent[key] = "full-auto";
+      count += 1;
+    }
+  });
+  return {
+    changed: count > 0,
+    count,
+    toml: count > 0 ? stringifyToml(parsed) : source,
+  };
+}
+
+export function patchCodexConfigFile(path, { now = () => new Date() } = {}) {
+  if (!path || !existsSync(path)) return { changed: false, count: 0 };
+  const source = readFileSync(path, "utf8");
+  const patched = patchMcpApprovalMode(source);
+  if (!patched.changed) return patched;
+  const stamp = now()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..*$/, "")
+    .replace("T", "-");
+  writeFileSync(`${path}.bak-${stamp}`, source);
+  writeFileSync(path, patched.toml);
+  return patched;
+}

--- a/scripts/tfx-route.mjs
+++ b/scripts/tfx-route.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+// tfx-route.mjs — Node 단일 진입점 (Phase 1).
+//
+// 외부 인터페이스는 tfx-route.sh 와 동일한 positional 인자 (agent, prompt, [mcp], [timeout],
+// [context]) + 동일한 플래그 (--async, --job-status, --job-result, --version). Phase 0 는
+// 라우팅 결정 (agent → CLI 타입 → adapter plan) 만 Node 에서 수행하고, 실제 spawn 은
+// TFX_ROUTE_NODE_BYPASS=1 로 tfx-route.sh 를 재호출하여 위임한다.
+//
+// 활성화: TFX_ROUTE_NODE=1 환경변수가 설정되면 tfx-route.sh 의 게이트웨이가 이 파일로
+// exec 한다 (.triflux/plans/node-cli-single-entry-migration.md Phase 0).
+//
+// Phase 1 부터 timeout/TMP/PID/Async/Quota 등 16개 책임을 직접 흡수한다.
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createJob, getJobResult, getJobStatus } from "./lib/async.mjs";
+import * as agyAdapter from "./lib/cli-agy.mjs";
+import * as claudeAdapter from "./lib/cli-claude.mjs";
+import * as codexAdapter from "./lib/cli-codex.mjs";
+import * as geminiAdapter from "./lib/cli-gemini.mjs";
+import { buildPreflightEnv } from "./lib/env.mjs";
+import { resolveJobsDir, resolveTmpDir } from "./lib/tmp.mjs";
+import { patchCodexConfigFile } from "./lib/toml.mjs";
+
+export const MJS_VERSION = "0.2.0-phase1";
+const MIN_NODE_MAJOR = 18;
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const AGENT_MAP_PATH = join(REPO_ROOT, "hub/team/agent-map.json");
+
+const ADAPTERS = {
+  codex: codexAdapter,
+  gemini: geminiAdapter,
+  claude: claudeAdapter,
+  "claude-native": claudeAdapter,
+  antigravity: agyAdapter,
+  agy: agyAdapter,
+};
+
+export function preflightNodeVersion(versionString = process.versions.node) {
+  const major = Number(versionString.split(".")[0]);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    throw new Error(
+      `Node.js v${MIN_NODE_MAJOR}+ required (current: v${versionString})`,
+    );
+  }
+  return major;
+}
+
+export function loadAgentMap(path = AGENT_MAP_PATH) {
+  if (!existsSync(path)) {
+    throw new Error(`agent-map.json not found at ${path}`);
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function resolveCliTypeForAgent(agent, agentMap) {
+  const raw = agentMap[agent];
+  if (!raw) {
+    throw new Error(`Unknown agent type: ${agent}`);
+  }
+  return raw === "claude" ? "claude-native" : raw;
+}
+
+export function selectAdapter(cliType) {
+  const adapter = ADAPTERS[cliType];
+  if (!adapter) {
+    throw new Error(`No adapter registered for CLI type: ${cliType}`);
+  }
+  return adapter;
+}
+
+export function parseArgs(argv) {
+  const args = [...argv];
+  const result = { mode: "run", dryRun: false };
+
+  // -h shorthand 는 short-flag 라 아래 `--` while 루프에 안 잡힌다.
+  if (args[0] === "-h") {
+    return { ...result, mode: "help" };
+  }
+
+  while (args.length > 0 && args[0].startsWith("--")) {
+    const flag = args.shift();
+    switch (flag) {
+      case "--version":
+        return { ...result, mode: "version" };
+      case "--help":
+        return { ...result, mode: "help" };
+      case "--async":
+        result.mode = "async";
+        break;
+      case "--job-status":
+        return { ...result, mode: "job-status", jobId: args.shift() };
+      case "--job-result":
+        return { ...result, mode: "job-result", jobId: args.shift() };
+      case "--route-print":
+        result.mode = "route-print";
+        result.dryRun = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  if (result.mode === "version" || result.mode === "help") {
+    return result;
+  }
+
+  const [
+    agent,
+    prompt,
+    mcpProfile = "auto",
+    timeoutRaw = "",
+    contextFile = "",
+  ] = args;
+
+  if (!agent) {
+    throw new Error("Agent type required (executor, debugger, designer, ...)");
+  }
+  if (prompt === undefined || prompt === null) {
+    throw new Error("Prompt required");
+  }
+  if (mcpProfile.startsWith("--")) {
+    throw new Error(`MCP profile (3rd arg) cannot be a flag: ${mcpProfile}`);
+  }
+
+  const timeoutSec = timeoutRaw === "" ? undefined : Number(timeoutRaw);
+  if (timeoutRaw !== "" && !Number.isFinite(timeoutSec)) {
+    throw new Error(`timeout_sec must be numeric, got: ${timeoutRaw}`);
+  }
+
+  return {
+    ...result,
+    agent,
+    prompt,
+    mcpProfile,
+    timeoutSec,
+    contextFile: contextFile || undefined,
+  };
+}
+
+export function buildRoutePlan(request, agentMap) {
+  const cliType = resolveCliTypeForAgent(request.agent, agentMap);
+  const adapter = selectAdapter(cliType);
+  const adapterPlan = adapter.plan({
+    agent: request.agent,
+    prompt: request.prompt ?? "",
+    mcpProfile: request.mcpProfile ?? "auto",
+    timeoutSec: request.timeoutSec,
+    contextFile: request.contextFile,
+  });
+  return {
+    agent: request.agent,
+    cliType,
+    adapter: adapter.id,
+    ...adapterPlan,
+  };
+}
+
+function helpText() {
+  return [
+    `tfx-route.mjs ${MJS_VERSION} — Phase 0 PoC (Node single entry)`,
+    "",
+    "Usage:",
+    "  tfx-route.mjs <agent_type> <prompt> [mcp_profile] [timeout_sec] [context_file]",
+    "  tfx-route.mjs --async <agent_type> <prompt> [mcp_profile] [timeout_sec] [context_file]",
+    "  tfx-route.mjs --job-status <job_id>",
+    "  tfx-route.mjs --job-result <job_id>",
+    "  tfx-route.mjs --route-print <agent_type> <prompt> ...   (dry-run, prints JSON plan)",
+    "  tfx-route.mjs --version",
+    "",
+    "Phase 1: cross-cutting process concerns live in Node; detailed CLI dispatch",
+    "is still delegated to tfx-route.sh until Phase 2.",
+    "",
+  ].join("\n");
+}
+
+function delegateToBash(argv) {
+  const bashScript = join(SCRIPT_DIR, "tfx-route.sh");
+  if (!existsSync(bashScript)) {
+    process.stderr.write(
+      `[tfx-route.mjs] bash entry not found at ${bashScript}\n`,
+    );
+    process.exit(2);
+  }
+  const env = { ...process.env, TFX_ROUTE_NODE_BYPASS: "1" };
+  const child = spawn("bash", [bashScript, ...argv], {
+    stdio: "inherit",
+    env,
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      try {
+        process.kill(process.pid, signal);
+      } catch {
+        process.exit(1);
+      }
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+  child.on("error", (err) => {
+    process.stderr.write(
+      `[tfx-route.mjs] bash delegate failed: ${err.message}\n`,
+    );
+    process.exit(1);
+  });
+}
+
+async function main(argv) {
+  preflightNodeVersion();
+  const request = parseArgs(argv);
+
+  if (request.mode === "version") {
+    process.stdout.write(`tfx-route.mjs ${MJS_VERSION}\n`);
+    return;
+  }
+  if (request.mode === "help") {
+    process.stdout.write(helpText());
+    return;
+  }
+
+  if (request.mode === "job-status" || request.mode === "job-result") {
+    const tmpDir = resolveTmpDir();
+    const jobsDir = resolveJobsDir({ tmpDir });
+    if (!request.jobId) {
+      throw new Error("job_id required");
+    }
+    if (request.mode === "job-status") {
+      const status = getJobStatus(request.jobId, { jobsDir });
+      process.stdout.write(`${status.text}\n`);
+      if (status.state === "error") process.exit(1);
+      return;
+    }
+    const result = getJobResult(request.jobId, { jobsDir });
+    process.stdout.write(result.stdout);
+    process.exitCode = result.exitCode;
+    return;
+  }
+
+  if (request.mode === "async") {
+    const tmpDir = resolveTmpDir();
+    const jobsDir = resolveJobsDir({ tmpDir });
+    const childArgv = argv.filter((arg) => arg !== "--async");
+    const job = createJob({
+      jobsDir,
+      command: process.execPath,
+      args: [fileURLToPath(import.meta.url), ...childArgv],
+      env: { ...buildPreflightEnv(process.env), TFX_ROUTE_NODE: "1" },
+      cwd: process.cwd(),
+      timeoutMs: request.timeoutSec ? request.timeoutSec * 1000 : 0,
+    });
+    process.stdout.write(`${job.id}\n`);
+    return;
+  }
+
+  const agentMap = loadAgentMap();
+  const plan = buildRoutePlan(request, agentMap);
+
+  if (request.mode === "route-print") {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return;
+  }
+
+  patchCodexConfigFile(join(homedir(), ".codex", "config.toml"));
+
+  process.stderr.write(
+    `[tfx-route.mjs] Phase 1: agent=${plan.agent} cli=${plan.cliType} effort=${plan.effort} — bash lane retained for CLI dispatch\n`,
+  );
+  delegateToBash(argv);
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`[tfx-route.mjs] ${err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -27,6 +27,14 @@ VERSION="2.7"
 #   tfx-route.sh --job-status 1742400000-12345-9876
 #   tfx-route.sh --job-result 1742400000-12345-9876
 
+# ── Phase 0 PoC: Node single-entry gateway ──
+# TFX_ROUTE_NODE=1 일 때 scripts/tfx-route.mjs 로 exec. Node 진입점이 다시 이 스크립트를
+# 호출할 때는 TFX_ROUTE_NODE_BYPASS=1 을 세팅해 무한 루프를 방지한다.
+# PRD: .triflux/plans/node-cli-single-entry-migration.md (Phase 0).
+if [ "${TFX_ROUTE_NODE:-0}" = "1" ] && [ "${TFX_ROUTE_NODE_BYPASS:-0}" != "1" ]; then
+  exec node "$(dirname "$0")/tfx-route.mjs" "$@"
+fi
+
 set -euo pipefail
 
 # ── timeout 명령 호환성 — Windows에서 TIMEOUT.exe 대신 Git Bash coreutils timeout 사용 ──


### PR DESCRIPTION
## Summary
- Phase 0 PoC: scripts/tfx-route.mjs Node single entry + 4 CLI adapters (cli-codex/gemini/claude/agy.mjs) + bash gateway via TFX_ROUTE_NODE=1
- Phase 1: 10 cross-cutting responsibility modules (timeout / tmp / pid / env / toml / async / agent-json / hub / team / quota)
- Bash/Node parallel-lane operation: TFX_ROUTE_NODE=1 hands off to Node entry, TFX_ROUTE_NODE_BYPASS=1 delegates execution back to bash
- packages/core + packages/triflux mirror byte-identical per .claude/rules/tfx-mirror-policy.md

PRD: .triflux/plans/node-cli-single-entry-migration.md (Phase 0 + Phase 1; Phase 2/3 follow-up)

## Validation
- 358 targeted tests pass (Phase 0 route + Phase 1 lib modules + bash/node parity)
- biome lint 660 files: No fixes applied
- release:check-mirror + check-sync (v10.24.0) pass
- npm test root: existing unrelated failures (Node 26 + better-sqlite3 engine mismatch, pre-existing bridge/store/pipeline/reflexion)