### PR TITLE
test(agy): opt-in gate for real-agy regression (skip by default)

### DIFF
--- a/tests/integration/agy-stdout-pipe.test.mjs
+++ b/tests/integration/agy-stdout-pipe.test.mjs
@@ -34,6 +34,15 @@ function getAgyPath() {
 }
 
 const AGY_PATH = getAgyPath();
+
+// 실측 agy CLI 를 직접 호출하는 5종 flag-mechanism regression 은 OAuth
+// 토큰 차감이 발생한다. CI / 기본 `npm test` 에서는 항상 skip 하고, 명시적
+// `TFX_AGY_LIVE=1 npm test` 또는 release 직전 검증 시에만 실행한다.
+// tfx-route.sh routing regression (이 파일 line 217+) 은 `tests/fixtures/bin/agy`
+// mock 으로 PATH override 되어 OAuth 와 무관하게 항상 실행된다.
+const AGY_LIVE_REGRESSION =
+  process.env.TFX_AGY_LIVE === "1" || process.env.TFX_AGY_LIVE === "true";
+
 const TEST_PROMPT = "Reply with single word: hi";
 const WELCOME_KEYWORDS = [
   "antigravity",
@@ -92,7 +101,11 @@ function out(result) {
 }
 
 test("agy --print prompt-passing regression tests", {
-  skip: !AGY_PATH ? "agy not in PATH" : false,
+  skip: !AGY_PATH
+    ? "agy not in PATH"
+    : !AGY_LIVE_REGRESSION
+      ? "set TFX_AGY_LIVE=1 to run real-agy regression (OAuth cost)"
+      : false,
 }, async (t) => {
   await t.test(
     "1. alpha commit pattern: --print --dangerously + stdin pipe -> success",


### PR DESCRIPTION
## Summary

`tests/integration/agy-stdout-pipe.test.mjs` 의 5종 flag-mechanism regression 이 매 `npm test` 마다 실측 agy binary 를 호출 → OAuth refresh + 사용량 차감 (지난 24h 에 약 130 + 66 호출 누적, swarm restart 까지 누적). 기본 `npm test` 에서는 skip 하고 명시적 `TFX_AGY_LIVE=1 npm test` opt-in 시에만 실행하도록 게이트 추가.

## Change

- `skip` 게이트에 `TFX_AGY_LIVE=1` 환경변수 검사를 한 단계 추가.
- regression 1-5 (real agy --print mechanism 검증): default skip / opt-in 실행.
- tfx-route.sh routing regression 2건 (line 217, 228): `tests/fixtures/bin/agy` mock 이 PATH override 로 적용되어 OAuth 와 무관 — 기존 그대로 항상 실행.

## Why opt-in rather than always-on mock?

regression 5종은 agy CLI 의 Go flag library 동작 (`--print` string value-flag, flag absorption, alpha commit pattern) 을 실측 검증하는 게 목적. `tests/fixtures/fake-agy-cli.mjs` mock 은 Go flag library 의 실제 mechanism (e.g. `--print` 뒤 다른 flag 가 오면 value 흡수 사고) 을 재현 못 함 → mock 화 하면 회귀 가드 의미 상실.

opt-in 으로 두면 release 직전 또는 agy CLI 버전 업그레이드 시 수동 검증 가능. CI default 는 OAuth 침묵.

## Tested

- Default `node --test tests/integration/agy-stdout-pipe.test.mjs` → 3 tests, 2 pass + 1 skip. OAuth 호출 0회.
- `npm run release:check-mirror` → Mirror OK (tests/ 는 mirror 제외 정책).
- `TFX_AGY_LIVE=1` 옵트인 검증은 OAuth 차감 발생하므로 머지 후 release 직전 별도 검증 권장.

## Constraint

- AI attribution trailer/footer 금지 (`CLAUDE.md` 정책 준수).
- Scope-risk: **low** — 단일 파일 +14/-1, opt-in 게이트 추가라 기존 CI 동작 보존.

## Test plan

- [ ] 머지 후 `TFX_AGY_LIVE=1 node --test tests/integration/agy-stdout-pipe.test.mjs` 로 5종 regression 한 번 통과 확인 (release prep 단계)
- [ ] 후속 — `tests/integration/tfx-route-quota.test.mjs` 의 5곳 `AGY_BIN="agy"` 도 quota 회귀가 목적이라 별도 평가 필요 (본 PR scope 아님)