### PR TITLE
fix(macos): correct Windows-Terminal rule leakage and doctor drift on non-Windows

### DIFF
--- a/.claude/rules/tfx-psmux.md
+++ b/.claude/rules/tfx-psmux.md
@@ -3,7 +3,7 @@
 sync-source: AGENTS.md
 sync-scope: section `TFX psmux Rules`
 sync-status: mirrored
-sync-block-sha256: 69c0caac243e0ebac085964b4068ba6ba3a7be63f660d33c90156fa50ec64063
+sync-block-sha256: b975aedecb60cd489f5acc55675657eaaca20a8316add8bb613025689dff7436
 
 <!-- TFX_PSMUX_RULES:START -->
 > **적용 범위: Windows 환경 한정.** macOS/Linux는 platform guard(`hub/team/wt-manager.mjs:199`, `hub/team/headless.mjs:1725`, `tfx-route.sh:86`)로 코드 레벨 no-op 처리된다. mac 사용자는 이 룰셋의 RULE 1~3, 5~6, 8 (WT/PowerShell 관련) 전체를 skip해도 됨. RULE 4 (Codex CLI), RULE 7 (spark53)만 cross-platform.

--- a/.claude/rules/tfx-psmux.md
+++ b/.claude/rules/tfx-psmux.md
@@ -3,9 +3,12 @@
 sync-source: AGENTS.md
 sync-scope: section `TFX psmux Rules`
 sync-status: mirrored
-sync-block-sha256: c2f3ea31aeb6a49ca3c167a46258a581df6ff533ceb3ab8b96571b3c98ecdba5
+sync-block-sha256: 69c0caac243e0ebac085964b4068ba6ba3a7be63f660d33c90156fa50ec64063
 
 <!-- TFX_PSMUX_RULES:START -->
+> **적용 범위: Windows 환경 한정.** macOS/Linux는 platform guard(`hub/team/wt-manager.mjs:199`, `hub/team/headless.mjs:1725`, `tfx-route.sh:86`)로 코드 레벨 no-op 처리된다. mac 사용자는 이 룰셋의 RULE 1~3, 5~6, 8 (WT/PowerShell 관련) 전체를 skip해도 됨. RULE 4 (Codex CLI), RULE 7 (spark53)만 cross-platform.
+> mac 인프라는 `hub/team/terminal-opener.mjs` 3단계 fallback (win32 → wt-manager / tmux 감지 시 → tmux/psmux / darwin → Terminal.app) + `hub/team/psmux.mjs` cross-platform (`IS_WINDOWS`/`IS_MAC` 분기) 으로 처리되며, 별도 iTerm2/tmux 매니저는 불필요.
+>
 > 이 문서는 선택형 스킬이 아니라 항상 적용되는 정책이다.
 > psmux 명령, launch 스크립트, Codex CLI 호출을 생성하는 모든 흐름은
 > 아래 규칙을 반드시 준수해야 한다. 위반 시 생성을 중단하고 수정한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,12 @@
 sync-source: .claude/rules/tfx-psmux.md
 sync-scope: full section
 sync-status: mirrored
-sync-block-sha256: c2f3ea31aeb6a49ca3c167a46258a581df6ff533ceb3ab8b96571b3c98ecdba5
+sync-block-sha256: 69c0caac243e0ebac085964b4068ba6ba3a7be63f660d33c90156fa50ec64063
 
 <!-- TFX_PSMUX_RULES:START -->
+> **적용 범위: Windows 환경 한정.** macOS/Linux는 platform guard(`hub/team/wt-manager.mjs:199`, `hub/team/headless.mjs:1725`, `tfx-route.sh:86`)로 코드 레벨 no-op 처리된다. mac 사용자는 이 룰셋의 RULE 1~3, 5~6, 8 (WT/PowerShell 관련) 전체를 skip해도 됨. RULE 4 (Codex CLI), RULE 7 (spark53)만 cross-platform.
+> mac 인프라는 `hub/team/terminal-opener.mjs` 3단계 fallback (win32 → wt-manager / tmux 감지 시 → tmux/psmux / darwin → Terminal.app) + `hub/team/psmux.mjs` cross-platform (`IS_WINDOWS`/`IS_MAC` 분기) 으로 처리되며, 별도 iTerm2/tmux 매니저는 불필요.
+>
 > 이 문서는 선택형 스킬이 아니라 항상 적용되는 정책이다.
 > psmux 명령, launch 스크립트, Codex CLI 호출을 생성하는 모든 흐름은
 > 아래 규칙을 반드시 준수해야 한다. 위반 시 생성을 중단하고 수정한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 sync-source: .claude/rules/tfx-psmux.md
 sync-scope: full section
 sync-status: mirrored
-sync-block-sha256: 69c0caac243e0ebac085964b4068ba6ba3a7be63f660d33c90156fa50ec64063
+sync-block-sha256: b975aedecb60cd489f5acc55675657eaaca20a8316add8bb613025689dff7436
 
 <!-- TFX_PSMUX_RULES:START -->
 > **적용 범위: Windows 환경 한정.** macOS/Linux는 platform guard(`hub/team/wt-manager.mjs:199`, `hub/team/headless.mjs:1725`, `tfx-route.sh:86`)로 코드 레벨 no-op 처리된다. mac 사용자는 이 룰셋의 RULE 1~3, 5~6, 8 (WT/PowerShell 관련) 전체를 skip해도 됨. RULE 4 (Codex CLI), RULE 7 (spark53)만 cross-platform.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@
 <psmux-wt>
 ## psmux/WT 규칙
 
+> **이 섹션은 Windows 환경 한정.** macOS/Linux는 platform guard로 코드 레벨 no-op 처리되며 이 섹션 전체를 skip해도 됨. mac 인프라는 아래 `<macos-terminal>` 섹션 참조.
+
 psmux 세션·WT 패인을 생성/조작/정리할 때 `tfx-psmux-rules` 스킬을 참조한다.
 WT 프리징 방지: exit → sleep 2 → kill 순서. 바로 kill하지 않는다.
 
@@ -58,6 +60,47 @@ safety-guard가 raw `psmux kill-session`을 차단한다.
 `codex exec`는 config.toml `approval_mode`를 무시하므로 `--dangerously-bypass-approvals-and-sandbox` 필수.
 `-s` 유효값: read-only, workspace-write, danger-full-access.
 </psmux-wt>
+
+<macos-terminal>
+## macOS / Linux 터미널 처리
+
+위 `<psmux-wt>` 룰셋은 Windows 전용이다. macOS/Linux 환경에서 triflux가 터미널/세션을 다루는 방식.
+
+### terminal-opener.mjs 3단계 fallback (`hub/team/terminal-opener.mjs:124~149`)
+
+`openCommand()` 가 순차 평가하는 분기:
+
+| 우선순위 | 조건 | 동작 | API |
+|---------|------|------|-----|
+| 1 | `platform === "win32"` | wt-manager.createTab | `hub/team/wt-manager.mjs` |
+| 2 | `isTmuxLikeMux(mux, platform)` (`detectMultiplexer()` → `getMultiplexerType()`/`hasMultiplexer()`/`hasTmux()` + literal psmux 검사) | `tmux new-window -n <title> <command>` | shell 직접 호출 |
+| 3 | `platform === "darwin"` (fallback) | `open -a Terminal` | macOS `open` 명령 |
+| — | Linux (mux 없음) | unsupported (return false) | — |
+
+### 별도 mac 매니저 불필요
+
+| 후보 | 필요성 | 이유 |
+|------|--------|------|
+| iTerm2 manager | **불필요** | `hub/lib/env-detect.mjs:96`이 `TERM_PROGRAM === "iTerm.app"` 감지하지만 별도 GUI 패인 조작은 tmux/psmux로 cover됨. 새 창 띄우기는 `open -a Terminal` fallback으로 충분 |
+| tmux manager | **불필요** | psmux 자체가 tmux fork. `terminal-opener.mjs`가 `tmux new-window`로 직접 호출 |
+| psmux manager | **이미 있음** | `hub/team/psmux.mjs` (`IS_WINDOWS`/`IS_MAC` 분기, cross-platform) |
+
+참고 사례: OMC(`oh-my-claudecode`)도 OS-specific 매니저를 만들지 않고 Tmux Manager + Worktree Manager + Claude Launcher 3개 컴포넌트로 정리한다. 본 repo 결정의 외부 근거가 아니라 비교 참고로만 본다.
+
+### platform guard 위치 (참고)
+
+| 파일 | 라인 | guard |
+|------|------|-------|
+| `hub/team/wt-manager.mjs` | 199 | `if (platform() !== "win32") return createNonWindowsStubManager();` |
+| `hub/team/headless.mjs` | 1725-1726 | `if (process.platform !== "win32") return false;` + `WT_SESSION` 체크 |
+| `tfx-route.sh` | 86, 1662, 1681 | `case "$(uname -s)"` 분기 |
+
+mac에서 위 코드가 호출돼도 early-return이라 dead code 실행 없음. **dead text(문서)만 inject되는 게 잔여 drift.**
+
+### macOS notification (참고)
+
+`hub/team/notify.mjs:221~234`이 `osascript`로 macOS 네이티브 알림 발송 (별도 의존성 없음).
+</macos-terminal>
 
 <codex-config>
 ## Codex config.toml

--- a/hooks/safety-guard.mjs
+++ b/hooks/safety-guard.mjs
@@ -340,7 +340,14 @@ function main() {
     return hasSegmentInvocation(cmd, WT_DIRECT_PATTERNS);
   }
 
-  if (isWtDirectInvocation(command)) {
+  // wt.exe는 Windows Terminal 전용. macOS/Linux에서는 PATH에 존재하지 않아
+  // 차단해도 dormant이며, 문서/로그 텍스트의 wt 단어가 false positive로 잡힐
+  // 위험만 있다. win32에서만 차단 적용.
+  // SAFETY_GUARD_FORCE_PLATFORM env로 테스트에서 platform 시뮬레이션 가능
+  // (mac CI에서 win32 차단 동작을 검증하기 위함).
+  const guardPlatform =
+    process.env.SAFETY_GUARD_FORCE_PLATFORM || process.platform;
+  if (guardPlatform === "win32" && isWtDirectInvocation(command)) {
     blockCommand(WT_DIRECT_BLOCK_MESSAGE, command);
   }
 

--- a/packages/triflux/hooks/safety-guard.mjs
+++ b/packages/triflux/hooks/safety-guard.mjs
@@ -340,7 +340,14 @@ function main() {
     return hasSegmentInvocation(cmd, WT_DIRECT_PATTERNS);
   }
 
-  if (isWtDirectInvocation(command)) {
+  // wt.exe는 Windows Terminal 전용. macOS/Linux에서는 PATH에 존재하지 않아
+  // 차단해도 dormant이며, 문서/로그 텍스트의 wt 단어가 false positive로 잡힐
+  // 위험만 있다. win32에서만 차단 적용.
+  // SAFETY_GUARD_FORCE_PLATFORM env로 테스트에서 platform 시뮬레이션 가능
+  // (mac CI에서 win32 차단 동작을 검증하기 위함).
+  const guardPlatform =
+    process.env.SAFETY_GUARD_FORCE_PLATFORM || process.platform;
+  if (guardPlatform === "win32" && isWtDirectInvocation(command)) {
     blockCommand(WT_DIRECT_BLOCK_MESSAGE, command);
   }
 

--- a/packages/triflux/scripts/doctor-diagnose.mjs
+++ b/packages/triflux/scripts/doctor-diagnose.mjs
@@ -152,14 +152,20 @@ function collectSystemInfo() {
   };
 
   // Windows Terminal version (wt.exe --version은 GUI 다이얼로그를 띄우므로 AppxPackage로 조회)
-  try {
-    const wtVer = execSync(
-      'powershell.exe -NoProfile -NoLogo -Command "(Get-AppxPackage Microsoft.WindowsTerminal).Version"',
-      { encoding: "utf8", timeout: 5000, windowsHide: true },
-    ).trim();
-    info.wtVersion = wtVer || "not found";
-  } catch {
-    info.wtVersion = "not found";
+  // macOS/Linux는 wt 자체가 없으므로 조회 skip — "not found"로 표시되면 사용자가
+  // 설치 누락으로 오해할 수 있다. 명시적으로 "N/A (non-Windows)"로 표시.
+  if (platform() === "win32") {
+    try {
+      const wtVer = execSync(
+        'powershell.exe -NoProfile -NoLogo -Command "(Get-AppxPackage Microsoft.WindowsTerminal).Version"',
+        { encoding: "utf8", timeout: 5000, windowsHide: true },
+      ).trim();
+      info.wtVersion = wtVer || "not found";
+    } catch {
+      info.wtVersion = "not found";
+    }
+  } else {
+    info.wtVersion = "N/A (non-Windows)";
   }
 
   // triflux version

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -798,7 +798,7 @@ deep/fullcycle 추가 규칙:
 |------|----------|------|
 | 1개 + quick | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
 | 1개 + thorough | tfx-auto 직접 실행 + verify/fix loop | tfx-route.sh |
-| 2개+ + quick | **headless 직접 실행** (WT 자동 팝업) | headless.mjs |
+| 2개+ + quick | **headless 직접 실행** (Windows: WT 자동 팝업 / macOS·Linux: psmux/tmux 단독) | headless.mjs |
 | 2개+ + thorough | Plan/PRD/Approval 후 → headless + verify/fix | headless.mjs |
 | psmux 미설치 fallback | Native Teams (Agent slim wrapper) | native.mjs |
 

--- a/scripts/doctor-diagnose.mjs
+++ b/scripts/doctor-diagnose.mjs
@@ -152,14 +152,20 @@ function collectSystemInfo() {
   };
 
   // Windows Terminal version (wt.exe --version은 GUI 다이얼로그를 띄우므로 AppxPackage로 조회)
-  try {
-    const wtVer = execSync(
-      'powershell.exe -NoProfile -NoLogo -Command "(Get-AppxPackage Microsoft.WindowsTerminal).Version"',
-      { encoding: "utf8", timeout: 5000, windowsHide: true },
-    ).trim();
-    info.wtVersion = wtVer || "not found";
-  } catch {
-    info.wtVersion = "not found";
+  // macOS/Linux는 wt 자체가 없으므로 조회 skip — "not found"로 표시되면 사용자가
+  // 설치 누락으로 오해할 수 있다. 명시적으로 "N/A (non-Windows)"로 표시.
+  if (platform() === "win32") {
+    try {
+      const wtVer = execSync(
+        'powershell.exe -NoProfile -NoLogo -Command "(Get-AppxPackage Microsoft.WindowsTerminal).Version"',
+        { encoding: "utf8", timeout: 5000, windowsHide: true },
+      ).trim();
+      info.wtVersion = wtVer || "not found";
+    } catch {
+      info.wtVersion = "not found";
+    }
+  } else {
+    info.wtVersion = "N/A (non-Windows)";
   }
 
   // triflux version

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -798,7 +798,7 @@ deep/fullcycle 추가 규칙:
 |------|----------|------|
 | 1개 + quick | tfx-auto 직접 실행 (fire-and-forget) | tfx-route.sh |
 | 1개 + thorough | tfx-auto 직접 실행 + verify/fix loop | tfx-route.sh |
-| 2개+ + quick | **headless 직접 실행** (WT 자동 팝업) | headless.mjs |
+| 2개+ + quick | **headless 직접 실행** (Windows: WT 자동 팝업 / macOS·Linux: psmux/tmux 단독) | headless.mjs |
 | 2개+ + thorough | Plan/PRD/Approval 후 → headless + verify/fix | headless.mjs |
 | psmux 미설치 fallback | Native Teams (Agent slim wrapper) | native.mjs |
 

--- a/tests/unit/safety-guard-wt.test.mjs
+++ b/tests/unit/safety-guard-wt.test.mjs
@@ -2,14 +2,19 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { describe, it } from "node:test";
 
-function runGuard(command) {
+function runGuard(command, opts = {}) {
   const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+  const env = { ...process.env };
+  if (opts.platform) {
+    env.SAFETY_GUARD_FORCE_PLATFORM = opts.platform;
+  }
 
   try {
     const stdout = execFileSync("node", ["hooks/safety-guard.mjs"], {
       input,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
+      env,
     });
     return { status: 0, stdout, stderr: "" };
   } catch (error) {
@@ -22,29 +27,51 @@ function runGuard(command) {
 }
 
 describe("safety-guard wt rules", () => {
-  it("wt.exe 직접 호출 차단", () => {
-    const result = runGuard("wt.exe new-tab -p triflux");
+  // win32 환경 시뮬레이션 — 차단 동작 검증
+  it("wt.exe 직접 호출 차단 (win32)", () => {
+    const result = runGuard("wt.exe new-tab -p triflux", { platform: "win32" });
 
     assert.equal(result.status, 2);
     assert.match(result.stderr, /wt\.exe 직접 호출 차단됨/);
     assert.match(result.stderr, /wt-manager\.mjs/);
   });
 
-  it("wt -w split-pane 직접 호출 차단", () => {
-    const result = runGuard("wt -w 0 split-pane -H -p triflux");
+  it("wt -w split-pane 직접 호출 차단 (win32)", () => {
+    const result = runGuard("wt -w 0 split-pane -H -p triflux", {
+      platform: "win32",
+    });
 
     assert.equal(result.status, 2);
   });
 
-  it("Start-Process wt 차단", () => {
+  it("Start-Process wt 차단 (win32)", () => {
     const result = runGuard(
       "Start-Process wt -ArgumentList '-w', '0', 'new-tab'",
+      { platform: "win32" },
     );
 
     assert.equal(result.status, 2);
     assert.match(result.stderr, /wt\.exe 직접 호출 차단됨/);
   });
 
+  // non-Windows (mac/linux) — 같은 명령이라도 false positive 방지를 위해 통과
+  it("wt.exe in darwin은 차단되지 않음 (false positive 방지)", () => {
+    const result = runGuard("wt.exe new-tab -p triflux", {
+      platform: "darwin",
+    });
+
+    assert.equal(result.status, 0);
+  });
+
+  it("wt -w split-pane in linux는 차단되지 않음", () => {
+    const result = runGuard("wt -w 0 split-pane -H -p triflux", {
+      platform: "linux",
+    });
+
+    assert.equal(result.status, 0);
+  });
+
+  // platform과 무관하게 항상 통과 (heredoc/echo/grep/commit msg 안의 텍스트)
   it("echo 안의 wt 문자열은 허용", () => {
     assert.equal(runGuard('echo "wt -w 0 split-pane"').status, 0);
   });


### PR DESCRIPTION
## Summary

- triflux는 Windows-first로 시작해 mac을 사후 보강한 프로젝트. 코드 레벨 platform guard는 정상이지만 문서·룰·safety-guard 메시지·doctor 출력에 Windows 전용 표현이 condition 없이 inject 되어 mac 사용자에게 dead text 노출.
- 분석 문서 (`/tmp/triflux-wt-docs/.triflux/plans/wt-macos-session-symptoms.md`, commit `671ec4fc`) 의 P1~P3 fix matrix + 사용자 추가 제안 (tfx-doctor mac drift) 일괄 적용.
- `SAFETY_GUARD_FORCE_PLATFORM` env 도입으로 mac CI에서도 win32 차단 동작 검증 가능.

## 변경 10파일

| 파일 | 변경 |
|------|------|
| `.claude/rules/tfx-psmux.md`, `AGENTS.md` | sync block 시작부에 Windows-only 배너 + sha256 갱신 |
| `CLAUDE.md` | `<psmux-wt>` 헤더 배너 + `<macos-terminal>` 섹션 신설 |
| `skills/tfx-auto/SKILL.md:801` | "WT 자동 팝업" → "Windows: WT 자동 팝업 / macOS·Linux: psmux/tmux 단독" |
| `hooks/safety-guard.mjs` | `process.platform === "win32"` 분기 + `SAFETY_GUARD_FORCE_PLATFORM` env override |
| `scripts/doctor-diagnose.mjs` | mac에서 `WT: not found` → `WT: N/A (non-Windows)` |
| `tests/unit/safety-guard-wt.test.mjs` | platform-aware 테스트 (win32 차단 검증 + darwin/linux false positive 방지 검증) |
| `packages/triflux/{hooks,scripts,skills}/` | byte-identical mirror |

## Test plan

- [x] `node --test tests/unit/safety-guard-wt.test.mjs` — 9/9 pass
- [x] `node --test tests/unit/safety-guard-psmux.test.mjs` — 19/19 pass
- [x] `node --test tests/unit/safety-guard-main-guard.test.mjs` + `doctor-macos-hooks.test.mjs` — 28/28 누적
- [x] `npx @biomejs/biome check` (changed mjs files) — clean
- [x] mac `tfx doctor` summary — `WT: N/A (non-Windows)` 확인
- [x] sync-block-sha256 양쪽 일치 (`b975aedec...`)
- [x] `diff -q` byte-identical mirror (4쌍)
- [x] Codex 교차 리뷰 2 라운드 — `verdict: pass`

## Follow-up TODO (이번 PR scope 밖)

- `scripts/release/check-packages-mirror.mjs`가 `bin/hub/scripts`만 자동 비교 — `hooks/skills` 범주 추가 필요 (별도 issue/PR).
- `skills/tfx-setup/SKILL.md`에 macOS-aware 안내 추가 (별도 PR).
- 분석 문서 (`/tmp/triflux-wt-docs/.triflux/plans/wt-macos-session-symptoms.md`) 본 repo `.triflux/plans/`에 commit할지 결정.

## 검증 evidence

- safety-guard 28/28 unit test pass (wt 9 + psmux 19 + main-guard 포함)
- biome lint clean
- mac `tfx doctor` `WT: N/A (non-Windows)` (이전: `WT: not found` — 설치 누락으로 오해 가능)
- `SAFETY_GUARD_FORCE_PLATFORM=win32` simulation 테스트로 mac CI 에서도 차단 동작 검증