### PR TITLE
docs(mirror-policy): include packages/remote/scripts/lib in mirror table

### DIFF
--- a/.claude/rules/tfx-mirror-policy.md
+++ b/.claude/rules/tfx-mirror-policy.md
@@ -7,7 +7,7 @@ triflux 는 root 와 `packages/{core,remote,triflux}/` 3개 published 레이어�
 | 레이어 | 역할 | mirror 룰 |
 |--------|------|----------|
 | `packages/core` (`@triflux/core`) | 공용 라이브러리 (hub primitives, scripts/lib helper) | root 와 byte-identical cp |
-| `packages/remote` (`@triflux/remote`) | 원격 entry / store / pipe / server | root subset + `@triflux/core/...` import path 변환 |
+| `packages/remote` (`@triflux/remote`) | 원격 entry / store / pipe / server / scripts helper | root subset + `@triflux/core/...` import path 변환 |
 | `packages/triflux` (`triflux` npm) | 사용자 facing CLI / runtime / skills | npm publish files 기준 byte-identical mirror |
 
 ## 레이어별 정책
@@ -56,7 +56,7 @@ mirror 변경은 **`Edit` 도구로 개별 수정**한다. `cp` 사용 금지 (�
 **mirror 대상** (root → packages 동기 필수):
 - `hub/lib/*` → `packages/core/hub/lib/`, `packages/triflux/hub/lib/`
 - `hub/team/*`, `hub/*.mjs` (entry/runtime) → `packages/triflux/hub/`, `packages/remote/hub/` (해당 모듈만)
-- `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`
+- `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`, `packages/remote/scripts/lib/` (PR #314 catch-up — remote 는 root subset, root-relative 의존 시 `@triflux/core/...` 로 import 변환)
 - `scripts/release/*`, `scripts/__tests__/*` → `packages/triflux/scripts/` (publish 포함)
 - `bin/*` → `packages/triflux/bin/`
 - `hooks/*`, `hud/*`, `mesh/*`, `config/*` → `packages/triflux/{hooks,hud,mesh,config}/`


### PR DESCRIPTION
## Why

PR #314 (chore: catch up packages/{core,remote} to v10.25.0 + Phase 1 mirror staging) 의 후속 정합화. 옵션 B catch-up 이 `packages/remote/scripts/lib/*.mjs` 37 파일을 mirror staging 한 후속으로, mirror policy 표가 이 경로를 명시 포함하도록 갱신한다.

PR #314 의 non-goal 에서 "사용자 직접 Edit 영역" 으로 명시 분리됐던 부분 (rule 파일 자체 갱신) 을 별도 PR 로 처리.

## What

`.claude/rules/tfx-mirror-policy.md` 2 라인 갱신:

1. **Layer 표** — `packages/remote` 역할에 `scripts helper` 추가
   ```diff
   - | `packages/remote` (`@triflux/remote`) | 원격 entry / store / pipe / server | root subset + ...
   + | `packages/remote` (`@triflux/remote`) | 원격 entry / store / pipe / server / scripts helper | root subset + ...
   ```

2. **Mirror 범위 표** — `scripts/lib/*` 줄에 `packages/remote/scripts/lib/` 추가
   ```diff
   - - `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`
   + - `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`, `packages/remote/scripts/lib/` (PR #314 catch-up — remote 는 root subset, root-relative 의존 시 \`@triflux/core/...\` 로 import 변환)
   ```

## Effect

- 다음 release 의 verify 단계에서 `packages/remote/scripts/lib` 도 mirror 검사 편입
- `packages/remote/scripts/lib/*.mjs` 의 import 변환 룰 (`@triflux/core/...`) 명시
- 후속 PR (`packages/remote/hub/team/*.mjs` 같은 다른 mirror 영역) 도 같은 패턴 적용 근거 확보

## Non-changes

- `.claude/rules/` 외 영역 손대지 않음 — 순수 docs PR
- AI trailer / Co-Authored-By 부재 (triflux release governance)

## Reference

- PR #314: chore: catch up packages/{core,remote} to v10.25.0 + Phase 1 mirror staging (merged)
- Issue #315: tfx swarm sub-worktree 회귀 (별도 트래킹)