### PR TITLE
fix(release): include config in npm publish files

### DIFF
--- a/packages/triflux/package.json
+++ b/packages/triflux/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "bin",
+    "config",
     "skills",
     "!skills/tfx-workspace",
     "hooks",

--- a/tests/unit/packages-mirror.test.mjs
+++ b/tests/unit/packages-mirror.test.mjs
@@ -1,6 +1,7 @@
 // packages-mirror — smoke test that check-packages-mirror.mjs reports
 // Mirror OK on a healthy tree. If this fails in CI, the dev forgot to
-// run `npm run release:check-mirror:fix` after editing hub/bin/scripts.
+// run `npm run release:check-mirror:fix` after editing any mirrored top
+// (bin, config, hooks, hub, hud, mesh, scripts, skills).
 
 import assert from "node:assert/strict";
 import { rmSync, writeFileSync } from "node:fs";


### PR DESCRIPTION
## Summary

- PR #325 (머지됨, `f8348d51`) 가 mirror gate에 `hud/config`를 추가했지만 `packages/triflux/package.json` files 에 `"config"` 추가를 누락. 결과: mirror gate는 config을 검증하지만 npm pack은 silently 누락.
- 이 PR이 publish scope를 mirror policy (`hooks/*, hud/*, mesh/*, config/*` mirror 대상) 와 정합화.
- `tests/unit/packages-mirror.test.mjs` 헤더 주석을 전체 8개 mirror tops (`bin/config/hooks/hub/hud/mesh/scripts/skills`) 로 갱신 — PR #325 retro review NIT 해소.

## Test plan

- [x] `npm pack --dry-run --json`: config 2 files 포함 (516 total, 1075KB)
- [x] `node scripts/release/check-packages-mirror.mjs`: Mirror OK
- [x] `node --test tests/unit/packages-mirror.test.mjs`: 6/6 pass
- [x] Codex cross-review: verdict pass (no BLOCKER/CONCERN/NIT)

## 관련 PR

- #319 (mac wt 호환성), #321 (tfx-setup macOS), #322 (hooks/skills mirror gate), #325 (hud/config mirror gate)
- 이 PR은 #325의 follow-up — Codex retro review가 발견한 publish/mirror 정합성 갭 해소.