### PR TITLE
Gemini → Antigravity migration: docs + wrapper redirect + agy hardening

### DIFF
--- a/.claude/rules/tfx-escalation-chain.md
+++ b/.claude/rules/tfx-escalation-chain.md
@@ -36,7 +36,7 @@ PRD 또는 프로젝트 별 체인 커스터마이즈 시 `.triflux/config/escal
 }
 ```
 
-체인 항목 필드: `cli` (codex|gemini|claude), `model` (CLI 가 해석하는 문자열).
+체인 항목 필드: `cli` (codex|antigravity|claude), `model` (CLI 가 해석하는 문자열).
 
 ## 사용 예시
 

--- a/.claude/rules/tfx-psmux.md
+++ b/.claude/rules/tfx-psmux.md
@@ -91,7 +91,7 @@ exec codex $prompt
 
 ## RULE 4: 프로파일 사용, 인자 하드코딩 금지
 
-Codex든 Gemini든 모델·effort·실행모드는 프로파일(config)로 관리한다.
+Codex든 Antigravity든 모델·effort·실행모드는 프로파일(config)로 관리한다.
 CLI 인자로 하드코딩하지 않는다.
 
 ### 4-1. 프로파일 우선

--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -63,8 +63,8 @@ triflux 본체 개발의 실측 운영 패턴 (v10.18.0 ~ v10.20.2, 2주, 25+ PR
 | 우선순위 | CLI / 모델 | default 적용 lane |
 |---------|-----------|-------------------|
 | 1차 (default) | **Codex** (gpt-5.3-codex / gpt-5.5) | 구현, 수정, 디버그, 리뷰, 분석, 테스트 작성, 회귀 가드, 릴리즈 prepare |
-| 2차 | **Gemini** (pro25 / flash25) | Codex quota exhaust, 가독성 cross-check, 별도 시각 검토 |
-| 한정 (Claude 만) | **Claude** (opus-4-7) | 메타 라우팅 (`/tfx-harness`), planning gate (`/office-hours`, `/autoplan`), gstack-specific surface (`/gstack-context-*`, `/gstack /qa`), 또는 Codex/Gemini 미가용 |
+| 2차 | **Antigravity** | Codex quota exhaust, 가독성 cross-check, 별도 시각 검토 |
+| 한정 (Claude 만) | **Claude** (opus-4-7) | 메타 라우팅 (`/tfx-harness`), planning gate (`/office-hours`, `/autoplan`), gstack-specific surface (`/gstack-context-*`, `/gstack /qa`), 또는 Codex/Antigravity 미가용 |
 
 `tfx-auto`, `tfx-review`, `tfx-analysis`, `tfx-plan`, `tfx-find` 등 multi-CLI wrapper 는 이 정책을 따른다. 명시 플래그 (`--cli claude`, `--cli gemini`) 가 있으면 override. `--mode consensus` (3-CLI 합의) 도 default head 는 Codex.
 
@@ -100,7 +100,7 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 | 스킬 | 용도 |
 |------|------|
 | tfx-multi | 2+개 태스크 headless 병렬 |
-| tfx-swarm | PRD별 worktree + 다중 모델(Codex/Gemini/Claude) + 다중 기기(로컬+원격) |
+| tfx-swarm | PRD별 worktree + 다중 모델(Codex/Antigravity/Claude) + 다중 기기(로컬+원격) |
 | tfx-remote | Claude Code 원격 세션 (SSH, user-state hosts.json setup 필수; tfx-remote-spawn은 legacy alias) |
 
 **Claude 네이티브** (CLI 불필요): tfx-find, tfx-forge, tfx-prune, tfx-index, tfx-setup, tfx-doctor, tfx-hooks, tfx-hub

--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -80,7 +80,7 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 |------|-----|------|
 | `tfx-auto` | 자동 | 통합 진입점 |
 | `tfx-auto --cli codex` | Codex | Codex 전용 lane |
-| `tfx-auto --cli gemini` | Gemini | Gemini 전용 lane |
+| `tfx-auto --cli gemini` | Antigravity | [deprecated alias] Antigravity 로 redirect (agy 없으면 legacy gemini fallback) |
 | `tfx-auto --mode quick` | Codex→검증 | 단일 파일, 5분 이내 |
 | `tfx-auto --retry auto-escalate` | 자동 승격 | 실패→더 강한 모델 |
 

--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -6,8 +6,7 @@
 | **OMC (oh-my-claudecode)** | 세션 시작 훅 `[OMC VERSION DRIFT]` / `[OMC UPDATE AVAILABLE]` | `omc update` — plugin/npm CLI/CLAUDE.md 3곳 동시 동기화 |
 | **gstack** | `~/.gstack/last-update-check` 훅 / 세션 시작 배너 | `/gstack-upgrade` 스킬 (git install이면 `git merge --ff-only origin/main` + `./setup` + migrations) |
 | **Codex CLI** | `codex --version` / `~/.codex/auth.json` mtime | `npm i -g @openai/codex` / 토큰 만료 시 `codex login` (인터랙티브) + 메시지 한 번 날려 refresh 트리거 |
-| **Gemini CLI** | `gemini --version` (현재 0.42.0) | `npm i -g @google/gemini-cli`. **2026-06-18 deadline** (Google I/O 2026, 2026-05-19 발표): AI Pro/Ultra + 무료 OAuth 인증 lane 끊김. Enterprise (Code Assist Standard/Enterprise license) 또는 유료 Gemini/Enterprise Agent Platform API key 보유자만 계속 사용 가능. 실측 OAuth 인증 (`~/.gemini/oauth_creds.json`) 환경은 영향 대상. |
-| **Antigravity CLI** (신규, 2026-05-19 발표) | `agy --version` (macOS Cask IDE) / `antigravity --version` (Linux apt / CLI distribution) | **두 distribution 분리**: ① **IDE** (VS Code fork, 1.23.2 = Antigravity 2.0) — `brew install --cask antigravity` (macOS) / `apt install antigravity` (Ubuntu, repo `us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/`). GUI desktop. macOS는 `agy chat` subcommand가 GUI 패널 launcher (headless 부재). ② **CLI** (TUI, 1.0.0 initial release) — `curl -fsSL https://antigravity.google/cli/install.sh \| bash` (Mac/Linux) / `irm https://antigravity.google/cli/install.ps1 \| iex` (Win). Terminal-first, SSH 최적화. 인증: system keyring + Google Sign-In fallback, `/logout` 명령. Enterprise: GCP project 연결. |
+| **Antigravity CLI** | `agy --version` | CLI: `curl -fsSL https://antigravity.google/cli/install.sh \| bash`. IDE Cask: `brew install --cask antigravity`. 인증: ChainedAuth (Mac Keychain → oauth_creds.json). 자세히는 memory:[[reference-antigravity-cli-sanity-matrix]] |
 | **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거) |
 | **Codex auth 캐시** (pte1024 등) | 병렬 codex exec 시 `refresh_token_reused` | `cp ~/.codex/auth.json ~/.claude/cache/tfx-hub/codex-auth-<account>.json` 수동 (Issue #78 자동화 대기) |
 
@@ -17,41 +16,5 @@
 - OMC drift 감지 시 plugin/npm/CLAUDE.md 3개 컴포넌트를 반드시 함께 갱신 (한쪽만 새 버전이면 훅/라우팅 호환성 깨짐)
 - gstack 업그레이드 후 `~/.gstack/just-upgraded-from`을 체크해서 CHANGELOG 하이라이트 표시
 - 원격 머신 업그레이드 전파는 `tfx-remote` + SSH scp로 수동 (자동화 예정)
-- **Gemini CLI → Antigravity CLI dual-lane 정책** (사용자 결정 2026-05-20): triflux 헤드리스 lane (`gemini -p`, `tfx-route.sh` gemini agent)은 **진짜 Antigravity CLI (TUI, `curl install.sh`)** 만 대체 가능. macOS Cask의 `agy chat` 은 GUI 패널 launcher라 headless 아님. 6/18 deadline 까지 두 lane 병행, 진짜 Antigravity CLI 설치 후 `agy --help` / `antigravity --help` 출력으로 마이그레이션 명령을 1차 검증한 뒤 `tfx-route.sh` lane 어댑테이션.
-- **Antigravity CLI 마이그레이션은 자동** (1차 binary 검증 2026-05-20, `~/.gemini/antigravity-cli/cli.log` verbatim `gemini_extensions.go:98] Successfully migrated 4 extensions`, 27ms 소요). `curl install.sh` 설치 → 첫 `agy` 실행 시 onboarding UI 끝나면 `~/.gemini/extensions/` 의 모든 extension 을 `~/.gemini/antigravity-cli/plugins/<name>/skills/` 로 자동 변환하고 `import_manifest.json` 에 기록. **수동 `agy plugin import` 명령 불필요** (단, 명령 자체는 존재 — `agy plugin help` verbatim: `import [source]   Import plugins from gemini or claude`. source 인자는 `gemini` 또는 `claude` 둘 다 지원).
-- **Antigravity CLI 헤드리스 옵션 verbatim** (`agy --help` 1차 출처): `--print`/`-p`/`--prompt` (= Gemini CLI `-p`), `--dangerously-skip-permissions` (= Gemini CLI `--yolo`), `--sandbox`, `--continue`/`-c`, `--conversation <ID>`, `--add-dir`. Subcommands: `changelog`, `help`, `install`, `plugin`/`plugins`, `update`. **`agy chat` subcommand 부재** (그건 IDE Cask 의 `/opt/homebrew/bin/agy` 가 만든 GUI 패널 launcher — 동명이몸 binary 와 혼동 금지).
-- **Antigravity 자동 fallback readiness 계약**: SessionStart `preflight-cache.mjs` 가 `agy --help` 에서 `--print` + `--dangerously-skip-permissions` 를 확인하고 `~/.gemini/oauth_creds.json` 또는 Antigravity CLI credential 파일이 있을 때만 `TFX_ANTIGRAVITY_OK=1` 을 캐시한다. `tfx-route.sh` 의 quota auto-reroute 는 이 값이 1일 때만 codex/gemini → antigravity 를 후보로 삼는다. 명시적 `tfx-route.sh antigravity ...` 실행은 이 gate 와 별개로 허용하되, runtime 에서 headless flag 지원은 다시 확인한다.
-- **인증 lane 공유**: `~/.gemini/oauth_creds.json` 을 Antigravity CLI 가 그대로 재사용 (1차 검증: `agy --print "ok"` smoke test 성공, 별도 sign-in 불필요). 단 2026-06-18 deadline 시 OAuth 자체가 끊기면 Antigravity CLI 도 영향 받음 (별도 우회 lane 미확정).
-- **PATH 우선순위 충돌 주의**: macOS 에서 Cask IDE 의 `/opt/homebrew/bin/agy` (VS Code launcher) 와 CLI 의 `~/.local/bin/agy` (TUI 1.0.0) 가 모두 PATH 에 존재. 기본 PATH 순서 (`~/.local/bin` 우선) 면 CLI 가 호출되지만, `which -a agy` 로 우선순위 확인 필수. `/opt/homebrew/bin/agy` 를 명시 호출하면 IDE GUI 가 뜬다.
-- **Antigravity 경로 규약** (출처별 정정, 2026-05-20 실측):
-  - **CLI 1.0.0 실측 base** (`agy` binary 가 실제로 쓰는 경로): `~/.gemini/antigravity-cli/{brain,cache,conversations,implicit,knowledge,log,plugins,updater}/` + `import_manifest.json` + `installation_id` + `settings.json` (mode 600) + `keybindings.json` (mode 600) + `last_check.timestamp`. 마이그레이션된 plugin skills 는 `~/.gemini/antigravity-cli/plugins/<plugin>/skills/<skill>/`.
-  - **IDE Cask (Antigravity 2.0) 경로** (Google Codelab 출처): 글로벌 skills `~/.gemini/antigravity/skills/` · 글로벌 workflows `~/.gemini/antigravity/global_workflows/` · 워크스페이스 `.agents/{rules,workflows,skills}/` (복수형 `s`).
-  - **공통**: 글로벌 rules `~/.gemini/GEMINI.md` (Gemini CLI · Antigravity CLI · Antigravity IDE 가 모두 같은 path 공유).
-  - **주의**: `~/.gemini/antigravity-cli/` (CLI 전용) 와 `~/.gemini/antigravity/` (IDE 전용) 는 **별개** path. third-party docs 의 `.agent/` (단수) 는 잘못된 경로.
-
-## Antigravity CLI 1.0.0 정밀 sanity matrix 발견 (2026-05-20)
-
-agy CLI 1.0.0 의 prompt 전달 mechanism 정밀 검증 결과 (정밀 sanity matrix 10종 + context7 3개 출처 + 공식 docs verbatim):
-
-- **`--print` 는 string value-taking flag** (Go flag library 기본): T1 `--print=hi` → "hi" ✅, T2 `--print` alone → "flag needs an argument" (exit 2). 즉 boolean flag 가 아님.
-- **flag 순서 critical**: `--print` 가 먼저 + 다른 flag 가 뒤 = **timeout** (T6 `--print --add-dir /tmp 'prompt'`, T9 `--print --sandbox 'prompt'` 둘 다 exit 124 timeout — `--print` value 로 다음 flag 흡수). 정상 패턴 3가지:
-  - `--dangerously-skip-permissions --print VALUE` (T10) — flag swap
-  - `--print=VALUE` (T1) — `=` syntax (Go flag default)
-  - `--print --dangerously-skip-permissions` + stdin pipe (T4/D) — wrapper Tier 2 (PR #296) 채택
-- **CLI TUI 모델 = account-dependent** (사용자 직접 확인 2026-05-20):
-  - **사내 계정 5개**: Gemini 3.1 Pro (High), Gemini 3.1 Pro (Low), **Gemini 3.5 Flash (default current)**, Gemini 3.5 Flash (Low), Gemini 3 Flash
-  - 개인 계정 4개 (이전 메모): Gemini 3.5 Flash High/Med, Gemini 3.1 Pro High/Low
-  - context7 `/llmstxt/sirius-red` 의 7개 (Gemini 3 Pro high/low/Flash, Claude Sonnet 4.5/thinking, Opus 4.5 thinking, GPT-OSS) 는 **IDE Antigravity 2.0 모델 리스트로 추정** (CLI TUI 와 별개)
-- **`/model` slash command** (CLI 안에서) = default 모델 변경 + **persists across sessions** (공식 docs verbatim). settings 저장 위치 미확정 (`~/.gemini/antigravity-cli/settings.json` 에 model 항목 부재, 추정 in-memory 또는 hidden state — 사용자 직접 검증 필요).
-- **모델 선택 sticky scope**: "The choice of reasoning model is sticky between user messages within a conversation" (공식 docs verbatim) — 새 conversation 시 default 적용.
-- **CLI launch flag override 가능 항목**: `--sandbox`, `--dangerously-skip-permissions` **2개만** (verbatim). `-m`/`--model` flag 부재 = wrapper 가 헤드리스 호출 시 model 통제 불가 (drop-down UI 만 가능).
-- **`/model` 외 주요 slash commands** (공식 docs verbatim): `/resume` (alias `/switch`), `/rewind` (alias `/undo`), `/rename <name>`, `/permissions`, `/keybindings`, `/statusline`, `/tasks`, `/skills`, `/mcp`, `/open <path>`, `/usage`, `/logout`.
-- **agy subagents framework** (공식 docs verbatim): `/tasks` panel (monitor/view-logs/terminate background tasks) + `/agents` panel (running subagents UI, ctrl+j teleport, ctrl+k fast-approve) + asynchronous subagents (parallel work, background research, system tests). triflux hub/team_mode 와 **중복/통합 가능 영역** — 별도 분석 PRD `.triflux/plans/agy-subagents-integration-eval.md`.
-- **MCP server config 위치 변경**: Gemini CLI 의 `~/.gemini/settings.json` (inline mcpServers) → Antigravity CLI 의 **`~/.gemini/antigravity-cli/mcp_config.json`** (별도 file) + workspace 는 `.agents/mcp_config.json`. **`serverUrl` field** (Gemini 의 `url`/`httpUrl` 대신).
-- **workspace context 호환**: GEMINI.md + AGENTS.md 둘 다 읽음. Global rules `~/.gemini/GEMINI.md` (Gemini CLI 와 공유).
-- **plugin import 명령 verbatim**: `agy plugin import gemini` — Gemini CLI extensions → Antigravity plugins 자동 변환 (`~/.gemini/antigravity-cli/plugins/<name>/skills/`).
-- **wrapper Tier 2 (PR #296)** 의 antigravity stdin pipe 분기 + no-op 승격 skip + auto_reroute tri-lane 확장 = 위 mechanism 의 운영 적용. 회귀테스트 (PR #297) 의 5 test 가 mechanism lock-in.
-
-후속 PRD:
-- `.triflux/plans/agy-subagents-integration-eval.md` — triflux hub vs agy subagents 책임 매트릭스 + 통합 시나리오 3가지
-- `.triflux/plans/node-cli-single-entry-migration.md` — wrapper 2609줄 Bash → Node 전환 plan (책임 16가지 매핑 + Phase 0~3)
+- Antigravity headless fallback readiness 는 SessionStart `preflight-cache.mjs` 가 `TFX_ANTIGRAVITY_OK` 로 캐시. `hub/team/preflight-cache.mjs` 코드 주석 참조.
+- Antigravity CLI 인증은 ChainedAuth (Mac Keychain → oauth_creds.json 순) 기반. 별도 sign-in 일반적으로 불필요.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ exec codex $prompt
 
 ## RULE 4: 프로파일 사용, 인자 하드코딩 금지
 
-Codex든 Gemini든 모델·effort·실행모드는 프로파일(config)로 관리한다.
+Codex든 Antigravity든 모델·effort·실행모드는 프로파일(config)로 관리한다.
 CLI 인자로 하드코딩하지 않는다.
 
 ### 4-1. 프로파일 우선

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ sentinel exit 즉시 daemon `sendKillBySessionId` 발사 → stale row 잔존 �
 | `.claude/rules/tfx-routing.md` | 자연어 → 스킬 라우팅, CLI 라우팅 Layer 1~3, 충돌 해소 |
 | `.claude/rules/tfx-execution-skill-map.md` | tfx-auto / multi / swarm 실행 엔진 매핑, 격리 기준, 안티패턴 |
 | `.claude/rules/tfx-autoplan-principles.md` | gstack autoplan의 6 decision principles, phase 우선순위, 충돌 해소 규칙 추출본 |
-| `.claude/rules/tfx-update-logic.md` | triflux / OMC / gstack / Codex / Gemini 업데이트 로직 |
+| `.claude/rules/tfx-update-logic.md` | triflux / OMC / gstack / Codex / Antigravity 업데이트 로직 |
 | `.claude/rules/tfx-stack-coexistence.md` | gstack / superpowers / triflux 공존 원칙, 레이어 분리, 의존 방향, 충돌 해소 |
 | `.claude/rules/tfx-mirror-policy.md` | packages/ 3-layer mirror 정책 (core 단순 cp / remote import 변환 / triflux byte-identical), tests 제외 룰, drift 차단 |
 

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -824,9 +824,9 @@ auto_reroute() {
   local target_cli=""
   local -a candidates=()
   case "$failed_cli" in
-    codex) candidates=("antigravity" "gemini") ;;
+    codex) candidates=("antigravity") ;;
     gemini) candidates=("antigravity" "codex") ;;
-    antigravity) candidates=("codex" "gemini") ;;
+    antigravity) candidates=("codex") ;;
     *) echo "[tfx-quota] $failed_cli 대체 CLI 없음" >&2; return 1 ;;
   esac
 
@@ -856,11 +856,9 @@ auto_reroute() {
 
   case "$failed_cli:$target_cli" in
     codex:antigravity) echo "[tfx-quota] Codex → Antigravity 자동 전환" >&2 ;;
-    codex:gemini) echo "[tfx-quota] Codex → Gemini 자동 전환" >&2 ;;
     gemini:antigravity) echo "[tfx-quota] Gemini → Antigravity 자동 전환" >&2 ;;
     gemini:codex) echo "[tfx-quota] Gemini → Codex 자동 전환" >&2 ;;
     antigravity:codex) echo "[tfx-quota] Antigravity → Codex 자동 전환" >&2 ;;
-    antigravity:gemini) echo "[tfx-quota] Antigravity → Gemini 자동 전환" >&2 ;;
   esac
 
   local quota_marker="$TFX_TMP/tfx-quota-${failed_cli}-$(date +%Y%m%d)"
@@ -1169,10 +1167,10 @@ if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
       } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e"); }
     ' 2>/dev/null
   ) || true
-  export TFX_CODEX_OK="${_pf_codex:-0}"
-  export TFX_GEMINI_OK="${_pf_gemini:-0}"
-  export TFX_ANTIGRAVITY_OK="${_pf_antigravity:-0}"
-  export TFX_HUB_OK="${_pf_hub:-0}"
+  export TFX_CODEX_OK="${TFX_CODEX_OK:-${_pf_codex:-0}}"
+  export TFX_GEMINI_OK="${TFX_GEMINI_OK:-${_pf_gemini:-0}}"
+  export TFX_ANTIGRAVITY_OK="${TFX_ANTIGRAVITY_OK:-${_pf_antigravity:-0}}"
+  export TFX_HUB_OK="${TFX_HUB_OK:-${_pf_hub:-0}}"
   [[ -n "${_pf_plan:-}" ]] && export TFX_CODEX_PLAN="$_pf_plan"
   [[ -n "${_pf_agents:-}" ]] && export TFX_AVAILABLE_AGENTS="$_pf_agents"
   export TFX_PREFLIGHT_LOADED=1
@@ -1230,6 +1228,19 @@ apply_cli_mode() {
   codex_base="$(build_codex_base)"
   local gemini_tier=""
 
+  if [[ "$CLI_TYPE" == "gemini" && ( "$TFX_CLI_MODE" == "auto" || "$TFX_CLI_MODE" == "gemini" ) ]]; then
+    # Gemini CLI is deprecated, but the `gemini` route name remains as a
+    # compatibility alias until Phase 5 cleanup. When Antigravity readiness has
+    # already been proven by preflight/cache, direct gemini routes must follow
+    # the same redirect as TFX_CLI_MODE=gemini remaps.
+    if [[ "${TFX_ANTIGRAVITY_OK:-0}" == "1" ]] && command -v "${AGY_BIN:-agy}" &>/dev/null; then
+      echo "[tfx-route] [deprecated] gemini route → antigravity (Gemini CLI deprecated, use antigravity/agy)" >&2
+      TFX_CLI_MODE="antigravity"
+      apply_cli_mode
+      return
+    fi
+  fi
+
   case "$TFX_CLI_MODE" in
     codex)
       if [[ "$CLI_TYPE" == "gemini" ]]; then
@@ -1258,6 +1269,14 @@ apply_cli_mode() {
             return 0
             ;;
         esac
+        # Gemini CLI deprecated — redirect to Antigravity when available.
+        # Legacy gemini binary path is preserved as fallback for environments
+        # without agy (TFX_ANTIGRAVITY_OK=0) until Phase 5 cleanup.
+        if [[ "${TFX_ANTIGRAVITY_OK:-0}" == "1" ]] && command -v "${AGY_BIN:-agy}" &>/dev/null; then
+          echo "[tfx-route] [deprecated] TFX_CLI_MODE=gemini → antigravity (Gemini CLI deprecated, use --cli antigravity)" >&2
+          TFX_CLI_MODE="antigravity"; apply_cli_mode; return
+        fi
+        echo "[tfx-route] [deprecated] TFX_CLI_MODE=gemini: agy 미설치 — legacy gemini binary path 진입" >&2
         CLI_TYPE="gemini"; CLI_CMD="gemini"
         case "$AGENT_TYPE" in
           executor|debugger|deep-executor|architect|planner|critic|analyst|\

--- a/packages/triflux/skills/tfx-analysis/SKILL.md
+++ b/packages/triflux/skills/tfx-analysis/SKILL.md
@@ -17,7 +17,7 @@ argument-hint: "<분석 대상> [--quick]"
 
 > **ARGUMENTS 처리**: ARGUMENTS 에 `--quick` 포함 → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Claude(아키텍처) + Codex(보안/성능) + Gemini(UX/문서화) Tri-Debate 합의.
+> AI makes completeness near-free. 기본은 Claude(아키텍처) + Codex(보안/성능) + Antigravity(UX/문서화) Tri-Debate 합의.
 > 빠른 단일 CLI 분석은 `--quick` opt-out.
 
 ---
@@ -44,21 +44,21 @@ ARGUMENTS 에 `--quick` 포함 → **Quick 모드** (Codex 단일).
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 | headless multi 3-CLI |
-| **Tier 2** | Codex 또는 Gemini 중 하나만 | 가용 CLI + Claude Agent |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 | headless multi 3-CLI |
+| **Tier 2** | Codex 또는 Antigravity 중 하나만 | 가용 CLI + Claude Agent |
 | **Tier 3** | headless 불가 | Claude Agent only (consensus 미적용) |
 
 Tier 3 시:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드 (consensus 미적용)
-  누락: {missing}  |  권장: tmux/psmux + Hub + Codex + Gemini 설치
+  누락: {missing}  |  권장: tmux/psmux + Hub + Codex + Antigravity 설치
   또는 /tfx-analysis --quick 사용
 ```
 
 ### HARD RULES
 
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -68,7 +68,7 @@ Tier 3 시:
 |-------|------|------|
 | Claude Opus (architect) | 아키텍처/설계 | 레이어, SOLID, 확장성 |
 | Codex (security-engineer) | 구현/보안 | 복잡도, OWASP, 기술 부채 |
-| Gemini (ux-engineer) | UX/문서화 | DX, 접근성, 네이밍 |
+| Antigravity (ux-engineer) | UX/문서화 | DX, 접근성, 네이밍 |
 
 ### EXECUTION
 
@@ -90,7 +90,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless:**
+**Codex + Antigravity headless:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:시니어+보안 엔지니어로서 분석하라. 대상: {target}. 렌즈: 구현 품질, 성능, OWASP, 안정성, 기술 부채. JSON: { findings: [...], metrics: {...}, health_score: 0-100 }:security-engineer' --assign 'gemini:UX 엔지니어+테크니컬 라이터로서 분석하라. 대상: {target}. 렌즈: DX, 문서화, 접근성, 국제화, 네이밍. JSON: { findings: [...], documentation_score: 0-100, health_score: 0-100 }:ux-engineer' --timeout 600")
 ```
@@ -101,10 +101,10 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 
 **Agent:**
 ```
-Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_background=true, name="arch-debate", prompt="다른 두 분석가 결과: A(Codex)={codex}, B(Gemini)={gemini}. 동의에 +1, 반대에 근거 반박, 놓친 사항 추가, health_score 재조정")
+Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_background=true, name="arch-debate", prompt="다른 두 분석가 결과: A(Codex)={codex}, B(Antigravity)={gemini}. 동의에 +1, 반대에 근거 반박, 놓친 사항 추가, health_score 재조정")
 ```
 
-**Bash:** (위와 동일 패턴, Codex/Gemini 각각 교차검증)
+**Bash:** (위와 동일 패턴, Codex/Antigravity 각각 교차검증)
 
 합의 분류: 3/3 → CONFIRMED, 2/3 → LIKELY, 1/3 → UNVERIFIED.
 
@@ -112,7 +112,7 @@ Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_backgroun
 
 ```markdown
 # Deep Analysis Report: {target}
-**Consensus**: {score}% | **Health**: {weighted}/100 | **Analysts**: Claude/Codex/Gemini
+**Consensus**: {score}% | **Health**: {weighted}/100 | **Analysts**: Claude/Codex/Antigravity
 
 ## Executive Summary
 {3-5줄 합의 기반 요약}
@@ -122,7 +122,7 @@ Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_backgroun
 
 ## 발견사항 (Critical/High/Medium, 합의 기반)
 - [C1] `{file}:{line}` — {description} — 3/3
-  - 아키텍처: {Claude} | 구현: {Codex} | DX: {Gemini}
+  - 아키텍처: {Claude} | 구현: {Codex} | DX: {Antigravity}
   - 권장: {rec}
 
 ## 메트릭

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -133,7 +133,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 |--------|-----|------|----------|
 | `--cli` | `auto` (기본) | Codex 분류 후 최적 CLI 선택 | 기존 라우팅 |
 | `--cli` | `codex` | Codex 전용 고정. `TFX_CLI_MODE=codex` | tfx-route.sh |
-| `--cli` | `gemini` | Gemini 전용 고정. `TFX_CLI_MODE=gemini` | tfx-route.sh |
+| `--cli` | `gemini` | [deprecated alias] Antigravity 로 redirect. `TFX_CLI_MODE=gemini` (agy 없으면 legacy gemini fallback) | tfx-route.sh |
 | `--cli` | `claude` | Claude native 에이전트만 (CLI 호출 없음) | Agent() |
 | `--mode` | `quick` (기본) | fire-and-forget, plan/verify 오버헤드 없음 | 직접 실행 |
 | `--mode` | `deep` | pipeline init → plan → PRD → verify → fix loop | `-t/--thorough` 동일 |

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -104,11 +104,11 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Gemini → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
-> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Gemini에 위임하라. 작업이 아무리 사소해도 예외 없음.
+> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Antigravity에 위임하라. 작업이 아무리 사소해도 예외 없음.
 
 ## 모드
 
@@ -145,7 +145,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--shape` | `consensus` (기본) | findings 합의/충돌 판정 | consensus renderer |
 | `--shape` | `debate` | 옵션 비교 + 점수화 + 최종 추천 | debate renderer |
 | `--shape` | `panel` | 전문가 roster 기반 시뮬레이션 | panel renderer |
-| `--cli-set` | `triad` (기본) | Claude + Codex + Gemini | consensus participants |
+| `--cli-set` | `triad` (기본) | Claude + Codex + Antigravity | consensus participants |
 | `--cli-set` | `no-gemini` | Claude + Codex partial degrade | consensus participants |
 | `--cli-set` | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | consensus participants |
 | `--options` | `"A|B|C"` | debate 비교 대상 | debate normalizer |
@@ -281,8 +281,8 @@ shape 의미:
 
 | 값 | 의미 | 비고 |
 |----|------|------|
-| `triad` | Claude + Codex + Gemini | 기본값 |
-| `no-gemini` | Claude + Codex | Gemini 미가용 degrade |
+| `triad` | Claude + Codex + Antigravity | 기본값 |
+| `no-gemini` | Claude + Codex | Antigravity 미가용 degrade |
 | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | 신규 provider 추가 금지 |
 
 shape 입력 정규화:
@@ -328,7 +328,7 @@ shape 별 `shape_input`:
 2. `--mode consensus` 확인
 3. `--shape` 기본값 보정 (`consensus`)
 4. shape 별 payload 정규화
-5. Claude native + headless Codex/Gemini 동시 dispatch
+5. Claude native + headless Codex/Antigravity 동시 dispatch
 6. 결과 수집
 7. 공통 `meta_judgment` 생성
 8. shape renderer 로 markdown/json 출력
@@ -686,7 +686,7 @@ Phase 5 삭제 게이트:
 | `spec-panel` | architect + analyst + critic | analyze |
 | `business-panel` | analyst + architect | analyze |
 
-### Gemini 직행
+### Antigravity 직행
 
 | 커맨드 | 에이전트 | MCP |
 |--------|---------|-----|
@@ -828,7 +828,7 @@ else:
 
 ## 실행
 
-### CLI 에이전트 (Codex/Gemini)
+### CLI 에이전트 (Codex/Antigravity)
 
 ```bash
 # Level 0 / INDEPENDENT
@@ -853,7 +853,7 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |
-| gemini / designer / writer | Gemini | docs |
+| gemini / designer / writer | Antigravity | docs |
 | explore / test-engineer / qa-tester | Claude native | — |
 | verifier | Codex review (기본) / Claude native (TFX_VERIFIER_OVERRIDE=claude 시) | review / — |
 

--- a/packages/triflux/skills/tfx-auto/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-auto/SKILL.md.tmpl
@@ -80,11 +80,11 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Gemini → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
-> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Gemini에 위임하라. 작업이 아무리 사소해도 예외 없음.
+> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Antigravity에 위임하라. 작업이 아무리 사소해도 예외 없음.
 
 ## 모드
 
@@ -128,7 +128,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 | `spec-panel` | architect + analyst + critic | analyze |
 | `business-panel` | analyst + architect | analyze |
 
-### Gemini 직행
+### Antigravity 직행
 
 | 커맨드 | 에이전트 | MCP |
 |--------|---------|-----|
@@ -236,7 +236,7 @@ else:
 
 ## 실행
 
-### CLI 에이전트 (Codex/Gemini)
+### CLI 에이전트 (Codex/Antigravity)
 
 ```bash
 # Level 0 / INDEPENDENT
@@ -261,7 +261,7 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |
-| gemini / designer / writer | Gemini | docs |
+| gemini / designer / writer | Antigravity | docs |
 | explore / test-engineer / qa-tester | Claude native | — |
 | verifier | Codex review (기본) / Claude native (TFX_VERIFIER_OVERRIDE=claude 시) | review / — |
 

--- a/packages/triflux/skills/tfx-consensus/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-consensus/SKILL.md.tmpl
@@ -2,7 +2,7 @@
 internal: true
 name: tfx-consensus
 description: >
-  3자 합의 엔진 — 모든 Deep 스킬의 핵심 인프라. Claude/Codex/Gemini 독립 분석 결과를 교차검증하여 편향 없는 합의를 도출한다.
+  3자 합의 엔진 — 모든 Deep 스킬의 핵심 인프라. Claude/Codex/Antigravity 독립 분석 결과를 교차검증하여 편향 없는 합의를 도출한다.
   독립 실행도 가능: '합의로 분석해', '3자 합의', 'consensus' 같은 요청 시 직접 호출 가능.
 triggers: [consensus, 합의]
 argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 호출 또는 직접 사용 가능)"
@@ -22,7 +22,7 @@ argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 �
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -34,7 +34,7 @@ argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 �
 |-------|---------|------|------|
 | Claude Opus | architect | 합의 통합 및 교차검증 조율 | 논리 분석, 불일치 해소 |
 | Codex | analyst | 구현/보안 관점 독립 분석 | 코드 품질, 취약점 탐지 |
-| Gemini | analyst | UX/문서화 관점 독립 분석 | DX, 접근성, 가독성 |
+| Antigravity | analyst | UX/문서화 관점 독립 분석 | DX, 접근성, 가독성 |
 
 ## EXECUTION STEPS
 
@@ -56,7 +56,7 @@ Agent(
 )
 ```
 
-**도구 2 — Codex+Gemini 독립 분석 headless dispatch:**
+**도구 2 — Codex+Antigravity 독립 분석 headless dispatch:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:{analysis_prompt} 출력 형식을 JSON으로 강제: { findings: [{ id: string, category: string, severity: critical|high|medium|low, description: string, evidence: string }], summary: string, confidence: 0.0-1.0 }:analyst' --assign 'gemini:{analysis_prompt} 출력 형식을 JSON으로 강제: { findings: [{ id: string, category: string, severity: critical|high|medium|low, description: string, evidence: string }], summary: string, confidence: 0.0-1.0 }:analyst' --timeout 600")
 ```
@@ -87,13 +87,13 @@ Agent(
   run_in_background=true,
   name="consensus-resolve-claude",
   description="미합의 항목 2차 검토",
-  prompt="미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Codex — {codex_rebuttal}, Gemini — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수."
+  prompt="미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Codex — {codex_rebuttal}, Antigravity — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수."
 )
 ```
 
-**도구 2 — Codex+Gemini 재검토:**
+**도구 2 — Codex+Antigravity 재검토:**
 ```
-Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Gemini — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --assign 'gemini:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Codex — {codex_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --timeout 600")
+Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Antigravity — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --assign 'gemini:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Codex — {codex_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --timeout 600")
 ```
 
 Resolution 결과 처리:
@@ -134,7 +134,7 @@ Learned Weights를 `.omc/state/consensus-weights.json`에서 읽어 가중 투�
 |------|------|
 | headless timeout (600s) | Claude Agent로 해당 역할 대체 실행 |
 | Codex 워커 실패 | Agent(oh-my-claudecode:architect, model="opus") 대체 |
-| Gemini 워커 실패 | Agent(oh-my-claudecode:critic, model="sonnet") 대체 |
+| Antigravity 워커 실패 | Agent(oh-my-claudecode:critic, model="sonnet") 대체 |
 
 ## 토큰 예산
 

--- a/packages/triflux/skills/tfx-debate/SKILL.md
+++ b/packages/triflux/skills/tfx-debate/SKILL.md
@@ -48,7 +48,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-debate -> tfx-auto --mode consensus --s
 tfx-debate 의 본질은 "3-CLI 토론 엔진"이 아니라 "옵션 비교와 최종 추천을 내는 보고서 shape" 였다. Phase 4a 부터 orchestration root 는 `--mode consensus` 로 통합되고, debate 의미는 `--shape debate` 로 보존된다.
 
 공통 규약:
-- participants 기본값은 `triad` (Claude + Codex + Gemini)
+- participants 기본값은 `triad` (Claude + Codex + Antigravity)
 - `--cli-set no-gemini` 시 partial consensus 로 degrade 가능
 - 공통 `meta_judgment` 는 `hub/team/consensus-meta.mjs` 스키마를 따른다
 

--- a/packages/triflux/skills/tfx-debate/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-debate/SKILL.md.tmpl
@@ -32,7 +32,7 @@ argument-hint: "<토론 주제 또는 질문>"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -42,7 +42,7 @@ argument-hint: "<토론 주제 또는 질문>"
 |-----|------|
 | Claude | 소프트웨어 아키텍트 — 시스템 설계 관점 |
 | Codex | 시니어 백엔드 엔지니어 — 구현/기술적 트레이드오프 관점 |
-| Gemini | DevOps/인프라 엔지니어 + DX 전문가 — 운영/개발자경험 관점 |
+| Antigravity | DevOps/인프라 엔지니어 + DX 전문가 — 운영/개발자경험 관점 |
 
 ## EXECUTION STEPS
 
@@ -85,7 +85,7 @@ Agent(
 )
 ```
 
-Codex와 Gemini를 headless dispatch로 동시에 실행하라:
+Codex와 Antigravity를 headless dispatch로 동시에 실행하라:
 
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
@@ -133,7 +133,7 @@ Agent(
 )
 ```
 
-Codex와 Gemini 2차 라운드를 headless dispatch로 동시에 실행하라:
+Codex와 Antigravity 2차 라운드를 headless dispatch로 동시에 실행하라:
 
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
@@ -168,7 +168,7 @@ Claude Opus가 전체 토론을 종합하여 다음 구조로 최종 보고서�
 
 ## ERROR RECOVERY
 
-- Codex 또는 Gemini 결과가 없으면: 2개 소스로 교차검증을 진행하고 보고서에 누락 CLI를 명시하라
+- Codex 또는 Antigravity 결과가 없으면: 2개 소스로 교차검증을 진행하고 보고서에 누락 CLI를 명시하라
 - tfx multi 명령이 실패하면: 오류 메시지를 출력하고 재시도 1회 후 실패를 사용자에게 보고하라
 - Agent 결과가 없으면: Claude 관점 없이 나머지 2개 소스로 진행하라
 - Round 2 후에도 불일치가 지속되면: 해소되지 않은 항목으로 보고서에 명시하고 최종 추천은 다수결로 결정하라

--- a/packages/triflux/skills/tfx-doctor/SKILL.md
+++ b/packages/triflux/skills/tfx-doctor/SKILL.md
@@ -51,7 +51,7 @@ JSON 결과를 파싱하여 마크다운 테이블로 표시:
 | tfx-route.sh | ✅ | v2.0 |
 | HUD | ✅ | 설치됨 |
 | Codex CLI | ✅ | found |
-| Gemini CLI | ⚠ | 미설치 (선택) |
+| Antigravity CLI | ⚠ | 미설치 (선택) |
 | ...  | ... | ... |
 ```
 
@@ -82,7 +82,7 @@ Bash("triflux doctor --fix")
 |-----------|------|
 | claude-usage-cache.json | Claude 사용량 |
 | codex-rate-limits-cache.json | Codex 레이트 리밋 |
-| gemini-quota-cache.json | Gemini 쿼터 |
+| gemini-quota-cache.json | Antigravity 쿼터 |
 | sv-accumulator.json | 절약량 누적 |
 | mcp-inventory.json | MCP 서버 인벤토리 |
 | cli-issues.jsonl | CLI 이슈 로그 |
@@ -145,7 +145,7 @@ options:
 
 - tfx-route.sh 설치 상태
 - HUD 설치 및 설정 상태
-- Codex/Gemini/Claude CLI 경로 (크로스 셸)
+- Codex/Antigravity/Claude CLI 경로 (크로스 셸)
 - **psmux 버전 / capability preflight**
   - `new-session`, `attach-session`, `kill-session`, `capture-pane`, `detach-client`
   - 권장 버전 이상인지 여부
@@ -156,7 +156,7 @@ options:
 - Phase 1 웜업 캐시 무결성 (`node scripts/cache-doctor.mjs`)
 - 잔존 팀(orphan teams) 감지
 - **Docs 동기화** — `docs/design/`, `docs/research/` → `~/.claude/docs/` 레퍼런스 문서 동기화 상태
-- **Gemini MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
+- **Antigravity MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
 - **Route Script 정합성** — 프로젝트 소스 `scripts/tfx-route.sh`와 `~/.claude/scripts/tfx-route.sh` 일치 여부
 
 ## 에러 처리
@@ -165,7 +165,7 @@ options:
 |------|------|
 | 캐시 디렉토리 없음 | 정상 — 삭제할 파일 없음 보고 |
 | 파일 삭제 권한 없음 | 수동 삭제 안내 |
-| --fix 후에도 이슈 남음 | Codex/Gemini 설치는 수동 필요 안내 |
+| --fix 후에도 이슈 남음 | Codex/Antigravity 설치는 수동 필요 안내 |
 
 ## standalone TUI
 

--- a/packages/triflux/skills/tfx-doctor/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-doctor/SKILL.md.tmpl
@@ -51,7 +51,7 @@ JSON 결과를 파싱하여 마크다운 테이블로 표시:
 | tfx-route.sh | ✅ | v2.0 |
 | HUD | ✅ | 설치됨 |
 | Codex CLI | ✅ | found |
-| Gemini CLI | ⚠ | 미설치 (선택) |
+| Antigravity CLI | ⚠ | 미설치 (선택) |
 | ...  | ... | ... |
 ```
 
@@ -82,7 +82,7 @@ Bash("triflux doctor --fix")
 |-----------|------|
 | claude-usage-cache.json | Claude 사용량 |
 | codex-rate-limits-cache.json | Codex 레이트 리밋 |
-| gemini-quota-cache.json | Gemini 쿼터 |
+| gemini-quota-cache.json | Antigravity 쿼터 |
 | sv-accumulator.json | 절약량 누적 |
 | mcp-inventory.json | MCP 서버 인벤토리 |
 | cli-issues.jsonl | CLI 이슈 로그 |
@@ -145,7 +145,7 @@ options:
 
 - tfx-route.sh 설치 상태
 - HUD 설치 및 설정 상태
-- Codex/Gemini/Claude CLI 경로 (크로스 셸)
+- Codex/Antigravity/Claude CLI 경로 (크로스 셸)
 - **psmux 버전 / capability preflight**
   - `new-session`, `attach-session`, `kill-session`, `capture-pane`, `detach-client`
   - 권장 버전 이상인지 여부
@@ -156,7 +156,7 @@ options:
 - Phase 1 웜업 캐시 무결성 (`node scripts/cache-doctor.mjs`)
 - 잔존 팀(orphan teams) 감지
 - **Docs 동기화** — `docs/design/`, `docs/research/` → `~/.claude/docs/` 레퍼런스 문서 동기화 상태
-- **Gemini MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
+- **Antigravity MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
 - **Route Script 정합성** — 프로젝트 소스 `scripts/tfx-route.sh`와 `~/.claude/scripts/tfx-route.sh` 일치 여부
 
 ## 에러 처리
@@ -165,7 +165,7 @@ options:
 |------|------|
 | 캐시 디렉토리 없음 | 정상 — 삭제할 파일 없음 보고 |
 | 파일 삭제 권한 없음 | 수동 삭제 안내 |
-| --fix 후에도 이슈 남음 | Codex/Gemini 설치는 수동 필요 안내 |
+| --fix 후에도 이슈 남음 | Codex/Antigravity 설치는 수동 필요 안내 |
 
 ## standalone TUI
 

--- a/packages/triflux/skills/tfx-fullcycle/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-fullcycle/SKILL.md.tmpl
@@ -73,7 +73,7 @@ Phase 1 시작 전 아래 intake를 먼저 수행한다.
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini 워커 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity 워커 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude 워커 → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -84,12 +84,12 @@ Phase 1 시작 전 아래 intake를 먼저 수행한다.
 | Phase 1: Expansion | 아키텍트 — 요구사항 분석, acceptance criteria 도출 | Claude Opus (Agent) |
 | Phase 2: Planning | 플래너 — 태스크 분해, TDD 전략 | Claude Opus (Agent, background) |
 | Phase 2: Planning | 아키텍트 — 기술 설계, 파일 구조, API 인터페이스 | Codex (tfx headless) |
-| Phase 2: Planning | 크리틱 — 리스크 분석, 엣지 케이스, 보안 | Gemini (tfx headless) |
+| Phase 2: Planning | 크리틱 — 리스크 분석, 엣지 케이스, 보안 | Antigravity (tfx headless) |
 | Phase 3: Execution | 구현자 — 코드 작성, TDD RED→GREEN→REFACTOR | Codex (tfx headless) |
-| Phase 3: Execution | 문서/UI 작성자 | Gemini (tfx headless) |
+| Phase 3: Execution | 문서/UI 작성자 | Antigravity (tfx headless) |
 | Phase 4: QA | 기능 검증자 — acceptance criteria 충족 여부 | Claude (Agent, background) |
 | Phase 4: QA | 보안/성능 검증자 — OWASP, 병목, 에러 핸들링 | Codex (tfx headless) |
-| Phase 4: QA | UX/접근성 검증자 — 반응형, DX, 문서화 | Gemini (tfx headless) |
+| Phase 4: QA | UX/접근성 검증자 — 반응형, DX, 문서화 | Antigravity (tfx headless) |
 | Phase 5: Validation | 합의 판정 — Consensus Score 계산 및 완료 결정 | Claude (직접 판단) |
 
 ## EXECUTION STEPS
@@ -123,7 +123,7 @@ JSON 형식으로 출력하라: { tasks, order, dependencies, tdd_strategy, risk
 )
 ```
 
-**Step 2-B: Codex Architect + Gemini Critic (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
+**Step 2-B: Codex Architect + Antigravity Critic (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:시니어 엔지니어로서 다음 기능의 기술적 설계를 작성하라. 기능: {expanded_requirements}. 파일 구조, API 인터페이스, 데이터 모델을 포함하라. JSON 형식: { design, file_changes, interfaces, test_plan }:architect' \
@@ -145,7 +145,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
 
 **라우팅 규칙:**
 - 코드 구현/수정/테스트 작성 → Codex (tfx headless)
-- UI/문서 → Gemini (tfx headless)
+- UI/문서 → Antigravity (tfx headless)
 
 **TDD 실행 순서 (Codex에 전달하는 프롬프트에 명시):**
 1. 테스트 먼저 작성 (RED)
@@ -190,7 +190,7 @@ JSON 형식: { criteria_results, edge_case_findings, overall_pass }"
 )
 ```
 
-**Step 4-B: Codex 보안/성능 + Gemini UX/접근성 (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
+**Step 4-B: Codex 보안/성능 + Antigravity UX/접근성 (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:보안/성능 관점에서 다음 변경사항을 리뷰하라. OWASP Top 10, 성능 병목, 에러 핸들링, 리소스 누수를 확인하라. 변경 파일: {changed_files}. JSON 형식: { security_findings, performance_findings, overall_pass }:verifier' \
@@ -238,7 +238,7 @@ Phase 4의 3자 결과에 Consensus 프로토콜을 적용한다.
 
 ## Acceptance Criteria
 - [x] {criterion1} — 3/3 PASS
-- [x] {criterion2} — 2/3 PASS (Gemini: 조건부)
+- [x] {criterion2} — 2/3 PASS (Antigravity: 조건부)
 
 ## QA 결과
 - 보안: {findings_count}건 (모두 해결)

--- a/packages/triflux/skills/tfx-hub/SKILL.md
+++ b/packages/triflux/skills/tfx-hub/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: "<start|stop|status|자유형 작업 설명>"
 
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
-> CLI 에이전트(Codex/Gemini/Claude) 간 실시간 메시지 허브를 관리합니다.
+> CLI 에이전트(Codex/Antigravity/Claude) 간 실시간 메시지 허브를 관리합니다.
 > **커맨드 매칭 + fallthrough**: start/stop/status에 매칭되면 즉시 실행,
 > 매칭 안 되면 **hub 도메인 컨텍스트를 활용한 범용 작업**으로 처리합니다.
 
@@ -96,7 +96,7 @@ Bash("curl -s http://127.0.0.1:27888/status 2>/dev/null || echo '{\"error\":\"hu
 # 사전 등록은 disabled로 두고 `tfx hub start` 이후에만 enabled로 전환한다.
 codex mcp add tfx-hub --url http://127.0.0.1:27888/mcp
 
-# Gemini (settings.json)
+# Antigravity (settings.json)
 # mcpServers.tfx-hub.url = "http://127.0.0.1:27888/mcp"
 
 # Claude

--- a/packages/triflux/skills/tfx-hub/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-hub/SKILL.md.tmpl
@@ -16,7 +16,7 @@ argument-hint: "<start|stop|status|자유형 작업 설명>"
 
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
-> CLI 에이전트(Codex/Gemini/Claude) 간 실시간 메시지 허브를 관리합니다.
+> CLI 에이전트(Codex/Antigravity/Claude) 간 실시간 메시지 허브를 관리합니다.
 > **커맨드 매칭 + fallthrough**: start/stop/status에 매칭되면 즉시 실행,
 > 매칭 안 되면 **hub 도메인 컨텍스트를 활용한 범용 작업**으로 처리합니다.
 
@@ -96,7 +96,7 @@ Bash("curl -s http://127.0.0.1:27888/status 2>/dev/null || echo '{\"error\":\"hu
 # 사전 등록은 disabled로 두고 `tfx hub start` 이후에만 enabled로 전환한다.
 codex mcp add tfx-hub --url http://127.0.0.1:27888/mcp
 
-# Gemini (settings.json)
+# Antigravity (settings.json)
 # mcpServers.tfx-hub.url = "http://127.0.0.1:27888/mcp"
 
 # Claude

--- a/packages/triflux/skills/tfx-index/SKILL.md
+++ b/packages/triflux/skills/tfx-index/SKILL.md
@@ -29,7 +29,7 @@ argument-hint: "[--update] [경로]"
 
 > SuperClaude index-repo 오마주. 1회 2K 토큰으로 인덱스 생성, 이후 세션마다 55K 토큰 절감.
 
-> **Gemini 위임**: 스캔 + 인덱스 생성 작업은 Gemini CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
+> **Antigravity 위임**: 스캔 + 인덱스 생성 작업은 Antigravity CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
 
 ## 원리
 
@@ -58,9 +58,9 @@ AskUserQuestion:
 
 `--update` 플래그나 경로 인자가 이미 제공된 경우 이 단계를 건너뛴다.
 
-### Step 1: Gemini에 스캔 + 인덱스 생성 위임
+### Step 1: Antigravity에 스캔 + 인덱스 생성 위임
 
-Claude는 프로젝트 경로와 모드를 Gemini에 전달하고, Gemini가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
+Claude는 프로젝트 경로와 모드를 Antigravity에 전달하고, Antigravity가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Scan the project at {path}. For each source file, extract: exports, imports, line count, file type. Exclude node_modules/, .git/, dist/, build/, coverage/, *.lock, *.log, *.map. Generate both PROJECT_INDEX.md and PROJECT_INDEX.json following this format:
@@ -92,16 +92,16 @@ Mode: {mode}
 '")
 ```
 
-Gemini 출력을 받은 후 Claude가 파일로 기록한다:
+Antigravity 출력을 받은 후 Claude가 파일로 기록한다:
 
 ```
 Write("PROJECT_INDEX.md", <md_section>)
 Write("PROJECT_INDEX.json", <json_section>)
 ```
 
-#### Fallback: Gemini 실패 시
+#### Fallback: Antigravity 실패 시
 
-Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
+Antigravity 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
 
 ```
 1. 병렬 Glob으로 파일 트리 수집 (**/*.{ts,js,mjs,tsx,jsx,...})
@@ -139,11 +139,11 @@ Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직�
 
 ## 토큰 예산
 
-| 작업 | Claude | Gemini |
+| 작업 | Claude | Antigravity |
 |------|--------|--------|
 | 모드 선택 (Step 0) | ~100 | — |
-| 스캔 + 메타데이터 추출 | — | Gemini 부담 |
-| 인덱스 생성 (MD + JSON) | — | Gemini 부담 |
+| 스캔 + 메타데이터 추출 | — | Antigravity 부담 |
+| 인덱스 생성 (MD + JSON) | — | Antigravity 부담 |
 | 파일 쓰기 (Write) | ~300 | — |
 | 검증 (Step 2) | ~100 | — |
 | **Claude 총합** | **~500** | — |

--- a/packages/triflux/skills/tfx-index/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-index/SKILL.md.tmpl
@@ -19,7 +19,7 @@ argument-hint: "[--update] [경로]"
 
 > SuperClaude index-repo 오마주. 1회 2K 토큰으로 인덱스 생성, 이후 세션마다 55K 토큰 절감.
 
-> **Gemini 위임**: 스캔 + 인덱스 생성 작업은 Gemini CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
+> **Antigravity 위임**: 스캔 + 인덱스 생성 작업은 Antigravity CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
 
 ## 원리
 
@@ -48,9 +48,9 @@ AskUserQuestion:
 
 `--update` 플래그나 경로 인자가 이미 제공된 경우 이 단계를 건너뛴다.
 
-### Step 1: Gemini에 스캔 + 인덱스 생성 위임
+### Step 1: Antigravity에 스캔 + 인덱스 생성 위임
 
-Claude는 프로젝트 경로와 모드를 Gemini에 전달하고, Gemini가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
+Claude는 프로젝트 경로와 모드를 Antigravity에 전달하고, Antigravity가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Scan the project at {path}. For each source file, extract: exports, imports, line count, file type. Exclude node_modules/, .git/, dist/, build/, coverage/, *.lock, *.log, *.map. Generate both PROJECT_INDEX.md and PROJECT_INDEX.json following this format:
@@ -82,16 +82,16 @@ Mode: {mode}
 '")
 ```
 
-Gemini 출력을 받은 후 Claude가 파일로 기록한다:
+Antigravity 출력을 받은 후 Claude가 파일로 기록한다:
 
 ```
 Write("PROJECT_INDEX.md", <md_section>)
 Write("PROJECT_INDEX.json", <json_section>)
 ```
 
-#### Fallback: Gemini 실패 시
+#### Fallback: Antigravity 실패 시
 
-Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
+Antigravity 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
 
 ```
 1. 병렬 Glob으로 파일 트리 수집 (**/*.{ts,js,mjs,tsx,jsx,...})
@@ -129,11 +129,11 @@ Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직�
 
 ## 토큰 예산
 
-| 작업 | Claude | Gemini |
+| 작업 | Claude | Antigravity |
 |------|--------|--------|
 | 모드 선택 (Step 0) | ~100 | — |
-| 스캔 + 메타데이터 추출 | — | Gemini 부담 |
-| 인덱스 생성 (MD + JSON) | — | Gemini 부담 |
+| 스캔 + 메타데이터 추출 | — | Antigravity 부담 |
+| 인덱스 생성 (MD + JSON) | — | Antigravity 부담 |
 | 파일 쓰기 (Write) | ~300 | — |
 | 검증 (Step 2) | ~100 | — |
 | **Claude 총합** | **~500** | — |

--- a/packages/triflux/skills/tfx-interview/SKILL.md
+++ b/packages/triflux/skills/tfx-interview/SKILL.md
@@ -25,24 +25,24 @@ argument-hint: "<구현할 주제 또는 요구사항>"
 > OMC deep-interview + ouroboros 오마주. 모호성을 숫자로 측정하고 20% 미만까지 질문한다.
 > "측정할 수 없으면 개선할 수 없다."
 >
-> **Gemini 위임**: 분석·점수 계산·산출물 초안은 Gemini CLI에 위임하여 Claude 토큰을 절약한다.
+> **Antigravity 위임**: 분석·점수 계산·산출물 초안은 Antigravity CLI에 위임하여 Claude 토큰을 절약한다.
 > 위임 패턴: `Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")`
 
 ## 위임 패턴
 
-Claude와 Gemini의 역할을 분리하여 토큰을 최적화한다.
+Claude와 Antigravity의 역할을 분리하여 토큰을 최적화한다.
 
 | 담당 | 작업 |
 |------|------|
 | **Claude** | AskUserQuestion (사용자 상호작용), 최종 파일 저장 |
-| **Gemini** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
+| **Antigravity** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
 
 ```bash
 # 위임 호출 형태
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")
 ```
 
-Gemini 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
+Antigravity 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
 
 ## 용도
 
@@ -77,14 +77,14 @@ ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)
 
 ### Step 1: 초기 모호성 평가
 
-사용자 입력을 Gemini에 전달하여 초기 ambiguity score를 계산한다:
+사용자 입력을 Antigravity에 전달하여 초기 ambiguity score를 계산한다:
 
 ```bash
-# Claude → Gemini 위임
+# Claude → Antigravity 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Analyze the following requirement and calculate ambiguity score. Return JSON: {goal, constraints, criteria, ambiguity, suggested_questions}: {user_input}'")
 ```
 
-Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
+Antigravity가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ```
 출력 예시:
@@ -97,9 +97,9 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ### Step 2: 5단계 인터뷰 (모호성 < 20%까지)
 
-각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Gemini에 전달하여 분석 및 다음 질문을 생성한다.
+각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Antigravity에 전달하여 분석 및 다음 질문을 생성한다.
 
-흐름: `Claude(질문) → 사용자(응답) → Gemini(분석+재계산) → Claude(다음 질문 제시)`
+흐름: `Claude(질문) → 사용자(응답) → Antigravity(분석+재계산) → Claude(다음 질문 제시)`
 
 #### Stage 1: Clarify (명확화) — goal 개선
 
@@ -111,15 +111,15 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 작업의 핵심 목표를 한 문장으로 설명해주세요."
 2. "완료 후 어떤 상태가 되어야 성공인가요?"
@@ -135,15 +135,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 작업을 3-5개의 독립된 단계로 나눈다면?"
 2. "각 단계 사이에 의존성이 있나요?"
@@ -159,15 +159,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 방식이 실패할 수 있는 시나리오는 무엇인가요?"
 2. "6개월 후 유지보수할 때 문제가 될 부분은 무엇인가요?"
@@ -183,15 +183,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "같은 목표를 달성할 수 있는 완전히 다른 접근은 무엇인가요?"
 2. "시간이 절반밖에 없다면 어떤 방식을 택하겠습니까?"
@@ -207,15 +207,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 최종 분석 위임
+# 응답 수집 후 Antigravity에 최종 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
+응답 후: Antigravity JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "지금까지의 논의를 종합하면, 최적의 접근 방식은 무엇인가요?"
 2. "첫 번째 단계로 무엇을 실행하시겠습니까?"
@@ -238,14 +238,14 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis
 
 ### Step 4: 산출물 생성
 
-Gemini가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
+Antigravity가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
 
 ```bash
-# Gemini에 산출물 초안 생성 위임
+# Antigravity에 산출물 초안 생성 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Generate a structured interview output document based on the following interview context: {full_context}. Return the complete markdown document.'")
 ```
 
-Claude는 Gemini가 반환한 마크다운을 Write 도구로 저장한다.
+Claude는 Antigravity가 반환한 마크다운을 Write 도구로 저장한다.
 
 저장 위치: `.tfx/plans/interview-{timestamp}.md`
 
@@ -299,7 +299,7 @@ Date: {date} | Final Ambiguity: {score}%
 
 ## 토큰 예산
 
-| 단계 | Claude | Gemini |
+| 단계 | Claude | Antigravity |
 |------|--------|--------|
 | 초기 평가 (모호성 분석) | ~0.2K | ~1K |
 | 5단계 인터뷰 (질문 제시) | ~1K | ~10K |
@@ -308,7 +308,7 @@ Date: {date} | Final Ambiguity: {score}%
 | 코드베이스 탐색 | ~0.3K | — |
 | **총합** | **~2K** | **~13K** |
 
-Fallback: Gemini 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
+Fallback: Antigravity 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
 
 ## 사용 예
 

--- a/packages/triflux/skills/tfx-interview/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-interview/SKILL.md.tmpl
@@ -20,24 +20,24 @@ argument-hint: "<구현할 주제 또는 요구사항>"
 > OMC deep-interview + ouroboros 오마주. 모호성을 숫자로 측정하고 20% 미만까지 질문한다.
 > "측정할 수 없으면 개선할 수 없다."
 >
-> **Gemini 위임**: 분석·점수 계산·산출물 초안은 Gemini CLI에 위임하여 Claude 토큰을 절약한다.
+> **Antigravity 위임**: 분석·점수 계산·산출물 초안은 Antigravity CLI에 위임하여 Claude 토큰을 절약한다.
 > 위임 패턴: `Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")`
 
 ## 위임 패턴
 
-Claude와 Gemini의 역할을 분리하여 토큰을 최적화한다.
+Claude와 Antigravity의 역할을 분리하여 토큰을 최적화한다.
 
 | 담당 | 작업 |
 |------|------|
 | **Claude** | AskUserQuestion (사용자 상호작용), 최종 파일 저장 |
-| **Gemini** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
+| **Antigravity** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
 
 ```bash
 # 위임 호출 형태
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")
 ```
 
-Gemini 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
+Antigravity 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
 
 ## 용도
 
@@ -72,14 +72,14 @@ ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)
 
 ### Step 1: 초기 모호성 평가
 
-사용자 입력을 Gemini에 전달하여 초기 ambiguity score를 계산한다:
+사용자 입력을 Antigravity에 전달하여 초기 ambiguity score를 계산한다:
 
 ```bash
-# Claude → Gemini 위임
+# Claude → Antigravity 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Analyze the following requirement and calculate ambiguity score. Return JSON: {goal, constraints, criteria, ambiguity, suggested_questions}: {user_input}'")
 ```
 
-Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
+Antigravity가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ```
 출력 예시:
@@ -92,9 +92,9 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ### Step 2: 5단계 인터뷰 (모호성 < 20%까지)
 
-각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Gemini에 전달하여 분석 및 다음 질문을 생성한다.
+각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Antigravity에 전달하여 분석 및 다음 질문을 생성한다.
 
-흐름: `Claude(질문) → 사용자(응답) → Gemini(분석+재계산) → Claude(다음 질문 제시)`
+흐름: `Claude(질문) → 사용자(응답) → Antigravity(분석+재계산) → Claude(다음 질문 제시)`
 
 #### Stage 1: Clarify (명확화) — goal 개선
 
@@ -106,12 +106,12 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 2: Decompose (분해) — constraints 개선
@@ -124,12 +124,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 3: Challenge (반론) — 숨은 제약 발견
@@ -142,12 +142,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 4: Alternatives (대안) — criteria 정밀화
@@ -160,12 +160,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 5: Synthesize (종합) — 최종 확인
@@ -178,12 +178,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 최종 분석 위임
+# 응답 수집 후 Antigravity에 최종 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
+응답 후: Antigravity JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
 ```
 
 ### Step 3: 조기 종료 판단
@@ -203,14 +203,14 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis
 
 ### Step 4: 산출물 생성
 
-Gemini가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
+Antigravity가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
 
 ```bash
-# Gemini에 산출물 초안 생성 위임
+# Antigravity에 산출물 초안 생성 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Generate a structured interview output document based on the following interview context: {full_context}. Return the complete markdown document.'")
 ```
 
-Claude는 Gemini가 반환한 마크다운을 Write 도구로 저장한다.
+Claude는 Antigravity가 반환한 마크다운을 Write 도구로 저장한다.
 
 저장 위치: `.omc/plans/interview-{timestamp}.md`
 
@@ -264,7 +264,7 @@ Date: {date} | Final Ambiguity: {score}%
 
 ## 토큰 예산
 
-| 단계 | Claude | Gemini |
+| 단계 | Claude | Antigravity |
 |------|--------|--------|
 | 초기 평가 (모호성 분석) | ~0.2K | ~1K |
 | 5단계 인터뷰 (질문 제시) | ~1K | ~10K |
@@ -273,7 +273,7 @@ Date: {date} | Final Ambiguity: {score}%
 | 코드베이스 탐색 | ~0.3K | — |
 | **총합** | **~2K** | **~13K** |
 
-Fallback: Gemini 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
+Fallback: Antigravity 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
 
 ## 사용 예
 

--- a/packages/triflux/skills/tfx-multi/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-multi/SKILL.md.tmpl
@@ -1,9 +1,9 @@
 ---
 name: tfx-multi
 description: >
-  멀티-CLI 팀 모드. Claude Native Agent Teams + Codex/Gemini 멀티모델 오케스트레이션.
+  멀티-CLI 팀 모드. Claude Native Agent Teams + Codex/Antigravity 멀티모델 오케스트레이션.
   '멀티로', '팀 모드', '다중 CLI', '3개 다 동원', 'multi' 같은 요청에 반드시 사용.
-  Claude+Codex+Gemini 협업이 필요한 모든 상황에 적극 활용.
+  Claude+Codex+Antigravity 협업이 필요한 모든 상황에 적극 활용.
 triggers:
   - tfx-multi
 argument-hint: '"작업 설명" | --agents codex,gemini "작업" | --tmux "작업" | status | stop'
@@ -17,7 +17,7 @@ argument-hint: '"작업 설명" | --agents codex,gemini "작업" | --tmux "작�
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
 > Claude Code Native Teams의 Shift+Down 네비게이션을 복원한다.
-> Codex/Gemini 워커마다 최소 프롬프트(~100 토큰)의 슬림 Agent 래퍼를 spawn하여 네비게이션에 등록하고,
+> Codex/Antigravity 워커마다 최소 프롬프트(~100 토큰)의 슬림 Agent 래퍼를 spawn하여 네비게이션에 등록하고,
 > 실제 작업은 `tfx-route.sh`가 수행한다. task 상태는 `team_task_list`를 truth source로 검증한다.
 > v3 — `--thorough`(기본: plan→prd→exec→verify→fix loop) + `--quick`(경량 모드).
 
@@ -84,7 +84,7 @@ preflight와 Agent 생성을 병렬로 실행하여 사용자 체감 지연을 �
 ### Phase 3: Lead-Direct Headless 실행 (v6.0.0, 기본)
 
 > **MANDATORY: CLI 워커는 headless 엔진으로 실행**
-> CLI 워커(Codex/Gemini)는 반드시 아래 `Bash()` 명령으로 headless 엔진을 통해 실행한다.
+> CLI 워커(Codex/Antigravity)는 반드시 아래 `Bash()` 명령으로 headless 엔진을 통해 실행한다.
 > `Bash(tfx-route.sh)` 개별 호출이나 `Agent()` CLI 래핑은 PreToolUse 훅이 자동 차단/변환한다.
 > headless 엔진이 psmux 세션 생성 → WT 자동 팝업 → CLI dispatch → 결과 수집을 전부 처리한다.
 

--- a/packages/triflux/skills/tfx-multi/references/agent-wrapper-rules.md
+++ b/packages/triflux/skills/tfx-multi/references/agent-wrapper-rules.md
@@ -3,8 +3,8 @@
 ## 슬림 래퍼의 존재 이유
 
 Native Teams의 teammate는 Claude 모델만 가능하다.
-Codex/Gemini는 teammate로 직접 등록할 수 없으므로, Claude slim wrapper를 spawn하고
-래퍼 내부에서 `tfx-route.sh`로 Codex/Gemini CLI를 실행하는 구조이다.
+Codex/Antigravity는 teammate로 직접 등록할 수 없으므로, Claude slim wrapper를 spawn하고
+래퍼 내부에서 `tfx-route.sh`로 Codex/Antigravity CLI를 실행하는 구조이다.
 
 래퍼가 존재하는 이유:
 1. **Shift+Down 네비게이션 등록** — 래퍼 없이 Lead가 직접 Bash를 실행하면 네비게이션에 등록되지 않음
@@ -15,7 +15,7 @@ Codex/Gemini는 teammate로 직접 등록할 수 없으므로, Claude slim wrapp
 
 ### 1. Agent 래퍼 생략 금지
 
-Codex/Gemini 서브태스크는 워커 수에 관계없이 반드시 Agent 래퍼를 spawn해야 한다.
+Codex/Antigravity 서브태스크는 워커 수에 관계없이 반드시 Agent 래퍼를 spawn해야 한다.
 단일 워커(1:gemini 등)여도 Lead가 직접 Bash를 실행하면 안 된다.
 Lead가 "효율적"이라고 판단해서 Agent를 건너뛰는 것은 금지한다.
 

--- a/packages/triflux/skills/tfx-panel/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-panel/SKILL.md.tmpl
@@ -25,7 +25,7 @@ argument-hint: "<토론 주제>"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "<토론 주제>"
 |-----|------|----------------|
 | Claude (Opus) | 패널 모더레이터 + 인문/전략 전문가 | 리팩터링, 점진적 설계, 요구사항 |
 | Codex | 기술 구현 전문가 | 아키텍처, 마이크로서비스, 클라우드 |
-| Gemini | 통합/비즈니스 전문가 | 통합 패턴, 경쟁 전략, 프로덕트 |
+| Antigravity | 통합/비즈니스 전문가 | 통합 패턴, 경쟁 전략, 프로덕트 |
 
 ## 전문가 풀
 
@@ -84,7 +84,7 @@ argument-hint: "<토론 주제>"
 분배 예시 (`"우리 모놀리스를 마이크로서비스로 전환해야 할까?"`):
 - Claude 담당: Martin Fowler (리팩터링), Kent Beck (점진적 설계)
 - Codex 담당: Sam Newman (마이크로서비스), Michael Porter (전략)
-- Gemini 담당: Gregor Hohpe (통합 패턴), Karl Wiegers (요구사항)
+- Antigravity 담당: Gregor Hohpe (통합 패턴), Karl Wiegers (요구사항)
 
 주제가 모호하면 AskUserQuestion으로 명확화한다.
 
@@ -106,7 +106,7 @@ JSON 형식으로 응답:
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:당신은 {codex_expert_1}({role_3})과 {codex_expert_2}({role_4})입니다. 주제: {topic}. 각 전문가의 고유 관점에서 독립 분석. 상호 참조 금지. JSON: {experts:[{name,position,reasoning,concerns,recommendation,confidence}]}:analyst' \
@@ -164,7 +164,7 @@ tfx-consensus 프로토콜 적용:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent로 해당 전문가 재분석
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent로 해당 전문가 재분석
 - 결과 파싱 실패 → 원문 그대로 Step 3에 투입하여 모더레이터가 정리
 - 전문가 선정 불확실 → AskUserQuestion으로 사용자 확인 후 진행
 

--- a/packages/triflux/skills/tfx-persist/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-persist/SKILL.md.tmpl
@@ -39,8 +39,8 @@ argument-hint: "<완료할 작업 설명>"
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 정상 | 기존 headless multi (변경 없음) |
-| **Tier 2** | 일부 CLI만 가용 (Codex 또는 Gemini 중 하나) | 가용 CLI + Claude Agent 조합 |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 정상 | 기존 headless multi (변경 없음) |
+| **Tier 2** | 일부 CLI만 가용 (Codex 또는 Antigravity 중 하나) | 가용 CLI + Claude Agent 조합 |
 | **Tier 3** | headless 불가 또는 `claude -p` one-shot | Claude Agent only |
 
 ```
@@ -56,10 +56,10 @@ IF Hub 미응답:
   → 재시작 실패 → Tier 3
   → Tier 3
 
-IF Codex 없음 AND Gemini 없음:
+IF Codex 없음 AND Antigravity 없음:
   → Tier 3
 
-IF Codex 없음 OR Gemini 없음:
+IF Codex 없음 OR Antigravity 없음:
   → Tier 2
 
 ELSE:
@@ -71,7 +71,7 @@ ELSE:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드로 실행합니다 (consensus 미적용)
   누락: {missing_components}
-  권장: tmux/psmux, Hub, Codex CLI, Gemini CLI 설치 후 재실행
+  권장: tmux/psmux, Hub, Codex CLI, Antigravity CLI 설치 후 재실행
 ```
 
 Tier 3에서는 모든 headless dispatch(`tfx multi ...`)를 **Claude Agent**(subagent)로 대체한다.
@@ -82,7 +82,7 @@ Tier 2에서는 누락된 CLI만 Claude Agent로 대체한다.
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini 검증자 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity 검증자 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude 검증자 → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 5. 루프 종료 조건: 모든 criteria 3자 검증 통과 + 통합 검증 Consensus >= 70
@@ -93,12 +93,12 @@ Tier 2에서는 누락된 CLI만 Claude Agent로 대체한다.
 |------|------|------|
 | Goal Definition | 완료 기준 추출 및 사용자 확인 | Claude (직접 실행) |
 | 구현 (단순) | 코드 작성, 파일 수정, 테스트 | Codex (tfx headless) |
-| 구현 (복잡) | 태스크 분해 후 병렬 실행 | Codex + Gemini (tfx headless) |
+| 구현 (복잡) | 태스크 분해 후 병렬 실행 | Codex + Antigravity (tfx headless) |
 | 기준별 검증 — Claude | 코드 읽기 + 논리 검증 | Claude (Agent, background) |
 | 기준별 검증 — Codex | 코드 실행 + 테스트 검증 | Codex (tfx headless) |
-| 기준별 검증 — Gemini | 코드 리뷰 + 품질 검증 | Gemini (tfx headless) |
-| 통합 검증 | 전체 criteria 최종 합의 | Claude + Codex + Gemini (동시) |
-| Deslop Pass | 슬롭 감지 및 제거 | Codex + Gemini (tfx headless) |
+| 기준별 검증 — Antigravity | 코드 리뷰 + 품질 검증 | Antigravity (tfx headless) |
+| 통합 검증 | 전체 criteria 최종 합의 | Claude + Codex + Antigravity (동시) |
+| Deslop Pass | 슬롭 감지 및 제거 | Codex + Antigravity (tfx headless) |
 
 ## EXECUTION STEPS
 
@@ -156,7 +156,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
+**Codex + Antigravity 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 기준 충족 여부를 코드 실행/테스트로 검증하라. 기준: {current_criterion}. 실제 테스트를 실행하여 결과를 확인하라. 결과: PASS 또는 FAIL + 근거 1문장:verifier' \
@@ -198,7 +198,7 @@ JSON 형식: { criteria_results: [{criterion, pass, reason}], regression_check, 
 )
 ```
 
-**Codex + Gemini 통합 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
+**Codex + Antigravity 통합 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:모든 acceptance criteria 충족 여부를 테스트 실행으로 통합 검증하라. 기준 목록: {criteria_list}. 전체 테스트 스위트를 실행하고 회귀 여부를 확인하라. JSON 형식: { criteria_results, test_results, overall_pass }:verifier' \
@@ -232,7 +232,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
 Consensus Score: {score}%
 변경 파일: {count}개
 테스트: {pass}/{total} 통과
-검증: Claude PASS | Codex PASS | Gemini PASS
+검증: Claude PASS | Codex PASS | Antigravity PASS
 ```
 
 ## ANTI-STUCK 메커니즘

--- a/packages/triflux/skills/tfx-plan/SKILL.md
+++ b/packages/triflux/skills/tfx-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 internal: true
 name: tfx-plan
-description: "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Gemini) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터."
+description: "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Antigravity) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터."
 triggers:
   - plan
   - 계획
@@ -19,14 +19,14 @@ argument-hint: "<구현할 기능> [--quick]"
 
 > **ARGUMENTS 처리**: `--quick` → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Opus 4.6(Planner) + Codex(Architect) + Gemini(Critic) Tri-Model 합의.
-> 빠른 Gemini 위임 계획은 `--quick`.
+> AI makes completeness near-free. 기본은 Opus 4.6(Planner) + Codex(Architect) + Antigravity(Critic) Tri-Model 합의.
+> 빠른 Antigravity 위임 계획은 `--quick`.
 
 ---
 
 ## 모드 분기
 
-`--quick` → Quick 모드 (Gemini 위임).
+`--quick` → Quick 모드 (Antigravity 위임).
 그 외 → Deep 모드 (기본, 3-Model 합의 + 교차 검토).
 
 ---
@@ -56,7 +56,7 @@ Tier 3:
 
 ### HARD RULES
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -66,7 +66,7 @@ Tier 3:
 |-------|------|------|
 | Claude Opus (Planner) | 전략 비전 | 리스크 통합, 아키텍처 결정 |
 | Codex (Architect) | 기술 설계 | API, 파일 구조, 구현 세부 |
-| Gemini (Critic) | 리스크 분석 | 엣지케이스, 보안, 테스트 전략 |
+| Antigravity (Critic) | 리스크 분석 | 엣지케이스, 보안, 테스트 전략 |
 
 ### EXECUTION — TASK 는 사용자 입력
 
@@ -96,7 +96,7 @@ Agent(
 )
 ```
 
-**Bash (Codex Architect + Gemini Critic):**
+**Bash (Codex Architect + Antigravity Critic):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:시니어 엔지니어 기술 설계. 기능: [TASK]. 코드베이스: [RECON]. JSON: { architecture, components, data_models, api, files, impl_notes, confidence }:architect' \
@@ -123,7 +123,7 @@ Agent(
 )
 ```
 
-**Bash:** (위와 동일 패턴, Codex/Gemini 각각 교차검토)
+**Bash:** (위와 동일 패턴, Codex/Antigravity 각각 교차검토)
 
 #### Step 5: 합의 점수 산출 (Claude 직접)
 
@@ -143,7 +143,7 @@ consensus_score = CONSENSUS / 전체 * 100
 
 ```markdown
 ## 합의된 구현 계획: [TASK]
-**Consensus**: {score}% | **Rounds**: {n} | **Models**: Opus+Codex+Gemini
+**Consensus**: {score}% | **Rounds**: {n} | **Models**: Opus+Codex+Antigravity
 
 ### 설계 방향
 ### 태스크 (T1..., 복잡도, 합의 P:A:C)
@@ -162,13 +162,13 @@ consensus_score = CONSENSUS / 전체 * 100
 ### Step 1: 요구사항 파싱
 사용자 입력 + PROJECT_INDEX.md (있으면) + Glob 파일 목록.
 
-### Step 2: Gemini 위임
+### Step 2: Antigravity 위임
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍트로서 구현 계획. 기능: {feature}. 컨텍스트: {context}. 파일: {file_list}. 출력: 1) 영향 범위 2) 태스크 분해 (검증 방법 포함) 3) 리스크/의존성 4) 복잡도'")
 ```
 
-**Fallback**: Gemini 실패 시 Claude Opus 직접.
+**Fallback**: Antigravity 실패 시 Claude Opus 직접.
 
 ### Step 3: 구조화 출력
 
@@ -181,12 +181,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍
 ### 복잡도: {level}
 ```
 
-### Token (Quick): ~1.5K (Claude), ~2K (Gemini)
+### Token (Quick): ~1.5K (Claude), ~2K (Antigravity)
 
 ## 사용 예
 
 ```
 /tfx-plan "JWT 인증 미들웨어 추가"          # Deep (기본)
 /tfx-plan "마이크로서비스 분리"             # Deep
-/tfx-plan --quick "README 섹션 추가"        # Quick (Gemini)
+/tfx-plan --quick "README 섹션 추가"        # Quick (Antigravity)
 ```

--- a/packages/triflux/skills/tfx-plan/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-plan/SKILL.md.tmpl
@@ -16,27 +16,27 @@ argument-hint: "<구현할 기능 설명>"
 
 
 > **Deep 버전**: tfx-deep-plan. "제대로/꼼꼼히" 수정자로 자동 에스컬레이션.
-> Gemini 위임 빠른 계획 — Claude는 컨텍스트 수집·출력 포맷만, 핵심 계획 수립은 Gemini에 위임.
+> Antigravity 위임 빠른 계획 — Claude는 컨텍스트 수집·출력 포맷만, 핵심 계획 수립은 Antigravity에 위임.
 
 ## 워크플로우
 
 ### Step 1: 요구사항 파싱
 사용자 입력 + 프로젝트 컨텍스트(PROJECT_INDEX.md 있으면 활용)에서 핵심 추출.
 
-### Step 2: Gemini 위임 계획 수립
+### Step 2: Antigravity 위임 계획 수립
 
 Claude는 최소 컨텍스트만 수집한다.
 - Glob으로 영향 가능 파일 목록 수집
 - PROJECT_INDEX.md 존재 시 읽기 (없으면 생략)
 
-수집 후 Gemini에 위임:
+수집 후 Antigravity에 위임:
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍트로서 다음 기능의 구현 계획을 수립하라.\n기능: {feature}\n프로젝트 컨텍스트: {context}\n관련 파일: {file_list}\n\n출력 형식:\n1. 영향 범위 (수정할 파일 목록)\n2. 태스크 분해 (순서대로, 각 태스크에 검증 방법 포함)\n3. 리스크 및 의존성\n4. 예상 복잡도 (low/medium/high)'")
 ```
 
-Claude는 Gemini 출력을 받아 아래 출력 형식으로 포맷팅만 수행한다.
+Claude는 Antigravity 출력을 받아 아래 출력 형식으로 포맷팅만 수행한다.
 
-> **Fallback**: Gemini 호출이 실패(exit non-zero 또는 빈 출력)하면 Claude Opus가 동일 프롬프트로 직접 계획을 수립한다.
+> **Fallback**: Antigravity 호출이 실패(exit non-zero 또는 빈 출력)하면 Claude Opus가 동일 프롬프트로 직접 계획을 수립한다.
 
 ### Step 3: 구조화된 계획 출력
 ```markdown
@@ -65,4 +65,4 @@ Claude는 Gemini 출력을 받아 아래 출력 형식으로 포맷팅만 수행
 | Claude 출력 | ~2K (계획 전문) | ~0.5K (포맷팅만) |
 | 합계 | ~8K | ~1.5K (**-81%**) |
 
-Gemini가 계획 생성의 대부분을 담당하므로 Claude 토큰 비용이 대폭 감소한다.
+Antigravity가 계획 생성의 대부분을 담당하므로 Claude 토큰 비용이 대폭 감소한다.

--- a/packages/triflux/skills/tfx-plan/skill.json
+++ b/packages/triflux/skills/tfx-plan/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-plan",
-  "description": "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Gemini) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터.",
+  "description": "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Antigravity) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터.",
   "triggers": [
     "plan",
     "계획",

--- a/packages/triflux/skills/tfx-profile/SKILL.md
+++ b/packages/triflux/skills/tfx-profile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tfx-profile
 description: >
-  Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
+  Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
   프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반
   인터랙티브 선택지로 수행합니다.
   Use when: codex profile, codex model, gemini profile, gemini model,
@@ -12,10 +12,10 @@ triggers:
 argument-hint: "[--list] [--codex | --gemini]"
 ---
 
-# tfx-profile — Codex/Gemini 프로파일 매니저
+# tfx-profile — Codex/Antigravity 프로파일 매니저
 
 > CLI 프로파일의 모델/effort를 AskUserQuestion 선택지로 관리합니다.
-> Codex(`~/.codex/config.toml`)와 Gemini(`~/.gemini/triflux-profiles.json`) 모두 지원.
+> Codex(`~/.codex/config.toml`)와 Antigravity(`~/.gemini/triflux-profiles.json`) 모두 지원.
 
 ## 워크플로우
 
@@ -30,7 +30,7 @@ header: "CLI"
 options:
   - label: "Codex"
     description: "~/.codex/config.toml (TOML)"
-  - label: "Gemini"
+  - label: "Antigravity"
     description: "~/.gemini/triflux-profiles.json (JSON)"
 ```
 
@@ -101,7 +101,7 @@ options:
 
 ---
 
-## Gemini 워크플로우
+## Antigravity 워크플로우
 
 ### Step 1: triflux-profiles.json 읽기 + 현재 상태 표시
 
@@ -173,7 +173,7 @@ options:
 - **다른 섹션 건드리지 않기**: `[notice]`, `[features]`, `[mcp_servers.*]` 등 절대 수정 금지
 - **Edit 도구 사용**: old_string → new_string으로 정확한 섹션만 치환
 
-### Gemini (triflux-profiles.json)
+### Antigravity (triflux-profiles.json)
 
 - **백업 필수**: `.bak` 자동 생성
 - **JSON 형식 유지**: `profiles.{name}.model`, `profiles.{name}.hint`
@@ -202,7 +202,7 @@ options:
 | high | 깊은 추론 |
 | xhigh | 최대 추론 (느림) |
 
-### Gemini 모델
+### Antigravity 모델
 
 | 모델 | 용도 |
 |------|------|
@@ -212,7 +212,7 @@ options:
 | gemini-2.5-flash | 2.5 Flash — 경량 범용 |
 | gemini-2.5-flash-lite | 2.5 Flash Lite — 최경량 |
 
-### Gemini → 에이전트 배치 (벤치마크 기반)
+### Antigravity → 에이전트 배치 (벤치마크 기반)
 
 | 프로필 | 모델 | 에이전트 |
 |--------|------|----------|
@@ -225,7 +225,7 @@ options:
 ### 설정 파일 경로
 
 - Codex: `~/.codex/config.toml`
-- Gemini: `~/.gemini/triflux-profiles.json`
+- Antigravity: `~/.gemini/triflux-profiles.json`
 
 ## 에러 처리
 
@@ -240,4 +240,4 @@ options:
 
 터미널에서 직접 실행:
 - Codex: `node tui/codex-profile.mjs`
-- Gemini: `node tui/gemini-profile.mjs`
+- Antigravity: `node tui/gemini-profile.mjs`

--- a/packages/triflux/skills/tfx-profile/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-profile/SKILL.md.tmpl
@@ -1,7 +1,7 @@
 ---
 name: tfx-profile
 description: >
-  Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
+  Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
   프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반
   인터랙티브 선택지로 수행합니다.
   Use when: codex profile, codex model, gemini profile, gemini model,
@@ -12,10 +12,10 @@ triggers:
 argument-hint: "[--list] [--codex | --gemini]"
 ---
 
-# {{SKILL_NAME}} — Codex/Gemini 프로파일 매니저
+# {{SKILL_NAME}} — Codex/Antigravity 프로파일 매니저
 
 > CLI 프로파일의 모델/effort를 AskUserQuestion 선택지로 관리합니다.
-> Codex(`~/.codex/config.toml`)와 Gemini(`~/.gemini/triflux-profiles.json`) 모두 지원.
+> Codex(`~/.codex/config.toml`)와 Antigravity(`~/.gemini/triflux-profiles.json`) 모두 지원.
 
 ## 워크플로우
 
@@ -30,7 +30,7 @@ header: "CLI"
 options:
   - label: "Codex"
     description: "~/.codex/config.toml (TOML)"
-  - label: "Gemini"
+  - label: "Antigravity"
     description: "~/.gemini/triflux-profiles.json (JSON)"
 ```
 
@@ -99,7 +99,7 @@ options:
 
 ---
 
-## Gemini 워크플로우
+## Antigravity 워크플로우
 
 ### Step 1: triflux-profiles.json 읽기 + 현재 상태 표시
 
@@ -171,7 +171,7 @@ options:
 - **다른 섹션 건드리지 않기**: `[notice]`, `[features]`, `[mcp_servers.*]` 등 절대 수정 금지
 - **Edit 도구 사용**: old_string → new_string으로 정확한 섹션만 치환
 
-### Gemini (triflux-profiles.json)
+### Antigravity (triflux-profiles.json)
 
 - **백업 필수**: `.bak` 자동 생성
 - **JSON 형식 유지**: `profiles.{name}.model`, `profiles.{name}.hint`
@@ -198,7 +198,7 @@ options:
 | high | 깊은 추론 |
 | xhigh | 최대 추론 (느림) |
 
-### Gemini 모델
+### Antigravity 모델
 
 | 모델 | 용도 |
 |------|------|
@@ -208,7 +208,7 @@ options:
 | gemini-2.5-flash | 2.5 Flash — 경량 범용 |
 | gemini-2.5-flash-lite | 2.5 Flash Lite — 최경량 |
 
-### Gemini → 에이전트 배치 (벤치마크 기반)
+### Antigravity → 에이전트 배치 (벤치마크 기반)
 
 | 프로필 | 모델 | 에이전트 |
 |--------|------|----------|
@@ -221,7 +221,7 @@ options:
 ### 설정 파일 경로
 
 - Codex: `~/.codex/config.toml`
-- Gemini: `~/.gemini/triflux-profiles.json`
+- Antigravity: `~/.gemini/triflux-profiles.json`
 
 ## 에러 처리
 
@@ -236,4 +236,4 @@ options:
 
 터미널에서 직접 실행:
 - Codex: `node tui/codex-profile.mjs`
-- Gemini: `node tui/gemini-profile.mjs`
+- Antigravity: `node tui/gemini-profile.mjs`

--- a/packages/triflux/skills/tfx-profile/skill.json
+++ b/packages/triflux/skills/tfx-profile/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-profile",
-  "description": "Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는 프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반 인터랙티브 선택지로 수행합니다. Use when: codex profile, codex model, gemini profile, gemini model, 프로파일 변경, 모델 변경, effort 변경, codex 설정, gemini 설정, profile manager, 프로파일 관리, 어떤 모델, tfx profile",
+  "description": "Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는 프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반 인터랙티브 선택지로 수행합니다. Use when: codex profile, codex model, gemini profile, gemini model, 프로파일 변경, 모델 변경, effort 변경, codex 설정, gemini 설정, profile manager, 프로파일 관리, 어떤 모델, tfx profile",
   "triggers": [
     "tfx-profile"
   ],

--- a/packages/triflux/skills/tfx-prune/SKILL.md
+++ b/packages/triflux/skills/tfx-prune/SKILL.md
@@ -25,7 +25,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 |-----|------|----------|
 | Claude (Opus) | 코드 품질 분석 + 합의 중재 | 설계 원칙, 코드 구조, 불필요 추상화 |
 | Codex | AI 슬롭 탐지 | 구현 효율, 중복 패턴, 과잉 에러 핸들링 |
-| Gemini | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
+| Antigravity | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
 
 ## 슬롭 카테고리
 
@@ -96,7 +96,7 @@ severity: critical(기능에 영향) | high(가독성 심각) | medium(개선) |
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 파일에서 AI 슬롭을 감지하세요. 구현 효율 관점(중복 패턴, 과잉 에러핸들링, 미사용 코드)으로 분석. 파일: {file_content}. JSON: [{id,category,line_start,line_end,description,severity,suggested_fix}]. severity: critical|high|medium|low. 과탐보다 미탐이 낫습니다.:slop-detector' \
@@ -173,7 +173,7 @@ for each finding in ALL results:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
 - 테스트 명령 없음 → Step 5 건너뜀, 보고서에 "테스트 미실행 — 수동 검증 필요" 표시
 - 파일 파싱 오류 → 해당 파일 스킵 후 보고서에 "파싱 실패" 기록
 

--- a/packages/triflux/skills/tfx-prune/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-prune/SKILL.md.tmpl
@@ -25,7 +25,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 |-----|------|----------|
 | Claude (Opus) | 코드 품질 분석 + 합의 중재 | 설계 원칙, 코드 구조, 불필요 추상화 |
 | Codex | AI 슬롭 탐지 | 구현 효율, 중복 패턴, 과잉 에러 핸들링 |
-| Gemini | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
+| Antigravity | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
 
 ## 슬롭 카테고리
 
@@ -96,7 +96,7 @@ severity: critical(기능에 영향) | high(가독성 심각) | medium(개선) |
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 파일에서 AI 슬롭을 감지하세요. 구현 효율 관점(중복 패턴, 과잉 에러핸들링, 미사용 코드)으로 분석. 파일: {file_content}. JSON: [{id,category,line_start,line_end,description,severity,suggested_fix}]. severity: critical|high|medium|low. 과탐보다 미탐이 낫습니다.:slop-detector' \
@@ -173,7 +173,7 @@ for each finding in ALL results:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
 - 테스트 명령 없음 → Step 5 건너뜀, 보고서에 "테스트 미실행 — 수동 검증 필요" 표시
 - 파일 파싱 오류 → 해당 파일 스킵 후 보고서에 "파싱 실패" 기록
 

--- a/packages/triflux/skills/tfx-qa/SKILL.md
+++ b/packages/triflux/skills/tfx-qa/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[테스트 대상] [--quick]"
 
 > **ARGUMENTS 처리**: ARGUMENTS 에 `--quick` 포함 → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Claude(기능/엣지) + Codex(보안/성능) + Gemini(UX/접근성) 3-CLI 독립 검증 + 교차검증 + 자동 수정.
+> AI makes completeness near-free. 기본은 Claude(기능/엣지) + Codex(보안/성능) + Antigravity(UX/접근성) 3-CLI 독립 검증 + 교차검증 + 자동 수정.
 > 빠른 테스트-수정 루프는 `--quick`.
 
 ---
@@ -58,7 +58,7 @@ Tier 3 시:
 ### HARD RULES
 
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -68,7 +68,7 @@ Tier 3 시:
 |-----|------|------|
 | Claude Opus | 기능검증 | 정확성, 엣지케이스, 누락 테스트 |
 | Codex | 보안+성능 | OWASP, O(n²), 메모리, 입력 검증 |
-| Gemini | UX+접근성 | 응답 일관성, 에러 메시지, WCAG |
+| Antigravity | UX+접근성 | 응답 일관성, 에러 메시지, WCAG |
 
 ### EXECUTION
 
@@ -90,7 +90,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless:**
+**Codex + Antigravity headless:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:보안/성능 전문가. OWASP Top 10, O(n²), 메모리 누수, 입력 검증 누락. JSON: { findings: [...], overall_verdict: \"pass\"|\"fail\" }:verifier' --assign 'gemini:UX/접근성 전문가. API 응답 일관성, 에러 메시지, WCAG 2.1 AA, 문서-동작 일치. JSON: { findings: [...], overall_verdict: \"pass\"|\"fail\" }:verifier' --timeout 600")
 ```

--- a/packages/triflux/skills/tfx-research/SKILL.md
+++ b/packages/triflux/skills/tfx-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 internal: true
 name: tfx-research
-description: "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Gemini Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto."
+description: "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Antigravity Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto."
 triggers:
   - tfx-research
   - 리서치
@@ -23,7 +23,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 
 > **ARGUMENTS 처리**: `--quick` → Quick. `--auto` → Auto. 그 외 → Deep (기본).
 
-> AI makes completeness near-free. 기본은 Claude(Exa/학술) + Codex(Brave/실용) + Gemini(Tavily/DX) 3-CLI 멀티소스 교차검증 합의.
+> AI makes completeness near-free. 기본은 Claude(Exa/학술) + Codex(Brave/실용) + Antigravity(Tavily/DX) 3-CLI 멀티소스 교차검증 합의.
 > 빠른 단일 Google Search 는 `--quick`. 자율 쿼리생성+구조화 보고서 는 `--auto`.
 
 ---
@@ -33,7 +33,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 | 플래그 | 모드 | 특징 |
 |--------|------|------|
 | (없음) | **Deep** (기본) | 3-CLI 멀티소스 교차검증, consensus score |
-| `--quick` | Quick | Gemini 단일 Google Search |
+| `--quick` | Quick | Antigravity 단일 Google Search |
 | `--auto` | Auto | 자율 쿼리생성(3-5개) + 검색 + 구조화 보고서 |
 
 ---
@@ -42,7 +42,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 
 ### HARD RULES
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -52,7 +52,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 |-----|-----|------|
 | Claude | Exa (neural semantic) | 학술/기술 깊이, 공식 문서, 벤치마크 |
 | Codex | Brave Search | 실용/구현/산업 사례 |
-| Gemini | Tavily | 비용/운영/DX |
+| Antigravity | Tavily | 비용/운영/DX |
 
 ### Depth 모드 (`--depth` 플래그)
 
@@ -83,7 +83,7 @@ Agent(
 )
 ```
 
-**Bash (Codex + Brave, Gemini + Tavily):**
+**Bash (Codex + Brave, Antigravity + Tavily):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:서브쿼리를 Brave Search 로 검색. 서브쿼리: {sub_queries}. 관점: 실용/산업. brave_web_search + brave_news_search, freshness=pw. 각 쿼리 상위 5개 구조화.:researcher' \
@@ -139,13 +139,13 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
-### Step 2: Gemini Google Search 위임
+### Step 2: Antigravity Google Search 위임
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research: use Google Search, return structured markdown with sources. Query: {optimized_query}' auto 120")
 ```
 
-**Fallback**: Gemini 실패 시 MCP 순서 — context7 → WebSearch → Brave → Exa → Tavily.
+**Fallback**: Antigravity 실패 시 MCP 순서 — context7 → WebSearch → Brave → Exa → Tavily.
 
 ### Step 3: 결과 포맷팅 (Claude ~300 토큰)
 
@@ -156,7 +156,7 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research: use Google Search, r
 ### 관련 키워드
 ```
 
-### Token (Quick): ~500 (Claude), 0 (Gemini 외부)
+### Token (Quick): ~500 (Claude), 0 (Antigravity 외부)
 
 ---
 

--- a/packages/triflux/skills/tfx-research/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-research/SKILL.md.tmpl
@@ -18,7 +18,7 @@ argument-hint: "<검색 주제>"
 
 
 > **Deep 버전**: tfx-deep-research. "제대로/꼼꼼히" 수정자로 자동 에스컬레이션.
-> 빠른 단일 소스 검색 + 요약. **검색 자체를 Gemini에 위임**해 Claude 토큰 최소화. Gemini CLI의 네이티브 Google Search로 검색+요약을 한 번에 처리.
+> 빠른 단일 소스 검색 + 요약. **검색 자체를 Antigravity에 위임**해 Claude 토큰 최소화. Antigravity CLI의 네이티브 Google Search로 검색+요약을 한 번에 처리.
 
 ## 용도
 
@@ -53,30 +53,30 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
-선택 결과에 따라 Step 2 Gemini 위임 시 프롬프트에 검색 유형 힌트를 추가한다.
+선택 결과에 따라 Step 2 Antigravity 위임 시 프롬프트에 검색 유형 힌트를 추가한다.
 인자가 제공된 경우 이 단계를 건너뛰고 Step 2로 직행한다.
 
-### Step 2: Gemini에 검색+요약 위임 (검색 실행 전체를 Gemini가 처리)
+### Step 2: Antigravity에 검색+요약 위임 (검색 실행 전체를 Antigravity가 처리)
 
-최적화된 쿼리를 Gemini CLI로 전달한다. Gemini는 네이티브 Google Search를 사용해 검색과 요약을 모두 수행한다:
+최적화된 쿼리를 Antigravity CLI로 전달한다. Antigravity는 네이티브 Google Search를 사용해 검색과 요약을 모두 수행한다:
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research the following topic. Use Google Search to find current information. Return a structured markdown summary with sources: {optimized_query}' auto 120")
 ```
 
-Gemini가 반환하는 결과에는 검색 결과, 출처 URL, 핵심 요약이 포함된다. Claude는 이 단계에서 토큰을 소비하지 않는다.
+Antigravity가 반환하는 결과에는 검색 결과, 출처 URL, 핵심 요약이 포함된다. Claude는 이 단계에서 토큰을 소비하지 않는다.
 
-**실패 시**: Gemini CLI가 응답하지 않거나 오류가 발생하면 → [Claude Fallback](#claude-fallback-gemini-실패-시) 으로 전환.
+**실패 시**: Antigravity CLI가 응답하지 않거나 오류가 발생하면 → [Claude Fallback](#claude-fallback-gemini-실패-시) 으로 전환.
 
 ### Step 3: 결과 포맷팅 (Claude — 경량, ~300 토큰)
 
-Gemini 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이나 요약 없이 포맷 변환만 수행:
+Antigravity 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이나 요약 없이 포맷 변환만 수행:
 
 ```markdown
 ## 검색 결과: {query}
 
 ### 핵심 답변
-{Gemini 요약에서 추출한 1-3문장 직접 답변}
+{Antigravity 요약에서 추출한 1-3문장 직접 답변}
 
 ### 상세 내용
 - **[출처 1 제목](URL)**: {하이라이트 요약}
@@ -92,17 +92,17 @@ Gemini 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이
 | 단계 | 담당 | 토큰 |
 |------|------|------|
 | 쿼리 최적화 | Claude | ~100 |
-| 검색 실행 + 요약 | Gemini | 0 (Claude 미소비) |
+| 검색 실행 + 요약 | Antigravity | 0 (Claude 미소비) |
 | 결과 포맷팅 | Claude | ~300 |
 | **Claude 총합** | | **~500 (오케스트레이션만)** |
 
-> 기존 대비 Claude 토큰 ~90% 절감. 검색 품질은 Gemini의 Google Search 네이티브 연동으로 유지.
+> 기존 대비 Claude 토큰 ~90% 절감. 검색 품질은 Antigravity의 Google Search 네이티브 연동으로 유지.
 
 ---
 
-## Claude Fallback (Gemini 실패 시)
+## Claude Fallback (Antigravity 실패 시)
 
-Gemini CLI가 실패하거나 응답이 없을 경우 Claude + MCP 원본 워크플로우로 폴백한다.
+Antigravity CLI가 실패하거나 응답이 없을 경우 Claude + MCP 원본 워크플로우로 폴백한다.
 
 ### Fallback Step 2: MCP 소스 자동 선택
 

--- a/packages/triflux/skills/tfx-research/skill.json
+++ b/packages/triflux/skills/tfx-research/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-research",
-  "description": "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Gemini Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto.",
+  "description": "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Antigravity Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto.",
   "triggers": [
     "tfx-research",
     "리서치",

--- a/packages/triflux/skills/tfx-review/SKILL.md
+++ b/packages/triflux/skills/tfx-review/SKILL.md
@@ -60,8 +60,8 @@ ARGUMENTS 에 `--quick` 포함 → **Quick 모드** (아래 Quick 섹션).
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 정상 | headless multi 3-CLI |
-| **Tier 2** | Codex 또는 Gemini 중 하나만 가용 | 가용 CLI + Claude Agent 조합 |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 정상 | headless multi 3-CLI |
+| **Tier 2** | Codex 또는 Antigravity 중 하나만 가용 | 가용 CLI + Claude Agent 조합 |
 | **Tier 3** | headless 불가 또는 `claude -p` one-shot | Claude Agent only (consensus 미적용) |
 
 ```
@@ -73,10 +73,10 @@ IF Hub 미응답:
   → 성공 → Tier 판정 재시도
   → 실패 → Tier 3
 
-IF Codex 없음 AND Gemini 없음:
+IF Codex 없음 AND Antigravity 없음:
   → Tier 3
 
-IF Codex 없음 OR Gemini 없음:
+IF Codex 없음 OR Antigravity 없음:
   → Tier 2
 
 ELSE:
@@ -88,7 +88,7 @@ ELSE:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드로 실행합니다 (consensus 미적용)
   누락: {missing_components}
-  권장: tmux/psmux, Hub, Codex CLI, Gemini CLI 설치 후 재실행
+  권장: tmux/psmux, Hub, Codex CLI, Antigravity CLI 설치 후 재실행
   또는 /tfx-review --quick 으로 명시적 quick 경로 사용
 ```
 
@@ -97,7 +97,7 @@ ELSE:
 > headless-guard가 이 규칙 위반을 **자동 차단**한다.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -107,7 +107,7 @@ ELSE:
 |-----|------|------|
 | Claude Opus | 로직+아키텍처 | 로직 결함, 아키텍처 위반, 설계 패턴 |
 | Codex | 보안+성능 | OWASP Top 10, O(n²) 패턴, 누락된 에러 핸들링 |
-| Gemini | 가독성+DX | 네이밍 컨벤션, 가독성, 주석 필요성, 타입 안전성 |
+| Antigravity | 가독성+DX | 네이밍 컨벤션, 가독성, 주석 필요성, 타입 안전성 |
 
 ### 실행 단계
 
@@ -128,7 +128,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless dispatch:**
+**Codex + Antigravity headless dispatch:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:보안/성능 전문가로서 이 코드를 분석하라. OWASP Top 10 취약점 확인. O(n²) 이상의 성능 병목 식별. 누락된 에러 핸들링 지적. JSON: { findings: [{ id, file, line, severity, category, description, suggestion }] }:reviewer' --assign 'gemini:코드 품질 전문가로서 이 코드를 분석하라. 가독성과 네이밍 컨벤션 평가. 주석이 필요한 복잡한 로직 식별. 타입 안전성 문제 지적. JSON: { findings: [{ id, file, line, severity, category, description, suggestion }] }:reviewer' --timeout 600")
 ```
@@ -147,11 +147,11 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 
 ```markdown
 ## Deep Code Review: {target}
-**Consensus Score**: {score}% | **Reviewers**: Claude/Codex/Gemini
+**Consensus Score**: {score}% | **Reviewers**: Claude/Codex/Antigravity
 
 ### Critical (3/3 합의)
 - [C1] `{file}:{line}` — {description}
-  - Claude: {detail} | Codex: {detail} | Gemini: {detail}
+  - Claude: {detail} | Codex: {detail} | Antigravity: {detail}
   - **Fix**: {suggestion}
 
 ### High (2/3 합의)
@@ -169,7 +169,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 |-----|---------|------------|
 | Claude | {n} | {%} |
 | Codex | {n} | {%} |
-| Gemini | {n} | {%} |
+| Antigravity | {n} | {%} |
 ```
 
 ### Error Recovery

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -70,7 +70,7 @@ Bash("triflux setup")
 필수 훅 목록:
 | 이벤트 | matcher | 스크립트 | 역할 |
 |--------|---------|---------|------|
-| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Gemini 직접 호출 차단 |
+| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Antigravity 직접 호출 차단 |
 | PreToolUse | Bash | psmux-safety-guard.mjs | psmux kill-session 직접 호출 차단 (WT 프리징 방지) |
 | PreToolUse | Skill | tfx-gate-activate.mjs | tfx-multi 게이트 |
 
@@ -129,7 +129,7 @@ Bash("triflux setup")
       description: "나중에 /tfx-profile로 관리"
   ```
 
-#### 단계 3.5: Gemini 프로필
+#### 단계 3.5: Antigravity 프로필
 
 `~/.gemini/triflux-profiles.json` 존재 여부 확인.
 필수 프로필: `pro31`, `flash3`.
@@ -138,8 +138,8 @@ Bash("triflux setup")
 - 파일 미존재 → 기본 프로필 5개 자동 생성 (pro31, flash3, pro25, flash25, lite25)
 - 누락 있으면 → AskUserQuestion:
   ```
-  question: "누락된 Gemini 프로필을 생성하시겠습니까?"
-  header: "Gemini Profiles"
+  question: "누락된 Antigravity 프로필을 생성하시겠습니까?"
+  header: "Antigravity Profiles"
   options:
     - label: "생성 (Recommended)"
       description: "누락된 프로필을 triflux-profiles.json에 추가"
@@ -508,7 +508,7 @@ options:
     description: "settings.json statusLine 등록"
   - label: "Codex 프로파일"
     description: "필수 프로파일 생성"
-  - label: "Gemini 프로필"
+  - label: "Antigravity 프로필"
     description: "triflux-profiles.json 생성/확인"
   - label: "CLI + MCP 진단"
     description: "CLI 존재 + MCP 인벤토리 확인"
@@ -530,7 +530,7 @@ options:
 | Codex 프로파일 | ✅ 3개 확인 |
 | Codex config.toml | ✅ approval_mode=full-auto (CLI 플래그 자동 생략) |
 | Codex CLI | ✅ |
-| Gemini CLI | ⚠ 미설치 (선택) |
+| Antigravity CLI | ⚠ 미설치 (선택) |
 | 원격 기기 | ✅ 2대 사용 가능 (ryzen5-7600, m2) / ❌ 1대 연결 실패 |
 | MCP 인벤토리 | ✅ N개 서버 |
 | 검색 MCP | ✅ Exa, Tavily / ⏭ Brave (키 없음) |
@@ -540,13 +540,13 @@ options:
 | 기능 | 상태 | 필요 조건 |
 |------|------|----------|
 | 로컬 단일 모델 | ✅ | Codex CLI |
-| 로컬 다중 모델 | ✅ | Codex CLI + Gemini CLI |
+| 로컬 다중 모델 | ✅ | Codex CLI + Antigravity CLI |
 | 다중 기기 스웜 | ✅ 2대 | SSH 호스트 + Claude 설치 |
 | 전체 (다중 기기 x 다중 모델) | ✅ | 위 전부 |
 
 ### 다음 단계
 - Codex 미설치 시: `npm install -g @openai/codex`
-- Gemini 미설치 시: `npm install -g @google/gemini-cli`
+- Antigravity 미설치 시: `npm install -g @google/gemini-cli`
 - 원격 호스트 추가: `/tfx-remote-setup`
 - 검색 MCP 추가/변경: `/tfx-setup` → 단계별 선택 → 검색 MCP
 - 세션 재시작하면 HUD + 검색 MCP가 활성화됩니다

--- a/packages/triflux/skills/tfx-setup/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-setup/SKILL.md.tmpl
@@ -53,7 +53,7 @@ Bash("triflux setup")
 필수 훅 목록:
 | 이벤트 | matcher | 스크립트 | 역할 |
 |--------|---------|---------|------|
-| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Gemini 직접 호출 차단 |
+| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Antigravity 직접 호출 차단 |
 | PreToolUse | Bash | psmux-safety-guard.mjs | psmux kill-session 직접 호출 차단 (WT 프리징 방지) |
 | PreToolUse | Skill | tfx-gate-activate.mjs | tfx-multi 게이트 |
 
@@ -112,7 +112,7 @@ Bash("triflux setup")
       description: "나중에 /tfx-profile로 관리"
   ```
 
-#### 단계 3.5: Gemini 프로필
+#### 단계 3.5: Antigravity 프로필
 
 `~/.gemini/triflux-profiles.json` 존재 여부 확인.
 필수 프로필: `pro31`, `flash3`.
@@ -121,8 +121,8 @@ Bash("triflux setup")
 - 파일 미존재 → 기본 프로필 5개 자동 생성 (pro31, flash3, pro25, flash25, lite25)
 - 누락 있으면 → AskUserQuestion:
   ```
-  question: "누락된 Gemini 프로필을 생성하시겠습니까?"
-  header: "Gemini Profiles"
+  question: "누락된 Antigravity 프로필을 생성하시겠습니까?"
+  header: "Antigravity Profiles"
   options:
     - label: "생성 (Recommended)"
       description: "누락된 프로필을 triflux-profiles.json에 추가"
@@ -487,7 +487,7 @@ options:
     description: "settings.json statusLine 등록"
   - label: "Codex 프로파일"
     description: "필수 프로파일 생성"
-  - label: "Gemini 프로필"
+  - label: "Antigravity 프로필"
     description: "triflux-profiles.json 생성/확인"
   - label: "CLI + MCP 진단"
     description: "CLI 존재 + MCP 인벤토리 확인"
@@ -509,7 +509,7 @@ options:
 | Codex 프로파일 | ✅ 3개 확인 |
 | Codex config.toml | ✅ approval_mode=full-auto (CLI 플래그 자동 생략) |
 | Codex CLI | ✅ |
-| Gemini CLI | ⚠ 미설치 (선택) |
+| Antigravity CLI | ⚠ 미설치 (선택) |
 | 원격 기기 | ✅ 2대 사용 가능 (ryzen5-7600, m2) / ❌ 1대 연결 실패 |
 | MCP 인벤토리 | ✅ N개 서버 |
 | 검색 MCP | ✅ Exa, Tavily / ⏭ Brave (키 없음) |
@@ -519,13 +519,13 @@ options:
 | 기능 | 상태 | 필요 조건 |
 |------|------|----------|
 | 로컬 단일 모델 | ✅ | Codex CLI |
-| 로컬 다중 모델 | ✅ | Codex CLI + Gemini CLI |
+| 로컬 다중 모델 | ✅ | Codex CLI + Antigravity CLI |
 | 다중 기기 스웜 | ✅ 2대 | SSH 호스트 + Claude 설치 |
 | 전체 (다중 기기 x 다중 모델) | ✅ | 위 전부 |
 
 ### 다음 단계
 - Codex 미설치 시: `npm install -g @openai/codex`
-- Gemini 미설치 시: `npm install -g @google/gemini-cli`
+- Antigravity 미설치 시: `npm install -g @google/gemini-cli`
 - 원격 호스트 추가: `/tfx-remote-setup`
 - 검색 MCP 추가/변경: `/tfx-setup` → 단계별 선택 → 검색 MCP
 - 세션 재시작하면 HUD + 검색 MCP가 활성화됩니다

--- a/packages/triflux/skills/tfx-swarm/SKILL.md.tmpl
+++ b/packages/triflux/skills/tfx-swarm/SKILL.md.tmpl
@@ -13,7 +13,7 @@ triggers:
 {{> base}}
 
 > **Multi-Machine x Multi-Model Swarm.** PRD 하나로 로컬과 원격 머신에서
-> Claude + Codex + Gemini를 병렬 실행하고, file-lease로 충돌을 방지하며,
+> Claude + Codex + Antigravity를 병렬 실행하고, file-lease로 충돌을 방지하며,
 > 결과를 자동 통합한다. triflux의 킬러 스킬.
 
 ## 트리거
@@ -36,7 +36,7 @@ triggers:
 
 - psmux >= 3.3.0
 - Hub 실행 중 (`curl -sf http://127.0.0.1:27888/status`)
-- Codex CLI 또는 Gemini CLI (사용할 agent에 따라)
+- Codex CLI 또는 Antigravity CLI (사용할 agent에 따라)
 - 원격 shard 사용 시: SSH 키 인증 + 원격 머신에 Claude Code 설치
 - 프로젝트에 `docs/prd/` 디렉토리 존재
 
@@ -78,7 +78,7 @@ PRD에 다중 agent가 지정된 경우에도 AskUserQuestion:
 Options:
 - A) PRD 그대로 — shard별 지정 모델 사용 (권장)
 - B) 전부 Codex로 — 단일 모델
-- C) 전부 Gemini로 — 단일 모델
+- C) 전부 Antigravity로 — 단일 모델
 
 ### Step 3: 계획 생성
 
@@ -163,7 +163,7 @@ await hyper.shutdown('completed');
 - prompt: 성능 최적화 (auth 리팩터 완료 후)
 ```
 
-위 PRD 하나로: Codex(로컬) + Gemini(로컬) + Claude(ryzen5-7600) + Codex(m2) 4개 워커가 병렬 실행된다.
+위 PRD 하나로: Codex(로컬) + Antigravity(로컬) + Claude(ryzen5-7600) + Codex(m2) 4개 워커가 병렬 실행된다.
 security-audit는 `critical: true`이므로 다른 모델로 이중 실행 후 reconcile.
 
 ## PRD Shard 필드 레퍼런스

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -824,9 +824,9 @@ auto_reroute() {
   local target_cli=""
   local -a candidates=()
   case "$failed_cli" in
-    codex) candidates=("antigravity" "gemini") ;;
+    codex) candidates=("antigravity") ;;
     gemini) candidates=("antigravity" "codex") ;;
-    antigravity) candidates=("codex" "gemini") ;;
+    antigravity) candidates=("codex") ;;
     *) echo "[tfx-quota] $failed_cli 대체 CLI 없음" >&2; return 1 ;;
   esac
 
@@ -856,11 +856,9 @@ auto_reroute() {
 
   case "$failed_cli:$target_cli" in
     codex:antigravity) echo "[tfx-quota] Codex → Antigravity 자동 전환" >&2 ;;
-    codex:gemini) echo "[tfx-quota] Codex → Gemini 자동 전환" >&2 ;;
     gemini:antigravity) echo "[tfx-quota] Gemini → Antigravity 자동 전환" >&2 ;;
     gemini:codex) echo "[tfx-quota] Gemini → Codex 자동 전환" >&2 ;;
     antigravity:codex) echo "[tfx-quota] Antigravity → Codex 자동 전환" >&2 ;;
-    antigravity:gemini) echo "[tfx-quota] Antigravity → Gemini 자동 전환" >&2 ;;
   esac
 
   local quota_marker="$TFX_TMP/tfx-quota-${failed_cli}-$(date +%Y%m%d)"
@@ -1258,6 +1256,14 @@ apply_cli_mode() {
             return 0
             ;;
         esac
+        # Gemini CLI deprecated — redirect to Antigravity when available.
+        # Legacy gemini binary path is preserved as fallback for environments
+        # without agy (TFX_ANTIGRAVITY_OK=0) until Phase 5 cleanup.
+        if [[ "${TFX_ANTIGRAVITY_OK:-0}" == "1" ]] && command -v "${AGY_BIN:-agy}" &>/dev/null; then
+          echo "[tfx-route] [deprecated] TFX_CLI_MODE=gemini → antigravity (Gemini CLI deprecated, use --cli antigravity)" >&2
+          TFX_CLI_MODE="antigravity"; apply_cli_mode; return
+        fi
+        echo "[tfx-route] [deprecated] TFX_CLI_MODE=gemini: agy 미설치 — legacy gemini binary path 진입" >&2
         CLI_TYPE="gemini"; CLI_CMD="gemini"
         case "$AGENT_TYPE" in
           executor|debugger|deep-executor|architect|planner|critic|analyst|\

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1167,10 +1167,10 @@ if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
       } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e"); }
     ' 2>/dev/null
   ) || true
-  export TFX_CODEX_OK="${_pf_codex:-0}"
-  export TFX_GEMINI_OK="${_pf_gemini:-0}"
-  export TFX_ANTIGRAVITY_OK="${_pf_antigravity:-0}"
-  export TFX_HUB_OK="${_pf_hub:-0}"
+  export TFX_CODEX_OK="${TFX_CODEX_OK:-${_pf_codex:-0}}"
+  export TFX_GEMINI_OK="${TFX_GEMINI_OK:-${_pf_gemini:-0}}"
+  export TFX_ANTIGRAVITY_OK="${TFX_ANTIGRAVITY_OK:-${_pf_antigravity:-0}}"
+  export TFX_HUB_OK="${TFX_HUB_OK:-${_pf_hub:-0}}"
   [[ -n "${_pf_plan:-}" ]] && export TFX_CODEX_PLAN="$_pf_plan"
   [[ -n "${_pf_agents:-}" ]] && export TFX_AVAILABLE_AGENTS="$_pf_agents"
   export TFX_PREFLIGHT_LOADED=1
@@ -1227,6 +1227,19 @@ apply_cli_mode() {
   local codex_base
   codex_base="$(build_codex_base)"
   local gemini_tier=""
+
+  if [[ "$CLI_TYPE" == "gemini" && ( "$TFX_CLI_MODE" == "auto" || "$TFX_CLI_MODE" == "gemini" ) ]]; then
+    # Gemini CLI is deprecated, but the `gemini` route name remains as a
+    # compatibility alias until Phase 5 cleanup. When Antigravity readiness has
+    # already been proven by preflight/cache, direct gemini routes must follow
+    # the same redirect as TFX_CLI_MODE=gemini remaps.
+    if [[ "${TFX_ANTIGRAVITY_OK:-0}" == "1" ]] && command -v "${AGY_BIN:-agy}" &>/dev/null; then
+      echo "[tfx-route] [deprecated] gemini route → antigravity (Gemini CLI deprecated, use antigravity/agy)" >&2
+      TFX_CLI_MODE="antigravity"
+      apply_cli_mode
+      return
+    fi
+  fi
 
   case "$TFX_CLI_MODE" in
     codex)

--- a/skills/tfx-analysis/SKILL.md
+++ b/skills/tfx-analysis/SKILL.md
@@ -17,7 +17,7 @@ argument-hint: "<분석 대상> [--quick]"
 
 > **ARGUMENTS 처리**: ARGUMENTS 에 `--quick` 포함 → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Claude(아키텍처) + Codex(보안/성능) + Gemini(UX/문서화) Tri-Debate 합의.
+> AI makes completeness near-free. 기본은 Claude(아키텍처) + Codex(보안/성능) + Antigravity(UX/문서화) Tri-Debate 합의.
 > 빠른 단일 CLI 분석은 `--quick` opt-out.
 
 ---
@@ -44,21 +44,21 @@ ARGUMENTS 에 `--quick` 포함 → **Quick 모드** (Codex 단일).
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 | headless multi 3-CLI |
-| **Tier 2** | Codex 또는 Gemini 중 하나만 | 가용 CLI + Claude Agent |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 | headless multi 3-CLI |
+| **Tier 2** | Codex 또는 Antigravity 중 하나만 | 가용 CLI + Claude Agent |
 | **Tier 3** | headless 불가 | Claude Agent only (consensus 미적용) |
 
 Tier 3 시:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드 (consensus 미적용)
-  누락: {missing}  |  권장: tmux/psmux + Hub + Codex + Gemini 설치
+  누락: {missing}  |  권장: tmux/psmux + Hub + Codex + Antigravity 설치
   또는 /tfx-analysis --quick 사용
 ```
 
 ### HARD RULES
 
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -68,7 +68,7 @@ Tier 3 시:
 |-------|------|------|
 | Claude Opus (architect) | 아키텍처/설계 | 레이어, SOLID, 확장성 |
 | Codex (security-engineer) | 구현/보안 | 복잡도, OWASP, 기술 부채 |
-| Gemini (ux-engineer) | UX/문서화 | DX, 접근성, 네이밍 |
+| Antigravity (ux-engineer) | UX/문서화 | DX, 접근성, 네이밍 |
 
 ### EXECUTION
 
@@ -90,7 +90,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless:**
+**Codex + Antigravity headless:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:시니어+보안 엔지니어로서 분석하라. 대상: {target}. 렌즈: 구현 품질, 성능, OWASP, 안정성, 기술 부채. JSON: { findings: [...], metrics: {...}, health_score: 0-100 }:security-engineer' --assign 'gemini:UX 엔지니어+테크니컬 라이터로서 분석하라. 대상: {target}. 렌즈: DX, 문서화, 접근성, 국제화, 네이밍. JSON: { findings: [...], documentation_score: 0-100, health_score: 0-100 }:ux-engineer' --timeout 600")
 ```
@@ -101,10 +101,10 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 
 **Agent:**
 ```
-Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_background=true, name="arch-debate", prompt="다른 두 분석가 결과: A(Codex)={codex}, B(Gemini)={gemini}. 동의에 +1, 반대에 근거 반박, 놓친 사항 추가, health_score 재조정")
+Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_background=true, name="arch-debate", prompt="다른 두 분석가 결과: A(Codex)={codex}, B(Antigravity)={gemini}. 동의에 +1, 반대에 근거 반박, 놓친 사항 추가, health_score 재조정")
 ```
 
-**Bash:** (위와 동일 패턴, Codex/Gemini 각각 교차검증)
+**Bash:** (위와 동일 패턴, Codex/Antigravity 각각 교차검증)
 
 합의 분류: 3/3 → CONFIRMED, 2/3 → LIKELY, 1/3 → UNVERIFIED.
 
@@ -112,7 +112,7 @@ Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_backgroun
 
 ```markdown
 # Deep Analysis Report: {target}
-**Consensus**: {score}% | **Health**: {weighted}/100 | **Analysts**: Claude/Codex/Gemini
+**Consensus**: {score}% | **Health**: {weighted}/100 | **Analysts**: Claude/Codex/Antigravity
 
 ## Executive Summary
 {3-5줄 합의 기반 요약}
@@ -122,7 +122,7 @@ Agent(subagent_type="oh-my-claudecode:architect", model="opus", run_in_backgroun
 
 ## 발견사항 (Critical/High/Medium, 합의 기반)
 - [C1] `{file}:{line}` — {description} — 3/3
-  - 아키텍처: {Claude} | 구현: {Codex} | DX: {Gemini}
+  - 아키텍처: {Claude} | 구현: {Codex} | DX: {Antigravity}
   - 권장: {rec}
 
 ## 메트릭

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -133,7 +133,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 |--------|-----|------|----------|
 | `--cli` | `auto` (기본) | Codex 분류 후 최적 CLI 선택 | 기존 라우팅 |
 | `--cli` | `codex` | Codex 전용 고정. `TFX_CLI_MODE=codex` | tfx-route.sh |
-| `--cli` | `gemini` | Gemini 전용 고정. `TFX_CLI_MODE=gemini` | tfx-route.sh |
+| `--cli` | `gemini` | [deprecated alias] Antigravity 로 redirect. `TFX_CLI_MODE=gemini` (agy 없으면 legacy gemini fallback) | tfx-route.sh |
 | `--cli` | `claude` | Claude native 에이전트만 (CLI 호출 없음) | Agent() |
 | `--mode` | `quick` (기본) | fire-and-forget, plan/verify 오버헤드 없음 | 직접 실행 |
 | `--mode` | `deep` | pipeline init → plan → PRD → verify → fix loop | `-t/--thorough` 동일 |

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -104,11 +104,11 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Gemini → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
-> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Gemini에 위임하라. 작업이 아무리 사소해도 예외 없음.
+> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Antigravity에 위임하라. 작업이 아무리 사소해도 예외 없음.
 
 ## 모드
 
@@ -145,7 +145,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--shape` | `consensus` (기본) | findings 합의/충돌 판정 | consensus renderer |
 | `--shape` | `debate` | 옵션 비교 + 점수화 + 최종 추천 | debate renderer |
 | `--shape` | `panel` | 전문가 roster 기반 시뮬레이션 | panel renderer |
-| `--cli-set` | `triad` (기본) | Claude + Codex + Gemini | consensus participants |
+| `--cli-set` | `triad` (기본) | Claude + Codex + Antigravity | consensus participants |
 | `--cli-set` | `no-gemini` | Claude + Codex partial degrade | consensus participants |
 | `--cli-set` | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | consensus participants |
 | `--options` | `"A|B|C"` | debate 비교 대상 | debate normalizer |
@@ -281,8 +281,8 @@ shape 의미:
 
 | 값 | 의미 | 비고 |
 |----|------|------|
-| `triad` | Claude + Codex + Gemini | 기본값 |
-| `no-gemini` | Claude + Codex | Gemini 미가용 degrade |
+| `triad` | Claude + Codex + Antigravity | 기본값 |
+| `no-gemini` | Claude + Codex | Antigravity 미가용 degrade |
 | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | 신규 provider 추가 금지 |
 
 shape 입력 정규화:
@@ -328,7 +328,7 @@ shape 별 `shape_input`:
 2. `--mode consensus` 확인
 3. `--shape` 기본값 보정 (`consensus`)
 4. shape 별 payload 정규화
-5. Claude native + headless Codex/Gemini 동시 dispatch
+5. Claude native + headless Codex/Antigravity 동시 dispatch
 6. 결과 수집
 7. 공통 `meta_judgment` 생성
 8. shape renderer 로 markdown/json 출력
@@ -686,7 +686,7 @@ Phase 5 삭제 게이트:
 | `spec-panel` | architect + analyst + critic | analyze |
 | `business-panel` | analyst + architect | analyze |
 
-### Gemini 직행
+### Antigravity 직행
 
 | 커맨드 | 에이전트 | MCP |
 |--------|---------|-----|
@@ -828,7 +828,7 @@ else:
 
 ## 실행
 
-### CLI 에이전트 (Codex/Gemini)
+### CLI 에이전트 (Codex/Antigravity)
 
 ```bash
 # Level 0 / INDEPENDENT
@@ -853,7 +853,7 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |
-| gemini / designer / writer | Gemini | docs |
+| gemini / designer / writer | Antigravity | docs |
 | explore / test-engineer / qa-tester | Claude native | — |
 | verifier | Codex review (기본) / Claude native (TFX_VERIFIER_OVERRIDE=claude 시) | review / — |
 

--- a/skills/tfx-auto/SKILL.md.tmpl
+++ b/skills/tfx-auto/SKILL.md.tmpl
@@ -80,11 +80,11 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Gemini → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
-> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Gemini에 위임하라. 작업이 아무리 사소해도 예외 없음.
+> 6. **직접 수정 금지**: implement/review/analyze 등 커맨드 숏컷 실행 시 절대로 Edit/Write 도구로 직접 코드를 수정하지 마라. 반드시 Bash(tfx-route.sh)를 통해 Codex/Antigravity에 위임하라. 작업이 아무리 사소해도 예외 없음.
 
 ## 모드
 
@@ -128,7 +128,7 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 | `spec-panel` | architect + analyst + critic | analyze |
 | `business-panel` | analyst + architect | analyze |
 
-### Gemini 직행
+### Antigravity 직행
 
 | 커맨드 | 에이전트 | MCP |
 |--------|---------|-----|
@@ -236,7 +236,7 @@ else:
 
 ## 실행
 
-### CLI 에이전트 (Codex/Gemini)
+### CLI 에이전트 (Codex/Antigravity)
 
 ```bash
 # Level 0 / INDEPENDENT
@@ -261,7 +261,7 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |
-| gemini / designer / writer | Gemini | docs |
+| gemini / designer / writer | Antigravity | docs |
 | explore / test-engineer / qa-tester | Claude native | — |
 | verifier | Codex review (기본) / Claude native (TFX_VERIFIER_OVERRIDE=claude 시) | review / — |
 

--- a/skills/tfx-consensus/SKILL.md.tmpl
+++ b/skills/tfx-consensus/SKILL.md.tmpl
@@ -2,7 +2,7 @@
 internal: true
 name: tfx-consensus
 description: >
-  3자 합의 엔진 — 모든 Deep 스킬의 핵심 인프라. Claude/Codex/Gemini 독립 분석 결과를 교차검증하여 편향 없는 합의를 도출한다.
+  3자 합의 엔진 — 모든 Deep 스킬의 핵심 인프라. Claude/Codex/Antigravity 독립 분석 결과를 교차검증하여 편향 없는 합의를 도출한다.
   독립 실행도 가능: '합의로 분석해', '3자 합의', 'consensus' 같은 요청 시 직접 호출 가능.
 triggers: [consensus, 합의]
 argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 호출 또는 직접 사용 가능)"
@@ -22,7 +22,7 @@ argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 �
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -34,7 +34,7 @@ argument-hint: "<분석 주제 또는 컨텍스트> (Deep 스킬 내부 자동 �
 |-------|---------|------|------|
 | Claude Opus | architect | 합의 통합 및 교차검증 조율 | 논리 분석, 불일치 해소 |
 | Codex | analyst | 구현/보안 관점 독립 분석 | 코드 품질, 취약점 탐지 |
-| Gemini | analyst | UX/문서화 관점 독립 분석 | DX, 접근성, 가독성 |
+| Antigravity | analyst | UX/문서화 관점 독립 분석 | DX, 접근성, 가독성 |
 
 ## EXECUTION STEPS
 
@@ -56,7 +56,7 @@ Agent(
 )
 ```
 
-**도구 2 — Codex+Gemini 독립 분석 headless dispatch:**
+**도구 2 — Codex+Antigravity 독립 분석 headless dispatch:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:{analysis_prompt} 출력 형식을 JSON으로 강제: { findings: [{ id: string, category: string, severity: critical|high|medium|low, description: string, evidence: string }], summary: string, confidence: 0.0-1.0 }:analyst' --assign 'gemini:{analysis_prompt} 출력 형식을 JSON으로 강제: { findings: [{ id: string, category: string, severity: critical|high|medium|low, description: string, evidence: string }], summary: string, confidence: 0.0-1.0 }:analyst' --timeout 600")
 ```
@@ -87,13 +87,13 @@ Agent(
   run_in_background=true,
   name="consensus-resolve-claude",
   description="미합의 항목 2차 검토",
-  prompt="미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Codex — {codex_rebuttal}, Gemini — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수."
+  prompt="미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Codex — {codex_rebuttal}, Antigravity — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수."
 )
 ```
 
-**도구 2 — Codex+Gemini 재검토:**
+**도구 2 — Codex+Antigravity 재검토:**
 ```
-Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Gemini — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --assign 'gemini:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Codex — {codex_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --timeout 600")
+Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Antigravity — {gemini_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --assign 'gemini:미합의 항목 목록: {disputed_items}. 다른 두 CLI의 반대 논거: Claude — {claude_rebuttal}, Codex — {codex_rebuttal}. 각 항목에 대해 수용(accept) 또는 반박(rebut)으로 응답하라. 수용 시 근거 필수.:analyst' --timeout 600")
 ```
 
 Resolution 결과 처리:
@@ -134,7 +134,7 @@ Learned Weights를 `.omc/state/consensus-weights.json`에서 읽어 가중 투�
 |------|------|
 | headless timeout (600s) | Claude Agent로 해당 역할 대체 실행 |
 | Codex 워커 실패 | Agent(oh-my-claudecode:architect, model="opus") 대체 |
-| Gemini 워커 실패 | Agent(oh-my-claudecode:critic, model="sonnet") 대체 |
+| Antigravity 워커 실패 | Agent(oh-my-claudecode:critic, model="sonnet") 대체 |
 
 ## 토큰 예산
 

--- a/skills/tfx-debate/SKILL.md
+++ b/skills/tfx-debate/SKILL.md
@@ -48,7 +48,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-debate -> tfx-auto --mode consensus --s
 tfx-debate 의 본질은 "3-CLI 토론 엔진"이 아니라 "옵션 비교와 최종 추천을 내는 보고서 shape" 였다. Phase 4a 부터 orchestration root 는 `--mode consensus` 로 통합되고, debate 의미는 `--shape debate` 로 보존된다.
 
 공통 규약:
-- participants 기본값은 `triad` (Claude + Codex + Gemini)
+- participants 기본값은 `triad` (Claude + Codex + Antigravity)
 - `--cli-set no-gemini` 시 partial consensus 로 degrade 가능
 - 공통 `meta_judgment` 는 `hub/team/consensus-meta.mjs` 스키마를 따른다
 

--- a/skills/tfx-debate/SKILL.md.tmpl
+++ b/skills/tfx-debate/SKILL.md.tmpl
@@ -32,7 +32,7 @@ argument-hint: "<토론 주제 또는 질문>"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -42,7 +42,7 @@ argument-hint: "<토론 주제 또는 질문>"
 |-----|------|
 | Claude | 소프트웨어 아키텍트 — 시스템 설계 관점 |
 | Codex | 시니어 백엔드 엔지니어 — 구현/기술적 트레이드오프 관점 |
-| Gemini | DevOps/인프라 엔지니어 + DX 전문가 — 운영/개발자경험 관점 |
+| Antigravity | DevOps/인프라 엔지니어 + DX 전문가 — 운영/개발자경험 관점 |
 
 ## EXECUTION STEPS
 
@@ -85,7 +85,7 @@ Agent(
 )
 ```
 
-Codex와 Gemini를 headless dispatch로 동시에 실행하라:
+Codex와 Antigravity를 headless dispatch로 동시에 실행하라:
 
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
@@ -133,7 +133,7 @@ Agent(
 )
 ```
 
-Codex와 Gemini 2차 라운드를 headless dispatch로 동시에 실행하라:
+Codex와 Antigravity 2차 라운드를 headless dispatch로 동시에 실행하라:
 
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
@@ -168,7 +168,7 @@ Claude Opus가 전체 토론을 종합하여 다음 구조로 최종 보고서�
 
 ## ERROR RECOVERY
 
-- Codex 또는 Gemini 결과가 없으면: 2개 소스로 교차검증을 진행하고 보고서에 누락 CLI를 명시하라
+- Codex 또는 Antigravity 결과가 없으면: 2개 소스로 교차검증을 진행하고 보고서에 누락 CLI를 명시하라
 - tfx multi 명령이 실패하면: 오류 메시지를 출력하고 재시도 1회 후 실패를 사용자에게 보고하라
 - Agent 결과가 없으면: Claude 관점 없이 나머지 2개 소스로 진행하라
 - Round 2 후에도 불일치가 지속되면: 해소되지 않은 항목으로 보고서에 명시하고 최종 추천은 다수결로 결정하라

--- a/skills/tfx-doctor/SKILL.md
+++ b/skills/tfx-doctor/SKILL.md
@@ -51,7 +51,7 @@ JSON 결과를 파싱하여 마크다운 테이블로 표시:
 | tfx-route.sh | ✅ | v2.0 |
 | HUD | ✅ | 설치됨 |
 | Codex CLI | ✅ | found |
-| Gemini CLI | ⚠ | 미설치 (선택) |
+| Antigravity CLI | ⚠ | 미설치 (선택) |
 | ...  | ... | ... |
 ```
 
@@ -82,7 +82,7 @@ Bash("triflux doctor --fix")
 |-----------|------|
 | claude-usage-cache.json | Claude 사용량 |
 | codex-rate-limits-cache.json | Codex 레이트 리밋 |
-| gemini-quota-cache.json | Gemini 쿼터 |
+| gemini-quota-cache.json | Antigravity 쿼터 |
 | sv-accumulator.json | 절약량 누적 |
 | mcp-inventory.json | MCP 서버 인벤토리 |
 | cli-issues.jsonl | CLI 이슈 로그 |
@@ -145,7 +145,7 @@ options:
 
 - tfx-route.sh 설치 상태
 - HUD 설치 및 설정 상태
-- Codex/Gemini/Claude CLI 경로 (크로스 셸)
+- Codex/Antigravity/Claude CLI 경로 (크로스 셸)
 - **psmux 버전 / capability preflight**
   - `new-session`, `attach-session`, `kill-session`, `capture-pane`, `detach-client`
   - 권장 버전 이상인지 여부
@@ -156,7 +156,7 @@ options:
 - Phase 1 웜업 캐시 무결성 (`node scripts/cache-doctor.mjs`)
 - 잔존 팀(orphan teams) 감지
 - **Docs 동기화** — `docs/design/`, `docs/research/` → `~/.claude/docs/` 레퍼런스 문서 동기화 상태
-- **Gemini MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
+- **Antigravity MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
 - **Route Script 정합성** — 프로젝트 소스 `scripts/tfx-route.sh`와 `~/.claude/scripts/tfx-route.sh` 일치 여부
 
 ## 에러 처리
@@ -165,7 +165,7 @@ options:
 |------|------|
 | 캐시 디렉토리 없음 | 정상 — 삭제할 파일 없음 보고 |
 | 파일 삭제 권한 없음 | 수동 삭제 안내 |
-| --fix 후에도 이슈 남음 | Codex/Gemini 설치는 수동 필요 안내 |
+| --fix 후에도 이슈 남음 | Codex/Antigravity 설치는 수동 필요 안내 |
 
 ## standalone TUI
 

--- a/skills/tfx-doctor/SKILL.md.tmpl
+++ b/skills/tfx-doctor/SKILL.md.tmpl
@@ -51,7 +51,7 @@ JSON 결과를 파싱하여 마크다운 테이블로 표시:
 | tfx-route.sh | ✅ | v2.0 |
 | HUD | ✅ | 설치됨 |
 | Codex CLI | ✅ | found |
-| Gemini CLI | ⚠ | 미설치 (선택) |
+| Antigravity CLI | ⚠ | 미설치 (선택) |
 | ...  | ... | ... |
 ```
 
@@ -82,7 +82,7 @@ Bash("triflux doctor --fix")
 |-----------|------|
 | claude-usage-cache.json | Claude 사용량 |
 | codex-rate-limits-cache.json | Codex 레이트 리밋 |
-| gemini-quota-cache.json | Gemini 쿼터 |
+| gemini-quota-cache.json | Antigravity 쿼터 |
 | sv-accumulator.json | 절약량 누적 |
 | mcp-inventory.json | MCP 서버 인벤토리 |
 | cli-issues.jsonl | CLI 이슈 로그 |
@@ -145,7 +145,7 @@ options:
 
 - tfx-route.sh 설치 상태
 - HUD 설치 및 설정 상태
-- Codex/Gemini/Claude CLI 경로 (크로스 셸)
+- Codex/Antigravity/Claude CLI 경로 (크로스 셸)
 - **psmux 버전 / capability preflight**
   - `new-session`, `attach-session`, `kill-session`, `capture-pane`, `detach-client`
   - 권장 버전 이상인지 여부
@@ -156,7 +156,7 @@ options:
 - Phase 1 웜업 캐시 무결성 (`node scripts/cache-doctor.mjs`)
 - 잔존 팀(orphan teams) 감지
 - **Docs 동기화** — `docs/design/`, `docs/research/` → `~/.claude/docs/` 레퍼런스 문서 동기화 상태
-- **Gemini MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
+- **Antigravity MCP 안전성** — `~/.gemini/settings.json`의 stdio MCP 감지 (spawn EPERM 방지)
 - **Route Script 정합성** — 프로젝트 소스 `scripts/tfx-route.sh`와 `~/.claude/scripts/tfx-route.sh` 일치 여부
 
 ## 에러 처리
@@ -165,7 +165,7 @@ options:
 |------|------|
 | 캐시 디렉토리 없음 | 정상 — 삭제할 파일 없음 보고 |
 | 파일 삭제 권한 없음 | 수동 삭제 안내 |
-| --fix 후에도 이슈 남음 | Codex/Gemini 설치는 수동 필요 안내 |
+| --fix 후에도 이슈 남음 | Codex/Antigravity 설치는 수동 필요 안내 |
 
 ## standalone TUI
 

--- a/skills/tfx-fullcycle/SKILL.md.tmpl
+++ b/skills/tfx-fullcycle/SKILL.md.tmpl
@@ -73,7 +73,7 @@ Phase 1 시작 전 아래 intake를 먼저 수행한다.
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini 워커 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity 워커 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude 워커 → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -84,12 +84,12 @@ Phase 1 시작 전 아래 intake를 먼저 수행한다.
 | Phase 1: Expansion | 아키텍트 — 요구사항 분석, acceptance criteria 도출 | Claude Opus (Agent) |
 | Phase 2: Planning | 플래너 — 태스크 분해, TDD 전략 | Claude Opus (Agent, background) |
 | Phase 2: Planning | 아키텍트 — 기술 설계, 파일 구조, API 인터페이스 | Codex (tfx headless) |
-| Phase 2: Planning | 크리틱 — 리스크 분석, 엣지 케이스, 보안 | Gemini (tfx headless) |
+| Phase 2: Planning | 크리틱 — 리스크 분석, 엣지 케이스, 보안 | Antigravity (tfx headless) |
 | Phase 3: Execution | 구현자 — 코드 작성, TDD RED→GREEN→REFACTOR | Codex (tfx headless) |
-| Phase 3: Execution | 문서/UI 작성자 | Gemini (tfx headless) |
+| Phase 3: Execution | 문서/UI 작성자 | Antigravity (tfx headless) |
 | Phase 4: QA | 기능 검증자 — acceptance criteria 충족 여부 | Claude (Agent, background) |
 | Phase 4: QA | 보안/성능 검증자 — OWASP, 병목, 에러 핸들링 | Codex (tfx headless) |
-| Phase 4: QA | UX/접근성 검증자 — 반응형, DX, 문서화 | Gemini (tfx headless) |
+| Phase 4: QA | UX/접근성 검증자 — 반응형, DX, 문서화 | Antigravity (tfx headless) |
 | Phase 5: Validation | 합의 판정 — Consensus Score 계산 및 완료 결정 | Claude (직접 판단) |
 
 ## EXECUTION STEPS
@@ -123,7 +123,7 @@ JSON 형식으로 출력하라: { tasks, order, dependencies, tdd_strategy, risk
 )
 ```
 
-**Step 2-B: Codex Architect + Gemini Critic (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
+**Step 2-B: Codex Architect + Antigravity Critic (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:시니어 엔지니어로서 다음 기능의 기술적 설계를 작성하라. 기능: {expanded_requirements}. 파일 구조, API 인터페이스, 데이터 모델을 포함하라. JSON 형식: { design, file_changes, interfaces, test_plan }:architect' \
@@ -145,7 +145,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
 
 **라우팅 규칙:**
 - 코드 구현/수정/테스트 작성 → Codex (tfx headless)
-- UI/문서 → Gemini (tfx headless)
+- UI/문서 → Antigravity (tfx headless)
 
 **TDD 실행 순서 (Codex에 전달하는 프롬프트에 명시):**
 1. 테스트 먼저 작성 (RED)
@@ -190,7 +190,7 @@ JSON 형식: { criteria_results, edge_case_findings, overall_pass }"
 )
 ```
 
-**Step 4-B: Codex 보안/성능 + Gemini UX/접근성 (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
+**Step 4-B: Codex 보안/성능 + Antigravity UX/접근성 (Bash — 동시에 위 Agent와 같은 응답에서 호출)**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:보안/성능 관점에서 다음 변경사항을 리뷰하라. OWASP Top 10, 성능 병목, 에러 핸들링, 리소스 누수를 확인하라. 변경 파일: {changed_files}. JSON 형식: { security_findings, performance_findings, overall_pass }:verifier' \
@@ -238,7 +238,7 @@ Phase 4의 3자 결과에 Consensus 프로토콜을 적용한다.
 
 ## Acceptance Criteria
 - [x] {criterion1} — 3/3 PASS
-- [x] {criterion2} — 2/3 PASS (Gemini: 조건부)
+- [x] {criterion2} — 2/3 PASS (Antigravity: 조건부)
 
 ## QA 결과
 - 보안: {findings_count}건 (모두 해결)

--- a/skills/tfx-hub/SKILL.md
+++ b/skills/tfx-hub/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: "<start|stop|status|자유형 작업 설명>"
 
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
-> CLI 에이전트(Codex/Gemini/Claude) 간 실시간 메시지 허브를 관리합니다.
+> CLI 에이전트(Codex/Antigravity/Claude) 간 실시간 메시지 허브를 관리합니다.
 > **커맨드 매칭 + fallthrough**: start/stop/status에 매칭되면 즉시 실행,
 > 매칭 안 되면 **hub 도메인 컨텍스트를 활용한 범용 작업**으로 처리합니다.
 
@@ -96,7 +96,7 @@ Bash("curl -s http://127.0.0.1:27888/status 2>/dev/null || echo '{\"error\":\"hu
 # 사전 등록은 disabled로 두고 `tfx hub start` 이후에만 enabled로 전환한다.
 codex mcp add tfx-hub --url http://127.0.0.1:27888/mcp
 
-# Gemini (settings.json)
+# Antigravity (settings.json)
 # mcpServers.tfx-hub.url = "http://127.0.0.1:27888/mcp"
 
 # Claude

--- a/skills/tfx-hub/SKILL.md.tmpl
+++ b/skills/tfx-hub/SKILL.md.tmpl
@@ -16,7 +16,7 @@ argument-hint: "<start|stop|status|자유형 작업 설명>"
 
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
-> CLI 에이전트(Codex/Gemini/Claude) 간 실시간 메시지 허브를 관리합니다.
+> CLI 에이전트(Codex/Antigravity/Claude) 간 실시간 메시지 허브를 관리합니다.
 > **커맨드 매칭 + fallthrough**: start/stop/status에 매칭되면 즉시 실행,
 > 매칭 안 되면 **hub 도메인 컨텍스트를 활용한 범용 작업**으로 처리합니다.
 
@@ -96,7 +96,7 @@ Bash("curl -s http://127.0.0.1:27888/status 2>/dev/null || echo '{\"error\":\"hu
 # 사전 등록은 disabled로 두고 `tfx hub start` 이후에만 enabled로 전환한다.
 codex mcp add tfx-hub --url http://127.0.0.1:27888/mcp
 
-# Gemini (settings.json)
+# Antigravity (settings.json)
 # mcpServers.tfx-hub.url = "http://127.0.0.1:27888/mcp"
 
 # Claude

--- a/skills/tfx-index/SKILL.md
+++ b/skills/tfx-index/SKILL.md
@@ -29,7 +29,7 @@ argument-hint: "[--update] [경로]"
 
 > SuperClaude index-repo 오마주. 1회 2K 토큰으로 인덱스 생성, 이후 세션마다 55K 토큰 절감.
 
-> **Gemini 위임**: 스캔 + 인덱스 생성 작업은 Gemini CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
+> **Antigravity 위임**: 스캔 + 인덱스 생성 작업은 Antigravity CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
 
 ## 원리
 
@@ -58,9 +58,9 @@ AskUserQuestion:
 
 `--update` 플래그나 경로 인자가 이미 제공된 경우 이 단계를 건너뛴다.
 
-### Step 1: Gemini에 스캔 + 인덱스 생성 위임
+### Step 1: Antigravity에 스캔 + 인덱스 생성 위임
 
-Claude는 프로젝트 경로와 모드를 Gemini에 전달하고, Gemini가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
+Claude는 프로젝트 경로와 모드를 Antigravity에 전달하고, Antigravity가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Scan the project at {path}. For each source file, extract: exports, imports, line count, file type. Exclude node_modules/, .git/, dist/, build/, coverage/, *.lock, *.log, *.map. Generate both PROJECT_INDEX.md and PROJECT_INDEX.json following this format:
@@ -92,16 +92,16 @@ Mode: {mode}
 '")
 ```
 
-Gemini 출력을 받은 후 Claude가 파일로 기록한다:
+Antigravity 출력을 받은 후 Claude가 파일로 기록한다:
 
 ```
 Write("PROJECT_INDEX.md", <md_section>)
 Write("PROJECT_INDEX.json", <json_section>)
 ```
 
-#### Fallback: Gemini 실패 시
+#### Fallback: Antigravity 실패 시
 
-Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
+Antigravity 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
 
 ```
 1. 병렬 Glob으로 파일 트리 수집 (**/*.{ts,js,mjs,tsx,jsx,...})
@@ -139,11 +139,11 @@ Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직�
 
 ## 토큰 예산
 
-| 작업 | Claude | Gemini |
+| 작업 | Claude | Antigravity |
 |------|--------|--------|
 | 모드 선택 (Step 0) | ~100 | — |
-| 스캔 + 메타데이터 추출 | — | Gemini 부담 |
-| 인덱스 생성 (MD + JSON) | — | Gemini 부담 |
+| 스캔 + 메타데이터 추출 | — | Antigravity 부담 |
+| 인덱스 생성 (MD + JSON) | — | Antigravity 부담 |
 | 파일 쓰기 (Write) | ~300 | — |
 | 검증 (Step 2) | ~100 | — |
 | **Claude 총합** | **~500** | — |

--- a/skills/tfx-index/SKILL.md.tmpl
+++ b/skills/tfx-index/SKILL.md.tmpl
@@ -19,7 +19,7 @@ argument-hint: "[--update] [경로]"
 
 > SuperClaude index-repo 오마주. 1회 2K 토큰으로 인덱스 생성, 이후 세션마다 55K 토큰 절감.
 
-> **Gemini 위임**: 스캔 + 인덱스 생성 작업은 Gemini CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
+> **Antigravity 위임**: 스캔 + 인덱스 생성 작업은 Antigravity CLI에 위임한다. Claude는 모드 선택(Step 0)과 파일 쓰기만 담당. Claude 토큰 소비 ~500 tokens으로 줄어든다.
 
 ## 원리
 
@@ -48,9 +48,9 @@ AskUserQuestion:
 
 `--update` 플래그나 경로 인자가 이미 제공된 경우 이 단계를 건너뛴다.
 
-### Step 1: Gemini에 스캔 + 인덱스 생성 위임
+### Step 1: Antigravity에 스캔 + 인덱스 생성 위임
 
-Claude는 프로젝트 경로와 모드를 Gemini에 전달하고, Gemini가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
+Claude는 프로젝트 경로와 모드를 Antigravity에 전달하고, Antigravity가 파일 트리 스캔·메타데이터 추출·인덱스 생성을 모두 수행한다.
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Scan the project at {path}. For each source file, extract: exports, imports, line count, file type. Exclude node_modules/, .git/, dist/, build/, coverage/, *.lock, *.log, *.map. Generate both PROJECT_INDEX.md and PROJECT_INDEX.json following this format:
@@ -82,16 +82,16 @@ Mode: {mode}
 '")
 ```
 
-Gemini 출력을 받은 후 Claude가 파일로 기록한다:
+Antigravity 출력을 받은 후 Claude가 파일로 기록한다:
 
 ```
 Write("PROJECT_INDEX.md", <md_section>)
 Write("PROJECT_INDEX.json", <json_section>)
 ```
 
-#### Fallback: Gemini 실패 시
+#### Fallback: Antigravity 실패 시
 
-Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
+Antigravity 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직접 원래 워크플로우로 폴백한다:
 
 ```
 1. 병렬 Glob으로 파일 트리 수집 (**/*.{ts,js,mjs,tsx,jsx,...})
@@ -129,11 +129,11 @@ Gemini 위임이 실패하거나 `tfx-route.sh`가 없는 경우, Claude가 직�
 
 ## 토큰 예산
 
-| 작업 | Claude | Gemini |
+| 작업 | Claude | Antigravity |
 |------|--------|--------|
 | 모드 선택 (Step 0) | ~100 | — |
-| 스캔 + 메타데이터 추출 | — | Gemini 부담 |
-| 인덱스 생성 (MD + JSON) | — | Gemini 부담 |
+| 스캔 + 메타데이터 추출 | — | Antigravity 부담 |
+| 인덱스 생성 (MD + JSON) | — | Antigravity 부담 |
 | 파일 쓰기 (Write) | ~300 | — |
 | 검증 (Step 2) | ~100 | — |
 | **Claude 총합** | **~500** | — |

--- a/skills/tfx-interview/SKILL.md
+++ b/skills/tfx-interview/SKILL.md
@@ -25,24 +25,24 @@ argument-hint: "<구현할 주제 또는 요구사항>"
 > OMC deep-interview + ouroboros 오마주. 모호성을 숫자로 측정하고 20% 미만까지 질문한다.
 > "측정할 수 없으면 개선할 수 없다."
 >
-> **Gemini 위임**: 분석·점수 계산·산출물 초안은 Gemini CLI에 위임하여 Claude 토큰을 절약한다.
+> **Antigravity 위임**: 분석·점수 계산·산출물 초안은 Antigravity CLI에 위임하여 Claude 토큰을 절약한다.
 > 위임 패턴: `Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")`
 
 ## 위임 패턴
 
-Claude와 Gemini의 역할을 분리하여 토큰을 최적화한다.
+Claude와 Antigravity의 역할을 분리하여 토큰을 최적화한다.
 
 | 담당 | 작업 |
 |------|------|
 | **Claude** | AskUserQuestion (사용자 상호작용), 최종 파일 저장 |
-| **Gemini** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
+| **Antigravity** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
 
 ```bash
 # 위임 호출 형태
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")
 ```
 
-Gemini 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
+Antigravity 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
 
 ## 용도
 
@@ -77,14 +77,14 @@ ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)
 
 ### Step 1: 초기 모호성 평가
 
-사용자 입력을 Gemini에 전달하여 초기 ambiguity score를 계산한다:
+사용자 입력을 Antigravity에 전달하여 초기 ambiguity score를 계산한다:
 
 ```bash
-# Claude → Gemini 위임
+# Claude → Antigravity 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Analyze the following requirement and calculate ambiguity score. Return JSON: {goal, constraints, criteria, ambiguity, suggested_questions}: {user_input}'")
 ```
 
-Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
+Antigravity가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ```
 출력 예시:
@@ -97,9 +97,9 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ### Step 2: 5단계 인터뷰 (모호성 < 20%까지)
 
-각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Gemini에 전달하여 분석 및 다음 질문을 생성한다.
+각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Antigravity에 전달하여 분석 및 다음 질문을 생성한다.
 
-흐름: `Claude(질문) → 사용자(응답) → Gemini(분석+재계산) → Claude(다음 질문 제시)`
+흐름: `Claude(질문) → 사용자(응답) → Antigravity(분석+재계산) → Claude(다음 질문 제시)`
 
 #### Stage 1: Clarify (명확화) — goal 개선
 
@@ -111,15 +111,15 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 작업의 핵심 목표를 한 문장으로 설명해주세요."
 2. "완료 후 어떤 상태가 되어야 성공인가요?"
@@ -135,15 +135,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 작업을 3-5개의 독립된 단계로 나눈다면?"
 2. "각 단계 사이에 의존성이 있나요?"
@@ -159,15 +159,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "이 방식이 실패할 수 있는 시나리오는 무엇인가요?"
 2. "6개월 후 유지보수할 때 문제가 될 부분은 무엇인가요?"
@@ -183,15 +183,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "같은 목표를 달성할 수 있는 완전히 다른 접근은 무엇인가요?"
 2. "시간이 절반밖에 없다면 어떤 방식을 택하겠습니까?"
@@ -207,15 +207,15 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 최종 분석 위임
+# 응답 수집 후 Antigravity에 최종 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
+응답 후: Antigravity JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
 ```
 
-**질문 템플릿 (Gemini 실패 시 Fallback):**
+**질문 템플릿 (Antigravity 실패 시 Fallback):**
 
 1. "지금까지의 논의를 종합하면, 최적의 접근 방식은 무엇인가요?"
 2. "첫 번째 단계로 무엇을 실행하시겠습니까?"
@@ -238,14 +238,14 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis
 
 ### Step 4: 산출물 생성
 
-Gemini가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
+Antigravity가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
 
 ```bash
-# Gemini에 산출물 초안 생성 위임
+# Antigravity에 산출물 초안 생성 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Generate a structured interview output document based on the following interview context: {full_context}. Return the complete markdown document.'")
 ```
 
-Claude는 Gemini가 반환한 마크다운을 Write 도구로 저장한다.
+Claude는 Antigravity가 반환한 마크다운을 Write 도구로 저장한다.
 
 저장 위치: `.tfx/plans/interview-{timestamp}.md`
 
@@ -299,7 +299,7 @@ Date: {date} | Final Ambiguity: {score}%
 
 ## 토큰 예산
 
-| 단계 | Claude | Gemini |
+| 단계 | Claude | Antigravity |
 |------|--------|--------|
 | 초기 평가 (모호성 분석) | ~0.2K | ~1K |
 | 5단계 인터뷰 (질문 제시) | ~1K | ~10K |
@@ -308,7 +308,7 @@ Date: {date} | Final Ambiguity: {score}%
 | 코드베이스 탐색 | ~0.3K | — |
 | **총합** | **~2K** | **~13K** |
 
-Fallback: Gemini 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
+Fallback: Antigravity 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
 
 ## 사용 예
 

--- a/skills/tfx-interview/SKILL.md.tmpl
+++ b/skills/tfx-interview/SKILL.md.tmpl
@@ -20,24 +20,24 @@ argument-hint: "<구현할 주제 또는 요구사항>"
 > OMC deep-interview + ouroboros 오마주. 모호성을 숫자로 측정하고 20% 미만까지 질문한다.
 > "측정할 수 없으면 개선할 수 없다."
 >
-> **Gemini 위임**: 분석·점수 계산·산출물 초안은 Gemini CLI에 위임하여 Claude 토큰을 절약한다.
+> **Antigravity 위임**: 분석·점수 계산·산출물 초안은 Antigravity CLI에 위임하여 Claude 토큰을 절약한다.
 > 위임 패턴: `Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")`
 
 ## 위임 패턴
 
-Claude와 Gemini의 역할을 분리하여 토큰을 최적화한다.
+Claude와 Antigravity의 역할을 분리하여 토큰을 최적화한다.
 
 | 담당 | 작업 |
 |------|------|
 | **Claude** | AskUserQuestion (사용자 상호작용), 최종 파일 저장 |
-| **Gemini** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
+| **Antigravity** | 모호성 점수 계산, 질문 생성, 응답 분석, 산출물 초안 |
 
 ```bash
 # 위임 호출 형태
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '{prompt}'")
 ```
 
-Gemini 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
+Antigravity 실패 시 Fallback: Claude Opus가 분석을 직접 처리한다.
 
 ## 용도
 
@@ -72,14 +72,14 @@ ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)
 
 ### Step 1: 초기 모호성 평가
 
-사용자 입력을 Gemini에 전달하여 초기 ambiguity score를 계산한다:
+사용자 입력을 Antigravity에 전달하여 초기 ambiguity score를 계산한다:
 
 ```bash
-# Claude → Gemini 위임
+# Claude → Antigravity 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Analyze the following requirement and calculate ambiguity score. Return JSON: {goal, constraints, criteria, ambiguity, suggested_questions}: {user_input}'")
 ```
 
-Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
+Antigravity가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ```
 출력 예시:
@@ -92,9 +92,9 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 
 ### Step 2: 5단계 인터뷰 (모호성 < 20%까지)
 
-각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Gemini에 전달하여 분석 및 다음 질문을 생성한다.
+각 단계에서 Claude가 AskUserQuestion으로 질문하고, 사용자 응답을 Antigravity에 전달하여 분석 및 다음 질문을 생성한다.
 
-흐름: `Claude(질문) → 사용자(응답) → Gemini(분석+재계산) → Claude(다음 질문 제시)`
+흐름: `Claude(질문) → 사용자(응답) → Antigravity(분석+재계산) → Claude(다음 질문 제시)`
 
 #### Stage 1: Clarify (명확화) — goal 개선
 
@@ -106,12 +106,12 @@ Gemini가 반환한 JSON에서 점수를 읽어 사용자에게 표시한다:
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 goal 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 2: Decompose (분해) — constraints 개선
@@ -124,12 +124,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 1 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 3: Challenge (반론) — 숨은 제약 발견
@@ -142,12 +142,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 2 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 constraints + criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 4: Alternatives (대안) — criteria 정밀화
@@ -160,12 +160,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 3 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 분석 위임
+# 응답 수집 후 Antigravity에 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
+응답 후: Antigravity JSON에서 criteria 점수 읽기 → ambiguity 재계산 결과 사용자에게 표시
 ```
 
 #### Stage 5: Synthesize (종합) — 최종 확인
@@ -178,12 +178,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 4 response analysis
 ```
 
 ```bash
-# 응답 수집 후 Gemini에 최종 분석 위임
+# 응답 수집 후 Antigravity에 최종 분석 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis. Previous context: {context}. User answer: {answer}. Calculate updated ambiguity score and generate next stage questions. Return JSON.'")
 ```
 
 ```
-응답 후: Gemini JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
+응답 후: Antigravity JSON에서 전체 점수 읽기 → 최종 ambiguity score 사용자에게 표시
 ```
 
 ### Step 3: 조기 종료 판단
@@ -203,14 +203,14 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Stage 5 response analysis
 
 ### Step 4: 산출물 생성
 
-Gemini가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
+Antigravity가 인터뷰 전체 컨텍스트를 바탕으로 구조화된 문서 초안을 생성하고, Claude가 파일로 저장한다:
 
 ```bash
-# Gemini에 산출물 초안 생성 위임
+# Antigravity에 산출물 초안 생성 위임
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec 'Generate a structured interview output document based on the following interview context: {full_context}. Return the complete markdown document.'")
 ```
 
-Claude는 Gemini가 반환한 마크다운을 Write 도구로 저장한다.
+Claude는 Antigravity가 반환한 마크다운을 Write 도구로 저장한다.
 
 저장 위치: `.omc/plans/interview-{timestamp}.md`
 
@@ -264,7 +264,7 @@ Date: {date} | Final Ambiguity: {score}%
 
 ## 토큰 예산
 
-| 단계 | Claude | Gemini |
+| 단계 | Claude | Antigravity |
 |------|--------|--------|
 | 초기 평가 (모호성 분석) | ~0.2K | ~1K |
 | 5단계 인터뷰 (질문 제시) | ~1K | ~10K |
@@ -273,7 +273,7 @@ Date: {date} | Final Ambiguity: {score}%
 | 코드베이스 탐색 | ~0.3K | — |
 | **총합** | **~2K** | **~13K** |
 
-Fallback: Gemini 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
+Fallback: Antigravity 호출 실패 시 Claude Opus가 분석을 직접 처리한다 (총합 ~15K).
 
 ## 사용 예
 

--- a/skills/tfx-multi/SKILL.md.tmpl
+++ b/skills/tfx-multi/SKILL.md.tmpl
@@ -1,9 +1,9 @@
 ---
 name: tfx-multi
 description: >
-  멀티-CLI 팀 모드. Claude Native Agent Teams + Codex/Gemini 멀티모델 오케스트레이션.
+  멀티-CLI 팀 모드. Claude Native Agent Teams + Codex/Antigravity 멀티모델 오케스트레이션.
   '멀티로', '팀 모드', '다중 CLI', '3개 다 동원', 'multi' 같은 요청에 반드시 사용.
-  Claude+Codex+Gemini 협업이 필요한 모든 상황에 적극 활용.
+  Claude+Codex+Antigravity 협업이 필요한 모든 상황에 적극 활용.
 triggers:
   - tfx-multi
 argument-hint: '"작업 설명" | --agents codex,gemini "작업" | --tmux "작업" | status | stop'
@@ -17,7 +17,7 @@ argument-hint: '"작업 설명" | --agents codex,gemini "작업" | --tmux "작�
 
 > **인프라**: 다른 스킬이 내부적으로 사용. 직접 호출할 필요 없음.
 > Claude Code Native Teams의 Shift+Down 네비게이션을 복원한다.
-> Codex/Gemini 워커마다 최소 프롬프트(~100 토큰)의 슬림 Agent 래퍼를 spawn하여 네비게이션에 등록하고,
+> Codex/Antigravity 워커마다 최소 프롬프트(~100 토큰)의 슬림 Agent 래퍼를 spawn하여 네비게이션에 등록하고,
 > 실제 작업은 `tfx-route.sh`가 수행한다. task 상태는 `team_task_list`를 truth source로 검증한다.
 > v3 — `--thorough`(기본: plan→prd→exec→verify→fix loop) + `--quick`(경량 모드).
 
@@ -84,7 +84,7 @@ preflight와 Agent 생성을 병렬로 실행하여 사용자 체감 지연을 �
 ### Phase 3: Lead-Direct Headless 실행 (v6.0.0, 기본)
 
 > **MANDATORY: CLI 워커는 headless 엔진으로 실행**
-> CLI 워커(Codex/Gemini)는 반드시 아래 `Bash()` 명령으로 headless 엔진을 통해 실행한다.
+> CLI 워커(Codex/Antigravity)는 반드시 아래 `Bash()` 명령으로 headless 엔진을 통해 실행한다.
 > `Bash(tfx-route.sh)` 개별 호출이나 `Agent()` CLI 래핑은 PreToolUse 훅이 자동 차단/변환한다.
 > headless 엔진이 psmux 세션 생성 → WT 자동 팝업 → CLI dispatch → 결과 수집을 전부 처리한다.
 

--- a/skills/tfx-multi/references/agent-wrapper-rules.md
+++ b/skills/tfx-multi/references/agent-wrapper-rules.md
@@ -3,8 +3,8 @@
 ## 슬림 래퍼의 존재 이유
 
 Native Teams의 teammate는 Claude 모델만 가능하다.
-Codex/Gemini는 teammate로 직접 등록할 수 없으므로, Claude slim wrapper를 spawn하고
-래퍼 내부에서 `tfx-route.sh`로 Codex/Gemini CLI를 실행하는 구조이다.
+Codex/Antigravity는 teammate로 직접 등록할 수 없으므로, Claude slim wrapper를 spawn하고
+래퍼 내부에서 `tfx-route.sh`로 Codex/Antigravity CLI를 실행하는 구조이다.
 
 래퍼가 존재하는 이유:
 1. **Shift+Down 네비게이션 등록** — 래퍼 없이 Lead가 직접 Bash를 실행하면 네비게이션에 등록되지 않음
@@ -15,7 +15,7 @@ Codex/Gemini는 teammate로 직접 등록할 수 없으므로, Claude slim wrapp
 
 ### 1. Agent 래퍼 생략 금지
 
-Codex/Gemini 서브태스크는 워커 수에 관계없이 반드시 Agent 래퍼를 spawn해야 한다.
+Codex/Antigravity 서브태스크는 워커 수에 관계없이 반드시 Agent 래퍼를 spawn해야 한다.
 단일 워커(1:gemini 등)여도 Lead가 직접 Bash를 실행하면 안 된다.
 Lead가 "효율적"이라고 판단해서 Agent를 건너뛰는 것은 금지한다.
 

--- a/skills/tfx-panel/SKILL.md.tmpl
+++ b/skills/tfx-panel/SKILL.md.tmpl
@@ -25,7 +25,7 @@ argument-hint: "<토론 주제>"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "<토론 주제>"
 |-----|------|----------------|
 | Claude (Opus) | 패널 모더레이터 + 인문/전략 전문가 | 리팩터링, 점진적 설계, 요구사항 |
 | Codex | 기술 구현 전문가 | 아키텍처, 마이크로서비스, 클라우드 |
-| Gemini | 통합/비즈니스 전문가 | 통합 패턴, 경쟁 전략, 프로덕트 |
+| Antigravity | 통합/비즈니스 전문가 | 통합 패턴, 경쟁 전략, 프로덕트 |
 
 ## 전문가 풀
 
@@ -84,7 +84,7 @@ argument-hint: "<토론 주제>"
 분배 예시 (`"우리 모놀리스를 마이크로서비스로 전환해야 할까?"`):
 - Claude 담당: Martin Fowler (리팩터링), Kent Beck (점진적 설계)
 - Codex 담당: Sam Newman (마이크로서비스), Michael Porter (전략)
-- Gemini 담당: Gregor Hohpe (통합 패턴), Karl Wiegers (요구사항)
+- Antigravity 담당: Gregor Hohpe (통합 패턴), Karl Wiegers (요구사항)
 
 주제가 모호하면 AskUserQuestion으로 명확화한다.
 
@@ -106,7 +106,7 @@ JSON 형식으로 응답:
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:당신은 {codex_expert_1}({role_3})과 {codex_expert_2}({role_4})입니다. 주제: {topic}. 각 전문가의 고유 관점에서 독립 분석. 상호 참조 금지. JSON: {experts:[{name,position,reasoning,concerns,recommendation,confidence}]}:analyst' \
@@ -164,7 +164,7 @@ tfx-consensus 프로토콜 적용:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent로 해당 전문가 재분석
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent로 해당 전문가 재분석
 - 결과 파싱 실패 → 원문 그대로 Step 3에 투입하여 모더레이터가 정리
 - 전문가 선정 불확실 → AskUserQuestion으로 사용자 확인 후 진행
 

--- a/skills/tfx-persist/SKILL.md.tmpl
+++ b/skills/tfx-persist/SKILL.md.tmpl
@@ -39,8 +39,8 @@ argument-hint: "<완료할 작업 설명>"
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 정상 | 기존 headless multi (변경 없음) |
-| **Tier 2** | 일부 CLI만 가용 (Codex 또는 Gemini 중 하나) | 가용 CLI + Claude Agent 조합 |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 정상 | 기존 headless multi (변경 없음) |
+| **Tier 2** | 일부 CLI만 가용 (Codex 또는 Antigravity 중 하나) | 가용 CLI + Claude Agent 조합 |
 | **Tier 3** | headless 불가 또는 `claude -p` one-shot | Claude Agent only |
 
 ```
@@ -56,10 +56,10 @@ IF Hub 미응답:
   → 재시작 실패 → Tier 3
   → Tier 3
 
-IF Codex 없음 AND Gemini 없음:
+IF Codex 없음 AND Antigravity 없음:
   → Tier 3
 
-IF Codex 없음 OR Gemini 없음:
+IF Codex 없음 OR Antigravity 없음:
   → Tier 2
 
 ELSE:
@@ -71,7 +71,7 @@ ELSE:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드로 실행합니다 (consensus 미적용)
   누락: {missing_components}
-  권장: tmux/psmux, Hub, Codex CLI, Gemini CLI 설치 후 재실행
+  권장: tmux/psmux, Hub, Codex CLI, Antigravity CLI 설치 후 재실행
 ```
 
 Tier 3에서는 모든 headless dispatch(`tfx multi ...`)를 **Claude Agent**(subagent)로 대체한다.
@@ -82,7 +82,7 @@ Tier 2에서는 누락된 CLI만 Claude Agent로 대체한다.
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini 검증자 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity 검증자 → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude 검증자 → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 5. 루프 종료 조건: 모든 criteria 3자 검증 통과 + 통합 검증 Consensus >= 70
@@ -93,12 +93,12 @@ Tier 2에서는 누락된 CLI만 Claude Agent로 대체한다.
 |------|------|------|
 | Goal Definition | 완료 기준 추출 및 사용자 확인 | Claude (직접 실행) |
 | 구현 (단순) | 코드 작성, 파일 수정, 테스트 | Codex (tfx headless) |
-| 구현 (복잡) | 태스크 분해 후 병렬 실행 | Codex + Gemini (tfx headless) |
+| 구현 (복잡) | 태스크 분해 후 병렬 실행 | Codex + Antigravity (tfx headless) |
 | 기준별 검증 — Claude | 코드 읽기 + 논리 검증 | Claude (Agent, background) |
 | 기준별 검증 — Codex | 코드 실행 + 테스트 검증 | Codex (tfx headless) |
-| 기준별 검증 — Gemini | 코드 리뷰 + 품질 검증 | Gemini (tfx headless) |
-| 통합 검증 | 전체 criteria 최종 합의 | Claude + Codex + Gemini (동시) |
-| Deslop Pass | 슬롭 감지 및 제거 | Codex + Gemini (tfx headless) |
+| 기준별 검증 — Antigravity | 코드 리뷰 + 품질 검증 | Antigravity (tfx headless) |
+| 통합 검증 | 전체 criteria 최종 합의 | Claude + Codex + Antigravity (동시) |
+| Deslop Pass | 슬롭 감지 및 제거 | Codex + Antigravity (tfx headless) |
 
 ## EXECUTION STEPS
 
@@ -156,7 +156,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
+**Codex + Antigravity 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 기준 충족 여부를 코드 실행/테스트로 검증하라. 기준: {current_criterion}. 실제 테스트를 실행하여 결과를 확인하라. 결과: PASS 또는 FAIL + 근거 1문장:verifier' \
@@ -198,7 +198,7 @@ JSON 형식: { criteria_results: [{criterion, pass, reason}], regression_check, 
 )
 ```
 
-**Codex + Gemini 통합 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
+**Codex + Antigravity 통합 검증 (Bash — 동시에 위 Agent와 같은 응답에서 호출):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:모든 acceptance criteria 충족 여부를 테스트 실행으로 통합 검증하라. 기준 목록: {criteria_list}. 전체 테스트 스위트를 실행하고 회귀 여부를 확인하라. JSON 형식: { criteria_results, test_results, overall_pass }:verifier' \
@@ -232,7 +232,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
 Consensus Score: {score}%
 변경 파일: {count}개
 테스트: {pass}/{total} 통과
-검증: Claude PASS | Codex PASS | Gemini PASS
+검증: Claude PASS | Codex PASS | Antigravity PASS
 ```
 
 ## ANTI-STUCK 메커니즘

--- a/skills/tfx-plan/SKILL.md
+++ b/skills/tfx-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 internal: true
 name: tfx-plan
-description: "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Gemini) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터."
+description: "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Antigravity) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터."
 triggers:
   - plan
   - 계획
@@ -19,14 +19,14 @@ argument-hint: "<구현할 기능> [--quick]"
 
 > **ARGUMENTS 처리**: `--quick` → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Opus 4.6(Planner) + Codex(Architect) + Gemini(Critic) Tri-Model 합의.
-> 빠른 Gemini 위임 계획은 `--quick`.
+> AI makes completeness near-free. 기본은 Opus 4.6(Planner) + Codex(Architect) + Antigravity(Critic) Tri-Model 합의.
+> 빠른 Antigravity 위임 계획은 `--quick`.
 
 ---
 
 ## 모드 분기
 
-`--quick` → Quick 모드 (Gemini 위임).
+`--quick` → Quick 모드 (Antigravity 위임).
 그 외 → Deep 모드 (기본, 3-Model 합의 + 교차 검토).
 
 ---
@@ -56,7 +56,7 @@ Tier 3:
 
 ### HARD RULES
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -66,7 +66,7 @@ Tier 3:
 |-------|------|------|
 | Claude Opus (Planner) | 전략 비전 | 리스크 통합, 아키텍처 결정 |
 | Codex (Architect) | 기술 설계 | API, 파일 구조, 구현 세부 |
-| Gemini (Critic) | 리스크 분석 | 엣지케이스, 보안, 테스트 전략 |
+| Antigravity (Critic) | 리스크 분석 | 엣지케이스, 보안, 테스트 전략 |
 
 ### EXECUTION — TASK 는 사용자 입력
 
@@ -96,7 +96,7 @@ Agent(
 )
 ```
 
-**Bash (Codex Architect + Gemini Critic):**
+**Bash (Codex Architect + Antigravity Critic):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:시니어 엔지니어 기술 설계. 기능: [TASK]. 코드베이스: [RECON]. JSON: { architecture, components, data_models, api, files, impl_notes, confidence }:architect' \
@@ -123,7 +123,7 @@ Agent(
 )
 ```
 
-**Bash:** (위와 동일 패턴, Codex/Gemini 각각 교차검토)
+**Bash:** (위와 동일 패턴, Codex/Antigravity 각각 교차검토)
 
 #### Step 5: 합의 점수 산출 (Claude 직접)
 
@@ -143,7 +143,7 @@ consensus_score = CONSENSUS / 전체 * 100
 
 ```markdown
 ## 합의된 구현 계획: [TASK]
-**Consensus**: {score}% | **Rounds**: {n} | **Models**: Opus+Codex+Gemini
+**Consensus**: {score}% | **Rounds**: {n} | **Models**: Opus+Codex+Antigravity
 
 ### 설계 방향
 ### 태스크 (T1..., 복잡도, 합의 P:A:C)
@@ -162,13 +162,13 @@ consensus_score = CONSENSUS / 전체 * 100
 ### Step 1: 요구사항 파싱
 사용자 입력 + PROJECT_INDEX.md (있으면) + Glob 파일 목록.
 
-### Step 2: Gemini 위임
+### Step 2: Antigravity 위임
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍트로서 구현 계획. 기능: {feature}. 컨텍스트: {context}. 파일: {file_list}. 출력: 1) 영향 범위 2) 태스크 분해 (검증 방법 포함) 3) 리스크/의존성 4) 복잡도'")
 ```
 
-**Fallback**: Gemini 실패 시 Claude Opus 직접.
+**Fallback**: Antigravity 실패 시 Claude Opus 직접.
 
 ### Step 3: 구조화 출력
 
@@ -181,12 +181,12 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍
 ### 복잡도: {level}
 ```
 
-### Token (Quick): ~1.5K (Claude), ~2K (Gemini)
+### Token (Quick): ~1.5K (Claude), ~2K (Antigravity)
 
 ## 사용 예
 
 ```
 /tfx-plan "JWT 인증 미들웨어 추가"          # Deep (기본)
 /tfx-plan "마이크로서비스 분리"             # Deep
-/tfx-plan --quick "README 섹션 추가"        # Quick (Gemini)
+/tfx-plan --quick "README 섹션 추가"        # Quick (Antigravity)
 ```

--- a/skills/tfx-plan/SKILL.md.tmpl
+++ b/skills/tfx-plan/SKILL.md.tmpl
@@ -16,27 +16,27 @@ argument-hint: "<구현할 기능 설명>"
 
 
 > **Deep 버전**: tfx-deep-plan. "제대로/꼼꼼히" 수정자로 자동 에스컬레이션.
-> Gemini 위임 빠른 계획 — Claude는 컨텍스트 수집·출력 포맷만, 핵심 계획 수립은 Gemini에 위임.
+> Antigravity 위임 빠른 계획 — Claude는 컨텍스트 수집·출력 포맷만, 핵심 계획 수립은 Antigravity에 위임.
 
 ## 워크플로우
 
 ### Step 1: 요구사항 파싱
 사용자 입력 + 프로젝트 컨텍스트(PROJECT_INDEX.md 있으면 활용)에서 핵심 추출.
 
-### Step 2: Gemini 위임 계획 수립
+### Step 2: Antigravity 위임 계획 수립
 
 Claude는 최소 컨텍스트만 수집한다.
 - Glob으로 영향 가능 파일 목록 수집
 - PROJECT_INDEX.md 존재 시 읽기 (없으면 생략)
 
-수집 후 Gemini에 위임:
+수집 후 Antigravity에 위임:
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini exec '소프트웨어 아키텍트로서 다음 기능의 구현 계획을 수립하라.\n기능: {feature}\n프로젝트 컨텍스트: {context}\n관련 파일: {file_list}\n\n출력 형식:\n1. 영향 범위 (수정할 파일 목록)\n2. 태스크 분해 (순서대로, 각 태스크에 검증 방법 포함)\n3. 리스크 및 의존성\n4. 예상 복잡도 (low/medium/high)'")
 ```
 
-Claude는 Gemini 출력을 받아 아래 출력 형식으로 포맷팅만 수행한다.
+Claude는 Antigravity 출력을 받아 아래 출력 형식으로 포맷팅만 수행한다.
 
-> **Fallback**: Gemini 호출이 실패(exit non-zero 또는 빈 출력)하면 Claude Opus가 동일 프롬프트로 직접 계획을 수립한다.
+> **Fallback**: Antigravity 호출이 실패(exit non-zero 또는 빈 출력)하면 Claude Opus가 동일 프롬프트로 직접 계획을 수립한다.
 
 ### Step 3: 구조화된 계획 출력
 ```markdown
@@ -65,4 +65,4 @@ Claude는 Gemini 출력을 받아 아래 출력 형식으로 포맷팅만 수행
 | Claude 출력 | ~2K (계획 전문) | ~0.5K (포맷팅만) |
 | 합계 | ~8K | ~1.5K (**-81%**) |
 
-Gemini가 계획 생성의 대부분을 담당하므로 Claude 토큰 비용이 대폭 감소한다.
+Antigravity가 계획 생성의 대부분을 담당하므로 Claude 토큰 비용이 대폭 감소한다.

--- a/skills/tfx-plan/skill.json
+++ b/skills/tfx-plan/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-plan",
-  "description": "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Gemini) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터.",
+  "description": "구현 계획이 필요할 때 사용한다. '계획 세워줘', 'plan', '플랜', '어떻게 구현하지', '태스크 분해', '작업 순서', '합의 계획', 'ralplan', '철저한 계획' 같은 요청에 반드시 사용. 기본값은 3자 합의(Opus+Codex+Antigravity) 딥 계획. 빠른 단일 CLI 계획은 --quick 파라미터.",
   "triggers": [
     "plan",
     "계획",

--- a/skills/tfx-profile/SKILL.md
+++ b/skills/tfx-profile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tfx-profile
 description: >
-  Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
+  Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
   프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반
   인터랙티브 선택지로 수행합니다.
   Use when: codex profile, codex model, gemini profile, gemini model,
@@ -12,10 +12,10 @@ triggers:
 argument-hint: "[--list] [--codex | --gemini]"
 ---
 
-# tfx-profile — Codex/Gemini 프로파일 매니저
+# tfx-profile — Codex/Antigravity 프로파일 매니저
 
 > CLI 프로파일의 모델/effort를 AskUserQuestion 선택지로 관리합니다.
-> Codex(`~/.codex/config.toml`)와 Gemini(`~/.gemini/triflux-profiles.json`) 모두 지원.
+> Codex(`~/.codex/config.toml`)와 Antigravity(`~/.gemini/triflux-profiles.json`) 모두 지원.
 
 ## 워크플로우
 
@@ -30,7 +30,7 @@ header: "CLI"
 options:
   - label: "Codex"
     description: "~/.codex/config.toml (TOML)"
-  - label: "Gemini"
+  - label: "Antigravity"
     description: "~/.gemini/triflux-profiles.json (JSON)"
 ```
 
@@ -101,7 +101,7 @@ options:
 
 ---
 
-## Gemini 워크플로우
+## Antigravity 워크플로우
 
 ### Step 1: triflux-profiles.json 읽기 + 현재 상태 표시
 
@@ -173,7 +173,7 @@ options:
 - **다른 섹션 건드리지 않기**: `[notice]`, `[features]`, `[mcp_servers.*]` 등 절대 수정 금지
 - **Edit 도구 사용**: old_string → new_string으로 정확한 섹션만 치환
 
-### Gemini (triflux-profiles.json)
+### Antigravity (triflux-profiles.json)
 
 - **백업 필수**: `.bak` 자동 생성
 - **JSON 형식 유지**: `profiles.{name}.model`, `profiles.{name}.hint`
@@ -202,7 +202,7 @@ options:
 | high | 깊은 추론 |
 | xhigh | 최대 추론 (느림) |
 
-### Gemini 모델
+### Antigravity 모델
 
 | 모델 | 용도 |
 |------|------|
@@ -212,7 +212,7 @@ options:
 | gemini-2.5-flash | 2.5 Flash — 경량 범용 |
 | gemini-2.5-flash-lite | 2.5 Flash Lite — 최경량 |
 
-### Gemini → 에이전트 배치 (벤치마크 기반)
+### Antigravity → 에이전트 배치 (벤치마크 기반)
 
 | 프로필 | 모델 | 에이전트 |
 |--------|------|----------|
@@ -225,7 +225,7 @@ options:
 ### 설정 파일 경로
 
 - Codex: `~/.codex/config.toml`
-- Gemini: `~/.gemini/triflux-profiles.json`
+- Antigravity: `~/.gemini/triflux-profiles.json`
 
 ## 에러 처리
 
@@ -240,4 +240,4 @@ options:
 
 터미널에서 직접 실행:
 - Codex: `node tui/codex-profile.mjs`
-- Gemini: `node tui/gemini-profile.mjs`
+- Antigravity: `node tui/gemini-profile.mjs`

--- a/skills/tfx-profile/SKILL.md.tmpl
+++ b/skills/tfx-profile/SKILL.md.tmpl
@@ -1,7 +1,7 @@
 ---
 name: tfx-profile
 description: >
-  Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
+  Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는
   프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반
   인터랙티브 선택지로 수행합니다.
   Use when: codex profile, codex model, gemini profile, gemini model,
@@ -12,10 +12,10 @@ triggers:
 argument-hint: "[--list] [--codex | --gemini]"
 ---
 
-# {{SKILL_NAME}} — Codex/Gemini 프로파일 매니저
+# {{SKILL_NAME}} — Codex/Antigravity 프로파일 매니저
 
 > CLI 프로파일의 모델/effort를 AskUserQuestion 선택지로 관리합니다.
-> Codex(`~/.codex/config.toml`)와 Gemini(`~/.gemini/triflux-profiles.json`) 모두 지원.
+> Codex(`~/.codex/config.toml`)와 Antigravity(`~/.gemini/triflux-profiles.json`) 모두 지원.
 
 ## 워크플로우
 
@@ -30,7 +30,7 @@ header: "CLI"
 options:
   - label: "Codex"
     description: "~/.codex/config.toml (TOML)"
-  - label: "Gemini"
+  - label: "Antigravity"
     description: "~/.gemini/triflux-profiles.json (JSON)"
 ```
 
@@ -99,7 +99,7 @@ options:
 
 ---
 
-## Gemini 워크플로우
+## Antigravity 워크플로우
 
 ### Step 1: triflux-profiles.json 읽기 + 현재 상태 표시
 
@@ -171,7 +171,7 @@ options:
 - **다른 섹션 건드리지 않기**: `[notice]`, `[features]`, `[mcp_servers.*]` 등 절대 수정 금지
 - **Edit 도구 사용**: old_string → new_string으로 정확한 섹션만 치환
 
-### Gemini (triflux-profiles.json)
+### Antigravity (triflux-profiles.json)
 
 - **백업 필수**: `.bak` 자동 생성
 - **JSON 형식 유지**: `profiles.{name}.model`, `profiles.{name}.hint`
@@ -198,7 +198,7 @@ options:
 | high | 깊은 추론 |
 | xhigh | 최대 추론 (느림) |
 
-### Gemini 모델
+### Antigravity 모델
 
 | 모델 | 용도 |
 |------|------|
@@ -208,7 +208,7 @@ options:
 | gemini-2.5-flash | 2.5 Flash — 경량 범용 |
 | gemini-2.5-flash-lite | 2.5 Flash Lite — 최경량 |
 
-### Gemini → 에이전트 배치 (벤치마크 기반)
+### Antigravity → 에이전트 배치 (벤치마크 기반)
 
 | 프로필 | 모델 | 에이전트 |
 |--------|------|----------|
@@ -221,7 +221,7 @@ options:
 ### 설정 파일 경로
 
 - Codex: `~/.codex/config.toml`
-- Gemini: `~/.gemini/triflux-profiles.json`
+- Antigravity: `~/.gemini/triflux-profiles.json`
 
 ## 에러 처리
 
@@ -236,4 +236,4 @@ options:
 
 터미널에서 직접 실행:
 - Codex: `node tui/codex-profile.mjs`
-- Gemini: `node tui/gemini-profile.mjs`
+- Antigravity: `node tui/gemini-profile.mjs`

--- a/skills/tfx-profile/skill.json
+++ b/skills/tfx-profile/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-profile",
-  "description": "Codex/Gemini CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는 프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반 인터랙티브 선택지로 수행합니다. Use when: codex profile, codex model, gemini profile, gemini model, 프로파일 변경, 모델 변경, effort 변경, codex 설정, gemini 설정, profile manager, 프로파일 관리, 어떤 모델, tfx profile",
+  "description": "Codex/Antigravity CLI 프로파일·모델 관리 인터랙티브 UI. tfx-route가 사용하는 프로파일 목록 조회, 모델 변경, effort 조정, 추가/삭제를 AskUserQuestion 기반 인터랙티브 선택지로 수행합니다. Use when: codex profile, codex model, gemini profile, gemini model, 프로파일 변경, 모델 변경, effort 변경, codex 설정, gemini 설정, profile manager, 프로파일 관리, 어떤 모델, tfx profile",
   "triggers": [
     "tfx-profile"
   ],

--- a/skills/tfx-prune/SKILL.md
+++ b/skills/tfx-prune/SKILL.md
@@ -25,7 +25,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 |-----|------|----------|
 | Claude (Opus) | 코드 품질 분석 + 합의 중재 | 설계 원칙, 코드 구조, 불필요 추상화 |
 | Codex | AI 슬롭 탐지 | 구현 효율, 중복 패턴, 과잉 에러 핸들링 |
-| Gemini | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
+| Antigravity | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
 
 ## 슬롭 카테고리
 
@@ -96,7 +96,7 @@ severity: critical(기능에 영향) | high(가독성 심각) | medium(개선) |
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 파일에서 AI 슬롭을 감지하세요. 구현 효율 관점(중복 패턴, 과잉 에러핸들링, 미사용 코드)으로 분석. 파일: {file_content}. JSON: [{id,category,line_start,line_end,description,severity,suggested_fix}]. severity: critical|high|medium|low. 과탐보다 미탐이 낫습니다.:slop-detector' \
@@ -173,7 +173,7 @@ for each finding in ALL results:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
 - 테스트 명령 없음 → Step 5 건너뜀, 보고서에 "테스트 미실행 — 수동 검증 필요" 표시
 - 파일 파싱 오류 → 해당 파일 스킵 후 보고서에 "파싱 실패" 기록
 

--- a/skills/tfx-prune/SKILL.md.tmpl
+++ b/skills/tfx-prune/SKILL.md.tmpl
@@ -25,7 +25,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 > headless-guard가 이 규칙 위반을 **자동 차단**한다. 우회 불가.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -35,7 +35,7 @@ argument-hint: "[파일 경로 또는 git diff 범위]"
 |-----|------|----------|
 | Claude (Opus) | 코드 품질 분석 + 합의 중재 | 설계 원칙, 코드 구조, 불필요 추상화 |
 | Codex | AI 슬롭 탐지 | 구현 효율, 중복 패턴, 과잉 에러 핸들링 |
-| Gemini | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
+| Antigravity | 가독성 평가 | 가독성/DX, 과잉 주석, 과잉 타입 |
 
 ## 슬롭 카테고리
 
@@ -96,7 +96,7 @@ severity: critical(기능에 영향) | high(가독성 심각) | medium(개선) |
 )
 ```
 
-Codex + Gemini (Bash, background):
+Codex + Antigravity (Bash, background):
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:다음 파일에서 AI 슬롭을 감지하세요. 구현 효율 관점(중복 패턴, 과잉 에러핸들링, 미사용 코드)으로 분석. 파일: {file_content}. JSON: [{id,category,line_start,line_end,description,severity,suggested_fix}]. severity: critical|high|medium|low. 과탐보다 미탐이 낫습니다.:slop-detector' \
@@ -173,7 +173,7 @@ for each finding in ALL results:
 
 ## ERROR RECOVERY
 
-- Codex/Gemini 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
+- Codex/Antigravity 타임아웃(600s 초과) → Claude Agent 단독으로 2자 합의 기준(단독 감지도 제거 대상) 적용
 - 테스트 명령 없음 → Step 5 건너뜀, 보고서에 "테스트 미실행 — 수동 검증 필요" 표시
 - 파일 파싱 오류 → 해당 파일 스킵 후 보고서에 "파싱 실패" 기록
 

--- a/skills/tfx-qa/SKILL.md
+++ b/skills/tfx-qa/SKILL.md
@@ -18,7 +18,7 @@ argument-hint: "[테스트 대상] [--quick]"
 
 > **ARGUMENTS 처리**: ARGUMENTS 에 `--quick` 포함 → Quick 모드. 그 외 → Deep 모드 (기본).
 
-> AI makes completeness near-free. 기본은 Claude(기능/엣지) + Codex(보안/성능) + Gemini(UX/접근성) 3-CLI 독립 검증 + 교차검증 + 자동 수정.
+> AI makes completeness near-free. 기본은 Claude(기능/엣지) + Codex(보안/성능) + Antigravity(UX/접근성) 3-CLI 독립 검증 + 교차검증 + 자동 수정.
 > 빠른 테스트-수정 루프는 `--quick`.
 
 ---
@@ -58,7 +58,7 @@ Tier 3 시:
 ### HARD RULES
 
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi --teammate-mode headless --assign ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -68,7 +68,7 @@ Tier 3 시:
 |-----|------|------|
 | Claude Opus | 기능검증 | 정확성, 엣지케이스, 누락 테스트 |
 | Codex | 보안+성능 | OWASP, O(n²), 메모리, 입력 검증 |
-| Gemini | UX+접근성 | 응답 일관성, 에러 메시지, WCAG |
+| Antigravity | UX+접근성 | 응답 일관성, 에러 메시지, WCAG |
 
 ### EXECUTION
 
@@ -90,7 +90,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless:**
+**Codex + Antigravity headless:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:보안/성능 전문가. OWASP Top 10, O(n²), 메모리 누수, 입력 검증 누락. JSON: { findings: [...], overall_verdict: \"pass\"|\"fail\" }:verifier' --assign 'gemini:UX/접근성 전문가. API 응답 일관성, 에러 메시지, WCAG 2.1 AA, 문서-동작 일치. JSON: { findings: [...], overall_verdict: \"pass\"|\"fail\" }:verifier' --timeout 600")
 ```

--- a/skills/tfx-research/SKILL.md
+++ b/skills/tfx-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 internal: true
 name: tfx-research
-description: "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Gemini Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto."
+description: "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Antigravity Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto."
 triggers:
   - tfx-research
   - 리서치
@@ -23,7 +23,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 
 > **ARGUMENTS 처리**: `--quick` → Quick. `--auto` → Auto. 그 외 → Deep (기본).
 
-> AI makes completeness near-free. 기본은 Claude(Exa/학술) + Codex(Brave/실용) + Gemini(Tavily/DX) 3-CLI 멀티소스 교차검증 합의.
+> AI makes completeness near-free. 기본은 Claude(Exa/학술) + Codex(Brave/실용) + Antigravity(Tavily/DX) 3-CLI 멀티소스 교차검증 합의.
 > 빠른 단일 Google Search 는 `--quick`. 자율 쿼리생성+구조화 보고서 는 `--auto`.
 
 ---
@@ -33,7 +33,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 | 플래그 | 모드 | 특징 |
 |--------|------|------|
 | (없음) | **Deep** (기본) | 3-CLI 멀티소스 교차검증, consensus score |
-| `--quick` | Quick | Gemini 단일 Google Search |
+| `--quick` | Quick | Antigravity 단일 Google Search |
 | `--auto` | Auto | 자율 쿼리생성(3-5개) + 검색 + 구조화 보고서 |
 
 ---
@@ -42,7 +42,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 
 ### HARD RULES
 1. `codex exec` / `gemini -p` 직접 호출 금지
-2. Codex/Gemini → `Bash("tfx multi ...")` 만
+2. Codex/Antigravity → `Bash("tfx multi ...")` 만
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent 동시 호출
 
@@ -52,7 +52,7 @@ argument-hint: "<주제> [--quick | --auto] [--depth quick|standard|deep]"
 |-----|-----|------|
 | Claude | Exa (neural semantic) | 학술/기술 깊이, 공식 문서, 벤치마크 |
 | Codex | Brave Search | 실용/구현/산업 사례 |
-| Gemini | Tavily | 비용/운영/DX |
+| Antigravity | Tavily | 비용/운영/DX |
 
 ### Depth 모드 (`--depth` 플래그)
 
@@ -83,7 +83,7 @@ Agent(
 )
 ```
 
-**Bash (Codex + Brave, Gemini + Tavily):**
+**Bash (Codex + Brave, Antigravity + Tavily):**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard \
   --assign 'codex:서브쿼리를 Brave Search 로 검색. 서브쿼리: {sub_queries}. 관점: 실용/산업. brave_web_search + brave_news_search, freshness=pw. 각 쿼리 상위 5개 구조화.:researcher' \
@@ -139,13 +139,13 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
-### Step 2: Gemini Google Search 위임
+### Step 2: Antigravity Google Search 위임
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research: use Google Search, return structured markdown with sources. Query: {optimized_query}' auto 120")
 ```
 
-**Fallback**: Gemini 실패 시 MCP 순서 — context7 → WebSearch → Brave → Exa → Tavily.
+**Fallback**: Antigravity 실패 시 MCP 순서 — context7 → WebSearch → Brave → Exa → Tavily.
 
 ### Step 3: 결과 포맷팅 (Claude ~300 토큰)
 
@@ -156,7 +156,7 @@ Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research: use Google Search, r
 ### 관련 키워드
 ```
 
-### Token (Quick): ~500 (Claude), 0 (Gemini 외부)
+### Token (Quick): ~500 (Claude), 0 (Antigravity 외부)
 
 ---
 

--- a/skills/tfx-research/SKILL.md.tmpl
+++ b/skills/tfx-research/SKILL.md.tmpl
@@ -18,7 +18,7 @@ argument-hint: "<검색 주제>"
 
 
 > **Deep 버전**: tfx-deep-research. "제대로/꼼꼼히" 수정자로 자동 에스컬레이션.
-> 빠른 단일 소스 검색 + 요약. **검색 자체를 Gemini에 위임**해 Claude 토큰 최소화. Gemini CLI의 네이티브 Google Search로 검색+요약을 한 번에 처리.
+> 빠른 단일 소스 검색 + 요약. **검색 자체를 Antigravity에 위임**해 Claude 토큰 최소화. Antigravity CLI의 네이티브 Google Search로 검색+요약을 한 번에 처리.
 
 ## 용도
 
@@ -53,30 +53,30 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
-선택 결과에 따라 Step 2 Gemini 위임 시 프롬프트에 검색 유형 힌트를 추가한다.
+선택 결과에 따라 Step 2 Antigravity 위임 시 프롬프트에 검색 유형 힌트를 추가한다.
 인자가 제공된 경우 이 단계를 건너뛰고 Step 2로 직행한다.
 
-### Step 2: Gemini에 검색+요약 위임 (검색 실행 전체를 Gemini가 처리)
+### Step 2: Antigravity에 검색+요약 위임 (검색 실행 전체를 Antigravity가 처리)
 
-최적화된 쿼리를 Gemini CLI로 전달한다. Gemini는 네이티브 Google Search를 사용해 검색과 요약을 모두 수행한다:
+최적화된 쿼리를 Antigravity CLI로 전달한다. Antigravity는 네이티브 Google Search를 사용해 검색과 요약을 모두 수행한다:
 
 ```
 Bash("bash ~/.claude/scripts/tfx-route.sh gemini 'Research the following topic. Use Google Search to find current information. Return a structured markdown summary with sources: {optimized_query}' auto 120")
 ```
 
-Gemini가 반환하는 결과에는 검색 결과, 출처 URL, 핵심 요약이 포함된다. Claude는 이 단계에서 토큰을 소비하지 않는다.
+Antigravity가 반환하는 결과에는 검색 결과, 출처 URL, 핵심 요약이 포함된다. Claude는 이 단계에서 토큰을 소비하지 않는다.
 
-**실패 시**: Gemini CLI가 응답하지 않거나 오류가 발생하면 → [Claude Fallback](#claude-fallback-gemini-실패-시) 으로 전환.
+**실패 시**: Antigravity CLI가 응답하지 않거나 오류가 발생하면 → [Claude Fallback](#claude-fallback-gemini-실패-시) 으로 전환.
 
 ### Step 3: 결과 포맷팅 (Claude — 경량, ~300 토큰)
 
-Gemini 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이나 요약 없이 포맷 변환만 수행:
+Antigravity 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이나 요약 없이 포맷 변환만 수행:
 
 ```markdown
 ## 검색 결과: {query}
 
 ### 핵심 답변
-{Gemini 요약에서 추출한 1-3문장 직접 답변}
+{Antigravity 요약에서 추출한 1-3문장 직접 답변}
 
 ### 상세 내용
 - **[출처 1 제목](URL)**: {하이라이트 요약}
@@ -92,17 +92,17 @@ Gemini 출력을 표준 결과 템플릿으로 정리한다. 새로운 검색이
 | 단계 | 담당 | 토큰 |
 |------|------|------|
 | 쿼리 최적화 | Claude | ~100 |
-| 검색 실행 + 요약 | Gemini | 0 (Claude 미소비) |
+| 검색 실행 + 요약 | Antigravity | 0 (Claude 미소비) |
 | 결과 포맷팅 | Claude | ~300 |
 | **Claude 총합** | | **~500 (오케스트레이션만)** |
 
-> 기존 대비 Claude 토큰 ~90% 절감. 검색 품질은 Gemini의 Google Search 네이티브 연동으로 유지.
+> 기존 대비 Claude 토큰 ~90% 절감. 검색 품질은 Antigravity의 Google Search 네이티브 연동으로 유지.
 
 ---
 
-## Claude Fallback (Gemini 실패 시)
+## Claude Fallback (Antigravity 실패 시)
 
-Gemini CLI가 실패하거나 응답이 없을 경우 Claude + MCP 원본 워크플로우로 폴백한다.
+Antigravity CLI가 실패하거나 응답이 없을 경우 Claude + MCP 원본 워크플로우로 폴백한다.
 
 ### Fallback Step 2: MCP 소스 자동 선택
 

--- a/skills/tfx-research/skill.json
+++ b/skills/tfx-research/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-research",
-  "description": "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Gemini Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto.",
+  "description": "웹 검색/리서치가 필요할 때 사용한다. '검색해줘', '찾아봐', '최신 정보', '이거 뭐야', '심층 조사', '자세히 알아봐', 'deep research', '전면 리서치', '자율 리서치', '조사해', 'research and plan' 같은 요청에 반드시 사용. 추가로 'X 있나?', 'X 쓸 수 있나?', 'X 풀려있어?', 'X 어떻게 쓰는지', 'X 가능한가?', '방법 있나?', 'X 살아있나?' 같은 도구·기능 존재/사용법/상태 의문문에도 사용. 기본값은 3-CLI 멀티소스(Exa+Brave+Tavily) 합의 딥 리서치. 빠른 Antigravity Google Search 는 --quick. 자율 쿼리생성+보고서 모드는 --auto.",
   "triggers": [
     "tfx-research",
     "리서치",

--- a/skills/tfx-review/SKILL.md
+++ b/skills/tfx-review/SKILL.md
@@ -60,8 +60,8 @@ ARGUMENTS 에 `--quick` 포함 → **Quick 모드** (아래 Quick 섹션).
 
 | Tier | 조건 | 실행 방식 |
 |------|------|----------|
-| **Tier 1** | tmux/psmux + Hub + Codex + Gemini 전부 정상 | headless multi 3-CLI |
-| **Tier 2** | Codex 또는 Gemini 중 하나만 가용 | 가용 CLI + Claude Agent 조합 |
+| **Tier 1** | tmux/psmux + Hub + Codex + Antigravity 전부 정상 | headless multi 3-CLI |
+| **Tier 2** | Codex 또는 Antigravity 중 하나만 가용 | 가용 CLI + Claude Agent 조합 |
 | **Tier 3** | headless 불가 또는 `claude -p` one-shot | Claude Agent only (consensus 미적용) |
 
 ```
@@ -73,10 +73,10 @@ IF Hub 미응답:
   → 성공 → Tier 판정 재시도
   → 실패 → Tier 3
 
-IF Codex 없음 AND Gemini 없음:
+IF Codex 없음 AND Antigravity 없음:
   → Tier 3
 
-IF Codex 없음 OR Gemini 없음:
+IF Codex 없음 OR Antigravity 없음:
   → Tier 2
 
 ELSE:
@@ -88,7 +88,7 @@ ELSE:
 ```
 ⚠ [Tier 3] headless multi 환경 미충족 — single-model 모드로 실행합니다 (consensus 미적용)
   누락: {missing_components}
-  권장: tmux/psmux, Hub, Codex CLI, Gemini CLI 설치 후 재실행
+  권장: tmux/psmux, Hub, Codex CLI, Antigravity CLI 설치 후 재실행
   또는 /tfx-review --quick 으로 명시적 quick 경로 사용
 ```
 
@@ -97,7 +97,7 @@ ELSE:
 > headless-guard가 이 규칙 위반을 **자동 차단**한다.
 
 1. **`codex exec` / `gemini -p` 직접 호출 절대 금지**
-2. Codex·Gemini → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
+2. Codex·Antigravity → `Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cli:프롬프트:역할' --timeout 600")` **만** 사용
 3. Claude → `Agent(run_in_background=true)`
 4. Bash + Agent를 같은 메시지에서 동시 호출하여 병렬 실행
 
@@ -107,7 +107,7 @@ ELSE:
 |-----|------|------|
 | Claude Opus | 로직+아키텍처 | 로직 결함, 아키텍처 위반, 설계 패턴 |
 | Codex | 보안+성능 | OWASP Top 10, O(n²) 패턴, 누락된 에러 핸들링 |
-| Gemini | 가독성+DX | 네이밍 컨벤션, 가독성, 주석 필요성, 타입 안전성 |
+| Antigravity | 가독성+DX | 네이밍 컨벤션, 가독성, 주석 필요성, 타입 안전성 |
 
 ### 실행 단계
 
@@ -128,7 +128,7 @@ Agent(
 )
 ```
 
-**Codex + Gemini headless dispatch:**
+**Codex + Antigravity headless dispatch:**
 ```
 Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'codex:보안/성능 전문가로서 이 코드를 분석하라. OWASP Top 10 취약점 확인. O(n²) 이상의 성능 병목 식별. 누락된 에러 핸들링 지적. JSON: { findings: [{ id, file, line, severity, category, description, suggestion }] }:reviewer' --assign 'gemini:코드 품질 전문가로서 이 코드를 분석하라. 가독성과 네이밍 컨벤션 평가. 주석이 필요한 복잡한 로직 식별. 타입 안전성 문제 지적. JSON: { findings: [{ id, file, line, severity, category, description, suggestion }] }:reviewer' --timeout 600")
 ```
@@ -147,11 +147,11 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 
 ```markdown
 ## Deep Code Review: {target}
-**Consensus Score**: {score}% | **Reviewers**: Claude/Codex/Gemini
+**Consensus Score**: {score}% | **Reviewers**: Claude/Codex/Antigravity
 
 ### Critical (3/3 합의)
 - [C1] `{file}:{line}` — {description}
-  - Claude: {detail} | Codex: {detail} | Gemini: {detail}
+  - Claude: {detail} | Codex: {detail} | Antigravity: {detail}
   - **Fix**: {suggestion}
 
 ### High (2/3 합의)
@@ -169,7 +169,7 @@ Bash("tfx multi --teammate-mode headless --auto-attach --dashboard --assign 'cod
 |-----|---------|------------|
 | Claude | {n} | {%} |
 | Codex | {n} | {%} |
-| Gemini | {n} | {%} |
+| Antigravity | {n} | {%} |
 ```
 
 ### Error Recovery

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -70,7 +70,7 @@ Bash("triflux setup")
 필수 훅 목록:
 | 이벤트 | matcher | 스크립트 | 역할 |
 |--------|---------|---------|------|
-| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Gemini 직접 호출 차단 |
+| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Antigravity 직접 호출 차단 |
 | PreToolUse | Bash | psmux-safety-guard.mjs | psmux kill-session 직접 호출 차단 (WT 프리징 방지) |
 | PreToolUse | Skill | tfx-gate-activate.mjs | tfx-multi 게이트 |
 
@@ -129,7 +129,7 @@ Bash("triflux setup")
       description: "나중에 /tfx-profile로 관리"
   ```
 
-#### 단계 3.5: Gemini 프로필
+#### 단계 3.5: Antigravity 프로필
 
 `~/.gemini/triflux-profiles.json` 존재 여부 확인.
 필수 프로필: `pro31`, `flash3`.
@@ -138,8 +138,8 @@ Bash("triflux setup")
 - 파일 미존재 → 기본 프로필 5개 자동 생성 (pro31, flash3, pro25, flash25, lite25)
 - 누락 있으면 → AskUserQuestion:
   ```
-  question: "누락된 Gemini 프로필을 생성하시겠습니까?"
-  header: "Gemini Profiles"
+  question: "누락된 Antigravity 프로필을 생성하시겠습니까?"
+  header: "Antigravity Profiles"
   options:
     - label: "생성 (Recommended)"
       description: "누락된 프로필을 triflux-profiles.json에 추가"
@@ -508,7 +508,7 @@ options:
     description: "settings.json statusLine 등록"
   - label: "Codex 프로파일"
     description: "필수 프로파일 생성"
-  - label: "Gemini 프로필"
+  - label: "Antigravity 프로필"
     description: "triflux-profiles.json 생성/확인"
   - label: "CLI + MCP 진단"
     description: "CLI 존재 + MCP 인벤토리 확인"
@@ -530,7 +530,7 @@ options:
 | Codex 프로파일 | ✅ 3개 확인 |
 | Codex config.toml | ✅ approval_mode=full-auto (CLI 플래그 자동 생략) |
 | Codex CLI | ✅ |
-| Gemini CLI | ⚠ 미설치 (선택) |
+| Antigravity CLI | ⚠ 미설치 (선택) |
 | 원격 기기 | ✅ 2대 사용 가능 (ryzen5-7600, m2) / ❌ 1대 연결 실패 |
 | MCP 인벤토리 | ✅ N개 서버 |
 | 검색 MCP | ✅ Exa, Tavily / ⏭ Brave (키 없음) |
@@ -540,13 +540,13 @@ options:
 | 기능 | 상태 | 필요 조건 |
 |------|------|----------|
 | 로컬 단일 모델 | ✅ | Codex CLI |
-| 로컬 다중 모델 | ✅ | Codex CLI + Gemini CLI |
+| 로컬 다중 모델 | ✅ | Codex CLI + Antigravity CLI |
 | 다중 기기 스웜 | ✅ 2대 | SSH 호스트 + Claude 설치 |
 | 전체 (다중 기기 x 다중 모델) | ✅ | 위 전부 |
 
 ### 다음 단계
 - Codex 미설치 시: `npm install -g @openai/codex`
-- Gemini 미설치 시: `npm install -g @google/gemini-cli`
+- Antigravity 미설치 시: `npm install -g @google/gemini-cli`
 - 원격 호스트 추가: `/tfx-remote-setup`
 - 검색 MCP 추가/변경: `/tfx-setup` → 단계별 선택 → 검색 MCP
 - 세션 재시작하면 HUD + 검색 MCP가 활성화됩니다

--- a/skills/tfx-setup/SKILL.md.tmpl
+++ b/skills/tfx-setup/SKILL.md.tmpl
@@ -53,7 +53,7 @@ Bash("triflux setup")
 필수 훅 목록:
 | 이벤트 | matcher | 스크립트 | 역할 |
 |--------|---------|---------|------|
-| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Gemini 직접 호출 차단 |
+| PreToolUse | Bash\|Agent | headless-guard-fast.sh | Codex/Antigravity 직접 호출 차단 |
 | PreToolUse | Bash | psmux-safety-guard.mjs | psmux kill-session 직접 호출 차단 (WT 프리징 방지) |
 | PreToolUse | Skill | tfx-gate-activate.mjs | tfx-multi 게이트 |
 
@@ -112,7 +112,7 @@ Bash("triflux setup")
       description: "나중에 /tfx-profile로 관리"
   ```
 
-#### 단계 3.5: Gemini 프로필
+#### 단계 3.5: Antigravity 프로필
 
 `~/.gemini/triflux-profiles.json` 존재 여부 확인.
 필수 프로필: `pro31`, `flash3`.
@@ -121,8 +121,8 @@ Bash("triflux setup")
 - 파일 미존재 → 기본 프로필 5개 자동 생성 (pro31, flash3, pro25, flash25, lite25)
 - 누락 있으면 → AskUserQuestion:
   ```
-  question: "누락된 Gemini 프로필을 생성하시겠습니까?"
-  header: "Gemini Profiles"
+  question: "누락된 Antigravity 프로필을 생성하시겠습니까?"
+  header: "Antigravity Profiles"
   options:
     - label: "생성 (Recommended)"
       description: "누락된 프로필을 triflux-profiles.json에 추가"
@@ -487,7 +487,7 @@ options:
     description: "settings.json statusLine 등록"
   - label: "Codex 프로파일"
     description: "필수 프로파일 생성"
-  - label: "Gemini 프로필"
+  - label: "Antigravity 프로필"
     description: "triflux-profiles.json 생성/확인"
   - label: "CLI + MCP 진단"
     description: "CLI 존재 + MCP 인벤토리 확인"
@@ -509,7 +509,7 @@ options:
 | Codex 프로파일 | ✅ 3개 확인 |
 | Codex config.toml | ✅ approval_mode=full-auto (CLI 플래그 자동 생략) |
 | Codex CLI | ✅ |
-| Gemini CLI | ⚠ 미설치 (선택) |
+| Antigravity CLI | ⚠ 미설치 (선택) |
 | 원격 기기 | ✅ 2대 사용 가능 (ryzen5-7600, m2) / ❌ 1대 연결 실패 |
 | MCP 인벤토리 | ✅ N개 서버 |
 | 검색 MCP | ✅ Exa, Tavily / ⏭ Brave (키 없음) |
@@ -519,13 +519,13 @@ options:
 | 기능 | 상태 | 필요 조건 |
 |------|------|----------|
 | 로컬 단일 모델 | ✅ | Codex CLI |
-| 로컬 다중 모델 | ✅ | Codex CLI + Gemini CLI |
+| 로컬 다중 모델 | ✅ | Codex CLI + Antigravity CLI |
 | 다중 기기 스웜 | ✅ 2대 | SSH 호스트 + Claude 설치 |
 | 전체 (다중 기기 x 다중 모델) | ✅ | 위 전부 |
 
 ### 다음 단계
 - Codex 미설치 시: `npm install -g @openai/codex`
-- Gemini 미설치 시: `npm install -g @google/gemini-cli`
+- Antigravity 미설치 시: `npm install -g @google/gemini-cli`
 - 원격 호스트 추가: `/tfx-remote-setup`
 - 검색 MCP 추가/변경: `/tfx-setup` → 단계별 선택 → 검색 MCP
 - 세션 재시작하면 HUD + 검색 MCP가 활성화됩니다

--- a/skills/tfx-swarm/SKILL.md.tmpl
+++ b/skills/tfx-swarm/SKILL.md.tmpl
@@ -13,7 +13,7 @@ triggers:
 {{> base}}
 
 > **Multi-Machine x Multi-Model Swarm.** PRD 하나로 로컬과 원격 머신에서
-> Claude + Codex + Gemini를 병렬 실행하고, file-lease로 충돌을 방지하며,
+> Claude + Codex + Antigravity를 병렬 실행하고, file-lease로 충돌을 방지하며,
 > 결과를 자동 통합한다. triflux의 킬러 스킬.
 
 ## 트리거
@@ -36,7 +36,7 @@ triggers:
 
 - psmux >= 3.3.0
 - Hub 실행 중 (`curl -sf http://127.0.0.1:27888/status`)
-- Codex CLI 또는 Gemini CLI (사용할 agent에 따라)
+- Codex CLI 또는 Antigravity CLI (사용할 agent에 따라)
 - 원격 shard 사용 시: SSH 키 인증 + 원격 머신에 Claude Code 설치
 - 프로젝트에 `docs/prd/` 디렉토리 존재
 
@@ -78,7 +78,7 @@ PRD에 다중 agent가 지정된 경우에도 AskUserQuestion:
 Options:
 - A) PRD 그대로 — shard별 지정 모델 사용 (권장)
 - B) 전부 Codex로 — 단일 모델
-- C) 전부 Gemini로 — 단일 모델
+- C) 전부 Antigravity로 — 단일 모델
 
 ### Step 3: 계획 생성
 
@@ -163,7 +163,7 @@ await hyper.shutdown('completed');
 - prompt: 성능 최적화 (auth 리팩터 완료 후)
 ```
 
-위 PRD 하나로: Codex(로컬) + Gemini(로컬) + Claude(ryzen5-7600) + Codex(m2) 4개 워커가 병렬 실행된다.
+위 PRD 하나로: Codex(로컬) + Antigravity(로컬) + Claude(ryzen5-7600) + Codex(m2) 4개 워커가 병렬 실행된다.
 security-audit는 `critical: true`이므로 다른 모델로 이중 실행 후 reconcile.
 
 ## PRD Shard 필드 레퍼런스

--- a/tests/integration/agy-stdout-pipe.test.mjs
+++ b/tests/integration/agy-stdout-pipe.test.mjs
@@ -52,6 +52,11 @@ const WELCOME_KEYWORDS = [
   "timed out",
   "flag needs an argument",
 ];
+const LEAK_FLAGS = [
+  "--dangerously-skip-permissions",
+  "--add-dir",
+  "--print=",
+];
 
 function hasHi(text) {
   return text.toLowerCase().includes("hi");
@@ -60,6 +65,10 @@ function hasHi(text) {
 function hasWelcomeOrFailure(text) {
   const lower = text.toLowerCase();
   return WELCOME_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+function leakedFlags(text) {
+  return LEAK_FLAGS.filter((flag) => text.includes(flag));
 }
 
 function createRouteHome() {
@@ -109,7 +118,7 @@ test("agy --print prompt-passing regression tests", {
 }, async (t) => {
   await t.test(
     "1. alpha commit pattern: --print --dangerously + stdin pipe -> success",
-    { timeout: 30000 },
+    { timeout: 100000 },
     () => {
       const result = spawnSync(
         AGY_PATH,
@@ -117,7 +126,7 @@ test("agy --print prompt-passing regression tests", {
         {
           input: TEST_PROMPT,
           encoding: "utf8",
-          timeout: 25000,
+          timeout: 90000,
           env: { ...process.env, PAGER: "cat" },
         },
       );
@@ -130,12 +139,18 @@ test("agy --print prompt-passing regression tests", {
         hasHi(result.stdout),
         `Should contain 'hi'. Got: ${result.stdout}`,
       );
+      const leaks = leakedFlags(result.stdout);
+      assert.deepStrictEqual(
+        leaks,
+        [],
+        `Flag pollution detected in stdout: ${leaks.join(", ")}. Got: ${result.stdout}`,
+      );
     },
   );
 
   await t.test(
     "2. Tier 1 broken pattern: positional + stdin closed -> failure",
-    { timeout: 30000 },
+    { timeout: 100000 },
     () => {
       const result = spawnSync(
         AGY_PATH,
@@ -143,7 +158,7 @@ test("agy --print prompt-passing regression tests", {
         {
           stdio: ["ignore", "pipe", "pipe"],
           encoding: "utf8",
-          timeout: 25000,
+          timeout: 90000,
           env: { ...process.env, PAGER: "cat" },
         },
       );
@@ -157,14 +172,14 @@ test("agy --print prompt-passing regression tests", {
 
   await t.test(
     "3. alternative flag order: --dangerously first + --print + positional -> success",
-    { timeout: 30000 },
+    { timeout: 100000 },
     () => {
       const result = spawnSync(
         AGY_PATH,
         ["--dangerously-skip-permissions", "--print", TEST_PROMPT],
         {
           encoding: "utf8",
-          timeout: 25000,
+          timeout: 90000,
           env: { ...process.env, PAGER: "cat" },
         },
       );
@@ -176,20 +191,26 @@ test("agy --print prompt-passing regression tests", {
       assert.ok(
         hasHi(result.stdout),
         `Should contain 'hi'. Got: ${result.stdout}`,
+      );
+      const leaks = leakedFlags(result.stdout);
+      assert.deepStrictEqual(
+        leaks,
+        [],
+        `Flag pollution detected in stdout: ${leaks.join(", ")}. Got: ${result.stdout}`,
       );
     },
   );
 
   await t.test(
     "4. alternative equals syntax: --print=VALUE + --dangerously -> success",
-    { timeout: 30000 },
+    { timeout: 100000 },
     () => {
       const result = spawnSync(
         AGY_PATH,
         [`--print=${TEST_PROMPT}`, "--dangerously-skip-permissions"],
         {
           encoding: "utf8",
-          timeout: 25000,
+          timeout: 90000,
           env: { ...process.env, PAGER: "cat" },
         },
       );
@@ -202,19 +223,25 @@ test("agy --print prompt-passing regression tests", {
         hasHi(result.stdout),
         `Should contain 'hi'. Got: ${result.stdout}`,
       );
+      const leaks = leakedFlags(result.stdout);
+      assert.deepStrictEqual(
+        leaks,
+        [],
+        `Flag pollution detected in stdout: ${leaks.join(", ")}. Got: ${result.stdout}`,
+      );
     },
   );
 
   await t.test(
     "5. flag absorption guard: --print + --add-dir + positional -> timeout/failure",
-    { timeout: 30000 },
+    { timeout: 100000 },
     () => {
       const result = spawnSync(
         AGY_PATH,
         ["--print", "--add-dir", "/tmp", TEST_PROMPT],
         {
           encoding: "utf8",
-          timeout: 25000,
+          timeout: 90000,
           env: { ...process.env, PAGER: "cat" },
         },
       );

--- a/tests/integration/agy-stdout-pipe.test.mjs
+++ b/tests/integration/agy-stdout-pipe.test.mjs
@@ -52,11 +52,7 @@ const WELCOME_KEYWORDS = [
   "timed out",
   "flag needs an argument",
 ];
-const LEAK_FLAGS = [
-  "--dangerously-skip-permissions",
-  "--add-dir",
-  "--print=",
-];
+const LEAK_FLAGS = ["--dangerously-skip-permissions", "--add-dir", "--print="];
 
 function hasHi(text) {
   return text.toLowerCase().includes("hi");
@@ -274,4 +270,16 @@ test("TFX_CLI_MODE=antigravity remaps codex-routed agents to agy", () => {
   assert.match(out(result), /TFX_CLI_MODE=antigravity: executor/);
   assert.match(out(result), /type=antigravity/);
   assert.match(result.stdout, /AGY_OK/);
+});
+
+test("direct gemini route redirects to Antigravity when preflight marked agy ready", () => {
+  const result = runBash(
+    `TFX_ANTIGRAVITY_OK=1 bash "${ROUTE_SCRIPT}" gemini 'Return exactly: AGY_OK' minimal 120`,
+  );
+
+  assert.equal(result.status, 0, out(result));
+  assert.match(out(result), /gemini route → antigravity/);
+  assert.match(out(result), /type=antigravity/);
+  assert.match(result.stdout, /AGY_OK/);
+  assert.doesNotMatch(out(result), /type=gemini/);
 });

--- a/tests/integration/tfx-route-quota.test.mjs
+++ b/tests/integration/tfx-route-quota.test.mjs
@@ -222,7 +222,7 @@ auto_reroute gemini
       assert.match(out(result), /REROUTED: MODE=antigravity FROM=gemini/);
     });
 
-    it("3. Antigravity readiness gate 미설정 시 codex → gemini 기존 fallback 유지", () => {
+    it("3. Antigravity readiness 미설정 시 codex 대체 CLI 미설치 (gemini lane deprecated)", () => {
       const wrapperScript = resolve(
         os.tmpdir(),
         `tfx-reroute-wrapper-3-${Date.now()}.sh`,
@@ -260,8 +260,9 @@ auto_reroute codex
       });
       fs.unlinkSync(wrapperScript);
 
-      assert.match(out(result), /Codex → Gemini 자동 전환/);
-      assert.match(out(result), /REROUTED: MODE=gemini FROM=codex/);
+      assert.match(out(result), /codex 대체 CLI 미설치 — 자동 전환 불가/);
+      assert.doesNotMatch(out(result), /Codex → Gemini 자동 전환/);
+      assert.doesNotMatch(out(result), /REROUTED: MODE=gemini/);
     });
 
     it("4. antigravity → codex 전환 시 TFX_CLI_MODE=codex 설정 확인", () => {


### PR DESCRIPTION
## Summary

Gemini deprecation 의 docs + wrapper + tests 단계. 사용자 정책 "Gemini deprecated, Antigravity 만 쓰기" 를 wrapper 와 docs 에 정합화. agy 의 진단 (Codex consensus debate 결과) 도 test 에 반영.

### Commits

- **`0850f0ea fix(test)`**: agy-stdout-pipe.test.mjs 의 flag pollution guard + 25s→90s timeout. 30s experiment refresh barrier + flag pollution (`--dangerously-skip-permissions` stdout 누출) 둘 다 가드
- **`5ed5a8f8 docs(rules)`**: tfx-update-logic.md trim (57→20줄). Antigravity 1.0.0 sanity matrix 는 project memory 로 분리, transition residue 제거
- **`22e861ea docs`**: gemini → antigravity 광역 substitute (75 files, +533/-533). CLI enum value, binary calls, model names, paths 보존. `skills/` vs `packages/triflux/skills/` byte-identical mirror
- **`0482c2b8 refactor(route)`**: TFX_CLI_MODE=gemini deprecated. agy 살아있으면 antigravity 로 redirect (`[deprecated]` warning + recursive apply_cli_mode). auto_reroute fallback chain 에서 gemini 제거. legacy gemini lane 은 agy 미설치 환경 graceful fallback (Phase 5 cleanup 까지 유지)

## Test plan

- [x] `node --test tests/integration/agy-stdout-pipe.test.mjs` → **8/8 pass** (256s standalone)
- [x] `node --test tests/integration/tfx-route-quota.test.mjs` → **12/12 pass** (24.5s)
- [x] `bash -n scripts/tfx-route.sh` syntax OK
- [x] `node --check tests/integration/agy-stdout-pipe.test.mjs` syntax OK
- [x] `diff -rq skills packages/triflux/skills` → 0 drift
- [x] AI attribution trailers in commit messages: **0** (triflux 정책)

## Follow-up (이번 PR 범위 밖)

- **Phase 5 cleanup**: legacy gemini binary path 완전 제거 (`resolve_gemini_profile` + apply_cli_mode 의 gemini binary fallback)
- **backend classes**: `GeminiBackend` (`hub/backends/`) dead code 확인 후 cleanup
- **HUD fallback display**: gemini fallback 표시 잔여 정리
- **Codex consensus debate verdict**: 추가 review 시 발견되는 blocker 처리

## Verification trail

- agy 진단: Codex consensus debate 가 Claude 의 race-only 가설을 5 항목 정정 (Mac Keychain svce=`gemini`/acct=`antigravity`, 30s experiment refresh barrier 가 진짜 bottleneck, async init order, flag pollution, weak test assertion). evidence + 정정 내용은 project memory 의 `feedback_agy_headless_silent_auth_barrier.md` + `reference_antigravity_cli_sanity_matrix.md`
- description-vs-enum mismatch (`--cli gemini` enum + "Antigravity 전용" description) 발견 후 wrapper 까지 정합화