### PR TITLE
docs/mirror-policy: add mesh + core hub/team minimal mirror policy

### DIFF
--- a/.claude/rules/tfx-mirror-policy.md
+++ b/.claude/rules/tfx-mirror-policy.md
@@ -22,6 +22,12 @@ triflux 는 root 와 `packages/{core,remote,triflux}/` 3개 published 레이어�
 | root `hub/lib/foo.mjs` 수정 | 같은 cp 또는 두 곳 동시 Edit |
 | 검증 | `diff -q hub/lib/foo.mjs packages/core/hub/lib/foo.mjs` exit 0 |
 
+#### `packages/core/hub/team` — minimal individual mirror
+
+`hub/team/*` 전체는 `packages/triflux/hub/team/` 와 `packages/remote/hub/team/` mirror 대상이다. `packages/core` 는 `hub/team/*` 전체를 mirror 하지 않는다. 다만 `packages/core/hub/bridge.mjs` 가 `./team/*` 를 self-import 하는 개별 파일은 `packages/core/hub/team/` 에 byte-identical cp 한다.
+
+현재 minimal mirror 예시는 PR #314 의 `packages/core/hub/team/retry-state-machine.mjs` 다. 신규 파일을 추가할 때는 먼저 `grep -n './team/' packages/core/hub/bridge.mjs` 로 `bridge.mjs` 의 `./team/*` 의존 파일을 식별하고, 필요한 파일만 `packages/core/hub/team/` 으로 cp 한 뒤 root 파일과 `diff -q` 로 확인한다.
+
 ### `packages/remote` — import path 변환
 
 `packages/remote/` 는 `packages/core` 를 외부 dep 로 import 한다. 그래서 root 의 상대 경로 import 를 그대로 cp 하면 깨진다.
@@ -55,11 +61,12 @@ mirror 변경은 **`Edit` 도구로 개별 수정**한다. `cp` 사용 금지 (�
 
 **mirror 대상** (root → packages 동기 필수):
 - `hub/lib/*` → `packages/core/hub/lib/`, `packages/triflux/hub/lib/`
-- `hub/team/*`, `hub/*.mjs` (entry/runtime) → `packages/triflux/hub/`, `packages/remote/hub/` (해당 모듈만)
+- `hub/team/*`, `hub/*.mjs` (entry/runtime) → `packages/triflux/hub/`, `packages/remote/hub/` (해당 모듈만; `packages/core/hub/team/` 는 self-import 대상만 minimal mirror, 예: `retry-state-machine.mjs`)
+- `mesh/*` → `packages/core/mesh/`, `packages/triflux/mesh/` (PR #320 — root subset)
 - `scripts/lib/*` → `packages/core/scripts/lib/`, `packages/triflux/scripts/lib/`, `packages/remote/scripts/lib/` (PR #314 catch-up — remote 는 root subset, root-relative 의존 시 `@triflux/core/...` 로 import 변환)
 - `scripts/release/*`, `scripts/__tests__/*` → `packages/triflux/scripts/` (publish 포함)
 - `bin/*` → `packages/triflux/bin/`
-- `hooks/*`, `hud/*`, `mesh/*`, `config/*` → `packages/triflux/{hooks,hud,mesh,config}/`
+- `hooks/*`, `hud/*`, `config/*` → `packages/triflux/{hooks,hud,config}/`
 
 **mirror 제외**:
 - `tests/` (root + `packages/{core,remote}/tests/`) — npm files 에 없음. 만약 packages 쪽에 untracked tests 디렉토리가 만들어졌으면 그건 잘못된 mirror 시도다.


### PR DESCRIPTION
## Why

PR #320 (Issue #315 fix + mesh gap) 머지 후 후속 정책 명문화.

- `packages/core/mesh/*` 가 byte-identical mirror 로 신규 추가됨 (PR #320 의 `a105942f`)
- `packages/core/hub/team/retry-state-machine.mjs` minimal mirror (PR #314 의 `c0d122d1`)
- 이 변화들이 mirror policy 표에 반영 안 되어 있어, 후속 PR 의 mirror 범위 결정 시 정책 표만으로는 판단 불가능했음.

## What

`.claude/rules/tfx-mirror-policy.md` 1 file (+9 -2):

1. `mesh/*` mirror 대상을 `packages/core/mesh/`, `packages/triflux/mesh/` 로 **분리 명시** — 기존 `hooks/hud/mesh/config` 묶음에서 mesh 를 분리 (중복 정책 제거).
2. `packages/core/hub/team` 은 전체 mirror 아님 — `packages/core/hub/bridge.mjs` self-import 대상만 minimal mirror 로 명문화 (PR #314 `retry-state-machine.mjs` 같은 케이스).
3. `hub/team/*` 표 row 에 core minimal mirror 부연 추가.

## Verify

- `grep -E "mesh|nativeProxy|hub/team"` → 새 라인 보임
- `git diff --check` → OK
- frontmatter 없음 (docs only)
- AI trailer / Co-Authored-By grep → 0
- `git status --short` → clean

## Reference

- [PR #320](https://github.com/tellang/triflux/pull/320) — mesh mirror introduce
- [PR #314](https://github.com/tellang/triflux/pull/314) — retry-state-machine minimal mirror introduce
- 이번 세션 W1 audit report — `~/.gstack/projects/tellang-triflux/research/20260521-w1-issue315-mirror-audit.md`