### PR TITLE
fix(mcp): include secrets.env in mcp-gateway-startup wrapper sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to triflux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fix(mcp)`** `install-mcp-gateway-startup.mjs` 의 wrapper sourcing 목록과 systemd `EnvironmentFile` 목록에 `~/.config/triflux/secrets.env` 추가. 기존 `mcp-gateway.env` 후보 3개는 legacy 호환으로 유지. triflux 표준 secrets 파일이 wrapper 에 누락되어 있어 BRAVE_API_KEY 등이 주입되지 않고 supergateway 가 brave-search 를 `[WARN] missing env` 로 skip 하던 회귀 해결. usage 문구도 동기 갱신. 본체/`packages/triflux` mirror 와 테스트(`scripts/__tests__/install-mcp-gateway-startup.test.mjs`) 모두 동기.
+
 ## [10.25.0] - 2026-05-21
 
 ### Added

--- a/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -248,6 +248,10 @@ describe("install mcp gateway startup", () => {
     assert.equal(result.verified, true);
     assert.match(
       fs.files.get(unitPath),
+      /EnvironmentFile=-%h\/\.config\/triflux\/secrets\.env/,
+    );
+    assert.match(
+      fs.files.get(unitPath),
       /EnvironmentFile=-%h\/\.config\/triflux\/mcp-gateway\.env/,
     );
     assert.match(

--- a/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -124,6 +124,23 @@ describe("install mcp gateway startup", () => {
     assert.match(fs.files.get(plistPath), /mcp-gateway-wrapper\.sh/);
     assert.doesNotMatch(fs.files.get(plistPath), /API_KEY|TOKEN|SECRET/);
     assert.match(fs.files.get(wrapperPath), /mcp-gateway\.env/);
+    // Codex cross-review (PR #312): Darwin wrapper 도 Linux EnvironmentFile assertion
+    // 처럼 secrets.env 명시 검증 + sourcing 순서 (secrets.env → legacy mcp-gateway.env) 고정.
+    assert.match(
+      fs.files.get(wrapperPath),
+      /\$HOME\/\.config\/triflux\/secrets\.env/,
+    );
+    {
+      const body = fs.files.get(wrapperPath);
+      const secretsIdx = body.indexOf("$HOME/.config/triflux/secrets.env");
+      const legacyIdx = body.indexOf("$HOME/.config/triflux/mcp-gateway.env");
+      assert.ok(secretsIdx >= 0, "secrets.env 가 wrapper sourcing 목록에 있어야 한다");
+      assert.ok(legacyIdx >= 0, "legacy mcp-gateway.env 도 호환 유지");
+      assert.ok(
+        secretsIdx < legacyIdx,
+        "secrets.env 가 legacy mcp-gateway.env 보다 먼저 sourcing 되어야 한다",
+      );
+    }
     assert.match(
       fs.files.get(wrapperPath),
       /exec '\/usr\/local\/bin\/node' '\/repo\/scripts\/mcp-gateway-start\.mjs'/,

--- a/packages/triflux/scripts/install-mcp-gateway-startup.mjs
+++ b/packages/triflux/scripts/install-mcp-gateway-startup.mjs
@@ -164,7 +164,7 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-for env_file in "$HOME/.config/triflux/mcp-gateway.env" "$HOME/.config/tfx/mcp-gateway.env" "$HOME/.mcp-gateway.env"; do
+for env_file in "$HOME/.config/triflux/secrets.env" "$HOME/.config/triflux/mcp-gateway.env" "$HOME/.config/tfx/mcp-gateway.env" "$HOME/.mcp-gateway.env"; do
   if [ -f "$env_file" ]; then
     set -a
     . "$env_file"
@@ -366,6 +366,7 @@ After=network-online.target
 Type=simple
 WorkingDirectory=${systemdQuote(projectRoot)}
 Environment=PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+EnvironmentFile=-%h/.config/triflux/secrets.env
 EnvironmentFile=-%h/.config/triflux/mcp-gateway.env
 EnvironmentFile=-%h/.config/tfx/mcp-gateway.env
 EnvironmentFile=-%h/.mcp-gateway.env
@@ -423,6 +424,7 @@ function usage(stdout) {
 Register scripts/mcp-gateway-start.mjs with the current OS startup mechanism.
 
 Secrets are read by the startup process from one of:
+  ~/.config/triflux/secrets.env
   ~/.config/triflux/mcp-gateway.env
   ~/.config/tfx/mcp-gateway.env
   ~/.mcp-gateway.env

--- a/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -248,6 +248,10 @@ describe("install mcp gateway startup", () => {
     assert.equal(result.verified, true);
     assert.match(
       fs.files.get(unitPath),
+      /EnvironmentFile=-%h\/\.config\/triflux\/secrets\.env/,
+    );
+    assert.match(
+      fs.files.get(unitPath),
       /EnvironmentFile=-%h\/\.config\/triflux\/mcp-gateway\.env/,
     );
     assert.match(

--- a/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -124,6 +124,23 @@ describe("install mcp gateway startup", () => {
     assert.match(fs.files.get(plistPath), /mcp-gateway-wrapper\.sh/);
     assert.doesNotMatch(fs.files.get(plistPath), /API_KEY|TOKEN|SECRET/);
     assert.match(fs.files.get(wrapperPath), /mcp-gateway\.env/);
+    // Codex cross-review (PR #312): Darwin wrapper 도 Linux EnvironmentFile assertion
+    // 처럼 secrets.env 명시 검증 + sourcing 순서 (secrets.env → legacy mcp-gateway.env) 고정.
+    assert.match(
+      fs.files.get(wrapperPath),
+      /\$HOME\/\.config\/triflux\/secrets\.env/,
+    );
+    {
+      const body = fs.files.get(wrapperPath);
+      const secretsIdx = body.indexOf("$HOME/.config/triflux/secrets.env");
+      const legacyIdx = body.indexOf("$HOME/.config/triflux/mcp-gateway.env");
+      assert.ok(secretsIdx >= 0, "secrets.env 가 wrapper sourcing 목록에 있어야 한다");
+      assert.ok(legacyIdx >= 0, "legacy mcp-gateway.env 도 호환 유지");
+      assert.ok(
+        secretsIdx < legacyIdx,
+        "secrets.env 가 legacy mcp-gateway.env 보다 먼저 sourcing 되어야 한다",
+      );
+    }
     assert.match(
       fs.files.get(wrapperPath),
       /exec '\/usr\/local\/bin\/node' '\/repo\/scripts\/mcp-gateway-start\.mjs'/,

--- a/scripts/install-mcp-gateway-startup.mjs
+++ b/scripts/install-mcp-gateway-startup.mjs
@@ -164,7 +164,7 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-for env_file in "$HOME/.config/triflux/mcp-gateway.env" "$HOME/.config/tfx/mcp-gateway.env" "$HOME/.mcp-gateway.env"; do
+for env_file in "$HOME/.config/triflux/secrets.env" "$HOME/.config/triflux/mcp-gateway.env" "$HOME/.config/tfx/mcp-gateway.env" "$HOME/.mcp-gateway.env"; do
   if [ -f "$env_file" ]; then
     set -a
     . "$env_file"
@@ -366,6 +366,7 @@ After=network-online.target
 Type=simple
 WorkingDirectory=${systemdQuote(projectRoot)}
 Environment=PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+EnvironmentFile=-%h/.config/triflux/secrets.env
 EnvironmentFile=-%h/.config/triflux/mcp-gateway.env
 EnvironmentFile=-%h/.config/tfx/mcp-gateway.env
 EnvironmentFile=-%h/.mcp-gateway.env
@@ -423,6 +424,7 @@ function usage(stdout) {
 Register scripts/mcp-gateway-start.mjs with the current OS startup mechanism.
 
 Secrets are read by the startup process from one of:
+  ~/.config/triflux/secrets.env
   ~/.config/triflux/mcp-gateway.env
   ~/.config/tfx/mcp-gateway.env
   ~/.mcp-gateway.env


### PR DESCRIPTION
## Summary

- `install-mcp-gateway-startup.mjs` 가 만드는 LaunchAgent/systemd wrapper 의 sourcing 목록에 triflux 표준 secrets 파일인 `~/.config/triflux/secrets.env` 가 누락되어 있었음. 기존 후보 3 개 (`mcp-gateway.env` 변형) 만 존재.
- 결과: 부팅 후 wrapper 가 BRAVE_API_KEY · TAVILY_API_KEY · EXA_API_KEY 를 주입하지 못해 supergateway 가 brave-search 를 `[WARN] missing env` 로 skip → 클라이언트 (`codex`, `claude`, `gemini`) 가 brave-search MCP 미응답.
- Fix: sourcing 목록 맨 앞에 `~/.config/triflux/secrets.env` 추가 (wrapper · systemd unit · usage 문구 3 위치). 기존 `mcp-gateway.env` 후보는 legacy 호환으로 유지. 본체와 `packages/triflux` mirror byte-identical + 테스트 assertion 보강.

## 발견 경위

세션 시작 시 codex 가 다음 에러 출력:

```
⚠ MCP client for `brave-search` failed to start: ... port 8101
⚠ MCP client for `serena` failed to start: ... port 8105
⚠ The tavily MCP server is not logged in.
```

진단:
- `~/.local/state/triflux/mcp-gateway.out.log` 에 `[WARN] brave-search skipped — missing env: BRAVE_API_KEY`
- wrapper 코드 (`scripts/install-mcp-gateway-startup.mjs:167`) 가 sourcing 하는 파일 목록에 `secrets.env` 가 없음
- 실제 secrets 는 `~/.config/triflux/secrets.env` 에 있음 (mode 600, EXA/BRAVE/TAVILY_API_KEY 정상)

회피용 임시 조치 (이번 PR 의 정공 root fix 와 동일 효과): 사용자 머신에 `ln -sf secrets.env mcp-gateway.env` symlink. 같은 PR 패치 적용 후엔 symlink 불필요.

## Test plan

- [x] `node --test scripts/__tests__/install-mcp-gateway-startup.test.mjs` (9/9 pass, secrets.env assertion 추가됨)
- [x] `node --test packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs` (9/9 pass, mirror)
- [x] `npm run release:check-mirror` (Mirror OK — packages/triflux matches root)
- [x] `npm run release:check-sync` (Version sync OK 10.25.0)
- [x] 실제 머신에서 wrapper 가 secrets.env source 시 brave-search :8101 healthy (`curl :8101/healthz` → `ok`)
- [x] `mcp-gateway-verify.mjs`: context7 :8100 ✓, brave-search :8101 ✓, serena :8105 ✓

## Scope

- 사용자 사이드 영향 없음. 기존 `mcp-gateway.env` 후보 3 개는 유지되어 호환성 유지.
- macOS LaunchAgent wrapper · Linux systemd EnvironmentFile · `--help` usage 문구 3 위치 모두 적용.
- `packages/triflux/` mirror byte-identical 동기 (`.claude/rules/tfx-mirror-policy.md` 준수).