### PR TITLE
Let release automation use trusted npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,16 +34,37 @@ jobs:
         working-directory: packages/core
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published; skipping."
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Publish @triflux/remote
         working-directory: packages/remote
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published; skipping."
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Publish triflux
         working-directory: packages/triflux
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published; skipping."
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,8 +26,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - name: Verify npm 11.5.1+
+        run: npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -36,9 +40,8 @@ jobs:
 
       - name: Publish release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --execute
+        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --provenance --execute
 
       - name: Verify release
         env:

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -137,6 +137,20 @@ describe("release governance scripts", () => {
       });
       assert.equal(publish.steps.length >= 3, true);
 
+      const trustedPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: true,
+        provenance: true,
+      });
+      assert.equal(trustedPublish.provenance, true);
+      assert.deepEqual(
+        trustedPublish.steps
+          .filter((step) => step.label.startsWith("npm publish"))
+          .map((step) => step.command.includes("--provenance")),
+        [true, true, true],
+      );
+
       const verify = await verifyRelease({
         rootDir: root,
         version: "1.2.3",
@@ -166,6 +180,30 @@ describe("release governance scripts", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("release workflows use trusted publishing and skip duplicate tag publishes", () => {
+    const releaseWorkflow = readFileSync(
+      new URL("../../.github/workflows/release.yml", import.meta.url),
+      "utf8",
+    );
+    assert.match(releaseWorkflow, /id-token:\s*write/);
+    assert.match(releaseWorkflow, /node-version:\s*24/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--provenance/);
+    assert.doesNotMatch(
+      releaseWorkflow,
+      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    );
+
+    const npmPublishWorkflow = readFileSync(
+      new URL("../../.github/workflows/npm-publish.yml", import.meta.url),
+      "utf8",
+    );
+    assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
+    assert.equal(
+      (npmPublishWorkflow.match(/already published; skipping/g) || []).length,
+      3,
+    );
   });
 
   it("verify reports explicit npm package/version failures", async () => {

--- a/packages/triflux/scripts/release/publish.mjs
+++ b/packages/triflux/scripts/release/publish.mjs
@@ -9,6 +9,7 @@ export async function publishRelease({
   channel = "stable",
   dryRun = true,
   createGithubRelease = true,
+  provenance = false,
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -18,24 +19,39 @@ export async function publishRelease({
 
   const releaseVersion = version || sync.rootVersion;
   const npmTag = channel === "canary" ? "canary" : "latest";
+  const provenanceArgs = provenance ? ["--provenance"] : [];
   const npmPublishTargets = [
     {
       label: "npm publish @triflux/core",
       cwd: join(rootDir, "packages", "core"),
       displayCwd: "packages/core",
-      args: ["publish", "--tag", npmTag, "--access", "public"],
+      args: [
+        "publish",
+        "--tag",
+        npmTag,
+        ...provenanceArgs,
+        "--access",
+        "public",
+      ],
     },
     {
       label: "npm publish @triflux/remote",
       cwd: join(rootDir, "packages", "remote"),
       displayCwd: "packages/remote",
-      args: ["publish", "--tag", npmTag, "--access", "public"],
+      args: [
+        "publish",
+        "--tag",
+        npmTag,
+        ...provenanceArgs,
+        "--access",
+        "public",
+      ],
     },
     {
       label: "npm publish triflux",
       cwd: join(rootDir, "packages", "triflux"),
       displayCwd: "packages/triflux",
-      args: ["publish", "--tag", npmTag],
+      args: ["publish", "--tag", npmTag, ...provenanceArgs],
     },
   ];
   const notesPath = join(
@@ -90,6 +106,7 @@ export async function publishRelease({
     version: releaseVersion,
     channel,
     npmTag,
+    provenance,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -103,12 +120,15 @@ export async function publishRelease({
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   const args = parseArgs(process.argv.slice(2));
+  const envProvenance =
+    String(process.env.NPM_CONFIG_PROVENANCE || "").toLowerCase() === "true";
   const result = await publishRelease({
     version: args.version,
     rootDir: args.root,
     channel: args.channel || "stable",
     dryRun: !args.execute,
     createGithubRelease: !args["skip-gh-release"],
+    provenance: Boolean(args.provenance || envProvenance),
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -137,6 +137,20 @@ describe("release governance scripts", () => {
       });
       assert.equal(publish.steps.length >= 3, true);
 
+      const trustedPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: true,
+        provenance: true,
+      });
+      assert.equal(trustedPublish.provenance, true);
+      assert.deepEqual(
+        trustedPublish.steps
+          .filter((step) => step.label.startsWith("npm publish"))
+          .map((step) => step.command.includes("--provenance")),
+        [true, true, true],
+      );
+
       const verify = await verifyRelease({
         rootDir: root,
         version: "1.2.3",
@@ -166,6 +180,30 @@ describe("release governance scripts", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("release workflows use trusted publishing and skip duplicate tag publishes", () => {
+    const releaseWorkflow = readFileSync(
+      new URL("../../.github/workflows/release.yml", import.meta.url),
+      "utf8",
+    );
+    assert.match(releaseWorkflow, /id-token:\s*write/);
+    assert.match(releaseWorkflow, /node-version:\s*24/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--provenance/);
+    assert.doesNotMatch(
+      releaseWorkflow,
+      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    );
+
+    const npmPublishWorkflow = readFileSync(
+      new URL("../../.github/workflows/npm-publish.yml", import.meta.url),
+      "utf8",
+    );
+    assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
+    assert.equal(
+      (npmPublishWorkflow.match(/already published; skipping/g) || []).length,
+      3,
+    );
   });
 
   it("verify reports explicit npm package/version failures", async () => {

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -9,6 +9,7 @@ export async function publishRelease({
   channel = "stable",
   dryRun = true,
   createGithubRelease = true,
+  provenance = false,
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -18,24 +19,39 @@ export async function publishRelease({
 
   const releaseVersion = version || sync.rootVersion;
   const npmTag = channel === "canary" ? "canary" : "latest";
+  const provenanceArgs = provenance ? ["--provenance"] : [];
   const npmPublishTargets = [
     {
       label: "npm publish @triflux/core",
       cwd: join(rootDir, "packages", "core"),
       displayCwd: "packages/core",
-      args: ["publish", "--tag", npmTag, "--access", "public"],
+      args: [
+        "publish",
+        "--tag",
+        npmTag,
+        ...provenanceArgs,
+        "--access",
+        "public",
+      ],
     },
     {
       label: "npm publish @triflux/remote",
       cwd: join(rootDir, "packages", "remote"),
       displayCwd: "packages/remote",
-      args: ["publish", "--tag", npmTag, "--access", "public"],
+      args: [
+        "publish",
+        "--tag",
+        npmTag,
+        ...provenanceArgs,
+        "--access",
+        "public",
+      ],
     },
     {
       label: "npm publish triflux",
       cwd: join(rootDir, "packages", "triflux"),
       displayCwd: "packages/triflux",
-      args: ["publish", "--tag", npmTag],
+      args: ["publish", "--tag", npmTag, ...provenanceArgs],
     },
   ];
   const notesPath = join(
@@ -90,6 +106,7 @@ export async function publishRelease({
     version: releaseVersion,
     channel,
     npmTag,
+    provenance,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -103,12 +120,15 @@ export async function publishRelease({
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   const args = parseArgs(process.argv.slice(2));
+  const envProvenance =
+    String(process.env.NPM_CONFIG_PROVENANCE || "").toLowerCase() === "true";
   const result = await publishRelease({
     version: args.version,
     rootDir: args.root,
     channel: args.channel || "stable",
     dryRun: !args.execute,
     createGithubRelease: !args["skip-gh-release"],
+    provenance: Boolean(args.provenance || envProvenance),
   });
   console.log(JSON.stringify(result, null, 2));
 }


### PR DESCRIPTION
The release workflow reached publish on v10.25.1 but failed with ENEEDAUTH because NPM_TOKEN is not configured. The existing npm-publish workflow already uses GitHub OIDC/trusted publishing, so the release workflow now uses the same provenance path and the tag-triggered npm workflow skips versions already published by the release job.

Constraint: npm package publication must work from GitHub Actions without a legacy NPM_TOKEN secret.

Rejected: Re-add a long-lived NPM_TOKEN secret | duplicates existing trusted-publishing setup and keeps the release workflow dependent on secret drift.

Rejected: Publish locally from this workstation | would bypass the registered GitHub Actions release evidence.

Confidence: high

Scope-risk: narrow

Directive: Keep release.yml and npm-publish.yml on one trusted-publishing contract; tag-triggered npm publishes must remain idempotent.

Tested: node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check; publish.mjs --provenance dry-run

Not-tested: Live npm publish until this patch is merged and release.yml is rerun.
