### PR TITLE
test: skip sqlite suites when native binding is absent

### DIFF
--- a/tests/helpers/sqlite.mjs
+++ b/tests/helpers/sqlite.mjs
@@ -1,0 +1,35 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+let cached;
+let cachedCtor;
+
+export function getBetterSqlite3UnavailableReason() {
+  if (cached !== undefined) return cached;
+
+  try {
+    const mod = require("better-sqlite3");
+    const Database = mod.default ?? mod;
+    const probe = new Database(":memory:");
+    probe.prepare("SELECT 1").get();
+    probe.close();
+    cachedCtor = Database;
+    cached = "";
+    return cached;
+  } catch (error) {
+    cached = `better-sqlite3 native binding unavailable in this environment: ${error.message}`;
+    return cached;
+  }
+}
+
+export const SQLITE_SKIP = getBetterSqlite3UnavailableReason() || false;
+
+export function loadBetterSqlite3ForTest() {
+  const reason = getBetterSqlite3UnavailableReason();
+  if (reason) throw new Error(reason);
+  if (cachedCtor) return cachedCtor;
+  const mod = require("better-sqlite3");
+  cachedCtor = mod.default ?? mod;
+  return cachedCtor;
+}

--- a/tests/integration/bridge-pipe.test.mjs
+++ b/tests/integration/bridge-pipe.test.mjs
@@ -8,13 +8,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { promisify } from "node:util";
-import Database from "better-sqlite3";
 import { initPipelineState } from "../../hub/pipeline/state.mjs";
 import { startHub } from "../../hub/server.mjs";
 import {
   createConductorRegistry,
   setConductorRegistry,
 } from "../../hub/team/conductor-registry.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -166,7 +166,10 @@ describe("bridge.mjs pipe-first", () => {
     }
   });
 
-  it("pipeline-state는 HTTP가 죽어 있어도 pipe로 조회되어야 한다", async () => {
+  it("pipeline-state는 HTTP가 죽어 있어도 pipe로 조회되어야 한다", {
+    skip: SQLITE_SKIP,
+  }, async () => {
+    const Database = loadBetterSqlite3ForTest();
     const db = new Database(dbPath);
     initPipelineState(db, "pipe-state-team");
     db.close();
@@ -184,7 +187,10 @@ describe("bridge.mjs pipe-first", () => {
     assert.equal(result.data.phase, "plan");
   });
 
-  it("pipeline-advance는 pipe 실패 시 HTTP fallback으로 성공해야 한다", async () => {
+  it("pipeline-advance는 pipe 실패 시 HTTP fallback으로 성공해야 한다", {
+    skip: SQLITE_SKIP,
+  }, async () => {
+    const Database = loadBetterSqlite3ForTest();
     const db = new Database(dbPath);
     initPipelineState(db, "http-fallback-team");
     db.close();
@@ -228,7 +234,9 @@ describe("bridge.mjs pipe-first", () => {
     assert.equal(result.data.status, "queued");
   });
 
-  it("pipeline-init/list는 공통 transport helper를 통해 동작해야 한다", async () => {
+  it("pipeline-init/list는 공통 transport helper를 통해 동작해야 한다", {
+    skip: SQLITE_SKIP,
+  }, async () => {
     const initResult = await execBridge(
       [
         "pipeline-init",

--- a/tests/integration/router-route.test.mjs
+++ b/tests/integration/router-route.test.mjs
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { createRouter } from "../../hub/router.mjs";
 import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 // 격리된 임시 DB 경로 생성
 function tempDbPath() {
@@ -22,7 +23,7 @@ function tempDbPath() {
   return join(dir, "test.db");
 }
 
-describe("createRouter() — route() 직접 호출", () => {
+describe("createRouter() — route() 직접 호출", { skip: SQLITE_SKIP }, () => {
   let store;
   let _router;
 
@@ -98,7 +99,9 @@ describe("createRouter() — route() 직접 호출", () => {
   });
 });
 
-describe("createRouter() — responseEmitter 기반 ask/publish 응답 수신", () => {
+describe("createRouter() — responseEmitter 기반 ask/publish 응답 수신", {
+  skip: SQLITE_SKIP,
+}, () => {
   let store;
   let router;
   let dbPath;
@@ -199,7 +202,9 @@ describe("createRouter() — responseEmitter 기반 ask/publish 응답 수신", 
   });
 });
 
-describe("createRouter() — getStatus() 분기 보완", () => {
+describe("createRouter() — getStatus() 분기 보완", {
+  skip: SQLITE_SKIP,
+}, () => {
   let store;
   let router;
   let dbPath;

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { createRouter } from "../../hub/router.mjs";
 import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 function tempDbPath() {
   const dir = join(tmpdir(), `tfx-router-test-${randomUUID()}`);
@@ -16,7 +17,7 @@ function tempDbPath() {
   return join(dir, "test.db");
 }
 
-describe("createRouter()", () => {
+describe("createRouter()", { skip: SQLITE_SKIP }, () => {
   let store;
   let router;
   let dbPath;

--- a/tests/integration/store.test.mjs
+++ b/tests/integration/store.test.mjs
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 
 import { createStore, uuidv7 } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 // ── 헬퍼: 격리된 임시 DB 경로 생성 ──
 function tempDbPath() {
@@ -41,7 +42,7 @@ describe("uuidv7()", () => {
 });
 
 // ── createStore() ──
-describe("createStore()", () => {
+describe("createStore()", { skip: SQLITE_SKIP }, () => {
   let store;
   let dbPath;
 

--- a/tests/pipeline/state.test.mjs
+++ b/tests/pipeline/state.test.mjs
@@ -4,7 +4,6 @@ import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import Database from "better-sqlite3";
 import {
   ensurePipelineTable,
   initPipelineState,
@@ -13,153 +12,157 @@ import {
   removePipelineState,
   updatePipelineState,
 } from "../../hub/pipeline/state.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
-let db;
-let dbPath;
+describe("pipeline state sqlite", { skip: SQLITE_SKIP }, () => {
+  let db;
+  let dbPath;
 
-beforeEach(() => {
-  dbPath = join(
-    tmpdir(),
-    `tfx-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
-  );
-  db = new Database(dbPath);
-  db.pragma("journal_mode = WAL");
-  ensurePipelineTable(db);
-});
-
-afterEach(() => {
-  db.close();
-  try {
-    unlinkSync(dbPath);
-  } catch {}
-});
-
-describe("ensurePipelineTable", () => {
-  it("테이블 생성 (멱등)", () => {
-    // 이미 beforeEach에서 생성됨 — 두 번 호출해도 에러 없음
+  beforeEach(() => {
+    dbPath = join(
+      tmpdir(),
+      `tfx-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    const Database = loadBetterSqlite3ForTest();
+    db = new Database(dbPath);
+    db.pragma("journal_mode = WAL");
     ensurePipelineTable(db);
-    const tables = db
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='pipeline_state'",
-      )
-      .all();
-    assert.equal(tables.length, 1);
-  });
-});
-
-describe("initPipelineState", () => {
-  it("기본값으로 초기화", () => {
-    const state = initPipelineState(db, "test-team");
-    assert.equal(state.team_name, "test-team");
-    assert.equal(state.phase, "plan");
-    assert.equal(state.fix_attempt, 0);
-    assert.equal(state.fix_max, 3);
-    assert.equal(state.ralph_iteration, 0);
-    assert.equal(state.ralph_max, 10);
-    assert.deepEqual(state.artifacts, {});
-    assert.deepEqual(state.phase_history, []);
   });
 
-  it("커스텀 옵션 적용", () => {
-    const state = initPipelineState(db, "custom-team", {
-      fix_max: 5,
-      ralph_max: 20,
+  afterEach(() => {
+    db.close();
+    try {
+      unlinkSync(dbPath);
+    } catch {}
+  });
+
+  describe("ensurePipelineTable", () => {
+    it("테이블 생성 (멱등)", () => {
+      // 이미 beforeEach에서 생성됨 — 두 번 호출해도 에러 없음
+      ensurePipelineTable(db);
+      const tables = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='pipeline_state'",
+        )
+        .all();
+      assert.equal(tables.length, 1);
     });
-    assert.equal(state.fix_max, 5);
-    assert.equal(state.ralph_max, 20);
   });
 
-  it("기존 상태 덮어쓰기", () => {
-    initPipelineState(db, "overwrite-team");
-    const state = initPipelineState(db, "overwrite-team", { fix_max: 7 });
-    assert.equal(state.fix_max, 7);
-    assert.equal(state.phase, "plan");
-  });
-});
-
-describe("readPipelineState", () => {
-  it("존재하는 팀 조회", () => {
-    initPipelineState(db, "read-team");
-    const state = readPipelineState(db, "read-team");
-    assert.equal(state.team_name, "read-team");
-    assert.equal(state.phase, "plan");
-  });
-
-  it("존재하지 않는 팀 → null", () => {
-    const state = readPipelineState(db, "nonexistent");
-    assert.equal(state, null);
-  });
-
-  it("artifacts/phase_history JSON 파싱", () => {
-    initPipelineState(db, "json-team");
-    updatePipelineState(db, "json-team", {
-      artifacts: { plan_path: "/tmp/plan.md" },
-      phase_history: [{ from: "plan", to: "prd", at: 123 }],
+  describe("initPipelineState", () => {
+    it("기본값으로 초기화", () => {
+      const state = initPipelineState(db, "test-team");
+      assert.equal(state.team_name, "test-team");
+      assert.equal(state.phase, "plan");
+      assert.equal(state.fix_attempt, 0);
+      assert.equal(state.fix_max, 3);
+      assert.equal(state.ralph_iteration, 0);
+      assert.equal(state.ralph_max, 10);
+      assert.deepEqual(state.artifacts, {});
+      assert.deepEqual(state.phase_history, []);
     });
-    const state = readPipelineState(db, "json-team");
-    assert.equal(state.artifacts.plan_path, "/tmp/plan.md");
-    assert.equal(state.phase_history.length, 1);
-  });
-});
 
-describe("updatePipelineState", () => {
-  it("부분 패치 적용", () => {
-    initPipelineState(db, "patch-team");
-    const updated = updatePipelineState(db, "patch-team", {
-      phase: "exec",
-      fix_attempt: 2,
+    it("커스텀 옵션 적용", () => {
+      const state = initPipelineState(db, "custom-team", {
+        fix_max: 5,
+        ralph_max: 20,
+      });
+      assert.equal(state.fix_max, 5);
+      assert.equal(state.ralph_max, 20);
     });
-    assert.equal(updated.phase, "exec");
-    assert.equal(updated.fix_attempt, 2);
-    assert.equal(updated.fix_max, 3); // 변경하지 않은 필드 유지
-  });
 
-  it("team_name 변경 불가", () => {
-    initPipelineState(db, "immutable-team");
-    const updated = updatePipelineState(db, "immutable-team", {
-      team_name: "hacked",
+    it("기존 상태 덮어쓰기", () => {
+      initPipelineState(db, "overwrite-team");
+      const state = initPipelineState(db, "overwrite-team", { fix_max: 7 });
+      assert.equal(state.fix_max, 7);
+      assert.equal(state.phase, "plan");
     });
-    assert.equal(updated.team_name, "immutable-team");
   });
 
-  it("존재하지 않는 팀 → null", () => {
-    const result = updatePipelineState(db, "ghost", { phase: "exec" });
-    assert.equal(result, null);
-  });
-});
+  describe("readPipelineState", () => {
+    it("존재하는 팀 조회", () => {
+      initPipelineState(db, "read-team");
+      const state = readPipelineState(db, "read-team");
+      assert.equal(state.team_name, "read-team");
+      assert.equal(state.phase, "plan");
+    });
 
-describe("removePipelineState", () => {
-  it("삭제 성공", () => {
-    initPipelineState(db, "remove-team");
-    assert.ok(removePipelineState(db, "remove-team"));
-    assert.equal(readPipelineState(db, "remove-team"), null);
-  });
+    it("존재하지 않는 팀 → null", () => {
+      const state = readPipelineState(db, "nonexistent");
+      assert.equal(state, null);
+    });
 
-  it("존재하지 않는 팀 삭제 → false", () => {
-    assert.ok(!removePipelineState(db, "no-team"));
-  });
-});
-
-describe("listPipelineStates", () => {
-  it("여러 팀 목록", () => {
-    initPipelineState(db, "team-a");
-    initPipelineState(db, "team-b");
-    initPipelineState(db, "team-c");
-    const list = listPipelineStates(db);
-    assert.equal(list.length, 3);
+    it("artifacts/phase_history JSON 파싱", () => {
+      initPipelineState(db, "json-team");
+      updatePipelineState(db, "json-team", {
+        artifacts: { plan_path: "/tmp/plan.md" },
+        phase_history: [{ from: "plan", to: "prd", at: 123 }],
+      });
+      const state = readPipelineState(db, "json-team");
+      assert.equal(state.artifacts.plan_path, "/tmp/plan.md");
+      assert.equal(state.phase_history.length, 1);
+    });
   });
 
-  it("updated_at 내림차순 정렬", () => {
-    initPipelineState(db, "old-team");
-    initPipelineState(db, "new-team");
-    // updatePipelineState는 항상 Date.now()를 사용하므로 직접 SQL로 차이 부여
-    db.prepare(
-      "UPDATE pipeline_state SET updated_at = 1000 WHERE team_name = 'old-team'",
-    ).run();
-    db.prepare(
-      "UPDATE pipeline_state SET updated_at = 2000 WHERE team_name = 'new-team'",
-    ).run();
-    const list = listPipelineStates(db);
-    assert.equal(list[0].team_name, "new-team");
+  describe("updatePipelineState", () => {
+    it("부분 패치 적용", () => {
+      initPipelineState(db, "patch-team");
+      const updated = updatePipelineState(db, "patch-team", {
+        phase: "exec",
+        fix_attempt: 2,
+      });
+      assert.equal(updated.phase, "exec");
+      assert.equal(updated.fix_attempt, 2);
+      assert.equal(updated.fix_max, 3); // 변경하지 않은 필드 유지
+    });
+
+    it("team_name 변경 불가", () => {
+      initPipelineState(db, "immutable-team");
+      const updated = updatePipelineState(db, "immutable-team", {
+        team_name: "hacked",
+      });
+      assert.equal(updated.team_name, "immutable-team");
+    });
+
+    it("존재하지 않는 팀 → null", () => {
+      const result = updatePipelineState(db, "ghost", { phase: "exec" });
+      assert.equal(result, null);
+    });
+  });
+
+  describe("removePipelineState", () => {
+    it("삭제 성공", () => {
+      initPipelineState(db, "remove-team");
+      assert.ok(removePipelineState(db, "remove-team"));
+      assert.equal(readPipelineState(db, "remove-team"), null);
+    });
+
+    it("존재하지 않는 팀 삭제 → false", () => {
+      assert.ok(!removePipelineState(db, "no-team"));
+    });
+  });
+
+  describe("listPipelineStates", () => {
+    it("여러 팀 목록", () => {
+      initPipelineState(db, "team-a");
+      initPipelineState(db, "team-b");
+      initPipelineState(db, "team-c");
+      const list = listPipelineStates(db);
+      assert.equal(list.length, 3);
+    });
+
+    it("updated_at 내림차순 정렬", () => {
+      initPipelineState(db, "old-team");
+      initPipelineState(db, "new-team");
+      // updatePipelineState는 항상 Date.now()를 사용하므로 직접 SQL로 차이 부여
+      db.prepare(
+        "UPDATE pipeline_state SET updated_at = 1000 WHERE team_name = 'old-team'",
+      ).run();
+      db.prepare(
+        "UPDATE pipeline_state SET updated_at = 2000 WHERE team_name = 'new-team'",
+      ).run();
+      const list = listPipelineStates(db);
+      assert.equal(list[0].team_name, "new-team");
+    });
   });
 });

--- a/tests/unit/pipeline-gates-integration.test.mjs
+++ b/tests/unit/pipeline-gates-integration.test.mjs
@@ -4,7 +4,6 @@
 
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import Database from "better-sqlite3";
 
 import {
   createPipeline,
@@ -14,6 +13,7 @@ import {
   initPipelineState,
   readPipelineState,
 } from "../../hub/pipeline/state.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 // ── 헬퍼 ───────────────────────────────────────────────────────────────────
 
@@ -55,10 +55,13 @@ function pipelineAtDeslop(db, teamName) {
 
 // ── runConfidenceGate ───────────────────────────────────────────────────────
 
-describe("runConfidenceGate — decision별 상태 전이", () => {
+describe("runConfidenceGate — decision별 상태 전이", {
+  skip: SQLITE_SKIP,
+}, () => {
   let db;
 
   beforeEach(() => {
+    const Database = loadBetterSqlite3ForTest();
     db = new Database(":memory:");
     ensurePipelineTable(db);
   });
@@ -176,10 +179,13 @@ describe("runConfidenceGate — decision별 상태 전이", () => {
 
 // ── runSelfCheckGate ────────────────────────────────────────────────────────
 
-describe("runSelfCheckGate — pass/fail별 상태 전이", () => {
+describe("runSelfCheckGate — pass/fail별 상태 전이", {
+  skip: SQLITE_SKIP,
+}, () => {
   let db;
 
   beforeEach(() => {
+    const Database = loadBetterSqlite3ForTest();
     db = new Database(":memory:");
     ensurePipelineTable(db);
   });
@@ -294,10 +300,13 @@ describe("runSelfCheckGate — pass/fail별 상태 전이", () => {
 
 // ── runDeslopGate ───────────────────────────────────────────────────────────
 
-describe("runDeslopGate — unconditional verify 전이", () => {
+describe("runDeslopGate — unconditional verify 전이", {
+  skip: SQLITE_SKIP,
+}, () => {
   let db;
 
   beforeEach(() => {
+    const Database = loadBetterSqlite3ForTest();
     db = new Database(":memory:");
     ensurePipelineTable(db);
   });

--- a/tests/unit/pipeline-stop.test.mjs
+++ b/tests/unit/pipeline-stop.test.mjs
@@ -6,14 +6,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import Database from "better-sqlite3";
-
 import {
   ensurePipelineStateDbPath,
   ensurePipelineTable,
   initPipelineState,
   updatePipelineState,
 } from "../../hub/pipeline/state.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 const HOOK_PATH = fileURLToPath(
   new URL("../../hooks/pipeline-stop.mjs", import.meta.url),
@@ -32,6 +31,7 @@ function createValidPluginRoot(baseDir, name = "plugin-root") {
 
 function writePipelineState(baseDir, teamName, phase = "exec") {
   const dbPath = ensurePipelineStateDbPath(baseDir);
+  const Database = loadBetterSqlite3ForTest();
   const db = new Database(dbPath);
   ensurePipelineTable(db);
   initPipelineState(db, teamName);
@@ -83,7 +83,7 @@ function parseStdout(result) {
   return JSON.parse(result.stdout);
 }
 
-describe("pipeline-stop hook", () => {
+describe("pipeline-stop hook", { skip: SQLITE_SKIP }, () => {
   let sandboxDir;
   let homeDir;
   let pluginRoot;

--- a/tests/unit/pipeline.test.mjs
+++ b/tests/unit/pipeline.test.mjs
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import Database from "better-sqlite3";
 import {
   createPipeline,
   ensurePipelineTable,
 } from "../../hub/pipeline/index.mjs";
 import { initPipelineState } from "../../hub/pipeline/state.mjs";
 import { createTools } from "../../hub/tools.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 // 테스트 전용 임시 디렉토리 (CWD를 오염시키지 않기 위해)
 const TEST_BASE = resolve(
@@ -18,7 +18,7 @@ const TEST_BASE = resolve(
   ".test-tmp-pipeline",
 );
 
-describe("pipeline.writePlanFile()", () => {
+describe("pipeline.writePlanFile()", { skip: SQLITE_SKIP }, () => {
   let db;
   let origCwd;
 
@@ -30,6 +30,7 @@ describe("pipeline.writePlanFile()", () => {
     process.chdir(TEST_BASE);
 
     // in-memory SQLite
+    const Database = loadBetterSqlite3ForTest();
     db = new Database(":memory:");
   });
 
@@ -89,7 +90,7 @@ describe("pipeline.writePlanFile()", () => {
   });
 });
 
-describe("pipeline_advance_gated (이슈 2)", () => {
+describe("pipeline_advance_gated (이슈 2)", { skip: SQLITE_SKIP }, () => {
   let db;
   let pipelineAdvanceGatedTool;
   let hitlCalls;
@@ -101,6 +102,7 @@ describe("pipeline_advance_gated (이슈 2)", () => {
   }
 
   beforeEach(() => {
+    const Database = loadBetterSqlite3ForTest();
     db = new Database(":memory:");
     ensurePipelineTable(db);
 

--- a/tests/unit/reflexion.test.mjs
+++ b/tests/unit/reflexion.test.mjs
@@ -13,8 +13,9 @@ import {
   reportOutcome,
 } from "../../hub/reflexion.mjs";
 import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
-describe("reflexion", () => {
+describe("reflexion", { skip: SQLITE_SKIP }, () => {
   let store, tmpDir;
 
   before(() => {

--- a/tests/unit/store-adapter-tier2.test.mjs
+++ b/tests/unit/store-adapter-tier2.test.mjs
@@ -5,6 +5,10 @@ import { join } from "node:path";
 import { afterEach, describe, it, mock } from "node:test";
 
 import { createStoreAdapter } from "../../hub/store-adapter.mjs";
+import {
+  getBetterSqlite3UnavailableReason,
+  loadBetterSqlite3ForTest,
+} from "../helpers/sqlite.mjs";
 
 const TEMP_DIRS = [];
 
@@ -31,23 +35,12 @@ function assertTier2Interface(store) {
 }
 
 async function createSqliteStore(t) {
-  let sqliteCtor;
-  try {
-    const mod = await import("better-sqlite3");
-    sqliteCtor = mod.default ?? mod;
-  } catch {
-    t.skip("better-sqlite3 unavailable in this environment");
+  const unavailable = getBetterSqlite3UnavailableReason();
+  if (unavailable) {
+    t.skip(unavailable);
     return null;
   }
-  // native binding 검증 — import 성공해도 native fn 호출 시 fail 가능 (예: Node v26 + 12.6.2)
-  try {
-    const probe = new sqliteCtor(":memory:");
-    probe.prepare("SELECT 1").get();
-    probe.close();
-  } catch {
-    t.skip("better-sqlite3 native binding unavailable in this environment");
-    return null;
-  }
+  const sqliteCtor = loadBetterSqlite3ForTest();
 
   return createStoreAdapter(tempDbPath(), {
     loadDatabase: async () => sqliteCtor,

--- a/tests/unit/store-adapter.test.mjs
+++ b/tests/unit/store-adapter.test.mjs
@@ -5,6 +5,10 @@ import { join } from "node:path";
 import { afterEach, describe, it, mock } from "node:test";
 
 import { createStoreAdapter } from "../../hub/store-adapter.mjs";
+import {
+  getBetterSqlite3UnavailableReason,
+  loadBetterSqlite3ForTest,
+} from "../helpers/sqlite.mjs";
 
 const TEMP_DIRS = [];
 
@@ -59,23 +63,12 @@ function assertStoreInterface(store) {
 describe("hub/store-adapter.mjs", () => {
   it("better-sqlite3가 있으면 sqlite store를 사용한다", async (t) => {
     const dbPath = tempDbPath();
-    let sqliteCtor;
-    try {
-      const mod = await import("better-sqlite3");
-      sqliteCtor = mod.default ?? mod;
-    } catch {
-      t.skip("better-sqlite3 unavailable in this environment");
+    const unavailable = getBetterSqlite3UnavailableReason();
+    if (unavailable) {
+      t.skip(unavailable);
       return;
     }
-    // native binding 검증 — import 성공해도 native fn 호출 시 fail 가능 (예: Node v26 + 12.6.2)
-    try {
-      const probe = new sqliteCtor(":memory:");
-      probe.prepare("SELECT 1").get();
-      probe.close();
-    } catch {
-      t.skip("better-sqlite3 native binding unavailable in this environment");
-      return;
-    }
+    const sqliteCtor = loadBetterSqlite3ForTest();
 
     const store = await createStoreAdapter(dbPath, {
       loadDatabase: async () => sqliteCtor,


### PR DESCRIPTION
## Summary
- add a shared `better-sqlite3` native binding probe for tests
- skip SQLite-only suites when `better-sqlite3` imports but its native addon cannot load
- keep non-SQLite pipe/bridge tests active while isolating native-binding-dependent assertions

## Why
Local Node 26 can have the `better-sqlite3` package installed while the native `.node` binding is unavailable. The full test suite then fails before it can validate unrelated release and routing work.

## Verification
- `node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/helpers/sqlite.mjs tests/unit/store-adapter.test.mjs tests/unit/store-adapter-tier2.test.mjs tests/integration/store.test.mjs tests/integration/router.test.mjs tests/integration/router-route.test.mjs tests/unit/reflexion.test.mjs tests/pipeline/state.test.mjs tests/unit/pipeline.test.mjs tests/unit/pipeline-gates-integration.test.mjs tests/unit/pipeline-stop.test.mjs tests/integration/bridge-pipe.test.mjs`
- `npm test` — 3708 tests, 3690 pass, 18 skipped, 0 fail
- `node scripts/release/verify.mjs --version 10.25.1 --execute`
- `npx --no-install biome check tests/helpers/sqlite.mjs tests/integration/bridge-pipe.test.mjs tests/integration/router-route.test.mjs tests/integration/router.test.mjs tests/integration/store.test.mjs tests/pipeline/state.test.mjs tests/unit/pipeline-gates-integration.test.mjs tests/unit/pipeline-stop.test.mjs tests/unit/pipeline.test.mjs tests/unit/reflexion.test.mjs tests/unit/store-adapter-tier2.test.mjs tests/unit/store-adapter.test.mjs`

## Notes
- Production `createStore` stays strict; this only changes test environment gating.
- CI with a working `better-sqlite3` native binding should still execute the SQLite suites.
