### PR TITLE
Route releases through the registered npm publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,12 +38,59 @@ jobs:
       - name: Prepare release
         run: node scripts/release/prepare.mjs --version ${{ inputs.version }} --execute
 
-      - name: Publish release
+      - name: Create tag and GitHub release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --provenance --execute
+        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --execute
+
+      - name: Wait for npm publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ inputs.version }}"
+          head_sha="$(git rev-parse HEAD)"
+          deadline=$((SECONDS + 900))
+
+          echo "Waiting for npm-publish.yml push run for $tag at $head_sha"
+          while (( SECONDS < deadline )); do
+            run_json="$(
+              gh run list \
+                --workflow npm-publish.yml \
+                --limit 20 \
+                --json databaseId,status,conclusion,headBranch,headSha,event,url \
+                | jq -c --arg tag "$tag" --arg sha "$head_sha" '
+                  map(select(.event == "push" and .headBranch == $tag and .headSha == $sha))
+                  | first // empty
+                '
+            )"
+
+            if [[ -n "$run_json" ]]; then
+              run_id="$(jq -r '.databaseId' <<<"$run_json")"
+              status="$(jq -r '.status' <<<"$run_json")"
+              conclusion="$(jq -r '.conclusion // ""' <<<"$run_json")"
+              url="$(jq -r '.url' <<<"$run_json")"
+              echo "npm publish run $run_id: status=$status conclusion=${conclusion:-none} $url"
+
+              if [[ "$status" == "completed" ]]; then
+                if [[ "$conclusion" == "success" ]]; then
+                  exit 0
+                fi
+                gh run view "$run_id" --log-failed || true
+                exit 1
+              fi
+            else
+              echo "npm publish run has not started yet."
+            fi
+
+            sleep 15
+          done
+
+          echo "Timed out waiting for npm-publish.yml to complete for $tag"
+          exit 1
 
       - name: Verify release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/release/verify.mjs --version ${{ inputs.version }} --execute

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -150,6 +150,23 @@ describe("release governance scripts", () => {
           .map((step) => step.command.includes("--provenance")),
         [true, true, true],
       );
+      const tagOnlyPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: true,
+        publishNpm: false,
+      });
+      assert.equal(tagOnlyPublish.publishNpm, false);
+      assert.equal(
+        tagOnlyPublish.steps.some((step) =>
+          step.label.startsWith("npm publish"),
+        ),
+        false,
+      );
+      assert.deepEqual(
+        tagOnlyPublish.steps.map((step) => step.label),
+        ["git tag", "git push", "gh release create"],
+      );
 
       const verify = await verifyRelease({
         rootDir: root,
@@ -187,9 +204,11 @@ describe("release governance scripts", () => {
       new URL("../../.github/workflows/release.yml", import.meta.url),
       "utf8",
     );
-    assert.match(releaseWorkflow, /id-token:\s*write/);
+    assert.match(releaseWorkflow, /actions:\s*read/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
-    assert.match(releaseWorkflow, /publish\.mjs.*--provenance/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /npm-publish\.yml/);
+    assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,
       /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,

--- a/packages/triflux/scripts/release/publish.mjs
+++ b/packages/triflux/scripts/release/publish.mjs
@@ -9,6 +9,7 @@ export async function publishRelease({
   channel = "stable",
   dryRun = true,
   createGithubRelease = true,
+  publishNpm = true,
   provenance = false,
   execFileSyncFn,
 } = {}) {
@@ -61,13 +62,15 @@ export async function publishRelease({
     `release-notes-v${releaseVersion}.md`,
   );
   const steps = [
-    ...npmPublishTargets.map((target) => ({
-      label: target.label,
-      command: "npm",
-      args: target.args,
-      cwd: target.cwd,
-      displayCwd: target.displayCwd,
-    })),
+    ...(publishNpm
+      ? npmPublishTargets.map((target) => ({
+          label: target.label,
+          command: "npm",
+          args: target.args,
+          cwd: target.cwd,
+          displayCwd: target.displayCwd,
+        }))
+      : []),
     { label: "git tag", command: "git", args: ["tag", `v${releaseVersion}`] },
     {
       label: "git push",
@@ -106,6 +109,7 @@ export async function publishRelease({
     version: releaseVersion,
     channel,
     npmTag,
+    publishNpm,
     provenance,
     dryRun,
     notesPath,
@@ -128,6 +132,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     channel: args.channel || "stable",
     dryRun: !args.execute,
     createGithubRelease: !args["skip-gh-release"],
+    publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
   });
   console.log(JSON.stringify(result, null, 2));

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -150,6 +150,23 @@ describe("release governance scripts", () => {
           .map((step) => step.command.includes("--provenance")),
         [true, true, true],
       );
+      const tagOnlyPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: true,
+        publishNpm: false,
+      });
+      assert.equal(tagOnlyPublish.publishNpm, false);
+      assert.equal(
+        tagOnlyPublish.steps.some((step) =>
+          step.label.startsWith("npm publish"),
+        ),
+        false,
+      );
+      assert.deepEqual(
+        tagOnlyPublish.steps.map((step) => step.label),
+        ["git tag", "git push", "gh release create"],
+      );
 
       const verify = await verifyRelease({
         rootDir: root,
@@ -187,9 +204,11 @@ describe("release governance scripts", () => {
       new URL("../../.github/workflows/release.yml", import.meta.url),
       "utf8",
     );
-    assert.match(releaseWorkflow, /id-token:\s*write/);
+    assert.match(releaseWorkflow, /actions:\s*read/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
-    assert.match(releaseWorkflow, /publish\.mjs.*--provenance/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /npm-publish\.yml/);
+    assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,
       /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -9,6 +9,7 @@ export async function publishRelease({
   channel = "stable",
   dryRun = true,
   createGithubRelease = true,
+  publishNpm = true,
   provenance = false,
   execFileSyncFn,
 } = {}) {
@@ -61,13 +62,15 @@ export async function publishRelease({
     `release-notes-v${releaseVersion}.md`,
   );
   const steps = [
-    ...npmPublishTargets.map((target) => ({
-      label: target.label,
-      command: "npm",
-      args: target.args,
-      cwd: target.cwd,
-      displayCwd: target.displayCwd,
-    })),
+    ...(publishNpm
+      ? npmPublishTargets.map((target) => ({
+          label: target.label,
+          command: "npm",
+          args: target.args,
+          cwd: target.cwd,
+          displayCwd: target.displayCwd,
+        }))
+      : []),
     { label: "git tag", command: "git", args: ["tag", `v${releaseVersion}`] },
     {
       label: "git push",
@@ -106,6 +109,7 @@ export async function publishRelease({
     version: releaseVersion,
     channel,
     npmTag,
+    publishNpm,
     provenance,
     dryRun,
     notesPath,
@@ -128,6 +132,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     channel: args.channel || "stable",
     dryRun: !args.execute,
     createGithubRelease: !args["skip-gh-release"],
+    publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
   });
   console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
Trusted npm publishing is authorized per package and workflow filename. The v10.25.1 release workflow proved release.yml can obtain OIDC but cannot publish packages configured for the existing npm-publish.yml publisher, so release.yml now creates the tag and GitHub release, waits for the tag-triggered npm-publish.yml run, then runs the existing verifier.

Constraint: npm Trusted Publishing accepts only the workflow filename configured for each package.

Rejected: Add release.yml as another direct npm publisher | npm allows one trusted publisher per package and the existing registration is npm-publish.yml.

Rejected: Reintroduce NPM_TOKEN publishing | the repository is already on tokenless trusted publishing.

Confidence: high

Scope-risk: moderate

Directive: Keep npm publish commands in npm-publish.yml; release.yml may tag, release, wait, and verify but should not publish npm directly unless package trusted-publisher settings are changed intentionally.

Tested: node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check; publish.mjs --skip-npm dry-run

Not-tested: Live tag-triggered npm publish until this patch is merged and release.yml is rerun.
