### PR TITLE
Group swarm bridge rows by run identity

### DIFF
--- a/hub/team/claude-native-bridge.mjs
+++ b/hub/team/claude-native-bridge.mjs
@@ -230,6 +230,49 @@ function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
   return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
 }
 
+function compactDisplayPart(value, fallback = "") {
+  const text = String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || fallback;
+}
+
+function toPositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function formatShardOrdinal({ shardIndex, shardCount }) {
+  const index = toPositiveInteger(shardIndex);
+  const count = toPositiveInteger(shardCount);
+  if (!index || !count) return null;
+  const width = Math.max(String(count).length, 2);
+  return `${String(index).padStart(width, "0")}/${String(count).padStart(width, "0")}`;
+}
+
+function buildSwarmShardDisplayName({
+  sessionId,
+  cli,
+  swarmName,
+  shardIndex,
+  shardCount,
+  shardName,
+}) {
+  const groupName = compactDisplayPart(swarmName || sessionId, "swarm");
+  const agentName = compactDisplayPart(cli, "agent");
+  const workerName = compactDisplayPart(shardName, "shard");
+  return [
+    "Triflux swarm",
+    groupName,
+    formatShardOrdinal({ shardIndex, shardCount }),
+    agentName,
+    workerName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 function isLocalHost(host) {
   const value = String(host || "local").toLowerCase();
   return value === "local" || value === "localhost" || value === "127.0.0.1";
@@ -247,6 +290,9 @@ export async function registerSwarmShard({
   sessionId,
   cli = "codex",
   role = "worker",
+  swarmName,
+  shardIndex,
+  shardCount,
   shardName,
   cwd = process.cwd(),
   host = "local",
@@ -257,6 +303,14 @@ export async function registerSwarmShard({
   if (!sessionId) throw new Error("sessionId is required");
   if (!shardName) throw new Error("shardName is required");
 
+  const displayName = buildSwarmShardDisplayName({
+    sessionId,
+    cli,
+    swarmName,
+    shardIndex,
+    shardCount,
+    shardName,
+  });
   const warn = _deps.warn || ((message) => console.warn(message));
   if (!isLocalHost(host)) {
     warn(
@@ -268,6 +322,7 @@ export async function registerSwarmShard({
       host,
       sessionId,
       shardName,
+      displayName,
       close() {},
     };
   }
@@ -295,7 +350,6 @@ export async function registerSwarmShard({
   const jobsDir =
     paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
-  const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -547,6 +547,17 @@ export function createSwarmHypervisor(opts) {
     return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
   }
 
+  function getShardDisplayPosition(shard) {
+    const shardIndex = plan?.shards?.findIndex(
+      (item) => item.name === shard.name,
+    );
+    if (!plan?.shards?.length || shardIndex < 0) return {};
+    return {
+      shardIndex: shardIndex + 1,
+      shardCount: plan.shards.length,
+    };
+  }
+
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
     if (worker?.nativeBridgeClosePromise) {
       await worker.nativeBridgeClosePromise;
@@ -584,6 +595,8 @@ export function createSwarmHypervisor(opts) {
         sessionId: sessionConfig.id,
         cli: shard.agent,
         role: shard.role || "worker",
+        swarmName: runId,
+        ...getShardDisplayPosition(shard),
         shardName: shard.name,
         cwd: workdir,
         host: shard.host || "local",
@@ -606,7 +619,7 @@ export function createSwarmHypervisor(opts) {
           shard: shard.name,
           sessionId: sessionConfig.id,
           host: shard.host || "local",
-          displayName: `Triflux swarm ${shard.name}`,
+          displayName: registration?.displayName || null,
         },
       );
       return registration;

--- a/packages/remote/hub/team/claude-native-bridge.mjs
+++ b/packages/remote/hub/team/claude-native-bridge.mjs
@@ -230,6 +230,49 @@ function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
   return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
 }
 
+function compactDisplayPart(value, fallback = "") {
+  const text = String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || fallback;
+}
+
+function toPositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function formatShardOrdinal({ shardIndex, shardCount }) {
+  const index = toPositiveInteger(shardIndex);
+  const count = toPositiveInteger(shardCount);
+  if (!index || !count) return null;
+  const width = Math.max(String(count).length, 2);
+  return `${String(index).padStart(width, "0")}/${String(count).padStart(width, "0")}`;
+}
+
+function buildSwarmShardDisplayName({
+  sessionId,
+  cli,
+  swarmName,
+  shardIndex,
+  shardCount,
+  shardName,
+}) {
+  const groupName = compactDisplayPart(swarmName || sessionId, "swarm");
+  const agentName = compactDisplayPart(cli, "agent");
+  const workerName = compactDisplayPart(shardName, "shard");
+  return [
+    "Triflux swarm",
+    groupName,
+    formatShardOrdinal({ shardIndex, shardCount }),
+    agentName,
+    workerName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 function isLocalHost(host) {
   const value = String(host || "local").toLowerCase();
   return value === "local" || value === "localhost" || value === "127.0.0.1";
@@ -247,6 +290,9 @@ export async function registerSwarmShard({
   sessionId,
   cli = "codex",
   role = "worker",
+  swarmName,
+  shardIndex,
+  shardCount,
   shardName,
   cwd = process.cwd(),
   host = "local",
@@ -257,6 +303,14 @@ export async function registerSwarmShard({
   if (!sessionId) throw new Error("sessionId is required");
   if (!shardName) throw new Error("shardName is required");
 
+  const displayName = buildSwarmShardDisplayName({
+    sessionId,
+    cli,
+    swarmName,
+    shardIndex,
+    shardCount,
+    shardName,
+  });
   const warn = _deps.warn || ((message) => console.warn(message));
   if (!isLocalHost(host)) {
     warn(
@@ -268,6 +322,7 @@ export async function registerSwarmShard({
       host,
       sessionId,
       shardName,
+      displayName,
       close() {},
     };
   }
@@ -294,7 +349,6 @@ export async function registerSwarmShard({
     paths.sessionsDir || path.join(paths.configDir || configDir, "sessions");
   const jobsDir = paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
-  const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -547,6 +547,17 @@ export function createSwarmHypervisor(opts) {
     return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
   }
 
+  function getShardDisplayPosition(shard) {
+    const shardIndex = plan?.shards?.findIndex(
+      (item) => item.name === shard.name,
+    );
+    if (!plan?.shards?.length || shardIndex < 0) return {};
+    return {
+      shardIndex: shardIndex + 1,
+      shardCount: plan.shards.length,
+    };
+  }
+
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
     if (worker?.nativeBridgeClosePromise) {
       await worker.nativeBridgeClosePromise;
@@ -584,6 +595,8 @@ export function createSwarmHypervisor(opts) {
         sessionId: sessionConfig.id,
         cli: shard.agent,
         role: shard.role || "worker",
+        swarmName: runId,
+        ...getShardDisplayPosition(shard),
         shardName: shard.name,
         cwd: workdir,
         host: shard.host || "local",
@@ -606,7 +619,7 @@ export function createSwarmHypervisor(opts) {
           shard: shard.name,
           sessionId: sessionConfig.id,
           host: shard.host || "local",
-          displayName: `Triflux swarm ${shard.name}`,
+          displayName: registration?.displayName || null,
         },
       );
       return registration;

--- a/packages/triflux/hub/team/claude-native-bridge.mjs
+++ b/packages/triflux/hub/team/claude-native-bridge.mjs
@@ -230,6 +230,49 @@ function buildSwarmShardBridgeCommand({ displayName, sessionId }) {
   return `printf '%s\\n' ${shellSingleQuote(banner)}; while true; do sleep 3600; done`;
 }
 
+function compactDisplayPart(value, fallback = "") {
+  const text = String(value ?? "")
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || fallback;
+}
+
+function toPositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function formatShardOrdinal({ shardIndex, shardCount }) {
+  const index = toPositiveInteger(shardIndex);
+  const count = toPositiveInteger(shardCount);
+  if (!index || !count) return null;
+  const width = Math.max(String(count).length, 2);
+  return `${String(index).padStart(width, "0")}/${String(count).padStart(width, "0")}`;
+}
+
+function buildSwarmShardDisplayName({
+  sessionId,
+  cli,
+  swarmName,
+  shardIndex,
+  shardCount,
+  shardName,
+}) {
+  const groupName = compactDisplayPart(swarmName || sessionId, "swarm");
+  const agentName = compactDisplayPart(cli, "agent");
+  const workerName = compactDisplayPart(shardName, "shard");
+  return [
+    "Triflux swarm",
+    groupName,
+    formatShardOrdinal({ shardIndex, shardCount }),
+    agentName,
+    workerName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 function isLocalHost(host) {
   const value = String(host || "local").toLowerCase();
   return value === "local" || value === "localhost" || value === "127.0.0.1";
@@ -247,6 +290,9 @@ export async function registerSwarmShard({
   sessionId,
   cli = "codex",
   role = "worker",
+  swarmName,
+  shardIndex,
+  shardCount,
   shardName,
   cwd = process.cwd(),
   host = "local",
@@ -257,6 +303,14 @@ export async function registerSwarmShard({
   if (!sessionId) throw new Error("sessionId is required");
   if (!shardName) throw new Error("shardName is required");
 
+  const displayName = buildSwarmShardDisplayName({
+    sessionId,
+    cli,
+    swarmName,
+    shardIndex,
+    shardCount,
+    shardName,
+  });
   const warn = _deps.warn || ((message) => console.warn(message));
   if (!isLocalHost(host)) {
     warn(
@@ -268,6 +322,7 @@ export async function registerSwarmShard({
       host,
       sessionId,
       shardName,
+      displayName,
       close() {},
     };
   }
@@ -295,7 +350,6 @@ export async function registerSwarmShard({
   const jobsDir =
     paths.jobsDir || path.join(paths.configDir || configDir, "jobs");
   const short = deriveSwarmShort({ sessionId, shardName, host });
-  const displayName = `Triflux swarm ${shardName}`;
   const command = buildSwarmShardBridgeCommand({ displayName, sessionId });
   const payload = buildPayload({
     short,

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -547,6 +547,17 @@ export function createSwarmHypervisor(opts) {
     return `swarm-${safeSessionPart(runId)}-${safeSessionPart(shard.name)}-${short8}`;
   }
 
+  function getShardDisplayPosition(shard) {
+    const shardIndex = plan?.shards?.findIndex(
+      (item) => item.name === shard.name,
+    );
+    if (!plan?.shards?.length || shardIndex < 0) return {};
+    return {
+      shardIndex: shardIndex + 1,
+      shardCount: plan.shards.length,
+    };
+  }
+
   async function closeNativeBridgeRegistration(worker, shardName, reason) {
     if (worker?.nativeBridgeClosePromise) {
       await worker.nativeBridgeClosePromise;
@@ -584,6 +595,8 @@ export function createSwarmHypervisor(opts) {
         sessionId: sessionConfig.id,
         cli: shard.agent,
         role: shard.role || "worker",
+        swarmName: runId,
+        ...getShardDisplayPosition(shard),
         shardName: shard.name,
         cwd: workdir,
         host: shard.host || "local",
@@ -606,7 +619,7 @@ export function createSwarmHypervisor(opts) {
           shard: shard.name,
           sessionId: sessionConfig.id,
           host: shard.host || "local",
-          displayName: `Triflux swarm ${shard.name}`,
+          displayName: registration?.displayName || null,
         },
       );
       return registration;

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -586,7 +586,11 @@ describe("swarm-hypervisor", () => {
           createConductor,
           registerSwarmShard: async (opts) => {
             registerCalls.push(opts);
-            return { close: () => closeCalls.push(opts.shardName) };
+            return {
+              displayName:
+                "Triflux swarm native-bridge-parent-cwd 01/01 claude worker-a",
+              close: () => closeCalls.push(opts.shardName),
+            };
           },
           ensureWorktree: async ({ slug, runId }) => ({
             worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
@@ -601,12 +605,21 @@ describe("swarm-hypervisor", () => {
       assert.equal(registerCalls[0].shardName, "worker-a");
       assert.equal(registerCalls[0].cwd, workdir);
       assert.equal(registerCalls[0].sessionId, conductors[0].sessionConfig.id);
+      assert.equal(registerCalls[0].swarmName, "native-bridge-parent-cwd");
+      assert.equal(registerCalls[0].shardIndex, 1);
+      assert.equal(registerCalls[0].shardCount, 1);
       assert.equal(
         conductors[0].sessionConfig.workdir,
         `${workdir}/.codex-swarm/wt-worker-a`,
       );
 
       await hv.shutdown("native_bridge_parent_cwd_cleanup");
+      assert.equal(
+        readEventLog(hv.eventLogPath).find(
+          (entry) => entry.event === "native_bridge_registration",
+        )?.displayName,
+        "Triflux swarm native-bridge-parent-cwd 01/01 claude worker-a",
+      );
       hv = null;
       assert.deepEqual(closeCalls, ["worker-a"]);
     });

--- a/tests/unit/swarm-native-bridge-registration.test.mjs
+++ b/tests/unit/swarm-native-bridge-registration.test.mjs
@@ -55,10 +55,14 @@ test("local shard registers Triflux swarm shard row with shard display name", as
   const { server, requests } = await listenDaemon(paths.controlSock);
 
   try {
+    const expectedDisplayName = "Triflux swarm run42 02/05 codex api";
     const registration = await registerSwarmShard({
       sessionId: "swarm-run42-api-feedface",
       cli: "codex",
       role: "executor",
+      swarmName: "run42",
+      shardIndex: 2,
+      shardCount: 5,
       shardName: "api",
       cwd: "/tmp/project",
       host: "local",
@@ -72,9 +76,10 @@ test("local shard registers Triflux swarm shard row with shard display name", as
     assert.notEqual(dispatch.d.sessionId, "swarm-run42-api-feedface");
     assert.equal(registration.swarmSessionId, "swarm-run42-api-feedface");
     assert.equal(registration.sessionId, dispatch.d.sessionId);
+    assert.equal(registration.displayName, expectedDisplayName);
     assert.equal(dispatch.d.cwd, "/tmp/project");
-    assert.equal(dispatch.d.seed.name, "Triflux swarm api");
-    assert.equal(dispatch.d.seed.intent, "Triflux swarm api");
+    assert.equal(dispatch.d.seed.name, expectedDisplayName);
+    assert.equal(dispatch.d.seed.intent, expectedDisplayName);
 
     const projection = JSON.parse(
       await fs.readFile(path.join(paths.sessionsDir, `${process.pid}.json`)),
@@ -84,10 +89,10 @@ test("local shard registers Triflux swarm shard row with shard display name", as
     });
     await fs.writeFile(
       path.join(paths.jobsDir, dispatch.d.short, "state.json"),
-      JSON.stringify({ name: "Triflux swarm api" }),
+      JSON.stringify({ name: expectedDisplayName }),
       "utf8",
     );
-    assert.equal(projection.name, "Triflux swarm api");
+    assert.equal(projection.name, expectedDisplayName);
     assert.equal(projection.agent, "codex");
     assert.equal(projection.sessionId, dispatch.d.sessionId);
     assert.equal(projection.jobId, dispatch.d.short);
@@ -113,6 +118,9 @@ test("remote shard skips native bridge registration and emits warning", async ()
     shardName: "api",
     cwd: "/tmp/project",
     host: "ultra4",
+    swarmName: "run42",
+    shardIndex: 1,
+    shardCount: 2,
     _deps: {
       warn(message) {
         warnings.push(message);
@@ -125,5 +133,6 @@ test("remote shard skips native bridge registration and emits warning", async ()
 
   assert.equal(registration.skipped, true);
   assert.equal(registration.host, "ultra4");
+  assert.equal(registration.displayName, "Triflux swarm run42 01/02 codex api");
   assert.match(warnings[0], /remote shard.*ultra4.*skipping/u);
 });


### PR DESCRIPTION
## Summary
- Add stable pseudo-group display names for native bridge swarm shard rows: run id, shard ordinal, agent, shard name.
- Pass swarm run metadata from the hypervisor into native bridge registration.
- Keep packages/triflux mirror and packages/remote copies aligned.

## Tests
- node --test tests/unit/swarm-native-bridge-registration.test.mjs tests/unit/swarm-hypervisor.test.mjs
- npm run release:check-mirror
- npx biome check hub/team/claude-native-bridge.mjs hub/team/swarm-hypervisor.mjs packages/remote/hub/team/claude-native-bridge.mjs packages/remote/hub/team/swarm-hypervisor.mjs tests/unit/swarm-native-bridge-registration.test.mjs tests/unit/swarm-hypervisor.test.mjs
- node --test tests/unit/packages-remote-imports.test.mjs tests/unit/packages-mirror.test.mjs