### PR TITLE
fix(release): include core and remote in publish prep

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm install --no-audit --no-fund
 
+      # Each npm package needs a Trusted Publisher entry for OIDC/provenance.
+      # If OIDC is not configured yet, set NPM_TOKEN as a fallback secret.
+      - name: Publish @triflux/core
+        working-directory: packages/core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+      - name: Publish @triflux/remote
+        working-directory: packages/remote
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
       - name: Publish triflux
         working-directory: packages/triflux
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -3304,8 +3304,8 @@
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@triflux/core": "10.0.1",
-        "@triflux/remote": "^10.0.0-alpha.1",
+        "@triflux/core": "^10.25.0",
+        "@triflux/remote": "^10.25.0",
         "tree-kill": "^1.2.2"
       },
       "bin": {
@@ -3317,20 +3317,6 @@
         "tfx-setup": "bin/tfx-setup.mjs",
         "tfx-setup-tui": "bin/tfx-setup-tui.mjs",
         "triflux": "bin/triflux.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/triflux/node_modules/@triflux/core": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@triflux/core/-/core-10.0.1.tgz",
-      "integrity": "sha512-IJfE7W23lgJEu9S28X4MjQ5IleTPKRCIySuMP8DK9FsJ27bdUWHQpBJl1y5oc8huN6hJKZSp82sxGmBIGsJW3A==",
-      "license": "MIT",
-      "dependencies": {
-        "pino": "^10.3.1",
-        "pino-pretty": "^13.1.3",
-        "zod": "^4.0.0"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/triflux/package.json
+++ b/packages/triflux/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
-    "@triflux/core": "10.0.1",
-    "@triflux/remote": "^10.0.0-alpha.1",
+    "@triflux/core": "^10.25.0",
+    "@triflux/remote": "^10.25.0",
     "tree-kill": "^1.2.2"
   },
   "files": [

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -143,7 +143,67 @@ describe("release governance scripts", () => {
         dryRun: true,
       });
       assert.equal(verify.ok, true);
-      assert.equal(verify.checks[1].name, "npm-view");
+      assert.deepEqual(
+        verify.checks
+          .filter((check) => check.name.startsWith("npm-view"))
+          .map((check) => check.name),
+        [
+          "npm-view @triflux/core",
+          "npm-view @triflux/remote",
+          "npm-view triflux",
+        ],
+      );
+      assert.deepEqual(
+        verify.checks
+          .filter((check) => check.name.startsWith("npm-view"))
+          .map((check) => check.detail),
+        [
+          "would run: npm view @triflux/core@1.2.3 version",
+          "would run: npm view @triflux/remote@1.2.3 version",
+          "would run: npm view triflux@1.2.3 version",
+        ],
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verify reports explicit npm package/version failures", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const calls = [];
+      const verify = await verifyRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        execFileSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (command === "npm" && args[1] === "@triflux/remote@1.2.3") {
+            const error = new Error("npm view failed");
+            error.stderr = Buffer.from("not found");
+            throw error;
+          }
+          if (command === "npm") return "1.2.3\n";
+          if (command === "gh") return '{"tagName":"v1.2.3"}\n';
+          return "";
+        },
+      });
+
+      assert.equal(verify.ok, false);
+      assert.deepEqual(
+        calls.filter((call) => call.command === "npm").map((call) => call.args),
+        [
+          ["view", "@triflux/core@1.2.3", "version"],
+          ["view", "@triflux/remote@1.2.3", "version"],
+          ["view", "triflux@1.2.3", "version"],
+        ],
+      );
+      assert.equal(
+        verify.checks.find((check) => check.name === "npm-view @triflux/remote")
+          .detail,
+        "npm view failed for @triflux/remote@1.2.3: not found",
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/triflux/scripts/release/verify.mjs
+++ b/packages/triflux/scripts/release/verify.mjs
@@ -3,6 +3,14 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { assertVersionSync, parseArgs, ROOT } from "./lib.mjs";
 
+const NPM_VERIFY_TARGETS = ["@triflux/core", "@triflux/remote", "triflux"];
+
+function errorMessage(error) {
+  const stderr = error?.stderr?.toString?.().trim();
+  const stdout = error?.stdout?.toString?.().trim();
+  return stderr || stdout || error?.message || "unknown error";
+}
+
 export async function verifyRelease({
   version,
   rootDir = ROOT,
@@ -23,15 +31,33 @@ export async function verifyRelease({
   ];
 
   if (!dryRun) {
-    const npmVersion = execFileSyncFn("npm", ["view", "triflux", "version"], {
-      cwd: rootDir,
-      encoding: "utf8",
-    }).trim();
-    checks.push({
-      name: "npm-view",
-      ok: npmVersion === releaseVersion,
-      detail: npmVersion,
-    });
+    for (const packageName of NPM_VERIFY_TARGETS) {
+      const packageSpec = `${packageName}@${releaseVersion}`;
+      try {
+        const npmVersion = execFileSyncFn(
+          "npm",
+          ["view", packageSpec, "version"],
+          {
+            cwd: rootDir,
+            encoding: "utf8",
+          },
+        ).trim();
+        checks.push({
+          name: `npm-view ${packageName}`,
+          ok: npmVersion === releaseVersion,
+          detail:
+            npmVersion === releaseVersion
+              ? npmVersion
+              : `expected ${releaseVersion}, got ${npmVersion}`,
+        });
+      } catch (error) {
+        checks.push({
+          name: `npm-view ${packageName}`,
+          ok: false,
+          detail: `npm view failed for ${packageSpec}: ${errorMessage(error)}`,
+        });
+      }
+    }
 
     const ghRelease = execFileSyncFn(
       "gh",
@@ -48,11 +74,11 @@ export async function verifyRelease({
     });
   } else {
     checks.push(
-      {
-        name: "npm-view",
+      ...NPM_VERIFY_TARGETS.map((packageName) => ({
+        name: `npm-view ${packageName}`,
         ok: null,
-        detail: `would run: npm view triflux version`,
-      },
+        detail: `would run: npm view ${packageName}@${releaseVersion} version`,
+      })),
       {
         name: "github-release",
         ok: null,

--- a/packages/triflux/skills/tfx-ship/SKILL.md
+++ b/packages/triflux/skills/tfx-ship/SKILL.md
@@ -36,7 +36,7 @@ triflux 는 아래 3채널로 동시 배포. 각 채널의 버전은 반드시 �
 | # | 채널 | 명령 | 우선순위 |
 |---|------|------|---------|
 | 1 | **GitHub Releases** | `gh release create vX.Y.Z --notes-file <notes>` | 공지 + changelog 공식 소스 |
-| 2 | **npm registry** | `cd packages/triflux && npm publish --access public` | primary distribution |
+| 2 | **npm registry** | `node scripts/release/publish.mjs --execute` | primary distribution |
 | 3 | **Claude Code marketplace** | `.claude-plugin/marketplace.json` (`source: npm` 참조) | `claude plugin add triflux` |
 | 4 | **pypi** (future, 비활성) | 현재 `pyproject.toml` 없음 | 활성화 시 Step 10.5 신설 |
 
@@ -221,15 +221,14 @@ gh release create "v${TARGET_VERSION}" \
 ```
 npm registry 에 배포하시겠습니까?
 
-A) cd packages/triflux && npm publish --access public
-B) dry-run 으로 먼저 검증 (npm publish --dry-run)
+A) node scripts/release/publish.mjs --execute
+B) dry-run 으로 먼저 검증 (node scripts/release/publish.mjs --dry-run)
 C) 건너뜀 (수동 배포)
 ```
 
 선택 A:
 ```bash
-cd packages/triflux
-npm publish --access public
+node scripts/release/publish.mjs --execute
 ```
 
 ### Step 10.5 — pypi publish (future, 현재 비활성)

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -143,7 +143,67 @@ describe("release governance scripts", () => {
         dryRun: true,
       });
       assert.equal(verify.ok, true);
-      assert.equal(verify.checks[1].name, "npm-view");
+      assert.deepEqual(
+        verify.checks
+          .filter((check) => check.name.startsWith("npm-view"))
+          .map((check) => check.name),
+        [
+          "npm-view @triflux/core",
+          "npm-view @triflux/remote",
+          "npm-view triflux",
+        ],
+      );
+      assert.deepEqual(
+        verify.checks
+          .filter((check) => check.name.startsWith("npm-view"))
+          .map((check) => check.detail),
+        [
+          "would run: npm view @triflux/core@1.2.3 version",
+          "would run: npm view @triflux/remote@1.2.3 version",
+          "would run: npm view triflux@1.2.3 version",
+        ],
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verify reports explicit npm package/version failures", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const calls = [];
+      const verify = await verifyRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        execFileSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (command === "npm" && args[1] === "@triflux/remote@1.2.3") {
+            const error = new Error("npm view failed");
+            error.stderr = Buffer.from("not found");
+            throw error;
+          }
+          if (command === "npm") return "1.2.3\n";
+          if (command === "gh") return '{"tagName":"v1.2.3"}\n';
+          return "";
+        },
+      });
+
+      assert.equal(verify.ok, false);
+      assert.deepEqual(
+        calls.filter((call) => call.command === "npm").map((call) => call.args),
+        [
+          ["view", "@triflux/core@1.2.3", "version"],
+          ["view", "@triflux/remote@1.2.3", "version"],
+          ["view", "triflux@1.2.3", "version"],
+        ],
+      );
+      assert.equal(
+        verify.checks.find((check) => check.name === "npm-view @triflux/remote")
+          .detail,
+        "npm view failed for @triflux/remote@1.2.3: not found",
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/release/verify.mjs
+++ b/scripts/release/verify.mjs
@@ -3,6 +3,14 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { assertVersionSync, parseArgs, ROOT } from "./lib.mjs";
 
+const NPM_VERIFY_TARGETS = ["@triflux/core", "@triflux/remote", "triflux"];
+
+function errorMessage(error) {
+  const stderr = error?.stderr?.toString?.().trim();
+  const stdout = error?.stdout?.toString?.().trim();
+  return stderr || stdout || error?.message || "unknown error";
+}
+
 export async function verifyRelease({
   version,
   rootDir = ROOT,
@@ -23,15 +31,33 @@ export async function verifyRelease({
   ];
 
   if (!dryRun) {
-    const npmVersion = execFileSyncFn("npm", ["view", "triflux", "version"], {
-      cwd: rootDir,
-      encoding: "utf8",
-    }).trim();
-    checks.push({
-      name: "npm-view",
-      ok: npmVersion === releaseVersion,
-      detail: npmVersion,
-    });
+    for (const packageName of NPM_VERIFY_TARGETS) {
+      const packageSpec = `${packageName}@${releaseVersion}`;
+      try {
+        const npmVersion = execFileSyncFn(
+          "npm",
+          ["view", packageSpec, "version"],
+          {
+            cwd: rootDir,
+            encoding: "utf8",
+          },
+        ).trim();
+        checks.push({
+          name: `npm-view ${packageName}`,
+          ok: npmVersion === releaseVersion,
+          detail:
+            npmVersion === releaseVersion
+              ? npmVersion
+              : `expected ${releaseVersion}, got ${npmVersion}`,
+        });
+      } catch (error) {
+        checks.push({
+          name: `npm-view ${packageName}`,
+          ok: false,
+          detail: `npm view failed for ${packageSpec}: ${errorMessage(error)}`,
+        });
+      }
+    }
 
     const ghRelease = execFileSyncFn(
       "gh",
@@ -48,11 +74,11 @@ export async function verifyRelease({
     });
   } else {
     checks.push(
-      {
-        name: "npm-view",
+      ...NPM_VERIFY_TARGETS.map((packageName) => ({
+        name: `npm-view ${packageName}`,
         ok: null,
-        detail: `would run: npm view triflux version`,
-      },
+        detail: `would run: npm view ${packageName}@${releaseVersion} version`,
+      })),
       {
         name: "github-release",
         ok: null,

--- a/skills/tfx-ship/SKILL.md
+++ b/skills/tfx-ship/SKILL.md
@@ -36,7 +36,7 @@ triflux 는 아래 3채널로 동시 배포. 각 채널의 버전은 반드시 �
 | # | 채널 | 명령 | 우선순위 |
 |---|------|------|---------|
 | 1 | **GitHub Releases** | `gh release create vX.Y.Z --notes-file <notes>` | 공지 + changelog 공식 소스 |
-| 2 | **npm registry** | `cd packages/triflux && npm publish --access public` | primary distribution |
+| 2 | **npm registry** | `node scripts/release/publish.mjs --execute` | primary distribution |
 | 3 | **Claude Code marketplace** | `.claude-plugin/marketplace.json` (`source: npm` 참조) | `claude plugin add triflux` |
 | 4 | **pypi** (future, 비활성) | 현재 `pyproject.toml` 없음 | 활성화 시 Step 10.5 신설 |
 
@@ -221,15 +221,14 @@ gh release create "v${TARGET_VERSION}" \
 ```
 npm registry 에 배포하시겠습니까?
 
-A) cd packages/triflux && npm publish --access public
-B) dry-run 으로 먼저 검증 (npm publish --dry-run)
+A) node scripts/release/publish.mjs --execute
+B) dry-run 으로 먼저 검증 (node scripts/release/publish.mjs --dry-run)
 C) 건너뜀 (수동 배포)
 ```
 
 선택 A:
 ```bash
-cd packages/triflux
-npm publish --access public
+node scripts/release/publish.mjs --execute
 ```
 
 ### Step 10.5 — pypi publish (future, 현재 비활성)


### PR DESCRIPTION
## Why

W3 audit (`~/.gstack/projects/tellang-triflux/research/20260521-w3-release-publish-prep.md`) 가 4건 stale 발견. PR #314 가 `publish.mjs` 자체는 core/remote 포함하도록 보강했지만, 주변 release 흐름 (tfx-ship 스킬 문서, verify.mjs, npm-publish.yml, packages/triflux deps) 이 stale 채 남아 다음 release 시 core/remote 누락 위험.

## What

9 files (single commit `1f8a1fbc`):

1. **`skills/tfx-ship/SKILL.md` + `packages/triflux/skills/tfx-ship/SKILL.md` mirror** — publish step 을 `node scripts/release/publish.mjs --execute` 로 단순화 (core/remote 자동 포함)
2. **`scripts/release/verify.mjs` + `packages/triflux/scripts/release/verify.mjs` mirror** — `@triflux/core` + `@triflux/remote` 도 `npm view` 검증
3. **`.github/workflows/npm-publish.yml`** — tag push 시 core/remote 도 publish step
4. **`packages/triflux/package.json`** — `@triflux/core` `10.0.1` → `^10.25.0`, `@triflux/remote` `^10.0.0-alpha.1` → `^10.25.0` (lockfile 자동 동기화)

## Verify

| Check | Result |
|-------|--------|
| `node scripts/release/publish.mjs --dry-run` | core → remote → triflux step 출력 |
| `node scripts/release/verify.mjs --dry-run` | core + remote + triflux 모두 npm view 시도 |
| `diff -q` root ↔ packages/triflux | exit 0 |
| `node scripts/release/check-sync.mjs` | OK |
| `node scripts/release/check-packages-mirror.mjs` | OK |
| `node --test scripts/__tests__/release-governance.test.mjs packages/triflux/scripts/__tests__/release-governance.test.mjs` | 10/10 pass |
| `git diff --check` | OK |
| AI trailer / Co-Authored-By grep | 0 |

`npm run lint` 와 전체 `npm test` 의 기존 unrelated 실패 (agy-stdout-pipe 3, tfx-route-smoke MCP 2 등 환경 의존) 는 이번 PR scope 외.

## Reference

- W3 audit report: `~/.gstack/projects/tellang-triflux/research/20260521-w3-release-publish-prep.md`
- PR #314: chore catch-up (`publish.mjs` 만 보강된 직전 PR)
- 이번 세션 누적: PR #314, #316, #320, #324, #326 (P3 mirror policy 갱신)