### PR TITLE
Dispatch release npm publishing from the current ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,28 +47,28 @@ jobs:
       - name: Dispatch npm publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run npm-publish.yml --ref v${{ inputs.version }}
+        run: gh workflow run npm-publish.yml --ref ${{ github.ref_name }}
 
       - name: Wait for npm publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="v${{ inputs.version }}"
+          publish_ref="${{ github.ref_name }}"
           head_sha="$(git rev-parse HEAD)"
           deadline=$((SECONDS + 900))
 
-          echo "Waiting for npm-publish.yml push run for $tag at $head_sha"
+          echo "Waiting for npm-publish.yml workflow_dispatch run for $publish_ref at $head_sha"
           while (( SECONDS < deadline )); do
             run_json="$(
               gh run list \
                 --workflow npm-publish.yml \
                 --limit 20 \
                 --json databaseId,status,conclusion,headBranch,headSha,event,url \
-                | jq -c --arg tag "$tag" --arg sha "$head_sha" '
+                | jq -c --arg publish_ref "$publish_ref" --arg sha "$head_sha" '
                   map(
                     select(
-                      (.event == "push" or .event == "workflow_dispatch")
-                      and .headBranch == $tag
+                      .event == "workflow_dispatch"
+                      and .headBranch == $publish_ref
                       and .headSha == $sha
                     )
                   )
@@ -97,7 +97,7 @@ jobs:
             sleep 15
           done
 
-          echo "Timed out waiting for npm-publish.yml to complete for $tag"
+          echo "Timed out waiting for npm-publish.yml to complete for $publish_ref"
           exit 1
 
       - name: Verify release

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -230,9 +230,13 @@ describe("release governance scripts", () => {
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
-    assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
+    assert.match(
+      releaseWorkflow,
+      /gh workflow run npm-publish\.yml --ref \$\{\{ github\.ref_name \}\}/,
+    );
     assert.match(releaseWorkflow, /npm-publish\.yml/);
     assert.match(releaseWorkflow, /workflow_dispatch/);
+    assert.match(releaseWorkflow, /publish_ref="\$\{\{ github\.ref_name \}\}"/);
     assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -230,9 +230,13 @@ describe("release governance scripts", () => {
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
-    assert.match(releaseWorkflow, /gh workflow run npm-publish\.yml/);
+    assert.match(
+      releaseWorkflow,
+      /gh workflow run npm-publish\.yml --ref \$\{\{ github\.ref_name \}\}/,
+    );
     assert.match(releaseWorkflow, /npm-publish\.yml/);
     assert.match(releaseWorkflow, /workflow_dispatch/);
+    assert.match(releaseWorkflow, /publish_ref="\$\{\{ github\.ref_name \}\}"/);
     assert.match(releaseWorkflow, /gh run list/);
     assert.doesNotMatch(
       releaseWorkflow,


### PR DESCRIPTION
The v10.25.1 recovery run proved that dispatching npm-publish.yml on the existing v10.25.1 tag reuses stale workflow code from the pre-fix release commit. Release.yml must dispatch npm publishing from the same ref and commit it just prepared, then wait for that workflow_dispatch run by ref and SHA.

Constraint: the public v10.25.1 tag currently points at the original release metadata commit, before the npm trusted-publishing workflow fixes.

Rejected: Dispatch npm-publish.yml on v10.25.1 | runs stale workflow code and reproduces the old empty-token failure.

Rejected: Force-move the public tag | destructive and unnecessary for publishing the versioned npm artifacts.

Confidence: high

Scope-risk: narrow

Directive: Release resume should run npm-publish.yml from the release workflow ref, not from an already-created historical tag.

Tested: node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check

Not-tested: Live publish remains dependent on npm Trusted Publisher package permissions.
