### PR TITLE
fix(release): include hooks/skills in check-packages-mirror auto compare

### DIFF
--- a/packages/triflux/scripts/release/check-packages-mirror.mjs
+++ b/packages/triflux/scripts/release/check-packages-mirror.mjs
@@ -22,10 +22,15 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
 const MIRROR_ROOT = join(REPO_ROOT, "packages", "triflux");
-const MIRROR_TOPS = ["bin", "hub", "mesh", "scripts"];
+const MIRROR_TOPS = ["bin", "hooks", "hub", "mesh", "scripts", "skills"];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
+// Per-top relative paths to skip. Mirror policy excludes these via
+// packages/triflux/package.json "files" negation patterns (e.g.
+// "!skills/tfx-workspace"), so source-tree drift in these subtrees does not
+// affect the npm tarball. See .claude/rules/tfx-mirror-policy.md.
+const SKIP_RELS = new Map([["skills", new Set(["tfx-workspace"])]]);
 
-function walkRelFiles(root) {
+function walkRelFiles(root, skipRels = new Set()) {
   const out = [];
   if (!existsSync(root)) return out;
   const stack = [""];
@@ -35,6 +40,7 @@ function walkRelFiles(root) {
     for (const entry of readdirSync(abs, { withFileTypes: true })) {
       if (SKIP_DIRS.has(entry.name)) continue;
       const subRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (skipRels.has(subRel)) continue;
       if (entry.isDirectory()) stack.push(subRel);
       else out.push(subRel);
     }
@@ -49,8 +55,9 @@ function compareMirror({ fix = false } = {}) {
   for (const top of MIRROR_TOPS) {
     const srcDir = join(REPO_ROOT, top);
     const dstDir = join(MIRROR_ROOT, top);
-    const srcFiles = new Set(walkRelFiles(srcDir));
-    const dstFiles = new Set(walkRelFiles(dstDir));
+    const skipRels = SKIP_RELS.get(top) ?? new Set();
+    const srcFiles = new Set(walkRelFiles(srcDir, skipRels));
+    const dstFiles = new Set(walkRelFiles(dstDir, skipRels));
     const allFiles = new Set([...srcFiles, ...dstFiles]);
 
     for (const rel of allFiles) {

--- a/scripts/release/check-packages-mirror.mjs
+++ b/scripts/release/check-packages-mirror.mjs
@@ -22,10 +22,15 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
 const MIRROR_ROOT = join(REPO_ROOT, "packages", "triflux");
-const MIRROR_TOPS = ["bin", "hub", "mesh", "scripts"];
+const MIRROR_TOPS = ["bin", "hooks", "hub", "mesh", "scripts", "skills"];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
+// Per-top relative paths to skip. Mirror policy excludes these via
+// packages/triflux/package.json "files" negation patterns (e.g.
+// "!skills/tfx-workspace"), so source-tree drift in these subtrees does not
+// affect the npm tarball. See .claude/rules/tfx-mirror-policy.md.
+const SKIP_RELS = new Map([["skills", new Set(["tfx-workspace"])]]);
 
-function walkRelFiles(root) {
+function walkRelFiles(root, skipRels = new Set()) {
   const out = [];
   if (!existsSync(root)) return out;
   const stack = [""];
@@ -35,6 +40,7 @@ function walkRelFiles(root) {
     for (const entry of readdirSync(abs, { withFileTypes: true })) {
       if (SKIP_DIRS.has(entry.name)) continue;
       const subRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (skipRels.has(subRel)) continue;
       if (entry.isDirectory()) stack.push(subRel);
       else out.push(subRel);
     }
@@ -49,8 +55,9 @@ function compareMirror({ fix = false } = {}) {
   for (const top of MIRROR_TOPS) {
     const srcDir = join(REPO_ROOT, top);
     const dstDir = join(MIRROR_ROOT, top);
-    const srcFiles = new Set(walkRelFiles(srcDir));
-    const dstFiles = new Set(walkRelFiles(dstDir));
+    const skipRels = SKIP_RELS.get(top) ?? new Set();
+    const srcFiles = new Set(walkRelFiles(srcDir, skipRels));
+    const dstFiles = new Set(walkRelFiles(dstDir, skipRels));
     const allFiles = new Set([...srcFiles, ...dstFiles]);
 
     for (const rel of allFiles) {

--- a/tests/unit/packages-mirror.test.mjs
+++ b/tests/unit/packages-mirror.test.mjs
@@ -3,8 +3,13 @@
 // run `npm run release:check-mirror:fix` after editing hub/bin/scripts.
 
 import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { compareMirror } from "../../scripts/release/check-packages-mirror.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 test("packages/triflux mirror is byte-identical to root", () => {
   const result = compareMirror({ fix: false });
@@ -18,4 +23,62 @@ test("packages/triflux mirror is byte-identical to root", () => {
   }
   assert.equal(result.ok, true);
   assert.equal(result.issues.length, 0);
+});
+
+// Lock-in coverage for hooks/skills tops. Without these in MIRROR_TOPS the
+// release gate silently ignores drift in hooks/ and skills/ — caught by Codex
+// review on PR #319 follow-up.
+function withMirrorProbe(rel, fn) {
+  const probePath = join(REPO_ROOT, rel);
+  writeFileSync(probePath, "probe");
+  try {
+    fn();
+  } finally {
+    rmSync(probePath, { force: true });
+  }
+}
+
+test("check-packages-mirror walks hooks/ top-level dir", () => {
+  withMirrorProbe("hooks/__mirror_probe_temp__.txt", () => {
+    const result = compareMirror({ fix: false });
+    const found = result.issues.find((i) =>
+      i.path.endsWith("hooks/__mirror_probe_temp__.txt"),
+    );
+    assert.ok(
+      found,
+      "hooks/ drift was not flagged — check-packages-mirror.mjs MIRROR_TOPS regression",
+    );
+    assert.equal(found.kind, "missing-in-mirror");
+  });
+});
+
+test("check-packages-mirror walks skills/ top-level dir", () => {
+  withMirrorProbe("skills/__mirror_probe_temp__.txt", () => {
+    const result = compareMirror({ fix: false });
+    const found = result.issues.find((i) =>
+      i.path.endsWith("skills/__mirror_probe_temp__.txt"),
+    );
+    assert.ok(
+      found,
+      "skills/ drift was not flagged — check-packages-mirror.mjs MIRROR_TOPS regression",
+    );
+    assert.equal(found.kind, "missing-in-mirror");
+  });
+});
+
+test("check-packages-mirror skips skills/tfx-workspace", () => {
+  // tfx-workspace is excluded from npm tarball via
+  // packages/triflux/package.json files negation ("!skills/tfx-workspace"),
+  // so source-tree drift in that subtree must not fail the release gate.
+  withMirrorProbe("skills/tfx-workspace/__mirror_probe_temp__.txt", () => {
+    const result = compareMirror({ fix: false });
+    const leaked = result.issues.find((i) =>
+      i.path.includes("tfx-workspace/__mirror_probe_temp__"),
+    );
+    assert.equal(
+      leaked,
+      undefined,
+      "tfx-workspace drift was flagged — SKIP_RELS regression",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- PR #319 Codex review CONCERN 2 follow-up — `scripts/release/check-packages-mirror.mjs` 의 `MIRROR_TOPS` 는 `bin`, `hub`, `scripts` 3개만 자동 비교했다. `.claude/rules/tfx-mirror-policy.md` 정책상 `hooks/` 와 `skills/` 도 `packages/triflux/{hooks,skills}/` 에 byte-identical mirror 대상이지만, 자동 release gate 가 없어서 PR 머지 시점 수동 `diff -q` 에 의존했다.
- `MIRROR_TOPS` 에 `hooks` + `skills` 추가, `skills/tfx-workspace` 는 npm publish 부정 패턴 (`!skills/tfx-workspace`) 대상이므로 `SKIP_RELS` 로 walker 단계에서 skip.
- 회귀 가드: `tests/unit/packages-mirror.test.mjs` 에 probe 3개 추가 — 누가 `MIRROR_TOPS` 에서 `hooks`/`skills` 를 빼면 CI 에서 즉시 적발. `tfx-workspace` skip 도 별도 잠금.

## 변경 3파일

| 파일 | 변경 |
|------|------|
| `scripts/release/check-packages-mirror.mjs` | `MIRROR_TOPS` 에 `hooks`/`skills` 추가, `SKIP_RELS` Map 도입, `walkRelFiles` 가 per-top skip set 수신 |
| `packages/triflux/scripts/release/check-packages-mirror.mjs` | byte-identical mirror sync |
| `tests/unit/packages-mirror.test.mjs` | hooks walk / skills walk / tfx-workspace skip 3 probe tests |

## Baseline 검증

- `diff -rq hooks/ packages/triflux/hooks/` → drift 없음 (clean)
- `diff -rq skills/ packages/triflux/skills/` → drift 없음 (clean)
- 즉 본 PR 은 검증 gate 만 추가하고 코드 동기화 작업은 없다.

## Test plan

- [x] `node --test tests/unit/packages-mirror.test.mjs` → 4/4 pass (기존 1 + 신규 3)
- [x] `node scripts/release/check-packages-mirror.mjs` → `Mirror OK — packages/triflux matches root`
- [x] `node scripts/release/check-packages-mirror.mjs --json` → `{"ok": true, "issues": [], "fixed": []}`
- [x] `npx @biomejs/biome check` (changed mjs files) → clean
- [x] probe 1: `hooks/__mirror_probe_temp__.txt` 만 root 에 생성 → `missing-in-mirror` 으로 잡힘 (회귀 시점 catch 가능 증명)
- [x] probe 2: `skills/__mirror_probe_temp__.txt` 동일 검증
- [x] probe 3: `skills/tfx-workspace/__mirror_probe_temp__.txt` 생성 → flag 안 됨 (skip 동작 증명)

## 분석 근거

`.claude/rules/tfx-mirror-policy.md` § "mirror 범위 (in / out)" 에서:

> `hooks/*`, `hud/*`, `mesh/*`, `config/*` → `packages/triflux/{hooks,hud,mesh,config}/`

`hooks/` 는 npm published 대상이라 root 와 packages/triflux 양쪽 모두 published files 에 들어간다. `release:check-mirror` 가 이걸 검증 안 하면 silent drift 가 release 까지 살아남을 수 있고, PR #319 review 가 이 gap 을 지적했다.

`hud/`, `mesh/`, `config/` 도 동일 정책이지만 본 PR 의 scope (#319 follow-up) 에서는 review 가 지적한 `hooks` + `skills` 두 개만 우선 적용. 추가 top-level 디렉토리 확장은 별도 PR 로 분리.