### PR TITLE
Fix release notes directory creation in prepare

### DIFF
--- a/packages/triflux/scripts/release/prepare.mjs
+++ b/packages/triflux/scripts/release/prepare.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -135,6 +135,7 @@ export async function prepareRelease({
     "plans",
     `release-notes-v${releaseVersion}.md`,
   );
+  mkdirSync(join(rootDir, ".omx", "plans"), { recursive: true });
   writeFileSync(notesPath, notes, "utf8");
 
   return {

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -135,6 +135,7 @@ export async function prepareRelease({
     "plans",
     `release-notes-v${releaseVersion}.md`,
   );
+  mkdirSync(join(rootDir, ".omx", "plans"), { recursive: true });
   writeFileSync(notesPath, notes, "utf8");
 
   return {

--- a/tests/regression/release-prepare-completes-all-steps.test.mjs
+++ b/tests/regression/release-prepare-completes-all-steps.test.mjs
@@ -14,7 +14,13 @@
 // step sequence 단락 회귀는 즉시 catch.
 
 import { strict as assert } from "node:assert";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
@@ -193,5 +199,48 @@ describe("release:prepare regression — step sequence completeness", () => {
     // skipTests=true 일 때 test 는 skip, lint + pack 만 호출
     assert.deepEqual(buildSteps, ["lint", "pack"]);
     assert.ok(result.releaseNotesPath);
+  });
+
+  it("CI fresh checkout 처럼 .omx/plans 가 없어도 release-notes 디렉터리를 생성", async () => {
+    const tmpRootNoOmx = mkdtempSync(join(tmpdir(), "tfx-prepare-no-omx-"));
+    try {
+      const manifest = {
+        canonicalFile: "package.json",
+        canonicalPath: ["version"],
+        targets: [{ file: "package.json", paths: [["version"]] }],
+      };
+
+      mkdirSync(join(tmpRootNoOmx, "scripts", "release"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(tmpRootNoOmx, "scripts", "release", "version-manifest.json"),
+        JSON.stringify(manifest, null, 2),
+      );
+      writeFileSync(
+        join(tmpRootNoOmx, "package.json"),
+        JSON.stringify({ name: "test", version: "10.25.1" }, null, 2),
+      );
+
+      const { fn } = makeMockExec();
+      const result = await prepareRelease({
+        version: "10.25.1",
+        rootDir: tmpRootNoOmx,
+        allowDirty: true,
+        dryRun: false,
+        skipTests: true,
+        execFileSyncFn: fn,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(
+        existsSync(
+          join(tmpRootNoOmx, ".omx", "plans", "release-notes-v10.25.1.md"),
+        ),
+        true,
+      );
+    } finally {
+      rmSync(tmpRootNoOmx, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Why
The v10.25.1 release workflow failed in `Prepare release` before any publish/tag/release side effect. Root cause: GitHub Actions fresh checkout has no `.omx/plans` directory, and `prepare.mjs` wrote `.omx/plans/release-notes-v10.25.1.md` without creating the parent directory.

## What changed
- `prepare.mjs` now creates `.omx/plans` recursively before writing release notes.
- Mirrored the change to `packages/triflux/scripts/release/prepare.mjs`.
- Added a regression test that simulates a CI fresh checkout without `.omx/plans`.

## Side-effect audit
- Failed run: https://github.com/tellang/triflux/actions/runs/26215957709
- Failure happened in `Prepare release`; `Publish release` and `Verify release` were skipped.
- Post-run checks confirmed no `10.25.1` npm packages, no `v10.25.1` tag, and no GitHub release.

## Tested
- `node --test tests/regression/release-prepare-completes-all-steps.test.mjs`
- `node --test scripts/__tests__/release-governance.test.mjs`
- `node --test tests/unit/release-prepare-testlock.test.mjs`
- `npm run release:check-sync`
- `npm run release:check-mirror`
- `npx biome check scripts/release/prepare.mjs packages/triflux/scripts/release/prepare.mjs tests/regression/release-prepare-completes-all-steps.test.mjs`
- `git diff --check`
- `node scripts/release/prepare.mjs --version 10.25.1 --execute --skip-tests --allow-dirty --json`

## Not tested
- GitHub Actions release workflow rerun
- `npm publish --execute`
