### PR TITLE
feat(doctor): add MCP Gateway Health diagnostic to tfx doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to triflux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`feat(doctor)`** `tfx doctor` 에 "MCP Gateway Health" 진단 섹션 추가. `~/.local/state/triflux/mcp-gateway.out.log` 를 파싱해 `[WARN] X skipped — missing env: Y` 패턴으로 skip 된 server 를 잡고, 같은 server 의 [START]/[SKIP-running] 이 더 최근이면 복구된 것으로 인식 (false-positive 회피). missing key 발견 시 `secrets.env` + `launchctl kickstart` 또는 `systemctl --user restart` 수정 힌트를 노출. 로그 파일이 없으면 gateway 미설치/미실행으로 침묵. `scripts/lib/mcp-gateway-health-check.mjs` 단위 테스트 8건. `packages/core` + `packages/triflux` mirror byte-identical 동기.
+
 ### Fixed
 
 - **`fix(mcp)`** `install-mcp-gateway-startup.mjs` 의 wrapper sourcing 목록과 systemd `EnvironmentFile` 목록에 `~/.config/triflux/secrets.env` 추가. 기존 `mcp-gateway.env` 후보 3개는 legacy 호환으로 유지. triflux 표준 secrets 파일이 wrapper 에 누락되어 있어 BRAVE_API_KEY 등이 주입되지 않고 supergateway 가 brave-search 를 `[WARN] missing env` 로 skip 하던 회귀 해결. usage 문구도 동기 갱신. 본체/`packages/triflux` mirror 와 테스트(`scripts/__tests__/install-mcp-gateway-startup.test.mjs`) 모두 동기.

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -4670,6 +4670,37 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // ── MCP Gateway Health ──
+    // install-mcp-gateway-startup 으로 띄운 LaunchAgent/systemd daemon 의 stdout
+    // (~/.local/state/triflux/mcp-gateway.out.log) 를 파싱해 missing-env 등으로
+    // skip 된 server 를 잡는다. 로그가 없으면 gateway 미설치/미실행으로 침묵.
+    section("MCP Gateway Health");
+    {
+      const { checkMcpGatewayHealth, summarizeMcpGatewayHealth } = await import(
+        "../scripts/lib/mcp-gateway-health-check.mjs"
+      );
+      const gatewayHealth = checkMcpGatewayHealth();
+      const summary = summarizeMcpGatewayHealth(gatewayHealth);
+      addDoctorCheck(report, {
+        name: "mcp-gateway-health",
+        status: summary.level === "warn" ? "warning" : "ok",
+        log_path: gatewayHealth.logPath,
+        findings: gatewayHealth.findings,
+        started: gatewayHealth.started,
+        skipped: gatewayHealth.skipped,
+        ...(summary.fix ? { fix: summary.fix } : {}),
+      });
+      if (summary.level === "skip") {
+        info(summary.message);
+      } else if (summary.level === "ok") {
+        ok(summary.message);
+      } else {
+        warn(summary.message);
+        if (summary.fix) info(`수정: ${summary.fix}`);
+        issues++;
+      }
+    }
+
     // ── Codex Config Health (BUG-H #132) ──
     // _codex_config_swap 의 restore 가 Windows lock/ACL 로 실패하면
     // ~/.codex/config.toml.pre-exec 가 남아 [mcp_servers.*] 섹션이 영구 손실된다.

--- a/packages/core/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-health-check.mjs
@@ -1,0 +1,159 @@
+// scripts/lib/mcp-gateway-health-check.mjs
+//
+// `~/.local/state/triflux/mcp-gateway.out.log` 파싱 헬퍼.
+// install-mcp-gateway-startup.mjs 가 LaunchAgent/systemd 로 띄운 gateway daemon
+// (mcp-gateway-start.mjs) 의 stdout 로그에서 다음 신호를 추출한다.
+//
+//   [WARN] <server> skipped — missing env: <KEY>   → missing-env finding
+//   [START] <server> on :<port>                    → started
+//   [SKIP]  <server> already running on :<port>    → started (preExisting)
+//   [SKIP]  <server> — manifest에서 비활성         → manifest-disabled skip
+//
+// 호출자는 `findings` 만 보고 doctor 진단을 출력할 수 있다.
+// log 파일이 없으면 `available: false` 로 반환하므로, gateway 미설치 환경에서는
+// 침묵한다 (false-positive 방지).
+
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_LOG_PATH = join(
+  homedir(),
+  ".local",
+  "state",
+  "triflux",
+  "mcp-gateway.out.log",
+);
+
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
+const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
+const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+export function checkMcpGatewayHealth({
+  fs = { readFileSync, statSync },
+  logPath = DEFAULT_LOG_PATH,
+} = {}) {
+  try {
+    fs.statSync(logPath);
+  } catch {
+    return {
+      available: false,
+      logPath,
+      findings: [],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  let text;
+  try {
+    text = fs.readFileSync(logPath, "utf8");
+  } catch (error) {
+    return {
+      available: true,
+      logPath,
+      findings: [
+        {
+          server: null,
+          reason: "log-read-error",
+          detail: error?.message || String(error),
+        },
+      ],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  // log 는 append-only 라 옛 [WARN] 라인 뒤에 새 [START] 라인이 올 수 있다.
+  // server 별 마지막 이벤트가 현재 상태이므로 그것만 finding 으로 환원한다.
+  // (예: BRAVE_API_KEY missing 으로 한 번 skip → secrets 추가 후 restart 로 start)
+  const lastEvent = new Map();
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    let m;
+    if ((m = MISSING_ENV_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "missing-env",
+        detail: m[2],
+      });
+      continue;
+    }
+    if ((m = START_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: false,
+      });
+      continue;
+    }
+    if ((m = SKIP_RUNNING_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: true,
+      });
+      continue;
+    }
+    if ((m = SKIP_DISABLED_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "manifest-disabled",
+      });
+      continue;
+    }
+  }
+
+  const findings = [];
+  const started = [];
+  const skipped = [];
+  for (const [server, ev] of lastEvent) {
+    if (ev.type === "missing-env") {
+      findings.push({ server, reason: "missing-env", detail: ev.detail });
+    } else if (ev.type === "started") {
+      started.push({ server, port: ev.port, preExisting: ev.preExisting });
+    } else if (ev.type === "manifest-disabled") {
+      skipped.push({ server, reason: "manifest-disabled" });
+    }
+  }
+
+  return {
+    available: true,
+    logPath,
+    findings,
+    started,
+    skipped,
+  };
+}
+
+export function summarizeMcpGatewayHealth(result) {
+  if (!result?.available) {
+    return {
+      level: "skip",
+      message: "mcp-gateway log 없음 (gateway 미설치 또는 미실행)",
+    };
+  }
+  if (result.findings.length === 0) {
+    return {
+      level: "ok",
+      message: `mcp-gateway healthy (${result.started.length}개 server up)`,
+    };
+  }
+  const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
+  if (missingEnv.length > 0) {
+    const list = missingEnv
+      .map((f) => `${f.server} (${f.detail})`)
+      .join(", ");
+    return {
+      level: "warn",
+      message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
+      fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  return {
+    level: "warn",
+    message: `${result.findings.length}개 gateway 이슈`,
+  };
+}

--- a/packages/core/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-health-check.mjs
@@ -25,7 +25,10 @@ const DEFAULT_LOG_PATH = join(
   "mcp-gateway.out.log",
 );
 
-const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+// producer (scripts/mcp-gateway-start.mjs:146) 가 missing env 를 `missing.join(", ")`
+// 로 출력하므로 detail 은 공백 포함 다중 키 (예: "JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL")
+// 일 수 있다. line 끝까지 캡처한다.
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$/;
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -4670,6 +4670,37 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // ── MCP Gateway Health ──
+    // install-mcp-gateway-startup 으로 띄운 LaunchAgent/systemd daemon 의 stdout
+    // (~/.local/state/triflux/mcp-gateway.out.log) 를 파싱해 missing-env 등으로
+    // skip 된 server 를 잡는다. 로그가 없으면 gateway 미설치/미실행으로 침묵.
+    section("MCP Gateway Health");
+    {
+      const { checkMcpGatewayHealth, summarizeMcpGatewayHealth } = await import(
+        "../scripts/lib/mcp-gateway-health-check.mjs"
+      );
+      const gatewayHealth = checkMcpGatewayHealth();
+      const summary = summarizeMcpGatewayHealth(gatewayHealth);
+      addDoctorCheck(report, {
+        name: "mcp-gateway-health",
+        status: summary.level === "warn" ? "warning" : "ok",
+        log_path: gatewayHealth.logPath,
+        findings: gatewayHealth.findings,
+        started: gatewayHealth.started,
+        skipped: gatewayHealth.skipped,
+        ...(summary.fix ? { fix: summary.fix } : {}),
+      });
+      if (summary.level === "skip") {
+        info(summary.message);
+      } else if (summary.level === "ok") {
+        ok(summary.message);
+      } else {
+        warn(summary.message);
+        if (summary.fix) info(`수정: ${summary.fix}`);
+        issues++;
+      }
+    }
+
     // ── Codex Config Health (BUG-H #132) ──
     // _codex_config_swap 의 restore 가 Windows lock/ACL 로 실패하면
     // ~/.codex/config.toml.pre-exec 가 남아 [mcp_servers.*] 섹션이 영구 손실된다.

--- a/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -112,6 +112,30 @@ describe("mcp-gateway-health-check", () => {
     assert.deepEqual(started, ["context7", "serena"]);
   });
 
+  it("다중 env 가 누락된 [WARN] (예: jira) 도 캡처한다", () => {
+    const multiEnvLog = `[SKIP] context7 already running on :8100
+[WARN] jira skipped — missing env: JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL
+[START] serena on :8105
+`;
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: multiEnvLog }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.findings.length, 1);
+    assert.deepEqual(result.findings[0], {
+      server: "jira",
+      reason: "missing-env",
+      detail: "JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL",
+    });
+    const summary = summarizeMcpGatewayHealth(result);
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /jira/);
+    assert.match(
+      summary.message,
+      /JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL/,
+    );
+  });
+
   it("read 에러는 log-read-error finding 으로 보고한다", () => {
     const fs = makeFs({ logBody: "" });
     fs.readFileSync = () => {

--- a/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  checkMcpGatewayHealth,
+  summarizeMcpGatewayHealth,
+} from "../lib/mcp-gateway-health-check.mjs";
+
+function makeFs({ logBody = null, statError = null, readError = null } = {}) {
+  return {
+    statSync(path) {
+      if (statError) throw statError;
+      if (logBody == null) {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return { path, size: logBody.length };
+    },
+    readFileSync(path, encoding) {
+      if (readError) throw readError;
+      assert.equal(encoding, "utf8");
+      return logBody ?? "";
+    },
+  };
+}
+
+const HEALTHY_LOG = `[START] brave-search on :8101
+[SKIP] context7 already running on :8100
+[SKIP] exa — manifest에서 비활성
+[SKIP] tavily — manifest에서 비활성
+[SKIP] jira — manifest에서 비활성
+[START] serena on :8105
+[SKIP] notion — manifest에서 비활성
+[SKIP] notion-guest — manifest에서 비활성
+
+[gateway] Waiting for 2 servers...
+
+Health Check
+==================================================
+  brave-search     :8101  ✓ ok
+  serena           :8105  ✓ ok
+
+[gateway] 2/2 healthy.
+`;
+
+const MISSING_ENV_LOG = `[SKIP] context7 already running on :8100
+[WARN] brave-search skipped — missing env: BRAVE_API_KEY
+[SKIP] exa — manifest에서 비활성
+[SKIP] tavily — manifest에서 비활성
+[SKIP] jira — manifest에서 비활성
+[START] serena on :8105
+[SKIP] notion — manifest에서 비활성
+[SKIP] notion-guest — manifest에서 비활성
+
+[gateway] Waiting for 1 servers...
+
+Health Check
+==================================================
+  serena           :8105  ✓ ok
+
+[gateway] 1/1 healthy.
+`;
+
+describe("mcp-gateway-health-check", () => {
+  it("log 파일이 없으면 available=false 로 침묵한다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs(),
+      logPath: "/tmp/nonexistent-mcp-gateway.out.log",
+    });
+    assert.equal(result.available, false);
+    assert.deepEqual(result.findings, []);
+    assert.deepEqual(result.started, []);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  it("정상 로그는 findings 가 비고 started 만 채워진다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: HEALTHY_LOG }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 0);
+    const started = result.started.map((s) => s.server).sort();
+    assert.deepEqual(started, ["brave-search", "context7", "serena"]);
+    const preExisting = result.started.find((s) => s.preExisting);
+    assert.equal(preExisting.server, "context7");
+    assert.equal(preExisting.port, 8100);
+    const skipped = result.skipped.map((s) => s.server).sort();
+    assert.deepEqual(skipped, [
+      "exa",
+      "jira",
+      "notion",
+      "notion-guest",
+      "tavily",
+    ]);
+  });
+
+  it("missing env 로그를 finding 으로 잡는다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: MISSING_ENV_LOG }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 1);
+    assert.deepEqual(result.findings[0], {
+      server: "brave-search",
+      reason: "missing-env",
+      detail: "BRAVE_API_KEY",
+    });
+    const started = result.started.map((s) => s.server).sort();
+    assert.deepEqual(started, ["context7", "serena"]);
+  });
+
+  it("read 에러는 log-read-error finding 으로 보고한다", () => {
+    const fs = makeFs({ logBody: "" });
+    fs.readFileSync = () => {
+      throw new Error("EACCES: permission denied");
+    };
+    const result = checkMcpGatewayHealth({ fs, logPath: "/fake/log" });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0].reason, "log-read-error");
+    assert.match(result.findings[0].detail, /EACCES/);
+  });
+
+  it("summarize: 로그 없음 → skip", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs(),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "skip");
+  });
+
+  it("summarize: missing-env → warn + fix hint", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs({ logBody: MISSING_ENV_LOG }),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /brave-search/);
+    assert.match(summary.message, /BRAVE_API_KEY/);
+    assert.match(summary.fix, /secrets\.env/);
+  });
+
+  it("옛 [WARN] 뒤에 [START] 가 오면 server 가 복구된 것으로 본다", () => {
+    const recoveredLog = `[WARN] brave-search skipped — missing env: BRAVE_API_KEY
+[SKIP] context7 already running on :8100
+[SKIP] serena already running on :8105
+
+# (사용자가 secrets.env 추가 후 launchctl kickstart)
+
+[START] brave-search on :8101
+[SKIP] context7 already running on :8100
+[SKIP] serena already running on :8105
+`;
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: recoveredLog }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.findings.length, 0, "복구된 server 는 finding 에서 빠진다");
+    const startedNames = result.started.map((s) => s.server).sort();
+    assert.deepEqual(startedNames, ["brave-search", "context7", "serena"]);
+  });
+
+  it("summarize: 정상 → ok", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs({ logBody: HEALTHY_LOG }),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "ok");
+    assert.match(summary.message, /healthy/);
+  });
+});

--- a/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
@@ -1,0 +1,159 @@
+// scripts/lib/mcp-gateway-health-check.mjs
+//
+// `~/.local/state/triflux/mcp-gateway.out.log` 파싱 헬퍼.
+// install-mcp-gateway-startup.mjs 가 LaunchAgent/systemd 로 띄운 gateway daemon
+// (mcp-gateway-start.mjs) 의 stdout 로그에서 다음 신호를 추출한다.
+//
+//   [WARN] <server> skipped — missing env: <KEY>   → missing-env finding
+//   [START] <server> on :<port>                    → started
+//   [SKIP]  <server> already running on :<port>    → started (preExisting)
+//   [SKIP]  <server> — manifest에서 비활성         → manifest-disabled skip
+//
+// 호출자는 `findings` 만 보고 doctor 진단을 출력할 수 있다.
+// log 파일이 없으면 `available: false` 로 반환하므로, gateway 미설치 환경에서는
+// 침묵한다 (false-positive 방지).
+
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_LOG_PATH = join(
+  homedir(),
+  ".local",
+  "state",
+  "triflux",
+  "mcp-gateway.out.log",
+);
+
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
+const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
+const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+export function checkMcpGatewayHealth({
+  fs = { readFileSync, statSync },
+  logPath = DEFAULT_LOG_PATH,
+} = {}) {
+  try {
+    fs.statSync(logPath);
+  } catch {
+    return {
+      available: false,
+      logPath,
+      findings: [],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  let text;
+  try {
+    text = fs.readFileSync(logPath, "utf8");
+  } catch (error) {
+    return {
+      available: true,
+      logPath,
+      findings: [
+        {
+          server: null,
+          reason: "log-read-error",
+          detail: error?.message || String(error),
+        },
+      ],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  // log 는 append-only 라 옛 [WARN] 라인 뒤에 새 [START] 라인이 올 수 있다.
+  // server 별 마지막 이벤트가 현재 상태이므로 그것만 finding 으로 환원한다.
+  // (예: BRAVE_API_KEY missing 으로 한 번 skip → secrets 추가 후 restart 로 start)
+  const lastEvent = new Map();
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    let m;
+    if ((m = MISSING_ENV_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "missing-env",
+        detail: m[2],
+      });
+      continue;
+    }
+    if ((m = START_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: false,
+      });
+      continue;
+    }
+    if ((m = SKIP_RUNNING_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: true,
+      });
+      continue;
+    }
+    if ((m = SKIP_DISABLED_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "manifest-disabled",
+      });
+      continue;
+    }
+  }
+
+  const findings = [];
+  const started = [];
+  const skipped = [];
+  for (const [server, ev] of lastEvent) {
+    if (ev.type === "missing-env") {
+      findings.push({ server, reason: "missing-env", detail: ev.detail });
+    } else if (ev.type === "started") {
+      started.push({ server, port: ev.port, preExisting: ev.preExisting });
+    } else if (ev.type === "manifest-disabled") {
+      skipped.push({ server, reason: "manifest-disabled" });
+    }
+  }
+
+  return {
+    available: true,
+    logPath,
+    findings,
+    started,
+    skipped,
+  };
+}
+
+export function summarizeMcpGatewayHealth(result) {
+  if (!result?.available) {
+    return {
+      level: "skip",
+      message: "mcp-gateway log 없음 (gateway 미설치 또는 미실행)",
+    };
+  }
+  if (result.findings.length === 0) {
+    return {
+      level: "ok",
+      message: `mcp-gateway healthy (${result.started.length}개 server up)`,
+    };
+  }
+  const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
+  if (missingEnv.length > 0) {
+    const list = missingEnv
+      .map((f) => `${f.server} (${f.detail})`)
+      .join(", ");
+    return {
+      level: "warn",
+      message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
+      fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  return {
+    level: "warn",
+    message: `${result.findings.length}개 gateway 이슈`,
+  };
+}

--- a/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
@@ -25,7 +25,10 @@ const DEFAULT_LOG_PATH = join(
   "mcp-gateway.out.log",
 );
 
-const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+// producer (scripts/mcp-gateway-start.mjs:146) 가 missing env 를 `missing.join(", ")`
+// 로 출력하므로 detail 은 공백 포함 다중 키 (예: "JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL")
+// 일 수 있다. line 끝까지 캡처한다.
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$/;
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;

--- a/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -112,6 +112,30 @@ describe("mcp-gateway-health-check", () => {
     assert.deepEqual(started, ["context7", "serena"]);
   });
 
+  it("다중 env 가 누락된 [WARN] (예: jira) 도 캡처한다", () => {
+    const multiEnvLog = `[SKIP] context7 already running on :8100
+[WARN] jira skipped — missing env: JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL
+[START] serena on :8105
+`;
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: multiEnvLog }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.findings.length, 1);
+    assert.deepEqual(result.findings[0], {
+      server: "jira",
+      reason: "missing-env",
+      detail: "JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL",
+    });
+    const summary = summarizeMcpGatewayHealth(result);
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /jira/);
+    assert.match(
+      summary.message,
+      /JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL/,
+    );
+  });
+
   it("read 에러는 log-read-error finding 으로 보고한다", () => {
     const fs = makeFs({ logBody: "" });
     fs.readFileSync = () => {

--- a/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  checkMcpGatewayHealth,
+  summarizeMcpGatewayHealth,
+} from "../lib/mcp-gateway-health-check.mjs";
+
+function makeFs({ logBody = null, statError = null, readError = null } = {}) {
+  return {
+    statSync(path) {
+      if (statError) throw statError;
+      if (logBody == null) {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return { path, size: logBody.length };
+    },
+    readFileSync(path, encoding) {
+      if (readError) throw readError;
+      assert.equal(encoding, "utf8");
+      return logBody ?? "";
+    },
+  };
+}
+
+const HEALTHY_LOG = `[START] brave-search on :8101
+[SKIP] context7 already running on :8100
+[SKIP] exa — manifest에서 비활성
+[SKIP] tavily — manifest에서 비활성
+[SKIP] jira — manifest에서 비활성
+[START] serena on :8105
+[SKIP] notion — manifest에서 비활성
+[SKIP] notion-guest — manifest에서 비활성
+
+[gateway] Waiting for 2 servers...
+
+Health Check
+==================================================
+  brave-search     :8101  ✓ ok
+  serena           :8105  ✓ ok
+
+[gateway] 2/2 healthy.
+`;
+
+const MISSING_ENV_LOG = `[SKIP] context7 already running on :8100
+[WARN] brave-search skipped — missing env: BRAVE_API_KEY
+[SKIP] exa — manifest에서 비활성
+[SKIP] tavily — manifest에서 비활성
+[SKIP] jira — manifest에서 비활성
+[START] serena on :8105
+[SKIP] notion — manifest에서 비활성
+[SKIP] notion-guest — manifest에서 비활성
+
+[gateway] Waiting for 1 servers...
+
+Health Check
+==================================================
+  serena           :8105  ✓ ok
+
+[gateway] 1/1 healthy.
+`;
+
+describe("mcp-gateway-health-check", () => {
+  it("log 파일이 없으면 available=false 로 침묵한다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs(),
+      logPath: "/tmp/nonexistent-mcp-gateway.out.log",
+    });
+    assert.equal(result.available, false);
+    assert.deepEqual(result.findings, []);
+    assert.deepEqual(result.started, []);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  it("정상 로그는 findings 가 비고 started 만 채워진다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: HEALTHY_LOG }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 0);
+    const started = result.started.map((s) => s.server).sort();
+    assert.deepEqual(started, ["brave-search", "context7", "serena"]);
+    const preExisting = result.started.find((s) => s.preExisting);
+    assert.equal(preExisting.server, "context7");
+    assert.equal(preExisting.port, 8100);
+    const skipped = result.skipped.map((s) => s.server).sort();
+    assert.deepEqual(skipped, [
+      "exa",
+      "jira",
+      "notion",
+      "notion-guest",
+      "tavily",
+    ]);
+  });
+
+  it("missing env 로그를 finding 으로 잡는다", () => {
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: MISSING_ENV_LOG }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 1);
+    assert.deepEqual(result.findings[0], {
+      server: "brave-search",
+      reason: "missing-env",
+      detail: "BRAVE_API_KEY",
+    });
+    const started = result.started.map((s) => s.server).sort();
+    assert.deepEqual(started, ["context7", "serena"]);
+  });
+
+  it("read 에러는 log-read-error finding 으로 보고한다", () => {
+    const fs = makeFs({ logBody: "" });
+    fs.readFileSync = () => {
+      throw new Error("EACCES: permission denied");
+    };
+    const result = checkMcpGatewayHealth({ fs, logPath: "/fake/log" });
+    assert.equal(result.available, true);
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0].reason, "log-read-error");
+    assert.match(result.findings[0].detail, /EACCES/);
+  });
+
+  it("summarize: 로그 없음 → skip", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs(),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "skip");
+  });
+
+  it("summarize: missing-env → warn + fix hint", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs({ logBody: MISSING_ENV_LOG }),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /brave-search/);
+    assert.match(summary.message, /BRAVE_API_KEY/);
+    assert.match(summary.fix, /secrets\.env/);
+  });
+
+  it("옛 [WARN] 뒤에 [START] 가 오면 server 가 복구된 것으로 본다", () => {
+    const recoveredLog = `[WARN] brave-search skipped — missing env: BRAVE_API_KEY
+[SKIP] context7 already running on :8100
+[SKIP] serena already running on :8105
+
+# (사용자가 secrets.env 추가 후 launchctl kickstart)
+
+[START] brave-search on :8101
+[SKIP] context7 already running on :8100
+[SKIP] serena already running on :8105
+`;
+    const result = checkMcpGatewayHealth({
+      fs: makeFs({ logBody: recoveredLog }),
+      logPath: "/fake/log",
+    });
+    assert.equal(result.findings.length, 0, "복구된 server 는 finding 에서 빠진다");
+    const startedNames = result.started.map((s) => s.server).sort();
+    assert.deepEqual(startedNames, ["brave-search", "context7", "serena"]);
+  });
+
+  it("summarize: 정상 → ok", () => {
+    const summary = summarizeMcpGatewayHealth(
+      checkMcpGatewayHealth({
+        fs: makeFs({ logBody: HEALTHY_LOG }),
+        logPath: "/fake/log",
+      }),
+    );
+    assert.equal(summary.level, "ok");
+    assert.match(summary.message, /healthy/);
+  });
+});

--- a/scripts/lib/mcp-gateway-health-check.mjs
+++ b/scripts/lib/mcp-gateway-health-check.mjs
@@ -1,0 +1,159 @@
+// scripts/lib/mcp-gateway-health-check.mjs
+//
+// `~/.local/state/triflux/mcp-gateway.out.log` 파싱 헬퍼.
+// install-mcp-gateway-startup.mjs 가 LaunchAgent/systemd 로 띄운 gateway daemon
+// (mcp-gateway-start.mjs) 의 stdout 로그에서 다음 신호를 추출한다.
+//
+//   [WARN] <server> skipped — missing env: <KEY>   → missing-env finding
+//   [START] <server> on :<port>                    → started
+//   [SKIP]  <server> already running on :<port>    → started (preExisting)
+//   [SKIP]  <server> — manifest에서 비활성         → manifest-disabled skip
+//
+// 호출자는 `findings` 만 보고 doctor 진단을 출력할 수 있다.
+// log 파일이 없으면 `available: false` 로 반환하므로, gateway 미설치 환경에서는
+// 침묵한다 (false-positive 방지).
+
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_LOG_PATH = join(
+  homedir(),
+  ".local",
+  "state",
+  "triflux",
+  "mcp-gateway.out.log",
+);
+
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
+const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
+const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+export function checkMcpGatewayHealth({
+  fs = { readFileSync, statSync },
+  logPath = DEFAULT_LOG_PATH,
+} = {}) {
+  try {
+    fs.statSync(logPath);
+  } catch {
+    return {
+      available: false,
+      logPath,
+      findings: [],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  let text;
+  try {
+    text = fs.readFileSync(logPath, "utf8");
+  } catch (error) {
+    return {
+      available: true,
+      logPath,
+      findings: [
+        {
+          server: null,
+          reason: "log-read-error",
+          detail: error?.message || String(error),
+        },
+      ],
+      started: [],
+      skipped: [],
+    };
+  }
+
+  // log 는 append-only 라 옛 [WARN] 라인 뒤에 새 [START] 라인이 올 수 있다.
+  // server 별 마지막 이벤트가 현재 상태이므로 그것만 finding 으로 환원한다.
+  // (예: BRAVE_API_KEY missing 으로 한 번 skip → secrets 추가 후 restart 로 start)
+  const lastEvent = new Map();
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    let m;
+    if ((m = MISSING_ENV_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "missing-env",
+        detail: m[2],
+      });
+      continue;
+    }
+    if ((m = START_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: false,
+      });
+      continue;
+    }
+    if ((m = SKIP_RUNNING_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "started",
+        port: Number(m[2]),
+        preExisting: true,
+      });
+      continue;
+    }
+    if ((m = SKIP_DISABLED_RE.exec(line))) {
+      lastEvent.set(m[1], {
+        type: "manifest-disabled",
+      });
+      continue;
+    }
+  }
+
+  const findings = [];
+  const started = [];
+  const skipped = [];
+  for (const [server, ev] of lastEvent) {
+    if (ev.type === "missing-env") {
+      findings.push({ server, reason: "missing-env", detail: ev.detail });
+    } else if (ev.type === "started") {
+      started.push({ server, port: ev.port, preExisting: ev.preExisting });
+    } else if (ev.type === "manifest-disabled") {
+      skipped.push({ server, reason: "manifest-disabled" });
+    }
+  }
+
+  return {
+    available: true,
+    logPath,
+    findings,
+    started,
+    skipped,
+  };
+}
+
+export function summarizeMcpGatewayHealth(result) {
+  if (!result?.available) {
+    return {
+      level: "skip",
+      message: "mcp-gateway log 없음 (gateway 미설치 또는 미실행)",
+    };
+  }
+  if (result.findings.length === 0) {
+    return {
+      level: "ok",
+      message: `mcp-gateway healthy (${result.started.length}개 server up)`,
+    };
+  }
+  const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
+  if (missingEnv.length > 0) {
+    const list = missingEnv
+      .map((f) => `${f.server} (${f.detail})`)
+      .join(", ");
+    return {
+      level: "warn",
+      message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
+      fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  return {
+    level: "warn",
+    message: `${result.findings.length}개 gateway 이슈`,
+  };
+}

--- a/scripts/lib/mcp-gateway-health-check.mjs
+++ b/scripts/lib/mcp-gateway-health-check.mjs
@@ -25,7 +25,10 @@ const DEFAULT_LOG_PATH = join(
   "mcp-gateway.out.log",
 );
 
-const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(\S+)$/;
+// producer (scripts/mcp-gateway-start.mjs:146) 가 missing env 를 `missing.join(", ")`
+// 로 출력하므로 detail 은 공백 포함 다중 키 (예: "JIRA_API_TOKEN, JIRA_EMAIL, JIRA_INSTANCE_URL")
+// 일 수 있다. line 끝까지 캡처한다.
+const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$/;
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;


### PR DESCRIPTION
## Summary

- `tfx doctor` 에 새 진단 섹션 **MCP Gateway Health** 추가.
- `~/.local/state/triflux/mcp-gateway.out.log` (LaunchAgent/systemd 가 띄운 daemon stdout) 를 파싱해 `[WARN] X skipped — missing env: Y` 패턴으로 skip 된 server 를 잡고, missing key 별 수정 힌트 (`secrets.env` + `launchctl kickstart`/`systemctl --user restart`) 를 노출.
- log 파일이 없으면 gateway 미설치/미실행으로 보고 침묵 (false-positive 회피).
- 같은 server 의 [START]/[SKIP-running] 이 [WARN] 보다 더 최근이면 복구된 것으로 인식하고 finding 에서 제외.

## 동기

PR #312 의 회귀 (wrapper sourcing 목록에 `secrets.env` 누락 → brave-search 가 `[WARN] missing env: BRAVE_API_KEY` 로 skip) 가 `tfx doctor` 의 사각지대였다. doctor 는 registry / client config 등록 일치성만 확인하고, gateway 데몬 런타임 로그는 보지 않았다.

이 보강은 동일 회귀가 다시 발생하면 (또는 다른 키가 누락되면) doctor 한 줄로 잡아낸다.

## 변경

| 파일 | 변경 |
|------|------|
| `scripts/lib/mcp-gateway-health-check.mjs` | 신규 — testable helper (`checkMcpGatewayHealth`, `summarizeMcpGatewayHealth`) |
| `scripts/__tests__/mcp-gateway-health-check.test.mjs` | 신규 — 단위 테스트 8 건 |
| `bin/triflux.mjs` | doctor 명령에 `section("MCP Gateway Health")` 블록 +31 lines |
| `packages/core/scripts/lib/mcp-gateway-health-check.mjs` | byte-identical mirror (`.claude/rules/tfx-mirror-policy.md`) |
| `packages/triflux/scripts/lib/mcp-gateway-health-check.mjs` | byte-identical mirror |
| `packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs` | byte-identical mirror |
| `packages/triflux/bin/triflux.mjs` | byte-identical mirror |
| `CHANGELOG.md` | Unreleased / Added 한 줄 |

## Test plan

- [x] `node --test scripts/__tests__/mcp-gateway-health-check.test.mjs` (8/8 pass)
- [x] `node --test packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs` (8/8 pass)
- [x] `npm run release:check-mirror` (Mirror OK)
- [x] `npm run release:check-sync` (Version sync OK 10.25.0)
- [x] 실제 머신에서 `node bin/triflux.mjs doctor` 실행:
  - 옛 [WARN] 라인이 있는 log 에서 [START] 가 더 최근이면 `✓ mcp-gateway healthy (3개 server up)` 출력
  - missing-env 만 있고 [START] 없는 시나리오에서 `⚠ N개 MCP 서버가 missing env 로 skip: ...` + 수정 힌트 출력
  - log 파일 없는 환경에서 침묵 (`mcp-gateway log 없음 (gateway 미설치 또는 미실행)`)

## Scope

- doctor 진단만 추가, 자동 fix 는 포함 안 함 (사용자가 secrets 수동 추가 + restart 필요).
- gateway 미설치 환경 (Linux 일부, 비-systemd) 침묵 — 새 false-positive 없음.
- 본체/mirror 4 곳 byte-identical (`.claude/rules/tfx-mirror-policy.md` 준수).

## Related

- PR #312 의 회귀를 doctor 가 잡지 못한 사각지대 메우기. PR #312 는 root fix (wrapper sourcing 보강), 본 PR 은 진단 보강. 두 PR 은 독립.