### PR TITLE
chore/lint: clean up biome warnings in bin and scripts areas

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -4711,10 +4711,13 @@ async function cmdDoctor(options = {}) {
       const wrapperCheck = await checkWrapperSourcing();
       addDoctorCheck(report, {
         name: "mcp-gateway-wrapper-sourcing",
-        status: wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
+        status:
+          wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
         path: wrapperCheck.wrapperPath,
         ...(wrapperCheck.message ? { message: wrapperCheck.message } : {}),
-        ...(wrapperCheck.suggestedFix ? { fix: wrapperCheck.suggestedFix } : {}),
+        ...(wrapperCheck.suggestedFix
+          ? { fix: wrapperCheck.suggestedFix }
+          : {}),
       });
 
       if (wrapperCheck.status === "ok") {

--- a/packages/core/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-health-check.mjs
@@ -105,7 +105,6 @@ export function checkMcpGatewayHealth({
       lastEvent.set(m[1], {
         type: "manifest-disabled",
       });
-      continue;
     }
   }
 
@@ -146,9 +145,7 @@ export function summarizeMcpGatewayHealth(result) {
   }
   const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
   if (missingEnv.length > 0) {
-    const list = missingEnv
-      .map((f) => `${f.server} (${f.detail})`)
-      .join(", ");
+    const list = missingEnv.map((f) => `${f.server} (${f.detail})`).join(", ");
     return {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,

--- a/packages/core/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 
 export async function checkWrapperSourcing({
-  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  wrapperPath = path.join(
+    os.homedir(),
+    ".local",
+    "bin",
+    "mcp-gateway-wrapper.sh",
+  ),
   marker = "secrets.env",
 } = {}) {
   let text;

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -4711,10 +4711,13 @@ async function cmdDoctor(options = {}) {
       const wrapperCheck = await checkWrapperSourcing();
       addDoctorCheck(report, {
         name: "mcp-gateway-wrapper-sourcing",
-        status: wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
+        status:
+          wrapperCheck.status === "warn" ? "warning" : wrapperCheck.status,
         path: wrapperCheck.wrapperPath,
         ...(wrapperCheck.message ? { message: wrapperCheck.message } : {}),
-        ...(wrapperCheck.suggestedFix ? { fix: wrapperCheck.suggestedFix } : {}),
+        ...(wrapperCheck.suggestedFix
+          ? { fix: wrapperCheck.suggestedFix }
+          : {}),
       });
 
       if (wrapperCheck.status === "ok") {

--- a/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/packages/triflux/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -134,7 +134,10 @@ describe("install mcp gateway startup", () => {
       const body = fs.files.get(wrapperPath);
       const secretsIdx = body.indexOf("$HOME/.config/triflux/secrets.env");
       const legacyIdx = body.indexOf("$HOME/.config/triflux/mcp-gateway.env");
-      assert.ok(secretsIdx >= 0, "secrets.env 가 wrapper sourcing 목록에 있어야 한다");
+      assert.ok(
+        secretsIdx >= 0,
+        "secrets.env 가 wrapper sourcing 목록에 있어야 한다",
+      );
       assert.ok(legacyIdx >= 0, "legacy mcp-gateway.env 도 호환 유지");
       assert.ok(
         secretsIdx < legacyIdx,

--- a/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -186,7 +186,11 @@ describe("mcp-gateway-health-check", () => {
       fs: makeFs({ logBody: recoveredLog }),
       logPath: "/fake/log",
     });
-    assert.equal(result.findings.length, 0, "복구된 server 는 finding 에서 빠진다");
+    assert.equal(
+      result.findings.length,
+      0,
+      "복구된 server 는 finding 에서 빠진다",
+    );
     const startedNames = result.started.map((s) => s.server).sort();
     assert.deepEqual(startedNames, ["brave-search", "context7", "serena"]);
   });

--- a/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
@@ -105,7 +105,6 @@ export function checkMcpGatewayHealth({
       lastEvent.set(m[1], {
         type: "manifest-disabled",
       });
-      continue;
     }
   }
 
@@ -146,9 +145,7 @@ export function summarizeMcpGatewayHealth(result) {
   }
   const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
   if (missingEnv.length > 0) {
-    const list = missingEnv
-      .map((f) => `${f.server} (${f.detail})`)
-      .join(", ");
+    const list = missingEnv.map((f) => `${f.server} (${f.detail})`).join(", ");
     return {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,

--- a/packages/triflux/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 
 export async function checkWrapperSourcing({
-  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  wrapperPath = path.join(
+    os.homedir(),
+    ".local",
+    "bin",
+    "mcp-gateway-wrapper.sh",
+  ),
   marker = "secrets.env",
 } = {}) {
   let text;

--- a/scripts/__tests__/install-mcp-gateway-startup.test.mjs
+++ b/scripts/__tests__/install-mcp-gateway-startup.test.mjs
@@ -134,7 +134,10 @@ describe("install mcp gateway startup", () => {
       const body = fs.files.get(wrapperPath);
       const secretsIdx = body.indexOf("$HOME/.config/triflux/secrets.env");
       const legacyIdx = body.indexOf("$HOME/.config/triflux/mcp-gateway.env");
-      assert.ok(secretsIdx >= 0, "secrets.env 가 wrapper sourcing 목록에 있어야 한다");
+      assert.ok(
+        secretsIdx >= 0,
+        "secrets.env 가 wrapper sourcing 목록에 있어야 한다",
+      );
       assert.ok(legacyIdx >= 0, "legacy mcp-gateway.env 도 호환 유지");
       assert.ok(
         secretsIdx < legacyIdx,

--- a/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -186,7 +186,11 @@ describe("mcp-gateway-health-check", () => {
       fs: makeFs({ logBody: recoveredLog }),
       logPath: "/fake/log",
     });
-    assert.equal(result.findings.length, 0, "복구된 server 는 finding 에서 빠진다");
+    assert.equal(
+      result.findings.length,
+      0,
+      "복구된 server 는 finding 에서 빠진다",
+    );
     const startedNames = result.started.map((s) => s.server).sort();
     assert.deepEqual(startedNames, ["brave-search", "context7", "serena"]);
   });

--- a/scripts/lib/mcp-gateway-health-check.mjs
+++ b/scripts/lib/mcp-gateway-health-check.mjs
@@ -105,7 +105,6 @@ export function checkMcpGatewayHealth({
       lastEvent.set(m[1], {
         type: "manifest-disabled",
       });
-      continue;
     }
   }
 
@@ -146,9 +145,7 @@ export function summarizeMcpGatewayHealth(result) {
   }
   const missingEnv = result.findings.filter((f) => f.reason === "missing-env");
   if (missingEnv.length > 0) {
-    const list = missingEnv
-      .map((f) => `${f.server} (${f.detail})`)
-      .join(", ");
+    const list = missingEnv.map((f) => `${f.server} (${f.detail})`).join(", ");
     return {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,

--- a/scripts/lib/mcp-gateway-wrapper-check.mjs
+++ b/scripts/lib/mcp-gateway-wrapper-check.mjs
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 
 export async function checkWrapperSourcing({
-  wrapperPath = path.join(os.homedir(), ".local", "bin", "mcp-gateway-wrapper.sh"),
+  wrapperPath = path.join(
+    os.homedir(),
+    ".local",
+    "bin",
+    "mcp-gateway-wrapper.sh",
+  ),
   marker = "secrets.env",
 } = {}) {
   let text;


### PR DESCRIPTION
## Why

W3 audit + 이번 세션의 PR #327 codex worker 가 release governance 작업 외 영역의 lint 실패를 `unrelated` 로 명시. 이번 PR 은 그 잔존 실패를 일괄 정리.

## What

12 files (single commit `7d1c40ca`, +49 -23):

- `bin/triflux.mjs` formatting
- `scripts/lib/mcp-gateway-*` warnings + `mcp-gateway-health-check` 루프 말단 `noUselessContinue` 제거
- `scripts/__tests__/*` formatting
- 대응 mirror: `packages/triflux/bin/`, `packages/{core,remote,triflux}/scripts/lib/`, `packages/triflux/scripts/__tests__/`

## Verify

| Check | Result |
|-------|--------|
| `npm run lint` | 688 files, no fixes |
| `npm run lint` error/warning grep | 0 |
| `node scripts/release/check-packages-mirror.mjs` | Mirror OK |
| `node scripts/release/check-sync.mjs` | Version sync OK (10.25.0) |
| targeted `node --test` | 36/36 pass |
| `git diff --check` | OK |
| AI trailer / Co-Authored-By grep | 0 |

`npm test` 전체 suite 는 돌리지 않음 (이 PR scope 밖, 환경 의존 실패는 별도 lane).

## Reference

- 이번 세션 누적: PR #314, #316, #320, #324, #326, #327 (6 PR + Issue #315 closed)
- 다음 단계: v10.25.1 patch release publish (`node scripts/release/publish.mjs --execute`)