### PR TITLE
Keep npm trusted publishing tokenless

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,11 +29,8 @@ jobs:
         run: npm ci || npm install --no-audit --no-fund
 
       # Each npm package needs a Trusted Publisher entry for OIDC/provenance.
-      # If OIDC is not configured yet, set NPM_TOKEN as a fallback secret.
       - name: Publish @triflux/core
         working-directory: packages/core
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
@@ -45,8 +42,6 @@ jobs:
 
       - name: Publish @triflux/remote
         working-directory: packages/remote
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
@@ -58,8 +53,6 @@ jobs:
 
       - name: Publish triflux
         working-directory: packages/triflux
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +44,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --execute
 
+      - name: Dispatch npm publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run npm-publish.yml --ref v${{ inputs.version }}
+
       - name: Wait for npm publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +65,13 @@ jobs:
                 --limit 20 \
                 --json databaseId,status,conclusion,headBranch,headSha,event,url \
                 | jq -c --arg tag "$tag" --arg sha "$head_sha" '
-                  map(select(.event == "push" and .headBranch == $tag and .headSha == $sha))
+                  map(
+                    select(
+                      (.event == "push" or .event == "workflow_dispatch")
+                      and .headBranch == $tag
+                      and .headSha == $sha
+                    )
+                  )
                   | first // empty
                 '
             )"

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -204,10 +204,12 @@ describe("release governance scripts", () => {
       new URL("../../.github/workflows/release.yml", import.meta.url),
       "utf8",
     );
-    assert.match(releaseWorkflow, /actions:\s*read/);
+    assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
     assert.match(releaseWorkflow, /npm-publish\.yml/);
+    assert.match(releaseWorkflow, /workflow_dispatch/);
     assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,
@@ -219,6 +221,10 @@ describe("release governance scripts", () => {
       "utf8",
     );
     assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
+    assert.doesNotMatch(
+      npmPublishWorkflow,
+      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    );
     assert.equal(
       (npmPublishWorkflow.match(/already published; skipping/g) || []).length,
       3,

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -204,10 +204,12 @@ describe("release governance scripts", () => {
       new URL("../../.github/workflows/release.yml", import.meta.url),
       "utf8",
     );
-    assert.match(releaseWorkflow, /actions:\s*read/);
+    assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
     assert.match(releaseWorkflow, /npm-publish\.yml/);
+    assert.match(releaseWorkflow, /workflow_dispatch/);
     assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,
@@ -219,6 +221,10 @@ describe("release governance scripts", () => {
       "utf8",
     );
     assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
+    assert.doesNotMatch(
+      npmPublishWorkflow,
+      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    );
     assert.equal(
       (npmPublishWorkflow.match(/already published; skipping/g) || []).length,
       3,


### PR DESCRIPTION
The manual v10.25.1 npm-publish dispatch still failed because each publish step injected an empty NODE_AUTH_TOKEN fallback, preventing npm from obtaining the OIDC trusted-publishing credential. The release workflow also needs to dispatch npm-publish.yml explicitly because tags pushed by GITHUB_TOKEN do not start downstream push workflows.

Constraint: npm trusted publishing requires id-token permission and no stale empty token override in the publish environment.

Rejected: Keep an empty NPM_TOKEN fallback | it masks the OIDC credential path and reproduces ENEEDAUTH.

Rejected: Rely on tag push from GITHUB_TOKEN | GitHub suppresses recursive workflow triggers for token-created pushes.

Confidence: high

Scope-risk: narrow

Directive: Do not set NODE_AUTH_TOKEN in trusted-publishing steps unless a real token-based publish path is intentionally restored and tested.

Tested: node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check

Not-tested: Live npm-publish rerun until this patch is merged.
