### PR TITLE
feat(doctor): verify mcp-gateway wrapper sources secrets.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to triflux will be documented in this file.
 
 ### Added
 
+- `tfx doctor`: verify wrapper script sources `secrets.env` (closes static-config gap left by PR #313 log-parser)
 - **`feat(doctor)`** `tfx doctor` 에 "MCP Gateway Health" 진단 섹션 추가. `~/.local/state/triflux/mcp-gateway.out.log` 를 파싱해 `[WARN] X skipped — missing env: Y` 패턴으로 skip 된 server 를 잡고, 같은 server 의 [START]/[SKIP-running] 이 더 최근이면 복구된 것으로 인식 (false-positive 회피). missing key 발견 시 `secrets.env` + `launchctl kickstart` 또는 `systemctl --user restart` 수정 힌트를 노출. 로그 파일이 없으면 gateway 미설치/미실행으로 침묵. `scripts/lib/mcp-gateway-health-check.mjs` 단위 테스트 8건. `packages/core` + `packages/triflux` mirror byte-identical 동기.
 
 ### Fixed

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -4701,6 +4701,34 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // ── MCP Gateway Wrapper ──
+    // 로그가 생기기 전 단계에서 wrapper 자체가 secrets.env 를 source 하는지 확인한다.
+    section("MCP Gateway Wrapper");
+    {
+      const { checkWrapperSourcing } = await import(
+        "../scripts/lib/mcp-gateway-wrapper-check.mjs"
+      );
+      const wrapperCheck = await checkWrapperSourcing();
+      addDoctorCheck(report, {
+        name: "mcp-gateway-wrapper-sourcing",
+        status: wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
+        path: wrapperCheck.wrapperPath,
+        ...(wrapperCheck.message ? { message: wrapperCheck.message } : {}),
+        ...(wrapperCheck.suggestedFix ? { fix: wrapperCheck.suggestedFix } : {}),
+      });
+
+      if (wrapperCheck.status === "ok") {
+        ok("wrapper sources secrets.env");
+      } else if (wrapperCheck.status === "warn") {
+        warn(wrapperCheck.message);
+        info(`수정: ${wrapperCheck.suggestedFix}`);
+        issues++;
+      } else {
+        warn("mcp-gateway wrapper not installed");
+        if (wrapperCheck.message) info(wrapperCheck.message);
+      }
+    }
+
     // ── Codex Config Health (BUG-H #132) ──
     // _codex_config_swap 의 restore 가 Windows lock/ACL 로 실패하면
     // ~/.codex/config.toml.pre-exec 가 남아 [mcp_servers.*] 섹션이 영구 손실된다.

--- a/packages/core/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export async function checkWrapperSourcing({
+  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  marker = "secrets.env",
+} = {}) {
+  let text;
+  try {
+    text = await readFile(wrapperPath, "utf8");
+  } catch (error) {
+    const result = { status: "missing", wrapperPath };
+    if (error?.code !== "ENOENT") {
+      result.message = `wrapper read failed: ${error?.message || String(error)}`;
+    }
+    return result;
+  }
+
+  if (text.includes(marker)) {
+    return { status: "ok", wrapperPath };
+  }
+
+  return {
+    status: "warn",
+    wrapperPath,
+    message: "wrapper exists but does not source secrets.env",
+    suggestedFix: "Re-run: node scripts/install-mcp-gateway-startup.mjs",
+  };
+}

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -4701,6 +4701,34 @@ async function cmdDoctor(options = {}) {
       }
     }
 
+    // ── MCP Gateway Wrapper ──
+    // 로그가 생기기 전 단계에서 wrapper 자체가 secrets.env 를 source 하는지 확인한다.
+    section("MCP Gateway Wrapper");
+    {
+      const { checkWrapperSourcing } = await import(
+        "../scripts/lib/mcp-gateway-wrapper-check.mjs"
+      );
+      const wrapperCheck = await checkWrapperSourcing();
+      addDoctorCheck(report, {
+        name: "mcp-gateway-wrapper-sourcing",
+        status: wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
+        path: wrapperCheck.wrapperPath,
+        ...(wrapperCheck.message ? { message: wrapperCheck.message } : {}),
+        ...(wrapperCheck.suggestedFix ? { fix: wrapperCheck.suggestedFix } : {}),
+      });
+
+      if (wrapperCheck.status === "ok") {
+        ok("wrapper sources secrets.env");
+      } else if (wrapperCheck.status === "warn") {
+        warn(wrapperCheck.message);
+        info(`수정: ${wrapperCheck.suggestedFix}`);
+        issues++;
+      } else {
+        warn("mcp-gateway wrapper not installed");
+        if (wrapperCheck.message) info(wrapperCheck.message);
+      }
+    }
+
     // ── Codex Config Health (BUG-H #132) ──
     // _codex_config_swap 의 restore 가 Windows lock/ACL 로 실패하면
     // ~/.codex/config.toml.pre-exec 가 남아 [mcp_servers.*] 섹션이 영구 손실된다.

--- a/packages/triflux/scripts/__tests__/mcp-gateway-wrapper-check.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-gateway-wrapper-check.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { checkWrapperSourcing } from "../lib/mcp-gateway-wrapper-check.mjs";
+
+const tmpRoot = path.join(os.tmpdir(), `triflux-wrapper-check-${randomUUID()}`);
+
+after(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function fixturePath(name) {
+  await mkdir(tmpRoot, { recursive: true });
+  return path.join(tmpRoot, name);
+}
+
+describe("mcp-gateway-wrapper-check", () => {
+  it("returns ok when wrapper contains secrets.env", async () => {
+    const wrapperPath = await fixturePath("ok-wrapper.sh");
+    await writeFile(
+      wrapperPath,
+      'source "$HOME/.config/triflux/secrets.env"\n',
+      "utf8",
+    );
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.wrapperPath, wrapperPath);
+  });
+
+  it("returns warn when wrapper does not contain secrets.env", async () => {
+    const wrapperPath = await fixturePath("warn-wrapper.sh");
+    await writeFile(wrapperPath, "exec node scripts/mcp-gateway-start.mjs\n");
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "warn");
+    assert.match(result.suggestedFix, /install-mcp-gateway-startup/);
+  });
+
+  it("returns missing when wrapper path does not exist", async () => {
+    const wrapperPath = path.join(tmpRoot, "missing-wrapper.sh");
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "missing");
+    assert.equal(result.wrapperPath, wrapperPath);
+  });
+});

--- a/packages/triflux/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export async function checkWrapperSourcing({
+  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  marker = "secrets.env",
+} = {}) {
+  let text;
+  try {
+    text = await readFile(wrapperPath, "utf8");
+  } catch (error) {
+    const result = { status: "missing", wrapperPath };
+    if (error?.code !== "ENOENT") {
+      result.message = `wrapper read failed: ${error?.message || String(error)}`;
+    }
+    return result;
+  }
+
+  if (text.includes(marker)) {
+    return { status: "ok", wrapperPath };
+  }
+
+  return {
+    status: "warn",
+    wrapperPath,
+    message: "wrapper exists but does not source secrets.env",
+    suggestedFix: "Re-run: node scripts/install-mcp-gateway-startup.mjs",
+  };
+}

--- a/scripts/__tests__/mcp-gateway-wrapper-check.test.mjs
+++ b/scripts/__tests__/mcp-gateway-wrapper-check.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+import { checkWrapperSourcing } from "../lib/mcp-gateway-wrapper-check.mjs";
+
+const tmpRoot = path.join(os.tmpdir(), `triflux-wrapper-check-${randomUUID()}`);
+
+after(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function fixturePath(name) {
+  await mkdir(tmpRoot, { recursive: true });
+  return path.join(tmpRoot, name);
+}
+
+describe("mcp-gateway-wrapper-check", () => {
+  it("returns ok when wrapper contains secrets.env", async () => {
+    const wrapperPath = await fixturePath("ok-wrapper.sh");
+    await writeFile(
+      wrapperPath,
+      'source "$HOME/.config/triflux/secrets.env"\n',
+      "utf8",
+    );
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.wrapperPath, wrapperPath);
+  });
+
+  it("returns warn when wrapper does not contain secrets.env", async () => {
+    const wrapperPath = await fixturePath("warn-wrapper.sh");
+    await writeFile(wrapperPath, "exec node scripts/mcp-gateway-start.mjs\n");
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "warn");
+    assert.match(result.suggestedFix, /install-mcp-gateway-startup/);
+  });
+
+  it("returns missing when wrapper path does not exist", async () => {
+    const wrapperPath = path.join(tmpRoot, "missing-wrapper.sh");
+
+    const result = await checkWrapperSourcing({ wrapperPath });
+
+    assert.equal(result.status, "missing");
+    assert.equal(result.wrapperPath, wrapperPath);
+  });
+});

--- a/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export async function checkWrapperSourcing({
+  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  marker = "secrets.env",
+} = {}) {
+  let text;
+  try {
+    text = await readFile(wrapperPath, "utf8");
+  } catch (error) {
+    const result = { status: "missing", wrapperPath };
+    if (error?.code !== "ENOENT") {
+      result.message = `wrapper read failed: ${error?.message || String(error)}`;
+    }
+    return result;
+  }
+
+  if (text.includes(marker)) {
+    return { status: "ok", wrapperPath };
+  }
+
+  return {
+    status: "warn",
+    wrapperPath,
+    message: "wrapper exists but does not source secrets.env",
+    suggestedFix: "Re-run: node scripts/install-mcp-gateway-startup.mjs",
+  };
+}


### PR DESCRIPTION
## Summary

Closes a static-config gap left by PR #313 (`feat(doctor): add MCP Gateway Health diagnostic`).

PR #313's log-parser catches `[WARN] X skipped — missing env: Y` patterns from `~/.local/state/triflux/mcp-gateway.out.log`. That only fires when the service actually runs. If the wrapper script is malformed (e.g., from an old installer that predates the `secrets.env` sourcing fix in PR #312), no warning log is produced because the wrapper itself never sources the env file in the first place.

This PR adds a sibling static check that reads `~/.local/bin/mcp-gateway-wrapper.sh` and verifies it contains a `secrets.env` substring. Catches the regression *before* the service starts.

## Changes

- New lib: `scripts/lib/mcp-gateway-wrapper-check.mjs` (`checkWrapperSourcing()` returns `ok` / `warn` / `missing`, never throws)
- Integrated into `bin/triflux.mjs` `tfx doctor` output as a new "MCP Gateway Wrapper" section, sibling to PR #313's "MCP Gateway Health"
- 3 unit tests (`scripts/__tests__/mcp-gateway-wrapper-check.test.mjs`): `ok`, `warn`, `missing` cases
- Mirror 3-layer per `.claude/rules/tfx-mirror-policy.md`:
  - `packages/core/scripts/lib/mcp-gateway-wrapper-check.mjs` (byte-identical)
  - `packages/triflux/scripts/lib/mcp-gateway-wrapper-check.mjs` (byte-identical)
  - `packages/triflux/scripts/__tests__/mcp-gateway-wrapper-check.test.mjs` (byte-identical)
  - `packages/triflux/bin/triflux.mjs` (byte-identical)
- CHANGELOG `## [Unreleased]` `### Added` entry

## Test plan

- [x] `node --test scripts/__tests__/mcp-gateway-wrapper-check.test.mjs` — 3/3 pass (ok/warn/missing)
- [x] `diff -q` checks across 4 mirror targets — all exit 0 (byte-identical)
- [x] `bin/triflux.mjs` integration verified — `addDoctorCheck()` called with correct status mapping (`warn` → `warning`, others passthrough), suggested fix surfaced to user
- [ ] CI: full suite (pre-existing `packages/remote imports core modules through @triflux/core` #586/#587 baseline failures are out-of-scope, tracked separately on `chore/v10.25.0-core-remote-catchup`)

## Out of scope

- The `packages/remote` import regression (#586/#587) is being addressed in another worktree on `chore/v10.25.0-core-remote-catchup`. Not touched here.