### PR TITLE
docs(native-bridge): UI default-on policy + opt-out routing (PR #323 follow-up)

### DIFF
--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -105,6 +105,8 @@ headless-guard 가 `codex exec` / `gemini -y -p` 직접 호출을 차단한다. 
 
 **Claude 네이티브** (CLI 불필요): tfx-find, tfx-forge, tfx-prune, tfx-index, tfx-setup, tfx-doctor, tfx-hooks, tfx-hub
 
+**Headless UI default** — `tfx-auto`, `tfx multi`, `tfx swarm` 로컬 shard 의 headless 워커는 default 로 `claude agents` 패널에 노출 (`--native-bridge-ui agents`). opt-out: `--no-native-bridge-ui`. interactive (tmux/wt) 경로는 default-off. `tfx swarm` 원격 shard 는 `registerSwarmShard()` 가 warn + skip 만 하고 원격 daemon 등록은 후속 PRD. 상세 행동표는 `CLAUDE.md` 의 `<native-bridge>` 섹션.
+
 자원 우선순위: remote-spawn > swarm > multi > Light > 로컬 단독
 
 원격 hosts 설정은 user-state 경로만 참조한다: macOS/Linux `~/.config/triflux/hosts.json`, Windows `%APPDATA%\triflux\hosts.json`. 기존 source-tree `references/hosts.json` 은 라우팅 입력으로 사용하지 않으며 첫 실행 lazy auto-migration 대상이다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to triflux will be documented in this file.
 
 ## [Unreleased]
 
+### Docs
+
+- **`docs(native-bridge)` (PR #323 follow-up)** `CLAUDE.md` 에 `<native-bridge>` 섹션 추가 (모드별 default + row visibility 표 + opt-out `--no-native-bridge-ui` + 원격 shard 의 `registerSwarmShard()` warn + skip 동작 명시). `.claude/rules/tfx-routing.md` CLI 라우팅 섹션에 "Headless UI default" 1단락 추가. PR #323 (`feat(native-bridge)`: expose swarm shards without stale agent rows, commit `6f741364`) 의 user-facing 정책을 SSOT 문서로 정합.
+
+### Notes
+
+- **Observability side-effect default enabled** — Triflux headless workers now appear in `claude agents` by default. Opt-out: `--no-native-bridge-ui`. (consensus codex+agy 답변 Q3, 2026-05-21, PR #323 머지에 동반)
+
 ### Added
 
 - `tfx doctor`: verify wrapper script sources `secrets.env` (closes static-config gap left by PR #313 log-parser)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,21 @@ background로 실행한 headless 결과는 **반드시 task-notification 완료 
 워커 상세: `$TMPDIR/tfx-headless/{sessionName}-worker-N.txt`
 </headless-retrieval>
 
+<native-bridge>
+## native-bridge UI (claude agents 노출)
+
+headless 워커는 default 로 `claude agents` 패널에 row 로 등장한다. opt-out 은 `--no-native-bridge-ui`.
+
+| 모드 | default | row 가 보이는 위치 |
+|------|---------|--------------------|
+| `tfx-auto` / `tfx multi` (headless) | on | 로컬 `claude agents` |
+| `tfx swarm` 로컬 shard | on | 로컬 `claude agents` (`Triflux swarm <shard-name>`) |
+| `tfx swarm` 원격 shard | **skip + warn** | n/a — `registerSwarmShard()` 가 host!=local 일 때 `{ ok: true, skipped: true }` 반환하며 `"remote launcher must register on that host"` 만 경고. 원격 daemon 실제 등록은 후속 PRD. |
+| interactive (tmux/wt) | off | n/a |
+
+sentinel exit 즉시 daemon `sendKillBySessionId` 발사 → stale row 잔존 없음. PRD: `.triflux/plans/native-bridge-ui-default-expansion.md` (PR #323 으로 머지).
+</native-bridge>
+
 <cross-review>
 ## 교차 검증
 


### PR DESCRIPTION
## Summary

PR #323 (`feat(native-bridge): expose swarm shards without stale agent rows`, squash `6f741364`) 의 user-facing 정책을 SSOT 문서에 정합. docs-only, +25/0, 3 파일.

- `CLAUDE.md` 에 `<native-bridge>` 섹션 신규 — 모드별 default + row visibility 표
- `.claude/rules/tfx-routing.md` 의 CLI 라우팅 섹션에 "Headless UI default" 1단락
- `CHANGELOG.md` Unreleased 에 `docs(native-bridge)` entry + observability side-effect note (consensus Q3 답변)

## Background — 원래 PR #329 의 successor

원래 PR #329 (`feat/native-bridge-ui-tests-docs` → `feat/native-bridge-ui-default-expansion`) 가 리뷰 중 base 가 squash-merge 로 사라지면서 auto-CLOSED. 그 사이에 #326 이 packages/core mesh + hub/team minimal mirror 갭을 별도 PR 로 fix 했고, main 의 `tests/unit/packages-remote-imports.test.mjs` 가 이미 본 PR 의 test 변경보다 강한 회귀 가드 (conductor mesh imports check + linkPackageDependencies + 전체 entrypoint runtime import) 를 갖추게 됨. 따라서 본 PR 은 docs 부분만 재제출.

## Reviewer 결과 (PR #329 시점, 본 PR 에 그대로 carry-over)

| Reviewer | Recommendation | Findings |
|----------|---------------|----------|
| Claude (opus, code-reviewer) | merge | 2 P3 nits (CHANGELOG 한 줄 길이, test assert 순서) |
| Codex (gpt-5.5 high, code-reviewer) | originally FIX_FIRST → fixed | 2 P2 (원격 shard visibility docs 정확성 + static guard typo gap) — 둘 다 본 commit 의 CLAUDE.md `<native-bridge>` 표에 "skip + warn" 명시로 반영. static guard typo gap fix 는 #326 이 구조적으로 해소했으므로 별도 test 변경 불필요. |
| Antigravity | n/a | API_KEY_INVALID degrade → partial 2-CLI consensus |

## Tested

- ✅ `node --test tests/unit/packages-mirror.test.mjs tests/unit/packages-remote-imports.test.mjs tests/unit/keyword-rules-skill-targets.test.mjs` → 13/13 pass (main 의 #326 conductor mesh imports 케이스 포함)
- ✅ `npm run release:check-mirror` → Mirror OK
- ✅ `npm run release:check-sync` → Version sync OK (10.25.0)

## Constraint / Scope

- AI attribution trailer/footer 금지 (CLAUDE.md `<cross-review>`).
- Scope-risk: **low** — docs 3 파일, 코드 미수정. mirror 정책 위반 없음.

## Test plan

- [ ] 머지 후 next release 시 CHANGELOG Unreleased 가 promote