### PR TITLE
Let release reruns resume existing artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --execute
+        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --allow-existing --execute
 
       - name: Dispatch npm publish
         env:

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -168,6 +168,29 @@ describe("release governance scripts", () => {
         ["git tag", "git push", "gh release create"],
       );
 
+      const executed = [];
+      const resumedPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        publishNpm: false,
+        allowExistingArtifacts: true,
+        execFileSyncFn: (command, args) => {
+          executed.push([command, ...args].join(" "));
+          if (command === "git" && args[0] === "rev-parse") return "tag\n";
+          if (command === "gh" && args[0] === "release") {
+            return '{"tagName":"v1.2.3"}\n';
+          }
+          return "";
+        },
+      });
+      assert.equal(resumedPublish.allowExistingArtifacts, true);
+      assert.deepEqual(executed, [
+        "git rev-parse --verify v1.2.3",
+        "git push origin HEAD --tags",
+        "gh release view v1.2.3 --json tagName",
+      ]);
+
       const verify = await verifyRelease({
         rootDir: root,
         version: "1.2.3",
@@ -206,7 +229,7 @@ describe("release governance scripts", () => {
     );
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
-    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
     assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
     assert.match(releaseWorkflow, /npm-publish\.yml/);
     assert.match(releaseWorkflow, /workflow_dispatch/);

--- a/packages/triflux/scripts/release/publish.mjs
+++ b/packages/triflux/scripts/release/publish.mjs
@@ -11,6 +11,7 @@ export async function publishRelease({
   createGithubRelease = true,
   publishNpm = true,
   provenance = false,
+  allowExistingArtifacts = false,
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -95,8 +96,46 @@ export async function publishRelease({
     });
   }
 
+  const shouldSkipExistingTag = (tagName) => {
+    if (!allowExistingArtifacts) return false;
+    try {
+      runCommand("git", ["rev-parse", "--verify", tagName], {
+        cwd: rootDir,
+        execFileSyncFn,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const shouldSkipExistingGithubRelease = (tagName) => {
+    if (!allowExistingArtifacts) return false;
+    try {
+      runCommand("gh", ["release", "view", tagName, "--json", "tagName"], {
+        cwd: rootDir,
+        execFileSyncFn,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   if (!dryRun) {
     for (const step of steps) {
+      const tagName = `v${releaseVersion}`;
+      if (step.label === "git tag" && shouldSkipExistingTag(tagName)) {
+        continue;
+      }
+      if (
+        step.label === "gh release create" &&
+        shouldSkipExistingGithubRelease(tagName)
+      ) {
+        continue;
+      }
       runCommand(step.command, step.args, {
         cwd: step.cwd || rootDir,
         execFileSyncFn,
@@ -111,6 +150,7 @@ export async function publishRelease({
     npmTag,
     publishNpm,
     provenance,
+    allowExistingArtifacts,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -134,6 +174,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     createGithubRelease: !args["skip-gh-release"],
     publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
+    allowExistingArtifacts: Boolean(args["allow-existing"]),
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -168,6 +168,29 @@ describe("release governance scripts", () => {
         ["git tag", "git push", "gh release create"],
       );
 
+      const executed = [];
+      const resumedPublish = await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        publishNpm: false,
+        allowExistingArtifacts: true,
+        execFileSyncFn: (command, args) => {
+          executed.push([command, ...args].join(" "));
+          if (command === "git" && args[0] === "rev-parse") return "tag\n";
+          if (command === "gh" && args[0] === "release") {
+            return '{"tagName":"v1.2.3"}\n';
+          }
+          return "";
+        },
+      });
+      assert.equal(resumedPublish.allowExistingArtifacts, true);
+      assert.deepEqual(executed, [
+        "git rev-parse --verify v1.2.3",
+        "git push origin HEAD --tags",
+        "gh release view v1.2.3 --json tagName",
+      ]);
+
       const verify = await verifyRelease({
         rootDir: root,
         version: "1.2.3",
@@ -206,7 +229,7 @@ describe("release governance scripts", () => {
     );
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
-    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
     assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
     assert.match(releaseWorkflow, /npm-publish\.yml/);
     assert.match(releaseWorkflow, /workflow_dispatch/);

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -11,6 +11,7 @@ export async function publishRelease({
   createGithubRelease = true,
   publishNpm = true,
   provenance = false,
+  allowExistingArtifacts = false,
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -95,8 +96,46 @@ export async function publishRelease({
     });
   }
 
+  const shouldSkipExistingTag = (tagName) => {
+    if (!allowExistingArtifacts) return false;
+    try {
+      runCommand("git", ["rev-parse", "--verify", tagName], {
+        cwd: rootDir,
+        execFileSyncFn,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const shouldSkipExistingGithubRelease = (tagName) => {
+    if (!allowExistingArtifacts) return false;
+    try {
+      runCommand("gh", ["release", "view", tagName, "--json", "tagName"], {
+        cwd: rootDir,
+        execFileSyncFn,
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   if (!dryRun) {
     for (const step of steps) {
+      const tagName = `v${releaseVersion}`;
+      if (step.label === "git tag" && shouldSkipExistingTag(tagName)) {
+        continue;
+      }
+      if (
+        step.label === "gh release create" &&
+        shouldSkipExistingGithubRelease(tagName)
+      ) {
+        continue;
+      }
       runCommand(step.command, step.args, {
         cwd: step.cwd || rootDir,
         execFileSyncFn,
@@ -111,6 +150,7 @@ export async function publishRelease({
     npmTag,
     publishNpm,
     provenance,
+    allowExistingArtifacts,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -134,6 +174,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     createGithubRelease: !args["skip-gh-release"],
     publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
+    allowExistingArtifacts: Boolean(args["allow-existing"]),
   });
   console.log(JSON.stringify(result, null, 2));
 }


### PR DESCRIPTION
The v10.25.1 recovery created the tag and GitHub release before npm publishing was fully unblocked. Subsequent release workflow runs must be able to skip already-created local release artifacts and continue to the npm-publish dispatch/wait phase instead of failing on duplicate git tag or gh release creation.

Constraint: v10.25.1 currently exists as a GitHub tag/release while npm packages are still missing.

Rejected: Delete and recreate the public tag/release | destructive and unnecessary while npm artifacts are still recoverable.

Rejected: Treat duplicate release artifacts as terminal failure | blocks safe recovery after CI/auth failures.

Confidence: high

Scope-risk: narrow

Directive: Use --allow-existing only for audited release-resume paths; do not use it to hide unexpected tag/release drift.

Tested: node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check; publish.mjs --skip-npm --allow-existing dry-run

Not-tested: Live release rerun remains blocked until npm trusted publisher permissions are corrected.
