### PR TITLE
fix(release): include hud/config in check-packages-mirror auto compare

### DIFF
--- a/packages/triflux/scripts/release/check-packages-mirror.mjs
+++ b/packages/triflux/scripts/release/check-packages-mirror.mjs
@@ -22,7 +22,16 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
 const MIRROR_ROOT = join(REPO_ROOT, "packages", "triflux");
-const MIRROR_TOPS = ["bin", "hooks", "hub", "mesh", "scripts", "skills"];
+const MIRROR_TOPS = [
+  "bin",
+  "config",
+  "hooks",
+  "hub",
+  "hud",
+  "mesh",
+  "scripts",
+  "skills",
+];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 // Per-top relative paths to skip. Mirror policy excludes these via
 // packages/triflux/package.json "files" negation patterns (e.g.

--- a/scripts/release/check-packages-mirror.mjs
+++ b/scripts/release/check-packages-mirror.mjs
@@ -22,7 +22,16 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
 const MIRROR_ROOT = join(REPO_ROOT, "packages", "triflux");
-const MIRROR_TOPS = ["bin", "hooks", "hub", "mesh", "scripts", "skills"];
+const MIRROR_TOPS = [
+  "bin",
+  "config",
+  "hooks",
+  "hub",
+  "hud",
+  "mesh",
+  "scripts",
+  "skills",
+];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 // Per-top relative paths to skip. Mirror policy excludes these via
 // packages/triflux/package.json "files" negation patterns (e.g.

--- a/tests/unit/packages-mirror.test.mjs
+++ b/tests/unit/packages-mirror.test.mjs
@@ -25,9 +25,9 @@ test("packages/triflux mirror is byte-identical to root", () => {
   assert.equal(result.issues.length, 0);
 });
 
-// Lock-in coverage for hooks/skills tops. Without these in MIRROR_TOPS the
-// release gate silently ignores drift in hooks/ and skills/ — caught by Codex
-// review on PR #319 follow-up.
+// Lock-in coverage for mirrored tops. Without these in MIRROR_TOPS the
+// release gate silently ignores drift in those root directories — caught by
+// Codex review on PR #319 follow-up and mirror-policy follow-ups.
 function withMirrorProbe(rel, fn) {
   const probePath = join(REPO_ROOT, rel);
   writeFileSync(probePath, "probe");
@@ -47,6 +47,34 @@ test("check-packages-mirror walks hooks/ top-level dir", () => {
     assert.ok(
       found,
       "hooks/ drift was not flagged — check-packages-mirror.mjs MIRROR_TOPS regression",
+    );
+    assert.equal(found.kind, "missing-in-mirror");
+  });
+});
+
+test("check-packages-mirror walks hud/ top-level dir", () => {
+  withMirrorProbe("hud/__mirror_probe_temp__.txt", () => {
+    const result = compareMirror({ fix: false });
+    const found = result.issues.find((i) =>
+      i.path.endsWith("hud/__mirror_probe_temp__.txt"),
+    );
+    assert.ok(
+      found,
+      "hud/ drift was not flagged — check-packages-mirror.mjs MIRROR_TOPS regression",
+    );
+    assert.equal(found.kind, "missing-in-mirror");
+  });
+});
+
+test("check-packages-mirror walks config/ top-level dir", () => {
+  withMirrorProbe("config/__mirror_probe_temp__.json", () => {
+    const result = compareMirror({ fix: false });
+    const found = result.issues.find((i) =>
+      i.path.endsWith("config/__mirror_probe_temp__.json"),
+    );
+    assert.ok(
+      found,
+      "config/ drift was not flagged — check-packages-mirror.mjs MIRROR_TOPS regression",
     );
     assert.equal(found.kind, "missing-in-mirror");
   });


### PR DESCRIPTION
## Summary
- mirror 자동 검증 게이트가 `.claude/rules/tfx-mirror-policy.md`의 `hud/`, `config/` 미러 대상을 빠뜨리지 않도록 `MIRROR_TOPS`에 추가했습니다.
- root script와 `packages/triflux` mirror script를 byte-identical하게 유지했습니다.
- `node scripts/release/check-packages-mirror.mjs`에서 baseline drift 없음(`Mirror OK`)을 확인했습니다.

## Test plan
- [x] `diff -q scripts/release/check-packages-mirror.mjs packages/triflux/scripts/release/check-packages-mirror.mjs`
- [x] `node scripts/release/check-packages-mirror.mjs`
- [x] `node --test tests/unit/packages-mirror.test.mjs`
- [x] `npx --yes @biomejs/biome check scripts/release/check-packages-mirror.mjs packages/triflux/scripts/release/check-packages-mirror.mjs tests/unit/packages-mirror.test.mjs`

관련 PR: #319, #320, #321, #322