### PR TITLE
feat(native-bridge): UI default-on, swarm shards, immediate cleanup

### DIFF
--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -133,6 +133,23 @@ export function findDaemonJobByShort(listResponse, short) {
   return listResponse.jobs.find((job) => job?.short === short) || null;
 }
 
+export function findDaemonJobBySessionId(listResponse, sessionId) {
+  if (!Array.isArray(listResponse?.jobs)) return null;
+  const expected = String(sessionId || "");
+  if (!expected) return null;
+  return (
+    listResponse.jobs.find((job) => {
+      const candidate =
+        job?.sessionId ??
+        job?.session_id ??
+        job?.dispatch?.sessionId ??
+        job?.d?.sessionId ??
+        "";
+      return String(candidate) === expected;
+    }) || null
+  );
+}
+
 export async function waitForDaemonJobPid(
   controlSock,
   short,
@@ -157,4 +174,46 @@ export async function killDaemonJob(controlSock, short) {
     op: "kill",
     short,
   });
+}
+
+export async function sendKillBySessionId({
+  daemonPaths,
+  sessionId,
+  timeoutMs = 6000,
+} = {}) {
+  const controlSock = daemonPaths?.controlSock;
+  if (!controlSock || !sessionId) {
+    return { ok: true, killed: false, reason: "missing_target" };
+  }
+
+  try {
+    const list = await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "list",
+      },
+      { timeoutMs },
+    );
+    const job = findDaemonJobBySessionId(list, sessionId);
+    if (!job?.short) {
+      return { ok: true, killed: false, reason: "not_found" };
+    }
+    return await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "kill",
+        short: job.short,
+      },
+      { timeoutMs },
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      killed: false,
+      reason: "control_unavailable",
+      error: error?.message || String(error),
+    };
+  }
 }

--- a/hub/team/claude-native-bridge.mjs
+++ b/hub/team/claude-native-bridge.mjs
@@ -48,6 +48,7 @@ export function deriveClaudeDaemonPaths({
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
+    jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
 }
 
@@ -215,6 +216,11 @@ export async function removeRosterWorkers(rosterPath, shorts) {
   });
 }
 
+export async function removeClaudeJobState(jobsDir, short) {
+  if (!short) return;
+  await fs.rm(path.join(jobsDir, short), { recursive: true, force: true });
+}
+
 function shellSingleQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
@@ -279,18 +285,20 @@ export async function registerSwarmShard({
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const removeProjection =
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
     paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const jobsDir =
+    paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
   const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,
-    sessionId,
     cwd,
     command,
     name: displayName,
@@ -334,6 +342,7 @@ export async function registerSwarmShard({
     skipped: false,
     host: "local",
     sessionId: payload.sessionId,
+    swarmSessionId: sessionId,
     shardName,
     cli,
     role,
@@ -346,6 +355,7 @@ export async function registerSwarmShard({
       closed = true;
       await removeProjection(sessionProjectionPath).catch(() => {});
       await killJob(paths.controlSock, short).catch(() => {});
+      await removeJobStateImpl(jobsDir, short).catch(() => {});
     },
   };
 }

--- a/hub/team/claude-native-bridge.mjs
+++ b/hub/team/claude-native-bridge.mjs
@@ -4,6 +4,17 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildDaemonExecDispatchPayload,
+  killDaemonJob,
+  sendClaudeControlRequest,
+  waitForDaemonJobPid,
+} from "./claude-daemon-control.mjs";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -36,6 +47,7 @@ export function deriveClaudeDaemonPaths({
     rendezvousDir: path.join(daemonDir, "rv"),
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
+    sessionsDir: path.join(resolvedConfigDir, "sessions"),
   };
 }
 
@@ -201,6 +213,141 @@ export async function removeRosterWorkers(rosterPath, shorts) {
     if (changed) await writeRoster(rosterPath, roster);
     return changed;
   });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
+  const banner = `${displayName} native bridge active (${sessionId})`;
+  return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
+}
+
+function isLocalHost(host) {
+  const value = String(host || "local").toLowerCase();
+  return value === "local" || value === "localhost" || value === "127.0.0.1";
+}
+
+function deriveSwarmShort({ sessionId, shardName, host }) {
+  return crypto
+    .createHash("sha256")
+    .update(`${sessionId}:${shardName}:${host || "local"}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export async function registerSwarmShard({
+  sessionId,
+  cli = "codex",
+  role = "worker",
+  shardName,
+  cwd = process.cwd(),
+  host = "local",
+  configDir = resolveClaudeConfigDir(),
+  tmpRoot = "/tmp",
+  _deps = {},
+} = {}) {
+  if (!sessionId) throw new Error("sessionId is required");
+  if (!shardName) throw new Error("shardName is required");
+
+  const warn = _deps.warn || ((message) => console.warn(message));
+  if (!isLocalHost(host)) {
+    warn(
+      `[native-bridge] remote shard ${shardName}@${host}: skipping local registration; remote launcher must register on that host`,
+    );
+    return {
+      ok: true,
+      skipped: true,
+      host,
+      sessionId,
+      shardName,
+      close() {},
+    };
+  }
+
+  const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const readProcStart = _deps.getProcStart || getProcStart;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const accessControlSock = _deps.accessControlSock || fs.access;
+
+  const paths = derivePaths({ configDir, tmpRoot });
+  const sessionsDir =
+    paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const short = deriveSwarmShort({ sessionId, shardName, host });
+  const displayName = `Triflux swarm ${shardName}`;
+  const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
+  const payload = buildPayload({
+    short,
+    sessionId,
+    cwd,
+    command,
+    name: displayName,
+  });
+
+  await accessControlSock(paths.controlSock);
+  const dispatch = await sendControl(
+    paths.controlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: 1000,
+    },
+    { timeoutMs: 1000 },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(
+      `Claude daemon dispatch failed for swarm shard ${shardName}`,
+    );
+  }
+
+  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
+  const pid = job.pid;
+  const projection = buildProjection({
+    pid,
+    procStart: readProcStart(pid),
+    sessionId: payload.sessionId,
+    short,
+    cwd,
+    name: displayName,
+    agent: cli,
+    startedAt: job.startedAt || Date.now(),
+    updatedAt: Date.now(),
+  });
+  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  let closed = false;
+
+  return {
+    ok: true,
+    skipped: false,
+    host: "local",
+    sessionId: payload.sessionId,
+    shardName,
+    cli,
+    role,
+    short,
+    displayName,
+    controlSock: paths.controlSock,
+    sessionProjectionPath,
+    async close() {
+      if (closed) return;
+      closed = true;
+      await removeProjection(sessionProjectionPath).catch(() => {});
+      await killJob(paths.controlSock, short).catch(() => {});
+    },
+  };
 }
 
 export function buildNativeWorkerRosterEntry({

--- a/hub/team/cli/commands/start/index.mjs
+++ b/hub/team/cli/commands/start/index.mjs
@@ -96,6 +96,7 @@ export async function teamStart(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   } = parseTeamArgs(args);
   // --assign 사용 시 task를 자동 생성
   const task =
@@ -133,6 +134,8 @@ export async function teamStart(args = []) {
   const { mode: effectiveMode, warnings: modeWarnings } =
     resolveEffectiveMode(teammateMode);
   for (const message of modeWarnings) warn(message);
+  const effectiveNativeBridge =
+    effectiveMode === "headless" && !nativeBridgeUiOptOut ? true : nativeBridge;
 
   console.log(`  세션:  ${WHITE}${sessionId}${RESET}`);
   console.log(`  모드:  ${effectiveMode}`);
@@ -180,7 +183,7 @@ export async function teamStart(args = []) {
             mcpProfile,
             model,
             cwd,
-            nativeBridge,
+            nativeBridge: effectiveNativeBridge,
             nativeBridgeMode,
           })
         : effectiveMode === "wt"

--- a/hub/team/cli/commands/start/parse-args.mjs
+++ b/hub/team/cli/commands/start/parse-args.mjs
@@ -77,7 +77,10 @@ export function parseTeamArgs(args = []) {
   let model = "";
   let cwd = "";
   let nativeBridge = false;
-  let nativeBridgeMode = "roster";
+  let nativeBridgeMode = "agents";
+  let nativeBridgeExplicit = false;
+  let nativeBridgeUiRequested = false;
+  let nativeBridgeUiOptOut = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const current = args[index];
@@ -127,9 +130,25 @@ export function parseTeamArgs(args = []) {
       model = args[++index].trim();
     } else if (current === "--native-bridge" || current === "-nb") {
       nativeBridge = true;
+      nativeBridgeExplicit = true;
     } else if (current === "--native-bridge-ui") {
+      if (nativeBridgeUiOptOut) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
       nativeBridge = true;
       nativeBridgeMode = "agents";
+      nativeBridgeExplicit = true;
+      nativeBridgeUiRequested = true;
+    } else if (current === "--no-native-bridge-ui") {
+      if (nativeBridgeUiRequested) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
+      nativeBridge = false;
+      nativeBridgeUiOptOut = true;
     } else if (current === "--native-bridge-mode") {
       const mode = args[++index];
       if (!NATIVE_BRIDGE_MODES.has(mode)) {
@@ -139,6 +158,7 @@ export function parseTeamArgs(args = []) {
       }
       nativeBridge = true;
       nativeBridgeMode = mode;
+      nativeBridgeExplicit = true;
     } else if (current === "--cwd" && args[index + 1]) {
       let p = args[++index].trim();
       // MSYS/Git Bash 드라이브 문자 변환: /c/... → C:/...
@@ -153,11 +173,20 @@ export function parseTeamArgs(args = []) {
     }
   }
 
+  const normalizedTeammateMode = normalizeTeammateMode(teammateMode);
+  if (
+    !nativeBridgeExplicit &&
+    !nativeBridgeUiOptOut &&
+    normalizedTeammateMode === "headless"
+  ) {
+    nativeBridge = true;
+  }
+
   return {
     agents,
     lead,
     layout: normalizeLayout(layout),
-    teammateMode: normalizeTeammateMode(teammateMode),
+    teammateMode: normalizedTeammateMode,
     task: taskParts.join(" ").trim(),
     assigns,
     autoAttach,
@@ -173,5 +202,6 @@ export function parseTeamArgs(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   };
 }

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -28,6 +28,7 @@ import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   killDaemonJob,
+  sendKillBySessionId,
   sendClaudeControlRequest,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
@@ -880,8 +881,11 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         workerId,
         cwd: assignment.cwd || assignment.workdir,
         daemonShort: short,
+        daemonPaths: paths,
         controlSock: paths.controlSock,
+        sessionId: "",
         sessionProjectionPath: "",
+        daemonCompletionMatched: false,
       };
       dispatches.push(record);
 
@@ -891,6 +895,7 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         command: buildDaemonWrappedCommand(command, token),
         name,
       });
+      record.sessionId = payload.sessionId;
       const dispatch = await sendClaudeControlRequest(paths.controlSock, {
         proto: 1,
         op: "dispatch",
@@ -933,13 +938,23 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
   return dispatches;
 }
 
-async function cleanupDaemonDispatches(dispatches) {
+export async function cleanupDaemonDispatches(dispatches) {
   await Promise.all(
     dispatches.map(async (dispatch) => {
       if (dispatch.sessionProjectionPath) {
         await removeClaudeSessionProjection(
           dispatch.sessionProjectionPath,
         ).catch(() => {});
+      }
+      if (
+        dispatch.daemonCompletionMatched === true &&
+        dispatch.daemonPaths &&
+        dispatch.sessionId
+      ) {
+        await sendKillBySessionId({
+          daemonPaths: dispatch.daemonPaths,
+          sessionId: dispatch.sessionId,
+        }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
         await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
@@ -1115,7 +1130,10 @@ async function waitForDaemonCompletion(
           token: dispatch.token,
           resultFile: dispatch.resultFile,
         });
-      if (!finalCompletion.matched) {
+      if (finalCompletion.matched) {
+        dispatch.daemonCompletionMatched = true;
+        cleanupDaemonDispatches([dispatch]).catch(() => {});
+      } else {
         killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
           () => {},
         );

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -28,8 +28,8 @@ import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   killDaemonJob,
-  sendKillBySessionId,
   sendClaudeControlRequest,
+  sendKillBySessionId,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
 import {

--- a/hub/team/swarm-cli.mjs
+++ b/hub/team/swarm-cli.mjs
@@ -84,8 +84,11 @@ export function parseFlags(args) {
     maxRestarts: 2,
     logsDir: null,
     baseBranch: "main",
+    nativeBridge: true,
   };
   const positional = [];
+  let nativeBridgeUiEnabled = false;
+  let nativeBridgeUiDisabled = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--dry-run" || a === "--plan-only") flags.dryRun = true;
@@ -101,11 +104,22 @@ export function parseFlags(args) {
         );
       }
       flags.baseBranch = v;
+    } else if (a === "--native-bridge-ui") {
+      nativeBridgeUiEnabled = true;
+      flags.nativeBridge = true;
+    } else if (a === "--no-native-bridge-ui") {
+      nativeBridgeUiDisabled = true;
+      flags.nativeBridge = false;
     } else if (a.startsWith("--")) {
       // ignore unknown flags silently
     } else {
       positional.push(a);
     }
+  }
+  if (nativeBridgeUiEnabled && nativeBridgeUiDisabled) {
+    throw new Error(
+      "conflicting native bridge flags: --native-bridge-ui and --no-native-bridge-ui",
+    );
   }
   return { flags, positional };
 }
@@ -252,6 +266,7 @@ export async function cmdSwarmRun(args, { json = false, deps = {} } = {}) {
     logsDir,
     maxRestarts: flags.maxRestarts,
     baseBranch: flags.baseBranch,
+    nativeBridge: flags.nativeBridge,
   });
 
   hyper.on("shardLaunched", ({ shardName, sessionId, remote }) => {

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -11,6 +11,7 @@
 //   F5: Merge conflict        → retry integration with conflict resolution
 
 import { execFile } from "node:child_process";
+import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,6 +22,7 @@ import {
 import { cleanupShardProcesses } from "../lib/process-utils.mjs";
 import { getHostConfig } from "../lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
+import { registerSwarmShard } from "./claude-native-bridge.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
 import { ensureConductorRegistry } from "./conductor-registry.mjs";
 import { createEventLog } from "./event-log.mjs";
@@ -162,6 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
+ * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -176,6 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
+    nativeBridge = true,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -200,6 +204,7 @@ export function createSwarmHypervisor(opts) {
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const cleanupShardProcessesImpl =
     _deps.cleanupShardProcesses || cleanupShardProcesses;
+  const registerSwarmShardImpl = _deps.registerSwarmShard || registerSwarmShard;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
   const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
@@ -530,9 +535,89 @@ export function createSwarmHypervisor(opts) {
 
   // ── Worker lifecycle ────────────────────────────────────────
 
+  function safeSessionPart(value) {
+    return String(value || "unknown")
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80);
+  }
+
+  function buildSwarmSessionId(shard) {
+    const short8 = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
+  }
+
+  async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    const registration = worker?.nativeBridgeRegistration;
+    if (!registration || typeof registration.close !== "function") return;
+    try {
+      await registration.close();
+      eventLog.append("native_bridge_registration_closed", {
+        shard: shardName,
+        reason,
+      });
+    } catch (err) {
+      eventLog.append("native_bridge_registration_close_failed", {
+        shard: shardName,
+        reason,
+        error: err.message,
+      });
+    }
+  }
+
+  async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
+    if (!nativeBridge) return null;
+    try {
+      const registration = await registerSwarmShardImpl({
+        sessionId: sessionConfig.id,
+        cli: shard.agent,
+        role: shard.role || "worker",
+        shardName: shard.name,
+        cwd: sessionConfig.workdir,
+        host: shard.host || "local",
+        _deps: {
+          warn(message) {
+            emitter.emit("warning", {
+              type: "native_bridge_registration_skipped",
+              shard: shard.name,
+              host: shard.host || "local",
+              message,
+            });
+          },
+        },
+      });
+      eventLog.append(
+        registration?.skipped
+          ? "native_bridge_registration_skipped"
+          : "native_bridge_registration",
+        {
+          shard: shard.name,
+          sessionId: sessionConfig.id,
+          host: shard.host || "local",
+          displayName: `Triflux swarm ${shard.name}`,
+        },
+      );
+      return registration;
+    } catch (err) {
+      eventLog.append("native_bridge_registration_failed", {
+        shard: shard.name,
+        sessionId: sessionConfig.id,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      emitter.emit("warning", {
+        type: "native_bridge_registration_failed",
+        shard: shard.name,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      return null;
+    }
+  }
+
   function buildSessionConfig(shard) {
     const config = {
-      id: `swarm-${shard.name}-${Date.now()}`,
+      id: buildSwarmSessionId(shard),
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
@@ -574,6 +659,7 @@ export function createSwarmHypervisor(opts) {
   async function launchShard(shard, isRedundant = false) {
     // Clone frozen shard so we can attach mutable runtime state (_remoteEnv)
     shard = { ...shard };
+    let nativeBridgeRegistration = null;
 
     const shardLogsDir = join(
       logsDir,
@@ -661,6 +747,10 @@ export function createSwarmHypervisor(opts) {
       // 직접 주입해야 shardCompleted 이벤트가 발화된다. 2026-04-17 세션에서
       // follow-up swarm 이 여기서 hang 했던 원인.
       const sessionConfig = buildSessionConfig(shard);
+      nativeBridgeRegistration = await maybeRegisterNativeBridgeShard(
+        shard,
+        sessionConfig,
+      );
       sessionConfig.onCompleted = ({ sessionId, completionPayload } = {}) =>
         handleShardCompleted(
           shard.name,
@@ -698,6 +788,7 @@ export function createSwarmHypervisor(opts) {
         startedAt: Date.now(),
         worktreePath: sessionConfig.worktreePath,
         branchName: sessionConfig.branchName,
+        nativeBridgeRegistration,
       };
 
       if (isRedundant) {
@@ -713,6 +804,13 @@ export function createSwarmHypervisor(opts) {
 
       return entry;
     } catch (err) {
+      if (nativeBridgeRegistration) {
+        await closeNativeBridgeRegistration(
+          { nativeBridgeRegistration },
+          shard.name,
+          "launch_failed",
+        );
+      }
       eventLog.append("shard_launch_failed", {
         shard: shard.name,
         isRedundant,
@@ -760,6 +858,16 @@ export function createSwarmHypervisor(opts) {
       isRedundant,
       hasPayload: completionPayload !== undefined,
     });
+    const completedWorker = isRedundant
+      ? redundantWorkers.get(shardName)
+      : workers.get(shardName);
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
+    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
@@ -845,6 +953,10 @@ export function createSwarmHypervisor(opts) {
     });
 
     if (isRedundant) return; // redundant failure is non-critical
+    const failedWorker = workers.get(shardName);
+    if (failedWorker) {
+      void closeNativeBridgeRegistration(failedWorker, shardName, "failed");
+    }
 
     // F2: Rate limit — try fallback agent
     if (failureMode === FAILURE_MODES.F2_RATE_LIMIT) {
@@ -1714,9 +1826,15 @@ export function createSwarmHypervisor(opts) {
     const shutdowns = [];
     for (const [, w] of workers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
     for (const [, w] of redundantWorkers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
 
     await Promise.allSettled(shutdowns);

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -164,7 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
- * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
+ * @param {boolean} [opts.nativeBridge=false] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -179,7 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
-    nativeBridge = true,
+    nativeBridge = false,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -548,21 +548,33 @@ export function createSwarmHypervisor(opts) {
   }
 
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    if (worker?.nativeBridgeClosePromise) {
+      await worker.nativeBridgeClosePromise;
+      return;
+    }
     const registration = worker?.nativeBridgeRegistration;
     if (!registration || typeof registration.close !== "function") return;
-    try {
-      await registration.close();
-      eventLog.append("native_bridge_registration_closed", {
-        shard: shardName,
-        reason,
-      });
-    } catch (err) {
-      eventLog.append("native_bridge_registration_close_failed", {
-        shard: shardName,
-        reason,
-        error: err.message,
-      });
-    }
+    worker.nativeBridgeClosePromise = (async () => {
+      let closed = false;
+      try {
+        await registration.close();
+        closed = true;
+        eventLog.append("native_bridge_registration_closed", {
+          shard: shardName,
+          reason,
+        });
+      } catch (err) {
+        eventLog.append("native_bridge_registration_close_failed", {
+          shard: shardName,
+          reason,
+          error: err.message,
+        });
+      } finally {
+        worker.nativeBridgeClosePromise = null;
+        if (closed) worker.nativeBridgeRegistration = null;
+      }
+    })();
+    await worker.nativeBridgeClosePromise;
   }
 
   async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
@@ -573,7 +585,7 @@ export function createSwarmHypervisor(opts) {
         cli: shard.agent,
         role: shard.role || "worker",
         shardName: shard.name,
-        cwd: sessionConfig.workdir,
+        cwd: workdir,
         host: shard.host || "local",
         _deps: {
           warn(message) {
@@ -892,10 +904,23 @@ export function createSwarmHypervisor(opts) {
         const worker = workers.get(shardName);
         const shard = plan?.shards.find((item) => item.name === shardName);
         if (worker && shard) {
-          void maybeCleanupWorktree(shardName, worker, shard, {
-            force: true,
-            failureReason: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
-          });
+          const cleanupPromise = maybeCleanupWorktree(
+            shardName,
+            worker,
+            shard,
+            {
+              force: true,
+              failureReason: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
+            },
+          );
+          worker.cleanupPromise = cleanupPromise;
+          void cleanupPromise
+            .finally(() => {
+              if (worker.cleanupPromise === cleanupPromise) {
+                worker.cleanupPromise = null;
+              }
+            })
+            .catch(() => {});
         }
 
         const redundant = redundantWorkers.get(shardName);
@@ -1125,6 +1150,8 @@ export function createSwarmHypervisor(opts) {
 
       for (const shardName of plan.mergeOrder) {
         if (failures.has(shardName)) {
+          const worker = workers.get(shardName);
+          if (worker?.cleanupPromise) await worker.cleanupPromise;
           eventLog.append("skip_failed_shard", { shard: shardName });
           appendIntegrationReport({
             shard: shardName,
@@ -1411,6 +1438,12 @@ export function createSwarmHypervisor(opts) {
     if (!worker?.worktreePath || shard?.host) return outcome;
     if (failureReason && keepFailedWorktrees) return outcome;
     if (cleanedWorktreePaths.has(worker.worktreePath)) return outcome;
+
+    await closeNativeBridgeRegistration(
+      worker,
+      shardName,
+      "before_worktree_cleanup",
+    );
 
     // Best-effort: preserve any uncommitted worker changes before removing
     // the worktree. Silent on failure — must not block cleanup or mask the

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -133,6 +133,23 @@ export function findDaemonJobByShort(listResponse, short) {
   return listResponse.jobs.find((job) => job?.short === short) || null;
 }
 
+export function findDaemonJobBySessionId(listResponse, sessionId) {
+  if (!Array.isArray(listResponse?.jobs)) return null;
+  const expected = String(sessionId || "");
+  if (!expected) return null;
+  return (
+    listResponse.jobs.find((job) => {
+      const candidate =
+        job?.sessionId ??
+        job?.session_id ??
+        job?.dispatch?.sessionId ??
+        job?.d?.sessionId ??
+        "";
+      return String(candidate) === expected;
+    }) || null
+  );
+}
+
 export async function waitForDaemonJobPid(
   controlSock,
   short,
@@ -157,4 +174,46 @@ export async function killDaemonJob(controlSock, short) {
     op: "kill",
     short,
   });
+}
+
+export async function sendKillBySessionId({
+  daemonPaths,
+  sessionId,
+  timeoutMs = 6000,
+} = {}) {
+  const controlSock = daemonPaths?.controlSock;
+  if (!controlSock || !sessionId) {
+    return { ok: true, killed: false, reason: "missing_target" };
+  }
+
+  try {
+    const list = await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "list",
+      },
+      { timeoutMs },
+    );
+    const job = findDaemonJobBySessionId(list, sessionId);
+    if (!job?.short) {
+      return { ok: true, killed: false, reason: "not_found" };
+    }
+    return await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "kill",
+        short: job.short,
+      },
+      { timeoutMs },
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      killed: false,
+      reason: "control_unavailable",
+      error: error?.message || String(error),
+    };
+  }
 }

--- a/packages/remote/hub/team/claude-native-bridge.mjs
+++ b/packages/remote/hub/team/claude-native-bridge.mjs
@@ -48,6 +48,7 @@ export function deriveClaudeDaemonPaths({
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
+    jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
 }
 
@@ -215,6 +216,11 @@ export async function removeRosterWorkers(rosterPath, shorts) {
   });
 }
 
+export async function removeClaudeJobState(jobsDir, short) {
+  if (!short) return;
+  await fs.rm(path.join(jobsDir, short), { recursive: true, force: true });
+}
+
 function shellSingleQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
@@ -279,18 +285,19 @@ export async function registerSwarmShard({
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const removeProjection =
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
     paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const jobsDir = paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
   const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,
-    sessionId,
     cwd,
     command,
     name: displayName,
@@ -334,6 +341,7 @@ export async function registerSwarmShard({
     skipped: false,
     host: "local",
     sessionId: payload.sessionId,
+    swarmSessionId: sessionId,
     shardName,
     cli,
     role,
@@ -346,6 +354,7 @@ export async function registerSwarmShard({
       closed = true;
       await removeProjection(sessionProjectionPath).catch(() => {});
       await killJob(paths.controlSock, short).catch(() => {});
+      await removeJobStateImpl(jobsDir, short).catch(() => {});
     },
   };
 }

--- a/packages/remote/hub/team/claude-native-bridge.mjs
+++ b/packages/remote/hub/team/claude-native-bridge.mjs
@@ -4,6 +4,17 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildDaemonExecDispatchPayload,
+  killDaemonJob,
+  sendClaudeControlRequest,
+  waitForDaemonJobPid,
+} from "./claude-daemon-control.mjs";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -36,6 +47,7 @@ export function deriveClaudeDaemonPaths({
     rendezvousDir: path.join(daemonDir, "rv"),
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
+    sessionsDir: path.join(resolvedConfigDir, "sessions"),
   };
 }
 
@@ -201,6 +213,141 @@ export async function removeRosterWorkers(rosterPath, shorts) {
     if (changed) await writeRoster(rosterPath, roster);
     return changed;
   });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
+  const banner = `${displayName} native bridge active (${sessionId})`;
+  return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
+}
+
+function isLocalHost(host) {
+  const value = String(host || "local").toLowerCase();
+  return value === "local" || value === "localhost" || value === "127.0.0.1";
+}
+
+function deriveSwarmShort({ sessionId, shardName, host }) {
+  return crypto
+    .createHash("sha256")
+    .update(`${sessionId}:${shardName}:${host || "local"}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export async function registerSwarmShard({
+  sessionId,
+  cli = "codex",
+  role = "worker",
+  shardName,
+  cwd = process.cwd(),
+  host = "local",
+  configDir = resolveClaudeConfigDir(),
+  tmpRoot = "/tmp",
+  _deps = {},
+} = {}) {
+  if (!sessionId) throw new Error("sessionId is required");
+  if (!shardName) throw new Error("shardName is required");
+
+  const warn = _deps.warn || ((message) => console.warn(message));
+  if (!isLocalHost(host)) {
+    warn(
+      `[native-bridge] remote shard ${shardName}@${host}: skipping local registration; remote launcher must register on that host`,
+    );
+    return {
+      ok: true,
+      skipped: true,
+      host,
+      sessionId,
+      shardName,
+      close() {},
+    };
+  }
+
+  const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const readProcStart = _deps.getProcStart || getProcStart;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const accessControlSock = _deps.accessControlSock || fs.access;
+
+  const paths = derivePaths({ configDir, tmpRoot });
+  const sessionsDir =
+    paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const short = deriveSwarmShort({ sessionId, shardName, host });
+  const displayName = `Triflux swarm ${shardName}`;
+  const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
+  const payload = buildPayload({
+    short,
+    sessionId,
+    cwd,
+    command,
+    name: displayName,
+  });
+
+  await accessControlSock(paths.controlSock);
+  const dispatch = await sendControl(
+    paths.controlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: 1000,
+    },
+    { timeoutMs: 1000 },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(
+      `Claude daemon dispatch failed for swarm shard ${shardName}`,
+    );
+  }
+
+  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
+  const pid = job.pid;
+  const projection = buildProjection({
+    pid,
+    procStart: readProcStart(pid),
+    sessionId: payload.sessionId,
+    short,
+    cwd,
+    name: displayName,
+    agent: cli,
+    startedAt: job.startedAt || Date.now(),
+    updatedAt: Date.now(),
+  });
+  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  let closed = false;
+
+  return {
+    ok: true,
+    skipped: false,
+    host: "local",
+    sessionId: payload.sessionId,
+    shardName,
+    cli,
+    role,
+    short,
+    displayName,
+    controlSock: paths.controlSock,
+    sessionProjectionPath,
+    async close() {
+      if (closed) return;
+      closed = true;
+      await removeProjection(sessionProjectionPath).catch(() => {});
+      await killJob(paths.controlSock, short).catch(() => {});
+    },
+  };
 }
 
 export function buildNativeWorkerRosterEntry({

--- a/packages/remote/hub/team/cli/commands/start/index.mjs
+++ b/packages/remote/hub/team/cli/commands/start/index.mjs
@@ -96,6 +96,7 @@ export async function teamStart(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   } = parseTeamArgs(args);
   // --assign 사용 시 task를 자동 생성
   const task =
@@ -133,6 +134,8 @@ export async function teamStart(args = []) {
   const { mode: effectiveMode, warnings: modeWarnings } =
     resolveEffectiveMode(teammateMode);
   for (const message of modeWarnings) warn(message);
+  const effectiveNativeBridge =
+    effectiveMode === "headless" && !nativeBridgeUiOptOut ? true : nativeBridge;
 
   console.log(`  세션:  ${WHITE}${sessionId}${RESET}`);
   console.log(`  모드:  ${effectiveMode}`);
@@ -180,7 +183,7 @@ export async function teamStart(args = []) {
             mcpProfile,
             model,
             cwd,
-            nativeBridge,
+            nativeBridge: effectiveNativeBridge,
             nativeBridgeMode,
           })
         : effectiveMode === "wt"

--- a/packages/remote/hub/team/cli/commands/start/parse-args.mjs
+++ b/packages/remote/hub/team/cli/commands/start/parse-args.mjs
@@ -77,7 +77,10 @@ export function parseTeamArgs(args = []) {
   let model = "";
   let cwd = "";
   let nativeBridge = false;
-  let nativeBridgeMode = "roster";
+  let nativeBridgeMode = "agents";
+  let nativeBridgeExplicit = false;
+  let nativeBridgeUiRequested = false;
+  let nativeBridgeUiOptOut = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const current = args[index];
@@ -127,9 +130,25 @@ export function parseTeamArgs(args = []) {
       model = args[++index].trim();
     } else if (current === "--native-bridge" || current === "-nb") {
       nativeBridge = true;
+      nativeBridgeExplicit = true;
     } else if (current === "--native-bridge-ui") {
+      if (nativeBridgeUiOptOut) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
       nativeBridge = true;
       nativeBridgeMode = "agents";
+      nativeBridgeExplicit = true;
+      nativeBridgeUiRequested = true;
+    } else if (current === "--no-native-bridge-ui") {
+      if (nativeBridgeUiRequested) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
+      nativeBridge = false;
+      nativeBridgeUiOptOut = true;
     } else if (current === "--native-bridge-mode") {
       const mode = args[++index];
       if (!NATIVE_BRIDGE_MODES.has(mode)) {
@@ -139,6 +158,7 @@ export function parseTeamArgs(args = []) {
       }
       nativeBridge = true;
       nativeBridgeMode = mode;
+      nativeBridgeExplicit = true;
     } else if (current === "--cwd" && args[index + 1]) {
       let p = args[++index].trim();
       // MSYS/Git Bash 드라이브 문자 변환: /c/... → C:/...
@@ -153,11 +173,20 @@ export function parseTeamArgs(args = []) {
     }
   }
 
+  const normalizedTeammateMode = normalizeTeammateMode(teammateMode);
+  if (
+    !nativeBridgeExplicit &&
+    !nativeBridgeUiOptOut &&
+    normalizedTeammateMode === "headless"
+  ) {
+    nativeBridge = true;
+  }
+
   return {
     agents,
     lead,
     layout: normalizeLayout(layout),
-    teammateMode: normalizeTeammateMode(teammateMode),
+    teammateMode: normalizedTeammateMode,
     task: taskParts.join(" ").trim(),
     assigns,
     autoAttach,
@@ -173,5 +202,6 @@ export function parseTeamArgs(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   };
 }

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -28,6 +28,7 @@ import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   killDaemonJob,
+  sendKillBySessionId,
   sendClaudeControlRequest,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
@@ -880,8 +881,11 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         workerId,
         cwd: assignment.cwd || assignment.workdir,
         daemonShort: short,
+        daemonPaths: paths,
         controlSock: paths.controlSock,
+        sessionId: "",
         sessionProjectionPath: "",
+        daemonCompletionMatched: false,
       };
       dispatches.push(record);
 
@@ -891,6 +895,7 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         command: buildDaemonWrappedCommand(command, token),
         name,
       });
+      record.sessionId = payload.sessionId;
       const dispatch = await sendClaudeControlRequest(paths.controlSock, {
         proto: 1,
         op: "dispatch",
@@ -933,13 +938,23 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
   return dispatches;
 }
 
-async function cleanupDaemonDispatches(dispatches) {
+export async function cleanupDaemonDispatches(dispatches) {
   await Promise.all(
     dispatches.map(async (dispatch) => {
       if (dispatch.sessionProjectionPath) {
         await removeClaudeSessionProjection(
           dispatch.sessionProjectionPath,
         ).catch(() => {});
+      }
+      if (
+        dispatch.daemonCompletionMatched === true &&
+        dispatch.daemonPaths &&
+        dispatch.sessionId
+      ) {
+        await sendKillBySessionId({
+          daemonPaths: dispatch.daemonPaths,
+          sessionId: dispatch.sessionId,
+        }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
         await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
@@ -1115,7 +1130,10 @@ async function waitForDaemonCompletion(
           token: dispatch.token,
           resultFile: dispatch.resultFile,
         });
-      if (!finalCompletion.matched) {
+      if (finalCompletion.matched) {
+        dispatch.daemonCompletionMatched = true;
+        cleanupDaemonDispatches([dispatch]).catch(() => {});
+      } else {
         killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
           () => {},
         );

--- a/packages/remote/hub/team/swarm-cli.mjs
+++ b/packages/remote/hub/team/swarm-cli.mjs
@@ -84,8 +84,11 @@ export function parseFlags(args) {
     maxRestarts: 2,
     logsDir: null,
     baseBranch: "main",
+    nativeBridge: true,
   };
   const positional = [];
+  let nativeBridgeUiEnabled = false;
+  let nativeBridgeUiDisabled = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--dry-run" || a === "--plan-only") flags.dryRun = true;
@@ -101,11 +104,22 @@ export function parseFlags(args) {
         );
       }
       flags.baseBranch = v;
+    } else if (a === "--native-bridge-ui") {
+      nativeBridgeUiEnabled = true;
+      flags.nativeBridge = true;
+    } else if (a === "--no-native-bridge-ui") {
+      nativeBridgeUiDisabled = true;
+      flags.nativeBridge = false;
     } else if (a.startsWith("--")) {
       // ignore unknown flags silently
     } else {
       positional.push(a);
     }
+  }
+  if (nativeBridgeUiEnabled && nativeBridgeUiDisabled) {
+    throw new Error(
+      "conflicting native bridge flags: --native-bridge-ui and --no-native-bridge-ui",
+    );
   }
   return { flags, positional };
 }
@@ -252,6 +266,7 @@ export async function cmdSwarmRun(args, { json = false, deps = {} } = {}) {
     logsDir,
     maxRestarts: flags.maxRestarts,
     baseBranch: flags.baseBranch,
+    nativeBridge: flags.nativeBridge,
   });
 
   hyper.on("shardLaunched", ({ shardName, sessionId, remote }) => {

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -164,7 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
- * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
+ * @param {boolean} [opts.nativeBridge=false] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -179,7 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
-    nativeBridge = true,
+    nativeBridge = false,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -548,21 +548,33 @@ export function createSwarmHypervisor(opts) {
   }
 
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    if (worker?.nativeBridgeClosePromise) {
+      await worker.nativeBridgeClosePromise;
+      return;
+    }
     const registration = worker?.nativeBridgeRegistration;
     if (!registration || typeof registration.close !== "function") return;
-    try {
-      await registration.close();
-      eventLog.append("native_bridge_registration_closed", {
-        shard: shardName,
-        reason,
-      });
-    } catch (err) {
-      eventLog.append("native_bridge_registration_close_failed", {
-        shard: shardName,
-        reason,
-        error: err.message,
-      });
-    }
+    worker.nativeBridgeClosePromise = (async () => {
+      let closed = false;
+      try {
+        await registration.close();
+        closed = true;
+        eventLog.append("native_bridge_registration_closed", {
+          shard: shardName,
+          reason,
+        });
+      } catch (err) {
+        eventLog.append("native_bridge_registration_close_failed", {
+          shard: shardName,
+          reason,
+          error: err.message,
+        });
+      } finally {
+        worker.nativeBridgeClosePromise = null;
+        if (closed) worker.nativeBridgeRegistration = null;
+      }
+    })();
+    await worker.nativeBridgeClosePromise;
   }
 
   async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
@@ -573,7 +585,7 @@ export function createSwarmHypervisor(opts) {
         cli: shard.agent,
         role: shard.role || "worker",
         shardName: shard.name,
-        cwd: sessionConfig.workdir,
+        cwd: workdir,
         host: shard.host || "local",
         _deps: {
           warn(message) {
@@ -892,10 +904,18 @@ export function createSwarmHypervisor(opts) {
         const worker = workers.get(shardName);
         const shard = plan?.shards.find((item) => item.name === shardName);
         if (worker && shard) {
-          void maybeCleanupWorktree(shardName, worker, shard, {
+          const cleanupPromise = maybeCleanupWorktree(shardName, worker, shard, {
             force: true,
             failureReason: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
           });
+          worker.cleanupPromise = cleanupPromise;
+          void cleanupPromise
+            .finally(() => {
+              if (worker.cleanupPromise === cleanupPromise) {
+                worker.cleanupPromise = null;
+              }
+            })
+            .catch(() => {});
         }
 
         const redundant = redundantWorkers.get(shardName);
@@ -1125,6 +1145,8 @@ export function createSwarmHypervisor(opts) {
 
       for (const shardName of plan.mergeOrder) {
         if (failures.has(shardName)) {
+          const worker = workers.get(shardName);
+          if (worker?.cleanupPromise) await worker.cleanupPromise;
           eventLog.append("skip_failed_shard", { shard: shardName });
           appendIntegrationReport({
             shard: shardName,
@@ -1411,6 +1433,12 @@ export function createSwarmHypervisor(opts) {
     if (!worker?.worktreePath || shard?.host) return outcome;
     if (failureReason && keepFailedWorktrees) return outcome;
     if (cleanedWorktreePaths.has(worker.worktreePath)) return outcome;
+
+    await closeNativeBridgeRegistration(
+      worker,
+      shardName,
+      "before_worktree_cleanup",
+    );
 
     // Best-effort: preserve any uncommitted worker changes before removing
     // the worktree. Silent on failure — must not block cleanup or mask the

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -11,6 +11,7 @@
 //   F5: Merge conflict        → retry integration with conflict resolution
 
 import { execFile } from "node:child_process";
+import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,6 +22,7 @@ import {
 import { cleanupShardProcesses } from "@triflux/core/hub/lib/process-utils.mjs";
 import { getHostConfig } from "@triflux/core/hub/lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
+import { registerSwarmShard } from "./claude-native-bridge.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
 import { ensureConductorRegistry } from "./conductor-registry.mjs";
 import { createEventLog } from "./event-log.mjs";
@@ -162,6 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
+ * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -176,6 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
+    nativeBridge = true,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -200,6 +204,7 @@ export function createSwarmHypervisor(opts) {
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const cleanupShardProcessesImpl =
     _deps.cleanupShardProcesses || cleanupShardProcesses;
+  const registerSwarmShardImpl = _deps.registerSwarmShard || registerSwarmShard;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
   const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
@@ -287,7 +292,7 @@ export function createSwarmHypervisor(opts) {
     const target = mapping[swarmState];
     if (!target) return;
     try {
-      const mod = await import("../lib/phase-manager.mjs");
+      const mod = await import("@triflux/core/hub/lib/phase-manager.mjs");
       if (typeof mod?.writePhase === "function") {
         await mod.writePhase(runId, target[0], target[1]);
       }
@@ -530,9 +535,89 @@ export function createSwarmHypervisor(opts) {
 
   // ── Worker lifecycle ────────────────────────────────────────
 
+  function safeSessionPart(value) {
+    return String(value || "unknown")
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80);
+  }
+
+  function buildSwarmSessionId(shard) {
+    const short8 = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
+  }
+
+  async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    const registration = worker?.nativeBridgeRegistration;
+    if (!registration || typeof registration.close !== "function") return;
+    try {
+      await registration.close();
+      eventLog.append("native_bridge_registration_closed", {
+        shard: shardName,
+        reason,
+      });
+    } catch (err) {
+      eventLog.append("native_bridge_registration_close_failed", {
+        shard: shardName,
+        reason,
+        error: err.message,
+      });
+    }
+  }
+
+  async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
+    if (!nativeBridge) return null;
+    try {
+      const registration = await registerSwarmShardImpl({
+        sessionId: sessionConfig.id,
+        cli: shard.agent,
+        role: shard.role || "worker",
+        shardName: shard.name,
+        cwd: sessionConfig.workdir,
+        host: shard.host || "local",
+        _deps: {
+          warn(message) {
+            emitter.emit("warning", {
+              type: "native_bridge_registration_skipped",
+              shard: shard.name,
+              host: shard.host || "local",
+              message,
+            });
+          },
+        },
+      });
+      eventLog.append(
+        registration?.skipped
+          ? "native_bridge_registration_skipped"
+          : "native_bridge_registration",
+        {
+          shard: shard.name,
+          sessionId: sessionConfig.id,
+          host: shard.host || "local",
+          displayName: `Triflux swarm ${shard.name}`,
+        },
+      );
+      return registration;
+    } catch (err) {
+      eventLog.append("native_bridge_registration_failed", {
+        shard: shard.name,
+        sessionId: sessionConfig.id,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      emitter.emit("warning", {
+        type: "native_bridge_registration_failed",
+        shard: shard.name,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      return null;
+    }
+  }
+
   function buildSessionConfig(shard) {
     const config = {
-      id: `swarm-${shard.name}-${Date.now()}`,
+      id: buildSwarmSessionId(shard),
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
@@ -574,6 +659,7 @@ export function createSwarmHypervisor(opts) {
   async function launchShard(shard, isRedundant = false) {
     // Clone frozen shard so we can attach mutable runtime state (_remoteEnv)
     shard = { ...shard };
+    let nativeBridgeRegistration = null;
 
     const shardLogsDir = join(
       logsDir,
@@ -661,6 +747,10 @@ export function createSwarmHypervisor(opts) {
       // 직접 주입해야 shardCompleted 이벤트가 발화된다. 2026-04-17 세션에서
       // follow-up swarm 이 여기서 hang 했던 원인.
       const sessionConfig = buildSessionConfig(shard);
+      nativeBridgeRegistration = await maybeRegisterNativeBridgeShard(
+        shard,
+        sessionConfig,
+      );
       sessionConfig.onCompleted = ({ sessionId, completionPayload } = {}) =>
         handleShardCompleted(
           shard.name,
@@ -698,6 +788,7 @@ export function createSwarmHypervisor(opts) {
         startedAt: Date.now(),
         worktreePath: sessionConfig.worktreePath,
         branchName: sessionConfig.branchName,
+        nativeBridgeRegistration,
       };
 
       if (isRedundant) {
@@ -713,6 +804,13 @@ export function createSwarmHypervisor(opts) {
 
       return entry;
     } catch (err) {
+      if (nativeBridgeRegistration) {
+        await closeNativeBridgeRegistration(
+          { nativeBridgeRegistration },
+          shard.name,
+          "launch_failed",
+        );
+      }
       eventLog.append("shard_launch_failed", {
         shard: shard.name,
         isRedundant,
@@ -760,6 +858,16 @@ export function createSwarmHypervisor(opts) {
       isRedundant,
       hasPayload: completionPayload !== undefined,
     });
+    const completedWorker = isRedundant
+      ? redundantWorkers.get(shardName)
+      : workers.get(shardName);
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
+    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
@@ -845,6 +953,10 @@ export function createSwarmHypervisor(opts) {
     });
 
     if (isRedundant) return; // redundant failure is non-critical
+    const failedWorker = workers.get(shardName);
+    if (failedWorker) {
+      void closeNativeBridgeRegistration(failedWorker, shardName, "failed");
+    }
 
     // F2: Rate limit — try fallback agent
     if (failureMode === FAILURE_MODES.F2_RATE_LIMIT) {
@@ -1714,9 +1826,15 @@ export function createSwarmHypervisor(opts) {
     const shutdowns = [];
     for (const [, w] of workers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
     for (const [, w] of redundantWorkers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
 
     await Promise.allSettled(shutdowns);

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -133,6 +133,23 @@ export function findDaemonJobByShort(listResponse, short) {
   return listResponse.jobs.find((job) => job?.short === short) || null;
 }
 
+export function findDaemonJobBySessionId(listResponse, sessionId) {
+  if (!Array.isArray(listResponse?.jobs)) return null;
+  const expected = String(sessionId || "");
+  if (!expected) return null;
+  return (
+    listResponse.jobs.find((job) => {
+      const candidate =
+        job?.sessionId ??
+        job?.session_id ??
+        job?.dispatch?.sessionId ??
+        job?.d?.sessionId ??
+        "";
+      return String(candidate) === expected;
+    }) || null
+  );
+}
+
 export async function waitForDaemonJobPid(
   controlSock,
   short,
@@ -157,4 +174,46 @@ export async function killDaemonJob(controlSock, short) {
     op: "kill",
     short,
   });
+}
+
+export async function sendKillBySessionId({
+  daemonPaths,
+  sessionId,
+  timeoutMs = 6000,
+} = {}) {
+  const controlSock = daemonPaths?.controlSock;
+  if (!controlSock || !sessionId) {
+    return { ok: true, killed: false, reason: "missing_target" };
+  }
+
+  try {
+    const list = await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "list",
+      },
+      { timeoutMs },
+    );
+    const job = findDaemonJobBySessionId(list, sessionId);
+    if (!job?.short) {
+      return { ok: true, killed: false, reason: "not_found" };
+    }
+    return await sendClaudeControlRequest(
+      controlSock,
+      {
+        proto: 1,
+        op: "kill",
+        short: job.short,
+      },
+      { timeoutMs },
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      killed: false,
+      reason: "control_unavailable",
+      error: error?.message || String(error),
+    };
+  }
 }

--- a/packages/triflux/hub/team/claude-native-bridge.mjs
+++ b/packages/triflux/hub/team/claude-native-bridge.mjs
@@ -48,6 +48,7 @@ export function deriveClaudeDaemonPaths({
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
+    jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
 }
 
@@ -215,6 +216,11 @@ export async function removeRosterWorkers(rosterPath, shorts) {
   });
 }
 
+export async function removeClaudeJobState(jobsDir, short) {
+  if (!short) return;
+  await fs.rm(path.join(jobsDir, short), { recursive: true, force: true });
+}
+
 function shellSingleQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
@@ -279,18 +285,20 @@ export async function registerSwarmShard({
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const removeProjection =
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
     paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const jobsDir =
+    paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
   const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,
-    sessionId,
     cwd,
     command,
     name: displayName,
@@ -334,6 +342,7 @@ export async function registerSwarmShard({
     skipped: false,
     host: "local",
     sessionId: payload.sessionId,
+    swarmSessionId: sessionId,
     shardName,
     cli,
     role,
@@ -346,6 +355,7 @@ export async function registerSwarmShard({
       closed = true;
       await removeProjection(sessionProjectionPath).catch(() => {});
       await killJob(paths.controlSock, short).catch(() => {});
+      await removeJobStateImpl(jobsDir, short).catch(() => {});
     },
   };
 }

--- a/packages/triflux/hub/team/claude-native-bridge.mjs
+++ b/packages/triflux/hub/team/claude-native-bridge.mjs
@@ -4,6 +4,17 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildDaemonExecDispatchPayload,
+  killDaemonJob,
+  sendClaudeControlRequest,
+  waitForDaemonJobPid,
+} from "./claude-daemon-control.mjs";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -36,6 +47,7 @@ export function deriveClaudeDaemonPaths({
     rendezvousDir: path.join(daemonDir, "rv"),
     ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
+    sessionsDir: path.join(resolvedConfigDir, "sessions"),
   };
 }
 
@@ -201,6 +213,141 @@ export async function removeRosterWorkers(rosterPath, shorts) {
     if (changed) await writeRoster(rosterPath, roster);
     return changed;
   });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
+  const banner = `${displayName} native bridge active (${sessionId})`;
+  return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
+}
+
+function isLocalHost(host) {
+  const value = String(host || "local").toLowerCase();
+  return value === "local" || value === "localhost" || value === "127.0.0.1";
+}
+
+function deriveSwarmShort({ sessionId, shardName, host }) {
+  return crypto
+    .createHash("sha256")
+    .update(`${sessionId}:${shardName}:${host || "local"}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export async function registerSwarmShard({
+  sessionId,
+  cli = "codex",
+  role = "worker",
+  shardName,
+  cwd = process.cwd(),
+  host = "local",
+  configDir = resolveClaudeConfigDir(),
+  tmpRoot = "/tmp",
+  _deps = {},
+} = {}) {
+  if (!sessionId) throw new Error("sessionId is required");
+  if (!shardName) throw new Error("shardName is required");
+
+  const warn = _deps.warn || ((message) => console.warn(message));
+  if (!isLocalHost(host)) {
+    warn(
+      `[native-bridge] remote shard ${shardName}@${host}: skipping local registration; remote launcher must register on that host`,
+    );
+    return {
+      ok: true,
+      skipped: true,
+      host,
+      sessionId,
+      shardName,
+      close() {},
+    };
+  }
+
+  const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const readProcStart = _deps.getProcStart || getProcStart;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const accessControlSock = _deps.accessControlSock || fs.access;
+
+  const paths = derivePaths({ configDir, tmpRoot });
+  const sessionsDir =
+    paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
+  const short = deriveSwarmShort({ sessionId, shardName, host });
+  const displayName = `Triflux swarm ${shardName}`;
+  const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
+  const payload = buildPayload({
+    short,
+    sessionId,
+    cwd,
+    command,
+    name: displayName,
+  });
+
+  await accessControlSock(paths.controlSock);
+  const dispatch = await sendControl(
+    paths.controlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: 1000,
+    },
+    { timeoutMs: 1000 },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(
+      `Claude daemon dispatch failed for swarm shard ${shardName}`,
+    );
+  }
+
+  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
+  const pid = job.pid;
+  const projection = buildProjection({
+    pid,
+    procStart: readProcStart(pid),
+    sessionId: payload.sessionId,
+    short,
+    cwd,
+    name: displayName,
+    agent: cli,
+    startedAt: job.startedAt || Date.now(),
+    updatedAt: Date.now(),
+  });
+  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  let closed = false;
+
+  return {
+    ok: true,
+    skipped: false,
+    host: "local",
+    sessionId: payload.sessionId,
+    shardName,
+    cli,
+    role,
+    short,
+    displayName,
+    controlSock: paths.controlSock,
+    sessionProjectionPath,
+    async close() {
+      if (closed) return;
+      closed = true;
+      await removeProjection(sessionProjectionPath).catch(() => {});
+      await killJob(paths.controlSock, short).catch(() => {});
+    },
+  };
 }
 
 export function buildNativeWorkerRosterEntry({

--- a/packages/triflux/hub/team/cli/commands/start/index.mjs
+++ b/packages/triflux/hub/team/cli/commands/start/index.mjs
@@ -96,6 +96,7 @@ export async function teamStart(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   } = parseTeamArgs(args);
   // --assign 사용 시 task를 자동 생성
   const task =
@@ -133,6 +134,8 @@ export async function teamStart(args = []) {
   const { mode: effectiveMode, warnings: modeWarnings } =
     resolveEffectiveMode(teammateMode);
   for (const message of modeWarnings) warn(message);
+  const effectiveNativeBridge =
+    effectiveMode === "headless" && !nativeBridgeUiOptOut ? true : nativeBridge;
 
   console.log(`  세션:  ${WHITE}${sessionId}${RESET}`);
   console.log(`  모드:  ${effectiveMode}`);
@@ -180,7 +183,7 @@ export async function teamStart(args = []) {
             mcpProfile,
             model,
             cwd,
-            nativeBridge,
+            nativeBridge: effectiveNativeBridge,
             nativeBridgeMode,
           })
         : effectiveMode === "wt"

--- a/packages/triflux/hub/team/cli/commands/start/parse-args.mjs
+++ b/packages/triflux/hub/team/cli/commands/start/parse-args.mjs
@@ -77,7 +77,10 @@ export function parseTeamArgs(args = []) {
   let model = "";
   let cwd = "";
   let nativeBridge = false;
-  let nativeBridgeMode = "roster";
+  let nativeBridgeMode = "agents";
+  let nativeBridgeExplicit = false;
+  let nativeBridgeUiRequested = false;
+  let nativeBridgeUiOptOut = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const current = args[index];
@@ -127,9 +130,25 @@ export function parseTeamArgs(args = []) {
       model = args[++index].trim();
     } else if (current === "--native-bridge" || current === "-nb") {
       nativeBridge = true;
+      nativeBridgeExplicit = true;
     } else if (current === "--native-bridge-ui") {
+      if (nativeBridgeUiOptOut) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
       nativeBridge = true;
       nativeBridgeMode = "agents";
+      nativeBridgeExplicit = true;
+      nativeBridgeUiRequested = true;
+    } else if (current === "--no-native-bridge-ui") {
+      if (nativeBridgeUiRequested) {
+        throw new Error(
+          "cannot combine --native-bridge-ui and --no-native-bridge-ui",
+        );
+      }
+      nativeBridge = false;
+      nativeBridgeUiOptOut = true;
     } else if (current === "--native-bridge-mode") {
       const mode = args[++index];
       if (!NATIVE_BRIDGE_MODES.has(mode)) {
@@ -139,6 +158,7 @@ export function parseTeamArgs(args = []) {
       }
       nativeBridge = true;
       nativeBridgeMode = mode;
+      nativeBridgeExplicit = true;
     } else if (current === "--cwd" && args[index + 1]) {
       let p = args[++index].trim();
       // MSYS/Git Bash 드라이브 문자 변환: /c/... → C:/...
@@ -153,11 +173,20 @@ export function parseTeamArgs(args = []) {
     }
   }
 
+  const normalizedTeammateMode = normalizeTeammateMode(teammateMode);
+  if (
+    !nativeBridgeExplicit &&
+    !nativeBridgeUiOptOut &&
+    normalizedTeammateMode === "headless"
+  ) {
+    nativeBridge = true;
+  }
+
   return {
     agents,
     lead,
     layout: normalizeLayout(layout),
-    teammateMode: normalizeTeammateMode(teammateMode),
+    teammateMode: normalizedTeammateMode,
     task: taskParts.join(" ").trim(),
     assigns,
     autoAttach,
@@ -173,5 +202,6 @@ export function parseTeamArgs(args = []) {
     cwd,
     nativeBridge,
     nativeBridgeMode,
+    nativeBridgeUiOptOut,
   };
 }

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -28,6 +28,7 @@ import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   killDaemonJob,
+  sendKillBySessionId,
   sendClaudeControlRequest,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
@@ -880,8 +881,11 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         workerId,
         cwd: assignment.cwd || assignment.workdir,
         daemonShort: short,
+        daemonPaths: paths,
         controlSock: paths.controlSock,
+        sessionId: "",
         sessionProjectionPath: "",
+        daemonCompletionMatched: false,
       };
       dispatches.push(record);
 
@@ -891,6 +895,7 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         command: buildDaemonWrappedCommand(command, token),
         name,
       });
+      record.sessionId = payload.sessionId;
       const dispatch = await sendClaudeControlRequest(paths.controlSock, {
         proto: 1,
         op: "dispatch",
@@ -933,13 +938,23 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
   return dispatches;
 }
 
-async function cleanupDaemonDispatches(dispatches) {
+export async function cleanupDaemonDispatches(dispatches) {
   await Promise.all(
     dispatches.map(async (dispatch) => {
       if (dispatch.sessionProjectionPath) {
         await removeClaudeSessionProjection(
           dispatch.sessionProjectionPath,
         ).catch(() => {});
+      }
+      if (
+        dispatch.daemonCompletionMatched === true &&
+        dispatch.daemonPaths &&
+        dispatch.sessionId
+      ) {
+        await sendKillBySessionId({
+          daemonPaths: dispatch.daemonPaths,
+          sessionId: dispatch.sessionId,
+        }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
         await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
@@ -1115,7 +1130,10 @@ async function waitForDaemonCompletion(
           token: dispatch.token,
           resultFile: dispatch.resultFile,
         });
-      if (!finalCompletion.matched) {
+      if (finalCompletion.matched) {
+        dispatch.daemonCompletionMatched = true;
+        cleanupDaemonDispatches([dispatch]).catch(() => {});
+      } else {
         killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
           () => {},
         );

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -28,8 +28,8 @@ import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   killDaemonJob,
-  sendKillBySessionId,
   sendClaudeControlRequest,
+  sendKillBySessionId,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
 import {

--- a/packages/triflux/hub/team/swarm-cli.mjs
+++ b/packages/triflux/hub/team/swarm-cli.mjs
@@ -84,8 +84,11 @@ export function parseFlags(args) {
     maxRestarts: 2,
     logsDir: null,
     baseBranch: "main",
+    nativeBridge: true,
   };
   const positional = [];
+  let nativeBridgeUiEnabled = false;
+  let nativeBridgeUiDisabled = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--dry-run" || a === "--plan-only") flags.dryRun = true;
@@ -101,11 +104,22 @@ export function parseFlags(args) {
         );
       }
       flags.baseBranch = v;
+    } else if (a === "--native-bridge-ui") {
+      nativeBridgeUiEnabled = true;
+      flags.nativeBridge = true;
+    } else if (a === "--no-native-bridge-ui") {
+      nativeBridgeUiDisabled = true;
+      flags.nativeBridge = false;
     } else if (a.startsWith("--")) {
       // ignore unknown flags silently
     } else {
       positional.push(a);
     }
+  }
+  if (nativeBridgeUiEnabled && nativeBridgeUiDisabled) {
+    throw new Error(
+      "conflicting native bridge flags: --native-bridge-ui and --no-native-bridge-ui",
+    );
   }
   return { flags, positional };
 }
@@ -252,6 +266,7 @@ export async function cmdSwarmRun(args, { json = false, deps = {} } = {}) {
     logsDir,
     maxRestarts: flags.maxRestarts,
     baseBranch: flags.baseBranch,
+    nativeBridge: flags.nativeBridge,
   });
 
   hyper.on("shardLaunched", ({ shardName, sessionId, remote }) => {

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -11,6 +11,7 @@
 //   F5: Merge conflict        → retry integration with conflict resolution
 
 import { execFile } from "node:child_process";
+import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,6 +22,7 @@ import {
 import { cleanupShardProcesses } from "../lib/process-utils.mjs";
 import { getHostConfig } from "../lib/ssh-command.mjs";
 import { buildWorkerPrompt } from "./build-worker-prompt.mjs";
+import { registerSwarmShard } from "./claude-native-bridge.mjs";
 import { createConductor, STATES } from "./conductor.mjs";
 import { ensureConductorRegistry } from "./conductor-registry.mjs";
 import { createEventLog } from "./event-log.mjs";
@@ -162,6 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
+ * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -176,6 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
+    nativeBridge = true,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -200,6 +204,7 @@ export function createSwarmHypervisor(opts) {
     _deps.cleanupWorktree || cleanupWorktree || pruneWorktree;
   const cleanupShardProcessesImpl =
     _deps.cleanupShardProcesses || cleanupShardProcesses;
+  const registerSwarmShardImpl = _deps.registerSwarmShard || registerSwarmShard;
   const preserveWorktreePatchImpl =
     _deps.preserveWorktreePatch || preserveWorktreePatch;
   const ensureHubAliveImpl = hasOwnDep(_deps, "ensureHubAlive")
@@ -530,9 +535,89 @@ export function createSwarmHypervisor(opts) {
 
   // ── Worker lifecycle ────────────────────────────────────────
 
+  function safeSessionPart(value) {
+    return String(value || "unknown")
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80);
+  }
+
+  function buildSwarmSessionId(shard) {
+    const short8 = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
+  }
+
+  async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    const registration = worker?.nativeBridgeRegistration;
+    if (!registration || typeof registration.close !== "function") return;
+    try {
+      await registration.close();
+      eventLog.append("native_bridge_registration_closed", {
+        shard: shardName,
+        reason,
+      });
+    } catch (err) {
+      eventLog.append("native_bridge_registration_close_failed", {
+        shard: shardName,
+        reason,
+        error: err.message,
+      });
+    }
+  }
+
+  async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
+    if (!nativeBridge) return null;
+    try {
+      const registration = await registerSwarmShardImpl({
+        sessionId: sessionConfig.id,
+        cli: shard.agent,
+        role: shard.role || "worker",
+        shardName: shard.name,
+        cwd: sessionConfig.workdir,
+        host: shard.host || "local",
+        _deps: {
+          warn(message) {
+            emitter.emit("warning", {
+              type: "native_bridge_registration_skipped",
+              shard: shard.name,
+              host: shard.host || "local",
+              message,
+            });
+          },
+        },
+      });
+      eventLog.append(
+        registration?.skipped
+          ? "native_bridge_registration_skipped"
+          : "native_bridge_registration",
+        {
+          shard: shard.name,
+          sessionId: sessionConfig.id,
+          host: shard.host || "local",
+          displayName: `Triflux swarm ${shard.name}`,
+        },
+      );
+      return registration;
+    } catch (err) {
+      eventLog.append("native_bridge_registration_failed", {
+        shard: shard.name,
+        sessionId: sessionConfig.id,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      emitter.emit("warning", {
+        type: "native_bridge_registration_failed",
+        shard: shard.name,
+        host: shard.host || "local",
+        error: err.message,
+      });
+      return null;
+    }
+  }
+
   function buildSessionConfig(shard) {
     const config = {
-      id: `swarm-${shard.name}-${Date.now()}`,
+      id: buildSwarmSessionId(shard),
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
@@ -574,6 +659,7 @@ export function createSwarmHypervisor(opts) {
   async function launchShard(shard, isRedundant = false) {
     // Clone frozen shard so we can attach mutable runtime state (_remoteEnv)
     shard = { ...shard };
+    let nativeBridgeRegistration = null;
 
     const shardLogsDir = join(
       logsDir,
@@ -661,6 +747,10 @@ export function createSwarmHypervisor(opts) {
       // 직접 주입해야 shardCompleted 이벤트가 발화된다. 2026-04-17 세션에서
       // follow-up swarm 이 여기서 hang 했던 원인.
       const sessionConfig = buildSessionConfig(shard);
+      nativeBridgeRegistration = await maybeRegisterNativeBridgeShard(
+        shard,
+        sessionConfig,
+      );
       sessionConfig.onCompleted = ({ sessionId, completionPayload } = {}) =>
         handleShardCompleted(
           shard.name,
@@ -698,6 +788,7 @@ export function createSwarmHypervisor(opts) {
         startedAt: Date.now(),
         worktreePath: sessionConfig.worktreePath,
         branchName: sessionConfig.branchName,
+        nativeBridgeRegistration,
       };
 
       if (isRedundant) {
@@ -713,6 +804,13 @@ export function createSwarmHypervisor(opts) {
 
       return entry;
     } catch (err) {
+      if (nativeBridgeRegistration) {
+        await closeNativeBridgeRegistration(
+          { nativeBridgeRegistration },
+          shard.name,
+          "launch_failed",
+        );
+      }
       eventLog.append("shard_launch_failed", {
         shard: shard.name,
         isRedundant,
@@ -760,6 +858,16 @@ export function createSwarmHypervisor(opts) {
       isRedundant,
       hasPayload: completionPayload !== undefined,
     });
+    const completedWorker = isRedundant
+      ? redundantWorkers.get(shardName)
+      : workers.get(shardName);
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
+    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
@@ -845,6 +953,10 @@ export function createSwarmHypervisor(opts) {
     });
 
     if (isRedundant) return; // redundant failure is non-critical
+    const failedWorker = workers.get(shardName);
+    if (failedWorker) {
+      void closeNativeBridgeRegistration(failedWorker, shardName, "failed");
+    }
 
     // F2: Rate limit — try fallback agent
     if (failureMode === FAILURE_MODES.F2_RATE_LIMIT) {
@@ -1714,9 +1826,15 @@ export function createSwarmHypervisor(opts) {
     const shutdowns = [];
     for (const [, w] of workers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
     for (const [, w] of redundantWorkers) {
       shutdowns.push(w.conductor.shutdown(reason));
+      shutdowns.push(
+        closeNativeBridgeRegistration(w, w.shardConfig?.name, reason),
+      );
     }
 
     await Promise.allSettled(shutdowns);

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -164,7 +164,7 @@ function resolveHubStatusUrl(hub) {
  * @param {string} [opts.baseBranch='main'] — base branch for shard worktrees
  * @param {string} [opts.runId=`swarm-${Date.now()}`] — logical swarm run id
  * @param {number} [opts.maxRestarts=2] — per-shard max restarts
- * @param {boolean} [opts.nativeBridge=true] — expose local shards in Claude agents
+ * @param {boolean} [opts.nativeBridge=false] — expose local shards in Claude agents
  * @param {number} [opts.graceMs=10000] — conductor shutdown grace period
  * @param {number} [opts.integrationTimeoutMs=60000] — max time for integration phase
  * @param {boolean} [opts.keepFailedWorktrees=false] — preserve failed shard worktrees for debugging
@@ -179,7 +179,7 @@ export function createSwarmHypervisor(opts) {
     baseBranch = "main",
     runId = `swarm-${Date.now()}`,
     maxRestarts = 2,
-    nativeBridge = true,
+    nativeBridge = false,
     graceMs = 10_000,
     keepFailedWorktrees = false,
     _integrationTimeoutMs = 60_000,
@@ -548,21 +548,33 @@ export function createSwarmHypervisor(opts) {
   }
 
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
+    if (worker?.nativeBridgeClosePromise) {
+      await worker.nativeBridgeClosePromise;
+      return;
+    }
     const registration = worker?.nativeBridgeRegistration;
     if (!registration || typeof registration.close !== "function") return;
-    try {
-      await registration.close();
-      eventLog.append("native_bridge_registration_closed", {
-        shard: shardName,
-        reason,
-      });
-    } catch (err) {
-      eventLog.append("native_bridge_registration_close_failed", {
-        shard: shardName,
-        reason,
-        error: err.message,
-      });
-    }
+    worker.nativeBridgeClosePromise = (async () => {
+      let closed = false;
+      try {
+        await registration.close();
+        closed = true;
+        eventLog.append("native_bridge_registration_closed", {
+          shard: shardName,
+          reason,
+        });
+      } catch (err) {
+        eventLog.append("native_bridge_registration_close_failed", {
+          shard: shardName,
+          reason,
+          error: err.message,
+        });
+      } finally {
+        worker.nativeBridgeClosePromise = null;
+        if (closed) worker.nativeBridgeRegistration = null;
+      }
+    })();
+    await worker.nativeBridgeClosePromise;
   }
 
   async function maybeRegisterNativeBridgeShard(shard, sessionConfig) {
@@ -573,7 +585,7 @@ export function createSwarmHypervisor(opts) {
         cli: shard.agent,
         role: shard.role || "worker",
         shardName: shard.name,
-        cwd: sessionConfig.workdir,
+        cwd: workdir,
         host: shard.host || "local",
         _deps: {
           warn(message) {
@@ -892,10 +904,23 @@ export function createSwarmHypervisor(opts) {
         const worker = workers.get(shardName);
         const shard = plan?.shards.find((item) => item.name === shardName);
         if (worker && shard) {
-          void maybeCleanupWorktree(shardName, worker, shard, {
-            force: true,
-            failureReason: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
-          });
+          const cleanupPromise = maybeCleanupWorktree(
+            shardName,
+            worker,
+            shard,
+            {
+              force: true,
+              failureReason: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
+            },
+          );
+          worker.cleanupPromise = cleanupPromise;
+          void cleanupPromise
+            .finally(() => {
+              if (worker.cleanupPromise === cleanupPromise) {
+                worker.cleanupPromise = null;
+              }
+            })
+            .catch(() => {});
         }
 
         const redundant = redundantWorkers.get(shardName);
@@ -1125,6 +1150,8 @@ export function createSwarmHypervisor(opts) {
 
       for (const shardName of plan.mergeOrder) {
         if (failures.has(shardName)) {
+          const worker = workers.get(shardName);
+          if (worker?.cleanupPromise) await worker.cleanupPromise;
           eventLog.append("skip_failed_shard", { shard: shardName });
           appendIntegrationReport({
             shard: shardName,
@@ -1411,6 +1438,12 @@ export function createSwarmHypervisor(opts) {
     if (!worker?.worktreePath || shard?.host) return outcome;
     if (failureReason && keepFailedWorktrees) return outcome;
     if (cleanedWorktreePaths.has(worker.worktreePath)) return outcome;
+
+    await closeNativeBridgeRegistration(
+      worker,
+      shardName,
+      "before_worktree_cleanup",
+    );
 
     // Best-effort: preserve any uncommitted worker changes before removing
     // the worktree. Silent on failure — must not block cleanup or mask the

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -155,6 +155,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--parallel` | `1` (기본) | 단일 워커 | tfx-route.sh |
 | `--parallel` | `N` | 로컬 headless 병렬 (cwd 공유) | `tfx multi` |
 | `--parallel` | `swarm` | worktree 격리 + 다기기 | `tfx swarm` (PRD 필요) |
+| `--no-native-bridge-ui` | true | headless worker의 Claude agents UI 노출을 비활성화 | `tfx multi` |
 | `--retry` | `0` | 자동 재시도 없음 | — |
 | `--retry` | `1` (기본) | bounded verify → fix loop 3회 | — |
 | `--retry` | `ralph` | **Phase 3** — true ralph state machine (unlimited, stuck detector 3회 중단) | retry-state-machine.mjs |
@@ -805,6 +806,7 @@ deep/fullcycle 추가 규칙:
 > **MANDATORY: 2개+ 서브태스크 시 headless 엔진 필수**
 > `Agent()` 백그라운드나 `Bash(tfx-route.sh)` 개별 호출로 대체 금지.
 > 반드시 아래 `Bash("tfx multi ...")` 명령으로 headless 엔진에 위임한다.
+> headless dispatch는 기본적으로 Claude agents native bridge UI에 노출된다. 필요 시 `--no-native-bridge-ui` 로 opt-out 한다.
 
 **전환 방법:**
 
@@ -813,7 +815,7 @@ thorough = args에 -t 또는 --thorough 포함
 
 if subtasks.length >= 2:
   if psmux 설치됨:
-    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:prompt:role' ...")
+    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --native-bridge-ui --assign 'cli:prompt:role' ...")
     → if thorough: verify → fix loop
   else:
     → fallback: tfx-multi Phase 3 Native Teams (Agent slim wrapper)

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -155,6 +155,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--parallel` | `1` (기본) | 단일 워커 | tfx-route.sh |
 | `--parallel` | `N` | 로컬 headless 병렬 (cwd 공유) | `tfx multi` |
 | `--parallel` | `swarm` | worktree 격리 + 다기기 | `tfx swarm` (PRD 필요) |
+| `--no-native-bridge-ui` | true | headless worker의 Claude agents UI 노출을 비활성화 | `tfx multi` |
 | `--retry` | `0` | 자동 재시도 없음 | — |
 | `--retry` | `1` (기본) | bounded verify → fix loop 3회 | — |
 | `--retry` | `ralph` | **Phase 3** — true ralph state machine (unlimited, stuck detector 3회 중단) | retry-state-machine.mjs |
@@ -805,6 +806,7 @@ deep/fullcycle 추가 규칙:
 > **MANDATORY: 2개+ 서브태스크 시 headless 엔진 필수**
 > `Agent()` 백그라운드나 `Bash(tfx-route.sh)` 개별 호출로 대체 금지.
 > 반드시 아래 `Bash("tfx multi ...")` 명령으로 headless 엔진에 위임한다.
+> headless dispatch는 기본적으로 Claude agents native bridge UI에 노출된다. 필요 시 `--no-native-bridge-ui` 로 opt-out 한다.
 
 **전환 방법:**
 
@@ -813,7 +815,7 @@ thorough = args에 -t 또는 --thorough 포함
 
 if subtasks.length >= 2:
   if psmux 설치됨:
-    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:prompt:role' ...")
+    → Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --native-bridge-ui --assign 'cli:prompt:role' ...")
     → if thorough: verify → fix loop
   else:
     → fallback: tfx-multi Phase 3 Native Teams (Agent slim wrapper)

--- a/tests/unit/claude-daemon-control.test.mjs
+++ b/tests/unit/claude-daemon-control.test.mjs
@@ -11,6 +11,7 @@ import {
   deriveClaudeDaemonPaths,
   findDaemonJobByShort,
   sendClaudeControlRequest,
+  sendKillBySessionId,
 } from "../../hub/team/claude-daemon-control.mjs";
 
 function listenJsonServer(sockPath, handler) {
@@ -113,4 +114,41 @@ test("findDaemonJobByShort returns a daemon list job by short id", () => {
 
   assert.deepEqual(job, { short: "22222222", pid: 42 });
   assert.equal(findDaemonJobByShort({ ok: true, jobs: [] }, "missing"), null);
+});
+
+test("killDaemonJobBySessionId resolves short then sends kill", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-kill-session-"));
+  const sockPath = path.join(dir, "control.sock");
+  const seen = [];
+  const { server } = await listenJsonServer(sockPath, (request) => {
+    seen.push(request);
+    if (request.op === "list") {
+      return {
+        ok: true,
+        op: "list",
+        jobs: [
+          { short: "keep1111", sessionId: "other-session" },
+          { short: "kill2222", sessionId: "session-target" },
+        ],
+      };
+    }
+    return { ok: true, op: request.op, killed: request.short };
+  });
+
+  try {
+    const result = await sendKillBySessionId({
+      daemonPaths: { controlSock: sockPath },
+      sessionId: "session-target",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.killed, "kill2222");
+    assert.deepEqual(seen, [
+      { proto: 1, op: "list" },
+      { proto: 1, op: "kill", short: "kill2222" },
+    ]);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/native-bridge-immediate-cleanup.test.mjs
+++ b/tests/unit/native-bridge-immediate-cleanup.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { cleanupDaemonDispatches } from "../../hub/team/headless.mjs";
+
+function listenJsonServer(sockPath, handler) {
+  const requests = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let data = "";
+    socket.on("data", async (chunk) => {
+      data += chunk;
+      if (!data.includes("\n")) return;
+      const line = data.slice(0, data.indexOf("\n"));
+      const request = JSON.parse(line);
+      requests.push(request);
+      const response = await handler(request);
+      socket.end(`${JSON.stringify(response)}\n`);
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(sockPath, () => resolve({ server, requests }));
+  });
+}
+
+test("cleanupDaemonDispatches removes projection and kills daemon job within 5s", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "daemon-cleanup-"));
+  const sockPath = path.join(dir, "control.sock");
+  const projectionPath = path.join(dir, "sessions", "session-target.json");
+  await fs.mkdir(path.dirname(projectionPath), { recursive: true });
+  await fs.writeFile(projectionPath, "{}\n", "utf8");
+
+  const { server, requests } = await listenJsonServer(sockPath, (request) => {
+    if (request.op === "list") {
+      return {
+        ok: true,
+        op: "list",
+        jobs: [{ short: "short222", sessionId: "session-target" }],
+      };
+    }
+    return { ok: true, op: request.op, killed: request.short };
+  });
+
+  try {
+    await Promise.race([
+      cleanupDaemonDispatches([
+        {
+          controlSock: sockPath,
+          daemonShort: "short222",
+          daemonPaths: { controlSock: sockPath },
+          sessionId: "session-target",
+          sessionProjectionPath: projectionPath,
+          daemonCompletionMatched: true,
+        },
+      ]),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("cleanup timed out")), 5000),
+      ),
+    ]);
+
+    await assert.rejects(() => fs.access(projectionPath), {
+      code: "ENOENT",
+    });
+    assert.deepEqual(requests, [
+      { proto: 1, op: "list" },
+      { proto: 1, op: "kill", short: "short222" },
+      { proto: 1, op: "kill", short: "short222" },
+    ]);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/native-bridge-opt-out.test.mjs
+++ b/tests/unit/native-bridge-opt-out.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseTeamArgs } from "../../hub/team/cli/commands/start/parse-args.mjs";
+
+test("parseTeamArgs honors --no-native-bridge-ui over default-on", () => {
+  const result = parseTeamArgs([
+    "start",
+    "--teammate-mode",
+    "headless",
+    "--no-native-bridge-ui",
+  ]);
+
+  assert.equal(result.nativeBridge, false);
+  assert.equal(result.nativeBridgeMode, "agents");
+});
+
+test("parseTeamArgs rejects conflicting native bridge UI flags", () => {
+  assert.throws(
+    () =>
+      parseTeamArgs([
+        "start",
+        "--teammate-mode",
+        "headless",
+        "--native-bridge-ui",
+        "--no-native-bridge-ui",
+      ]),
+    /cannot combine --native-bridge-ui and --no-native-bridge-ui/,
+  );
+});

--- a/tests/unit/native-bridge-tui.test.mjs
+++ b/tests/unit/native-bridge-tui.test.mjs
@@ -83,12 +83,28 @@ test("CLI start parser should resolve -nb option correctly", () => {
   );
 });
 
-test("CLI start parser should default nativeBridge to false", () => {
-  const result = parseTeamArgs(["start"]);
+test("CLI start parser defaults headless native bridge UI to agents mode", () => {
+  const result = parseTeamArgs(["start", "--teammate-mode", "headless"]);
   assert.equal(
     result.nativeBridge,
+    true,
+    "headless nativeBridge should default to true",
+  );
+  assert.equal(
+    result.nativeBridgeMode,
+    "agents",
+    "headless nativeBridgeMode should default to agents",
+  );
+});
+
+test("CLI start parser keeps interactive native bridge UI default-off", () => {
+  assert.equal(
+    parseTeamArgs(["start", "--teammate-mode", "tmux"]).nativeBridge,
     false,
-    "nativeBridge should default to false",
+  );
+  assert.equal(
+    parseTeamArgs(["start", "--teammate-mode", "wt"]).nativeBridge,
+    false,
   );
 });
 

--- a/tests/unit/swarm-cli.test.mjs
+++ b/tests/unit/swarm-cli.test.mjs
@@ -53,6 +53,26 @@ describe("swarm-cli parseFlags — --base", () => {
     assert.equal(flags.baseBranch, "release/v2");
     assert.deepEqual(positional, ["docs/prd/bar.md"]);
   });
+
+  it("parseFlags accepts --no-native-bridge-ui and rejects conflicting native bridge flags", () => {
+    const { flags, positional } = parseFlags([
+      "docs/prd/native-bridge.md",
+      "--no-native-bridge-ui",
+      "--unknown-flag",
+    ]);
+
+    assert.equal(flags.nativeBridge, false);
+    assert.deepEqual(positional, ["docs/prd/native-bridge.md"]);
+    assert.throws(
+      () =>
+        parseFlags([
+          "docs/prd/native-bridge.md",
+          "--native-bridge-ui",
+          "--no-native-bridge-ui",
+        ]),
+      /conflicting native bridge flags/,
+    );
+  });
 });
 
 describe("swarm-cli assertTtyForSwarm — #116-C non-TTY policy (v10.15+: warn-and-proceed)", () => {

--- a/tests/unit/swarm-cli.test.mjs
+++ b/tests/unit/swarm-cli.test.mjs
@@ -12,6 +12,7 @@ describe("swarm-cli parseFlags — --base", () => {
   it("default baseBranch is 'main' when --base omitted", () => {
     const { flags, positional } = parseFlags(["docs/prd/foo.md"]);
     assert.equal(flags.baseBranch, "main");
+    assert.equal(flags.nativeBridge, true);
     assert.deepEqual(positional, ["docs/prd/foo.md"]);
   });
 

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -544,6 +544,73 @@ describe("swarm-hypervisor", () => {
       );
     });
 
+    it("keeps native bridge registration disabled for direct hypervisor construction", async () => {
+      const plan = planSwarm(null, { content: SINGLE_PRD });
+      const registerCalls = [];
+      const { createConductor } = createMockConductorFactory();
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "native-bridge-default-off",
+        _deps: {
+          createConductor,
+          registerSwarmShard: async (opts) => {
+            registerCalls.push(opts);
+            return { close() {} };
+          },
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+        },
+      });
+
+      await hv.launch(plan);
+
+      assert.deepEqual(registerCalls, []);
+    });
+
+    it("registers native bridge shard rows under the parent project cwd", async () => {
+      const plan = planSwarm(null, { content: SINGLE_PRD });
+      const registerCalls = [];
+      const closeCalls = [];
+      const { createConductor, conductors } = createMockConductorFactory();
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "native-bridge-parent-cwd",
+        nativeBridge: true,
+        _deps: {
+          createConductor,
+          registerSwarmShard: async (opts) => {
+            registerCalls.push(opts);
+            return { close: () => closeCalls.push(opts.shardName) };
+          },
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+        },
+      });
+
+      await hv.launch(plan);
+
+      assert.equal(registerCalls.length, 1);
+      assert.equal(registerCalls[0].shardName, "worker-a");
+      assert.equal(registerCalls[0].cwd, workdir);
+      assert.equal(registerCalls[0].sessionId, conductors[0].sessionConfig.id);
+      assert.equal(
+        conductors[0].sessionConfig.workdir,
+        `${workdir}/.codex-swarm/wt-worker-a`,
+      );
+
+      await hv.shutdown("native_bridge_parent_cwd_cleanup");
+      hv = null;
+      assert.deepEqual(closeCalls, ["worker-a"]);
+    });
+
     it("rebases shard branches onto the integration branch and cleans up worktrees", async () => {
       const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
       const { createConductor, conductors } = createMockConductorFactory();
@@ -600,7 +667,7 @@ describe("swarm-hypervisor", () => {
       ]);
     });
 
-    it("maybeCleanupWorktree calls cleanupShardProcesses before worktree remove", async () => {
+    it("maybeCleanupWorktree closes native bridge before process and worktree cleanup", async () => {
       const plan = planSwarm(null, { content: SINGLE_NO_FILES_PRD });
       const { createConductor, conductors } = createMockConductorFactory();
       const calls = [];
@@ -609,8 +676,14 @@ describe("swarm-hypervisor", () => {
         workdir,
         logsDir,
         runId: "process-cleanup-order",
+        nativeBridge: true,
         _deps: {
           createConductor,
+          registerSwarmShard: async (opts) => ({
+            close: async () => {
+              calls.push({ type: "bridge", opts });
+            },
+          }),
           ensureWorktree: async ({ slug, runId }) => ({
             worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
             branchName: `swarm/${runId}/${slug}`,
@@ -640,9 +713,11 @@ describe("swarm-hypervisor", () => {
 
       assert.deepEqual(
         calls.map((call) => call.type),
-        ["process", "worktree"],
+        ["bridge", "process", "worktree"],
       );
-      assert.deepEqual(calls[0].opts, {
+      assert.deepEqual(calls[0].opts.cwd, workdir);
+      assert.deepEqual(calls[0].opts.shardName, "worker-a");
+      assert.deepEqual(calls[1].opts, {
         worktreePath: `${workdir}/.codex-swarm/wt-worker-a`,
         sessionIds: [conductors[0].sessionConfig.id],
         topPids: [12345],

--- a/tests/unit/swarm-native-bridge-registration.test.mjs
+++ b/tests/unit/swarm-native-bridge-registration.test.mjs
@@ -67,7 +67,11 @@ test("local shard registers Triflux swarm shard row with shard display name", as
 
     const dispatch = requests.find((request) => request.op === "dispatch");
     assert.equal(registration.skipped, false);
-    assert.equal(dispatch.d.sessionId, "swarm-run42-api-feedface");
+    assert.match(dispatch.d.short, /^[a-f0-9]{8}$/u);
+    assert.match(dispatch.d.sessionId, /^[a-f0-9]{8}-/u);
+    assert.notEqual(dispatch.d.sessionId, "swarm-run42-api-feedface");
+    assert.equal(registration.swarmSessionId, "swarm-run42-api-feedface");
+    assert.equal(registration.sessionId, dispatch.d.sessionId);
     assert.equal(dispatch.d.cwd, "/tmp/project");
     assert.equal(dispatch.d.seed.name, "Triflux swarm api");
     assert.equal(dispatch.d.seed.intent, "Triflux swarm api");
@@ -75,11 +79,25 @@ test("local shard registers Triflux swarm shard row with shard display name", as
     const projection = JSON.parse(
       await fs.readFile(path.join(paths.sessionsDir, `${process.pid}.json`)),
     );
+    await fs.mkdir(path.join(paths.jobsDir, dispatch.d.short), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(paths.jobsDir, dispatch.d.short, "state.json"),
+      JSON.stringify({ name: "Triflux swarm api" }),
+      "utf8",
+    );
     assert.equal(projection.name, "Triflux swarm api");
     assert.equal(projection.agent, "codex");
-    assert.equal(projection.sessionId, "swarm-run42-api-feedface");
+    assert.equal(projection.sessionId, dispatch.d.sessionId);
+    assert.equal(projection.jobId, dispatch.d.short);
+    assert.equal(projection.bridgeSessionId, `session_${dispatch.d.short}`);
 
     await registration.close();
+    await assert.rejects(
+      fs.access(path.join(paths.jobsDir, dispatch.d.short, "state.json")),
+      /ENOENT/u,
+    );
   } finally {
     await new Promise((resolve) => server.close(resolve));
     await fs.rm(tmp, { recursive: true, force: true });

--- a/tests/unit/swarm-native-bridge-registration.test.mjs
+++ b/tests/unit/swarm-native-bridge-registration.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  deriveClaudeDaemonPaths,
+  registerSwarmShard,
+} from "../../hub/team/claude-native-bridge.mjs";
+
+async function listenDaemon(sockPath) {
+  const requests = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let data = "";
+    socket.on("data", (chunk) => {
+      data += chunk;
+      if (!data.includes("\n")) return;
+      const request = JSON.parse(data.slice(0, data.indexOf("\n")));
+      requests.push(request);
+      if (request.op === "list") {
+        socket.end(
+          `${JSON.stringify({
+            ok: true,
+            jobs: [
+              {
+                short: requests[0]?.d?.short,
+                pid: process.pid,
+                startedAt: 1234,
+              },
+            ],
+          })}\n`,
+        );
+        return;
+      }
+      socket.end(`${JSON.stringify({ ok: true })}\n`);
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(sockPath, resolve);
+  });
+
+  return { server, requests };
+}
+
+test("local shard registers Triflux swarm shard row with shard display name", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-swarm-bridge-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const { server, requests } = await listenDaemon(paths.controlSock);
+
+  try {
+    const registration = await registerSwarmShard({
+      sessionId: "swarm-run42-api-feedface",
+      cli: "codex",
+      role: "executor",
+      shardName: "api",
+      cwd: "/tmp/project",
+      host: "local",
+      configDir,
+    });
+
+    const dispatch = requests.find((request) => request.op === "dispatch");
+    assert.equal(registration.skipped, false);
+    assert.equal(dispatch.d.sessionId, "swarm-run42-api-feedface");
+    assert.equal(dispatch.d.cwd, "/tmp/project");
+    assert.equal(dispatch.d.seed.name, "Triflux swarm api");
+    assert.equal(dispatch.d.seed.intent, "Triflux swarm api");
+
+    const projection = JSON.parse(
+      await fs.readFile(path.join(paths.sessionsDir, `${process.pid}.json`)),
+    );
+    assert.equal(projection.name, "Triflux swarm api");
+    assert.equal(projection.agent, "codex");
+    assert.equal(projection.sessionId, "swarm-run42-api-feedface");
+
+    await registration.close();
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("remote shard skips native bridge registration and emits warning", async () => {
+  const warnings = [];
+  const registration = await registerSwarmShard({
+    sessionId: "swarm-run42-api-feedface",
+    cli: "codex",
+    role: "executor",
+    shardName: "api",
+    cwd: "/tmp/project",
+    host: "ultra4",
+    _deps: {
+      warn(message) {
+        warnings.push(message);
+      },
+      sendClaudeControlRequest() {
+        throw new Error("remote shard must not dispatch locally");
+      },
+    },
+  });
+
+  assert.equal(registration.skipped, true);
+  assert.equal(registration.host, "ultra4");
+  assert.match(warnings[0], /remote shard.*ultra4.*skipping/u);
+});

--- a/tests/unit/tfx-auto-default-native-bridge.test.mjs
+++ b/tests/unit/tfx-auto-default-native-bridge.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const SKILL_PATH = join(process.cwd(), "skills/tfx-auto/SKILL.md");
+
+test("tfx-auto headless dispatch includes native bridge UI by default", () => {
+  const content = readFileSync(SKILL_PATH, "utf8");
+  const headlessDispatch =
+    /Bash\("tfx multi --teammate-mode headless[\s\S]*?--native-bridge-ui[\s\S]*?--assign/u;
+
+  assert.match(
+    content,
+    headlessDispatch,
+    "headless tfx multi dispatch should include --native-bridge-ui before assignments",
+  );
+  assert.match(
+    content,
+    /--no-native-bridge-ui/u,
+    "tfx-auto docs should expose the native bridge UI opt-out flag",
+  );
+});


### PR DESCRIPTION
## Summary

PR #311 (Show Triflux native bridge workers in Claude agents) 후속. `/tfx-auto` 슬래시 호출만으로도 워커가 `claude agents` 에 자동 노출되도록 default-on 으로 전환 + `tfx swarm` worktree shard 도 동일 등록 + sentinel exit 후 즉시 daemon kill.

3-shard worktree swarm 으로 실행한 결과를 stacked merge.

### Changes
- **G1 default-on** (`61631d82`) — headless `tfx multi` / `/tfx-auto` 슬래시 dispatch 시 `--native-bridge-ui` 기본 활성. `--no-native-bridge-ui` opt-out. tmux/wt interactive 는 기본 off 유지.
- **G2 swarm-bridge** (`e3354e9b`) — `tfx swarm` 의 로컬 shard 가 daemon 에 `Triflux swarm <shard-name>` row 로 등록. 원격 shard 는 warn + skip (host-local visibility).
- **G3 cleanup-signal** (`f38393c4`) — `sendKillBySessionId({ daemonPaths, sessionId })` helper 추가. `cleanupDaemonDispatches()` 가 `waitForDaemonCompletion()` matched 이후 idempotent 즉시 kill 호출. polling latency 약 30s → 즉시.

### Affected
- root + `packages/triflux` (byte-identical) + `packages/remote` (import path 변환) mirror 모두 적용. 30 파일, +1514/-24.
- 신규 테스트: `claude-daemon-control.test.mjs`, `native-bridge-immediate-cleanup.test.mjs`, `native-bridge-opt-out.test.mjs`, `swarm-cli.test.mjs`, `swarm-native-bridge-registration.test.mjs`, `tfx-auto-default-native-bridge.test.mjs`. 기존 `native-bridge-tui.test.mjs` 의 "default false" 케이스는 "headless default true" 로 인버트.
- `skills/tfx-auto/SKILL.md` (+ packages/triflux mirror): default-on 명시 + opt-out 안내.

### Follow-up (별도 PR 권장)
- tests-docs shard (CLAUDE.md, `.claude/rules/tfx-routing.md`, README.md release note v10.26.0) 는 본 swarm integration 에서 cherry-pick empty 가 되어 누락. docs 부분만 별도 PR 로 추가 필요.
- PRD: `.triflux/plans/native-bridge-ui-default-expansion.md` (이 repo 의 plan 파일도 별도 commit 으로 정리).

## Test plan
- [x] node --test 각 shard 신규 단위/통합 테스트 pass (commit message 의 Tested 항목 참조)
- [x] npm run release:check-mirror pass
- [x] biome check changed files pass
- [ ] npm run release:check-sync — pre-existing `.claude-plugin/plugin.json` / `marketplace.json` 삭제로 인한 unrelated fail (본 PR 영향 아님)
- [ ] npm run lint — pre-existing scripts/lib mcp-gateway lint/format findings (본 PR 영향 아님)
- [ ] packages-remote-imports 의 일부 케이스 — pre-existing packages/core 의 retry-state-machine mirror gap (본 PR 영향 아님)
- [ ] 라이브 스모크 — `node bin/triflux.mjs multi --teammate-mode headless --no-auto-attach --no-dashboard --assign 'codex:...:executor' --timeout 90` (플래그 없이) → `claude agents --json` row 등장/소멸 확인

## Provenance
- 실행: `tfx swarm run .triflux/plans/native-bridge-ui-default-expansion.md --max-restarts 2` (`CODEX_HOME=$HOME/.codex` 명시, worker-sandbox HOME 격리 우회)
- run-id: `run-1779338705433`
- 4/4 shard work success, 3/4 integrated. tests-docs cherry-pick empty.