### PR TITLE
Guard Hub MCP sync in protected test environments

### DIFF
--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -335,8 +335,13 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
     const mod = await import(
       new URL("../scripts/sync-hub-mcp-settings.mjs", import.meta.url)
     );
+    const protectedMcpSyncEnv = isProtectedImplicitMcpSyncEnv();
     if (typeof mod?.syncHubMcpSettings === "function") {
-      await mod.syncHubMcpSettings({ hubUrl });
+      if (process.env.TFX_USER_MCP_SYNC === "1" || !protectedMcpSyncEnv) {
+        await mod.syncHubMcpSettings({ hubUrl });
+      } else {
+        hubLog.debug({ hubUrl }, "hub.user_mcp_sync_skipped_protected_env");
+      }
     } else {
       hubLog.warn({ hubUrl }, "hub.mcp_sync_missing_export");
     }
@@ -344,12 +349,7 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
       await mod.syncCodexHubUrl({ hubUrl });
     }
     const allowProjectSync =
-      process.env.TFX_PROJECT_MCP_SYNC === "1" ||
-      !(
-        process.env.NODE_ENV === "test" ||
-        process.env.CI === "true" ||
-        process.env.TFX_TEST === "1"
-      );
+      process.env.TFX_PROJECT_MCP_SYNC === "1" || !protectedMcpSyncEnv;
     if (allowProjectSync && typeof mod?.syncProjectMcpJson === "function") {
       await mod.syncProjectMcpJson({ hubUrl, projectRoot: PROJECT_ROOT });
     }
@@ -361,6 +361,17 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
     }
     hubLog.warn({ hubUrl, err: message }, "hub.mcp_sync_skipped");
   }
+}
+
+function isProtectedImplicitMcpSyncEnv(env = process.env) {
+  return (
+    env.NODE_ENV === "test" ||
+    env.CI === "true" ||
+    env.TFX_TEST === "1" ||
+    Boolean(env.TRIFLUX_TEST_HOME) ||
+    Boolean(env.NODE_TEST_CONTEXT) ||
+    Boolean(env.NODE_TEST_WORKER_ID)
+  );
 }
 
 function findListeningPidByPort(

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -335,8 +335,13 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
     const mod = await import(
       new URL("../scripts/sync-hub-mcp-settings.mjs", import.meta.url)
     );
+    const protectedMcpSyncEnv = isProtectedImplicitMcpSyncEnv();
     if (typeof mod?.syncHubMcpSettings === "function") {
-      await mod.syncHubMcpSettings({ hubUrl });
+      if (process.env.TFX_USER_MCP_SYNC === "1" || !protectedMcpSyncEnv) {
+        await mod.syncHubMcpSettings({ hubUrl });
+      } else {
+        hubLog.debug({ hubUrl }, "hub.user_mcp_sync_skipped_protected_env");
+      }
     } else {
       hubLog.warn({ hubUrl }, "hub.mcp_sync_missing_export");
     }
@@ -344,12 +349,7 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
       await mod.syncCodexHubUrl({ hubUrl });
     }
     const allowProjectSync =
-      process.env.TFX_PROJECT_MCP_SYNC === "1" ||
-      !(
-        process.env.NODE_ENV === "test" ||
-        process.env.CI === "true" ||
-        process.env.TFX_TEST === "1"
-      );
+      process.env.TFX_PROJECT_MCP_SYNC === "1" || !protectedMcpSyncEnv;
     if (allowProjectSync && typeof mod?.syncProjectMcpJson === "function") {
       await mod.syncProjectMcpJson({ hubUrl, projectRoot: PROJECT_ROOT });
     }
@@ -361,6 +361,17 @@ async function syncHubMcpSettingsIfAvailable({ hubUrl }) {
     }
     hubLog.warn({ hubUrl, err: message }, "hub.mcp_sync_skipped");
   }
+}
+
+function isProtectedImplicitMcpSyncEnv(env = process.env) {
+  return (
+    env.NODE_ENV === "test" ||
+    env.CI === "true" ||
+    env.TFX_TEST === "1" ||
+    Boolean(env.TRIFLUX_TEST_HOME) ||
+    Boolean(env.NODE_TEST_CONTEXT) ||
+    Boolean(env.NODE_TEST_WORKER_ID)
+  );
 }
 
 function findListeningPidByPort(

--- a/tests/regression/hub-implicit-mcp-sync-test-env.test.mjs
+++ b/tests/regression/hub-implicit-mcp-sync-test-env.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+async function getUnusedPort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function readHubUrl(settingsPath) {
+  const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+  return settings.mcpServers["tfx-hub"].url;
+}
+
+test("startHub does not rewrite user MCP settings in protected test environments", async () => {
+  const tempHome = mkdtempSync(join(tmpdir(), "triflux-hub-mcp-home-"));
+  const dbDir = mkdtempSync(join(tmpdir(), "triflux-hub-mcp-db-"));
+  const settingsPath = join(tempHome, ".gemini", "settings.json");
+  const oldEnv = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    NODE_ENV: process.env.NODE_ENV,
+    TFX_TEST: process.env.TFX_TEST,
+  };
+  let hub;
+
+  try {
+    mkdirSync(join(tempHome, ".gemini"), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            "tfx-hub": {
+              type: "http",
+              url: "http://127.0.0.1:27888/mcp",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    process.env.NODE_ENV = "test";
+    process.env.TFX_TEST = "1";
+
+    const before = readHubUrl(settingsPath);
+    const { startHub } = await import("../../hub/server.mjs");
+    const port = await getUnusedPort();
+    hub = await startHub({
+      port,
+      host: "127.0.0.1",
+      dbPath: join(dbDir, "hub.db"),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    assert.equal(readHubUrl(settingsPath), before);
+  } finally {
+    if (hub?.stop) await hub.stop();
+    for (const [key, value] of Object.entries(oldEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+    rmSync(dbDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Skip implicit user MCP settings sync during protected test environments unless `TFX_USER_MCP_SYNC=1` opts in.
- Extend the same protected-env gate to project MCP sync while preserving `TFX_PROJECT_MCP_SYNC=1`.
- Add a regression test proving `startHub()` does not rewrite temp user Gemini settings to random test Hub ports.

## Root cause
`startHub()` fire-and-forget calls `syncHubMcpSettingsIfAvailable()` with the runtime `info.url`. User-level Gemini/Claude sync was unguarded, so node test processes starting Hubs on random ports could rewrite user MCP config and enter the backup-write window. Previous #193/#197 fixes covered Codex config and part of project sync, but not user-level settings.

## Verification
- `node --test tests/regression/hub-implicit-mcp-sync-test-env.test.mjs` (red before fix, green after)
- `node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=4 tests/regression/hub-implicit-mcp-sync-test-env.test.mjs tests/regression/codex-config-port-stable.test.mjs tests/unit/sync-hub-mcp-settings.test.mjs tests/integration/bridge-pipe.test.mjs`
- `node --test tests/unit/packages-mirror.test.mjs`
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `npx --no-install biome check hub/server.mjs packages/triflux/hub/server.mjs tests/regression/hub-implicit-mcp-sync-test-env.test.mjs`
- `git diff --check`

## Notes
A full `npm run test:guard-codex-config` attempt before mirror sync completed 3709 tests but failed on mirror drift plus mtime-only `~/.codex/config.toml` churn with unchanged SHA. Mirror drift is fixed in this PR; the mtime-only guard noise is not changed here.