### PR TITLE
ci: add release:check-mirror and check-sync fast-fail steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,15 @@ jobs:
         # npm install fallback. deterministic 손실 trade-off 있으나 CI 미실행 보다 낫다.
         run: npm ci || npm install --no-audit --no-fund
 
+      - name: packages/triflux mirror byte-identical
+        # packages-mirror.test.mjs 가 transitive 로 같은 검사를 돌지만, drift 시
+        # unit test 실행 전에 fast-fail 로 끊어주면 원인 파악이 명확해진다.
+        # PR #325 retro review (Codex) 가 발견한 dormant drift 같은 시나리오 가드.
+        run: npm run release:check-mirror
+
+      - name: packages version sync
+        # root vs packages/{core,remote,triflux} package.json version drift 감지.
+        run: npm run release:check-sync
+
       - name: Codex config stability guard
         run: npm run test:guard-codex-config


### PR DESCRIPTION
## Summary

- 현재 `.github/workflows/ci.yml` 은 `npm run test:guard-codex-config` 만 호출 — `packages-mirror.test.mjs` 가 transitive 로 mirror check 하지만 drift 시 원인 파악이 모호.
- 본 PR이 fast-fail 2 step 추가: `release:check-mirror` (mirror byte-identical) + `release:check-sync` (version sync).
- PR #325 retro review (Codex) 가 발견한 dormant drift 시나리오에 대한 자동 가드.

## Test plan

- [x] 로컬 `npm run release:check-mirror`: `Mirror OK`, 0.270s
- [x] 로컬 `npm run release:check-sync`: `Version sync OK (10.25.0)`, 0.192s
- [x] `git diff --check`: 공백/탭 이슈 없음
- [x] Codex cross-review verdict: pass (NIT: install 전 step도 가능하지만 현재 순서가 기존 흐름과 일관)

## 관련 PR

- #319 mac wt 호환성, #321 tfx-setup macOS, #322 hooks/skills mirror gate
- #325 hud/config mirror gate, #328 config publish files 정합화
- 이 PR이 위 5 PR의 가드 메커니즘을 CI에서 자동 실행되게 함