### PR TITLE
Let npm publishing fall back to the release token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,33 +31,48 @@ jobs:
       # Each npm package needs a Trusted Publisher entry for OIDC/provenance.
       - name: Publish @triflux/core
         working-directory: packages/core
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
           if npm view "$name@$version" version >/dev/null 2>&1; then
             echo "$name@$version is already published; skipping."
           else
+            if [[ -n "${NPM_TOKEN:-}" ]]; then
+              export NODE_AUTH_TOKEN="$NPM_TOKEN"
+            fi
             npm publish --provenance --access public
           fi
 
       - name: Publish @triflux/remote
         working-directory: packages/remote
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
           if npm view "$name@$version" version >/dev/null 2>&1; then
             echo "$name@$version is already published; skipping."
           else
+            if [[ -n "${NPM_TOKEN:-}" ]]; then
+              export NODE_AUTH_TOKEN="$NPM_TOKEN"
+            fi
             npm publish --provenance --access public
           fi
 
       - name: Publish triflux
         working-directory: packages/triflux
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
           if npm view "$name@$version" version >/dev/null 2>&1; then
             echo "$name@$version is already published; skipping."
           else
+            if [[ -n "${NPM_TOKEN:-}" ]]; then
+              export NODE_AUTH_TOKEN="$NPM_TOKEN"
+            fi
             npm publish --provenance --access public
           fi

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -248,9 +248,19 @@ describe("release governance scripts", () => {
       "utf8",
     );
     assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
-    assert.doesNotMatch(
-      npmPublishWorkflow,
-      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    assert.doesNotMatch(npmPublishWorkflow, /NODE_AUTH_TOKEN:\s*\$\{\{/);
+    assert.equal(
+      (
+        npmPublishWorkflow.match(
+          /NPM_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/g,
+        ) || []
+      ).length,
+      3,
+    );
+    assert.equal(
+      (npmPublishWorkflow.match(/export NODE_AUTH_TOKEN="\$NPM_TOKEN"/g) || [])
+        .length,
+      3,
     );
     assert.equal(
       (npmPublishWorkflow.match(/already published; skipping/g) || []).length,

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -248,9 +248,19 @@ describe("release governance scripts", () => {
       "utf8",
     );
     assert.match(npmPublishWorkflow, /npm view "\$name@\$version" version/);
-    assert.doesNotMatch(
-      npmPublishWorkflow,
-      /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/,
+    assert.doesNotMatch(npmPublishWorkflow, /NODE_AUTH_TOKEN:\s*\$\{\{/);
+    assert.equal(
+      (
+        npmPublishWorkflow.match(
+          /NPM_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/g,
+        ) || []
+      ).length,
+      3,
+    );
+    assert.equal(
+      (npmPublishWorkflow.match(/export NODE_AUTH_TOKEN="\$NPM_TOKEN"/g) || [])
+        .length,
+      3,
     );
     assert.equal(
       (npmPublishWorkflow.match(/already published; skipping/g) || []).length,


### PR DESCRIPTION
The npm token available to the release environment authenticates as tellang and has package read-write access, but npm trust management is forbidden. Keep the OIDC trusted-publishing path as the default while allowing npm-publish.yml to export NODE_AUTH_TOKEN from the NPM_TOKEN secret when present so the current v10.25.1 partial release can complete through GitHub Actions.

Constraint: npm trust github returns 403 for this token, while package collaborator access is read-write and dry-run publish succeeds.

Rejected: Local npm publish from the workstation | would bypass GitHub Actions release evidence.

Rejected: Hard-require NPM_TOKEN | would regress future tokenless trusted-publishing once package trust is configured.

Confidence: high

Scope-risk: narrow

Directive: Keep NODE_AUTH_TOKEN set inside the publish step only, derived from NPM_TOKEN when present; do not store tokens in package files or logs.

Tested: gh secret set/list NPM_TOKEN; npm whoami via temp npmrc; npm access collaborators; npm publish --dry-run for all packages; node --test scripts/__tests__/release-governance.test.mjs; npm run release:check-sync; npm run release:check-mirror; npx biome check targeted files; git diff --check

Not-tested: Live publish until this patch is merged and release.yml rerun.
