### PR TITLE
Fix tfx-route smoke config guard on macOS

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1994,7 +1994,7 @@ _codex_config_swap() {
     # Pre-validation: config.toml이 500 bytes 미만이면 이미 손상된 상태일 수 있음 — 스킵
     local config_size
     config_size=$(wc -c < "$config" 2>/dev/null | tr -d ' ') || config_size=0
-    if [[ "$config_size" -lt 500 ]]; then
+    if [[ "$config_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: config.toml 크기 ${config_size} bytes — 손상 의심, swap 스킵 (수동 확인 필요)" >&2
       return 0
     fi
@@ -2025,7 +2025,7 @@ _codex_config_swap() {
       # backup 이 원본을 담고 있는 한 그것을 살린다.
       local backup_restore_guard_size
       backup_restore_guard_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_guard_size=0
-      if [[ "$backup_restore_guard_size" -lt 500 ]]; then
+      if [[ "$backup_restore_guard_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
         # 작은 backup 은 이미 손상된 state. 현재 config 도 필터된 상태일 수 있으므로
         # 추가 swap 은 상황을 악화시킬 위험. 전체 스킵하고 수동 확인 유도.
         echo "[tfx-route] stale backup 작음 (size=${backup_restore_guard_size}B, pid=${owner_pid:-?} dead) — swap 스킵, 수동 확인: $backup" >&2
@@ -2065,7 +2065,7 @@ _codex_config_swap() {
     filtered_size=$(wc -c < "$tmp_filtered" 2>/dev/null | tr -d ' ') || filtered_size=0
     backup_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_size=1
     threshold=$(( backup_size * 30 / 100 ))
-    if [[ "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ]]; then
+    if [[ ( "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ) && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: 필터 결과 크기 ${filtered_size} bytes (백업 ${backup_size} bytes의 30% 미만) — 적용 거부, 백업에서 복원" >&2
       rm -f "$tmp_filtered" 2>/dev/null
       rm -f "$backup" 2>/dev/null
@@ -2092,7 +2092,7 @@ _codex_config_swap() {
     # Restore sanity check: 백업 자체가 비었거나 500 bytes 미만이면 복원 중단
     local backup_restore_size
     backup_restore_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_size=0
-    if [[ "$backup_restore_size" -lt 500 ]]; then
+    if [[ "$backup_restore_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: backup 크기 ${backup_restore_size} bytes — 손상 의심, 복원 중단. 수동 확인 필요: $backup" >&2
       return 1
     fi
@@ -2436,6 +2436,10 @@ FALLBACK_EOF
   fi
 
   if [[ "$CLI_TYPE" == "codex" ]]; then
+    # Degraded is a per-invocation result, not an inherited process contract.
+    # Test and wrapper environments can carry stale exported values from prior
+    # route calls; clear it before the current MCP preflight decides.
+    unset _TFX_MCP_DEGRADED
     # Preflight: dead MCP 감지 후 CODEX_CONFIG_FLAGS 에서 제거.
     # swap 이 allowed_pat 을 이 배열에서 계산하므로, 여기서 제거하면
     # dead section 이 config.toml 에서 자동으로 drop 된다.

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1994,7 +1994,7 @@ _codex_config_swap() {
     # Pre-validation: config.toml이 500 bytes 미만이면 이미 손상된 상태일 수 있음 — 스킵
     local config_size
     config_size=$(wc -c < "$config" 2>/dev/null | tr -d ' ') || config_size=0
-    if [[ "$config_size" -lt 500 ]]; then
+    if [[ "$config_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: config.toml 크기 ${config_size} bytes — 손상 의심, swap 스킵 (수동 확인 필요)" >&2
       return 0
     fi
@@ -2025,7 +2025,7 @@ _codex_config_swap() {
       # backup 이 원본을 담고 있는 한 그것을 살린다.
       local backup_restore_guard_size
       backup_restore_guard_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_guard_size=0
-      if [[ "$backup_restore_guard_size" -lt 500 ]]; then
+      if [[ "$backup_restore_guard_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
         # 작은 backup 은 이미 손상된 state. 현재 config 도 필터된 상태일 수 있으므로
         # 추가 swap 은 상황을 악화시킬 위험. 전체 스킵하고 수동 확인 유도.
         echo "[tfx-route] stale backup 작음 (size=${backup_restore_guard_size}B, pid=${owner_pid:-?} dead) — swap 스킵, 수동 확인: $backup" >&2
@@ -2065,7 +2065,7 @@ _codex_config_swap() {
     filtered_size=$(wc -c < "$tmp_filtered" 2>/dev/null | tr -d ' ') || filtered_size=0
     backup_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_size=1
     threshold=$(( backup_size * 30 / 100 ))
-    if [[ "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ]]; then
+    if [[ ( "$filtered_size" -eq 0 || "$filtered_size" -lt "$threshold" ) && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: 필터 결과 크기 ${filtered_size} bytes (백업 ${backup_size} bytes의 30% 미만) — 적용 거부, 백업에서 복원" >&2
       rm -f "$tmp_filtered" 2>/dev/null
       rm -f "$backup" 2>/dev/null
@@ -2092,7 +2092,7 @@ _codex_config_swap() {
     # Restore sanity check: 백업 자체가 비었거나 500 bytes 미만이면 복원 중단
     local backup_restore_size
     backup_restore_size=$(wc -c < "$backup" 2>/dev/null | tr -d ' ') || backup_restore_size=0
-    if [[ "$backup_restore_size" -lt 500 ]]; then
+    if [[ "$backup_restore_size" -lt 500 && "${TFX_ALLOW_SMALL_CODEX_CONFIG:-0}" != "1" ]]; then
       echo "[tfx-route] 경고: backup 크기 ${backup_restore_size} bytes — 손상 의심, 복원 중단. 수동 확인 필요: $backup" >&2
       return 1
     fi
@@ -2436,6 +2436,10 @@ FALLBACK_EOF
   fi
 
   if [[ "$CLI_TYPE" == "codex" ]]; then
+    # Degraded is a per-invocation result, not an inherited process contract.
+    # Test and wrapper environments can carry stale exported values from prior
+    # route calls; clear it before the current MCP preflight decides.
+    unset _TFX_MCP_DEGRADED
     # Preflight: dead MCP 감지 후 CODEX_CONFIG_FLAGS 에서 제거.
     # swap 이 allowed_pat 을 이 배열에서 계산하므로, 여기서 제거하면
     # dead section 이 config.toml 에서 자동으로 drop 된다.

--- a/tests/integration/tfx-route-smoke.test.mjs
+++ b/tests/integration/tfx-route-smoke.test.mjs
@@ -77,6 +77,9 @@ function runBash(command, extraEnv = {}) {
       // #148: 테스트 환경에서는 실제 MCP probe 가 모두 dead 로 나와 early-fail 발생.
       // 라우팅/트랜스포트 검증이 목적이므로 preflight 자체를 스킵.
       TFX_MCP_HEALTH_CHECK: "0",
+      // Fixture config is intentionally tiny but valid. Production keeps the
+      // small-config corruption guard unless a caller opts in explicitly.
+      TFX_ALLOW_SMALL_CODEX_CONFIG: "1",
       ...extraEnv,
     },
   });


### PR DESCRIPTION
## Why
`tfx-route-smoke` was failing on macOS because fixture `config.toml` files are intentionally tiny, while the production corruption guard treats sub-500-byte configs as suspicious. After that guard was bypassed for the fixture, stale inherited `_TFX_MCP_DEGRADED` could still force the Codex transport path away from the current invocation's preflight result.

## What changed
- Adds explicit `TFX_ALLOW_SMALL_CODEX_CONFIG=1` only inside the route smoke test harness.
- Keeps production small-config corruption guards default-on unless that opt-in is set.
- Clears inherited `_TFX_MCP_DEGRADED` before the Codex MCP preflight so each invocation decides transport from fresh state.
- Mirrors the root `tfx-route.sh` change into `packages/triflux`.

## Regression guard
- Preserves PR #332 Antigravity/Gemini redirect behavior on top of current `origin/main`.
- Avoids weakening real user `config.toml` corruption protection.

## Tested
- `timeout 320 node --test tests/integration/tfx-route-smoke.test.mjs` — 41/41 pass
- `node --test tests/integration/agy-stdout-pipe.test.mjs tests/integration/tfx-route-quota.test.mjs` — 15 pass, 1 live-AGY skip
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `npx biome check scripts/tfx-route.sh packages/triflux/scripts/tfx-route.sh tests/integration/tfx-route-smoke.test.mjs`
- `bash -n scripts/tfx-route.sh packages/triflux/scripts/tfx-route.sh`
- `git diff --check`

## Not tested
- Live AGY OAuth smoke with `TFX_AGY_LIVE=1`
- npm publish path
