### PR TITLE
Avoid stale Node paths in Claude setup commands

### DIFF
--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -830,6 +830,44 @@ function quoteWindowsTaskArg(value) {
   return `"${String(value).replace(/"/g, '\\"')}"`;
 }
 
+const STABLE_NODE_COMMAND_CANDIDATES = Object.freeze([
+  "/opt/homebrew/bin/node",
+  "/usr/local/bin/node",
+  "/home/linuxbrew/.linuxbrew/bin/node",
+]);
+
+function quoteShellCommandArg(value) {
+  const normalized = String(value).replace(/\\/g, "/");
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(normalized)) return normalized;
+  return `"${normalized.replace(/(["\\$`])/gu, "\\$1")}"`;
+}
+
+function resolveStableNodeCommand({ existsSyncFn = existsSync } = {}) {
+  if (process.platform !== "win32") {
+    for (const candidate of STABLE_NODE_COMMAND_CANDIDATES) {
+      try {
+        if (existsSyncFn(candidate)) return candidate;
+      } catch {
+        /* ignore candidate probe errors */
+      }
+    }
+  }
+  return "node";
+}
+
+function buildNodeScriptCommand(scriptPath) {
+  return `${quoteShellCommandArg(resolveStableNodeCommand())} ${quoteShellCommandArg(scriptPath)}`;
+}
+
+function refreshHookCommandForScript(hook, scriptName, scriptPath) {
+  if (typeof hook?.command !== "string") return false;
+  if (!hook.command.includes(scriptName)) return false;
+  const desired = buildNodeScriptCommand(scriptPath);
+  if (hook.command === desired) return false;
+  hook.command = desired;
+  return true;
+}
+
 function buildWindowsHubAutostartCommand({
   nodePath = process.execPath,
   pluginRoot = PLUGIN_ROOT,
@@ -1005,14 +1043,14 @@ function persistSettings(settings) {
 function applyStatusLine(settings) {
   if (!existsSync(HUD_PATH)) return false;
   const currentCmd = settings.statusLine?.command || "";
-  if (currentCmd.includes("hud-qos-status.mjs")) return false;
+  const desiredCommand = buildNodeScriptCommand(HUD_PATH);
+  if (currentCmd.includes("hud-qos-status.mjs")) {
+    if (currentCmd === desiredCommand) return false;
+    settings.statusLine = { type: "command", command: desiredCommand };
+    return true;
+  }
 
-  const nodePath = process.execPath.replace(/\\/g, "/");
-  const hudForward = HUD_PATH.replace(/\\/g, "/");
-  const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-  const hudRef = hudForward.includes(" ") ? `"${hudForward}"` : hudForward;
-
-  settings.statusLine = { type: "command", command: `${nodeRef} ${hudRef}` };
+  settings.statusLine = { type: "command", command: desiredCommand };
   return true;
 }
 
@@ -1054,32 +1092,54 @@ function applyHooks(settings) {
       ),
   );
 
-  if (!hasTrifluxHooks) {
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-    const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+  const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+  const commandForScript = (scriptName) =>
+    buildNodeScriptCommand(`${pluginRoot}/scripts/${scriptName}`);
 
+  if (!hasTrifluxHooks) {
     settings.hooks.SessionStart.push({
       matcher: "*",
       hooks: [
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/setup.mjs"`,
+          command: commandForScript("setup.mjs"),
           timeout: 10,
         },
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/hub-ensure.mjs"`,
+          command: commandForScript("hub-ensure.mjs"),
           timeout: 8,
         },
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/preflight-cache.mjs"`,
+          command: commandForScript("preflight-cache.mjs"),
           timeout: 5,
         },
       ],
     });
     changed = true;
+  }
+
+  for (const entry of settings.hooks.SessionStart) {
+    if (!Array.isArray(entry.hooks)) continue;
+    for (const hook of entry.hooks) {
+      for (const scriptName of [
+        "setup.mjs",
+        "hub-ensure.mjs",
+        "mcp-gateway-ensure.mjs",
+        "preflight-cache.mjs",
+      ]) {
+        if (
+          refreshHookCommandForScript(
+            hook,
+            scriptName,
+            `${pluginRoot}/scripts/${scriptName}`,
+          )
+        ) {
+          changed = true;
+        }
+      }
+    }
   }
 
   if (!Array.isArray(settings.hooks.PreToolUse)) settings.hooks.PreToolUse = [];
@@ -1148,7 +1208,7 @@ function applyHooks(settings) {
       hooks: [
         {
           type: "command",
-          command: `node "${gateScriptPath}"`,
+          command: buildNodeScriptCommand(gateScriptPath),
           timeout: 2,
         },
       ],
@@ -1161,9 +1221,9 @@ function applyHooks(settings) {
         if (
           typeof hook.command === "string" &&
           hook.command.includes("tfx-gate-activate") &&
-          !hook.command.includes(gateScriptPath)
+          hook.command !== buildNodeScriptCommand(gateScriptPath)
         ) {
-          hook.command = `node "${gateScriptPath}"`;
+          hook.command = buildNodeScriptCommand(gateScriptPath);
           changed = true;
         }
       }
@@ -1510,14 +1570,14 @@ export async function runDeferred(stdinData) {
   function applyStatusLine(s) {
     if (!existsSync(hudPath)) return false;
     const currentCmd = s.statusLine?.command || "";
-    if (currentCmd.includes("hud-qos-status.mjs")) return false;
+    const desiredCommand = buildNodeScriptCommand(hudPath);
+    if (currentCmd.includes("hud-qos-status.mjs")) {
+      if (currentCmd === desiredCommand) return false;
+      s.statusLine = { type: "command", command: desiredCommand };
+      return true;
+    }
 
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const hudForward = hudPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-    const hudRef = hudForward.includes(" ") ? `"${hudForward}"` : hudForward;
-
-    s.statusLine = { type: "command", command: `${nodeRef} ${hudRef}` };
+    s.statusLine = { type: "command", command: desiredCommand };
     return true;
   }
 
@@ -1568,11 +1628,9 @@ export async function runDeferred(stdinData) {
     // ── SessionStart 훅 ──
     if (!Array.isArray(s.hooks.SessionStart)) s.hooks.SessionStart = [];
 
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
     const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
     const commandForScript = (scriptName) =>
-      `${nodeRef} "${pluginRoot}/scripts/${scriptName}"`;
+      buildNodeScriptCommand(`${pluginRoot}/scripts/${scriptName}`);
 
     const hasTrifluxHooks = s.hooks.SessionStart.some(
       (entry) =>
@@ -1635,6 +1693,28 @@ export async function runDeferred(stdinData) {
       if (hubIndex >= 0) entry.hooks.splice(hubIndex + 1, 0, gatewayHook);
       else entry.hooks.push(gatewayHook);
       changed = true;
+    }
+
+    for (const entry of s.hooks.SessionStart) {
+      if (!Array.isArray(entry.hooks)) continue;
+      for (const hook of entry.hooks) {
+        for (const scriptName of [
+          "setup.mjs",
+          "hub-ensure.mjs",
+          "mcp-gateway-ensure.mjs",
+          "preflight-cache.mjs",
+        ]) {
+          if (
+            refreshHookCommandForScript(
+              hook,
+              scriptName,
+              `${pluginRoot}/scripts/${scriptName}`,
+            )
+          ) {
+            changed = true;
+          }
+        }
+      }
     }
 
     // ── PreToolUse 훅: headless-guard + tfx-gate-activate ──
@@ -1726,7 +1806,7 @@ export async function runDeferred(stdinData) {
           hooks: [
             {
               type: "command",
-              command: `node "${gateScriptPath}"`,
+              command: buildNodeScriptCommand(gateScriptPath),
               timeout: 2,
             },
           ],
@@ -1750,9 +1830,9 @@ export async function runDeferred(stdinData) {
         }
         if (
           h.command.includes("tfx-gate-activate") &&
-          !h.command.includes(gateScriptPath)
+          h.command !== buildNodeScriptCommand(gateScriptPath)
         ) {
-          h.command = `node "${gateScriptPath}"`;
+          h.command = buildNodeScriptCommand(gateScriptPath);
           changed = true;
         }
       }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -830,6 +830,44 @@ function quoteWindowsTaskArg(value) {
   return `"${String(value).replace(/"/g, '\\"')}"`;
 }
 
+const STABLE_NODE_COMMAND_CANDIDATES = Object.freeze([
+  "/opt/homebrew/bin/node",
+  "/usr/local/bin/node",
+  "/home/linuxbrew/.linuxbrew/bin/node",
+]);
+
+function quoteShellCommandArg(value) {
+  const normalized = String(value).replace(/\\/g, "/");
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(normalized)) return normalized;
+  return `"${normalized.replace(/(["\\$`])/gu, "\\$1")}"`;
+}
+
+function resolveStableNodeCommand({ existsSyncFn = existsSync } = {}) {
+  if (process.platform !== "win32") {
+    for (const candidate of STABLE_NODE_COMMAND_CANDIDATES) {
+      try {
+        if (existsSyncFn(candidate)) return candidate;
+      } catch {
+        /* ignore candidate probe errors */
+      }
+    }
+  }
+  return "node";
+}
+
+function buildNodeScriptCommand(scriptPath) {
+  return `${quoteShellCommandArg(resolveStableNodeCommand())} ${quoteShellCommandArg(scriptPath)}`;
+}
+
+function refreshHookCommandForScript(hook, scriptName, scriptPath) {
+  if (typeof hook?.command !== "string") return false;
+  if (!hook.command.includes(scriptName)) return false;
+  const desired = buildNodeScriptCommand(scriptPath);
+  if (hook.command === desired) return false;
+  hook.command = desired;
+  return true;
+}
+
 function buildWindowsHubAutostartCommand({
   nodePath = process.execPath,
   pluginRoot = PLUGIN_ROOT,
@@ -1005,14 +1043,14 @@ function persistSettings(settings) {
 function applyStatusLine(settings) {
   if (!existsSync(HUD_PATH)) return false;
   const currentCmd = settings.statusLine?.command || "";
-  if (currentCmd.includes("hud-qos-status.mjs")) return false;
+  const desiredCommand = buildNodeScriptCommand(HUD_PATH);
+  if (currentCmd.includes("hud-qos-status.mjs")) {
+    if (currentCmd === desiredCommand) return false;
+    settings.statusLine = { type: "command", command: desiredCommand };
+    return true;
+  }
 
-  const nodePath = process.execPath.replace(/\\/g, "/");
-  const hudForward = HUD_PATH.replace(/\\/g, "/");
-  const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-  const hudRef = hudForward.includes(" ") ? `"${hudForward}"` : hudForward;
-
-  settings.statusLine = { type: "command", command: `${nodeRef} ${hudRef}` };
+  settings.statusLine = { type: "command", command: desiredCommand };
   return true;
 }
 
@@ -1054,32 +1092,54 @@ function applyHooks(settings) {
       ),
   );
 
-  if (!hasTrifluxHooks) {
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-    const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+  const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
+  const commandForScript = (scriptName) =>
+    buildNodeScriptCommand(`${pluginRoot}/scripts/${scriptName}`);
 
+  if (!hasTrifluxHooks) {
     settings.hooks.SessionStart.push({
       matcher: "*",
       hooks: [
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/setup.mjs"`,
+          command: commandForScript("setup.mjs"),
           timeout: 10,
         },
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/hub-ensure.mjs"`,
+          command: commandForScript("hub-ensure.mjs"),
           timeout: 8,
         },
         {
           type: "command",
-          command: `${nodeRef} "${pluginRoot}/scripts/preflight-cache.mjs"`,
+          command: commandForScript("preflight-cache.mjs"),
           timeout: 5,
         },
       ],
     });
     changed = true;
+  }
+
+  for (const entry of settings.hooks.SessionStart) {
+    if (!Array.isArray(entry.hooks)) continue;
+    for (const hook of entry.hooks) {
+      for (const scriptName of [
+        "setup.mjs",
+        "hub-ensure.mjs",
+        "mcp-gateway-ensure.mjs",
+        "preflight-cache.mjs",
+      ]) {
+        if (
+          refreshHookCommandForScript(
+            hook,
+            scriptName,
+            `${pluginRoot}/scripts/${scriptName}`,
+          )
+        ) {
+          changed = true;
+        }
+      }
+    }
   }
 
   if (!Array.isArray(settings.hooks.PreToolUse)) settings.hooks.PreToolUse = [];
@@ -1148,7 +1208,7 @@ function applyHooks(settings) {
       hooks: [
         {
           type: "command",
-          command: `node "${gateScriptPath}"`,
+          command: buildNodeScriptCommand(gateScriptPath),
           timeout: 2,
         },
       ],
@@ -1161,9 +1221,9 @@ function applyHooks(settings) {
         if (
           typeof hook.command === "string" &&
           hook.command.includes("tfx-gate-activate") &&
-          !hook.command.includes(gateScriptPath)
+          hook.command !== buildNodeScriptCommand(gateScriptPath)
         ) {
-          hook.command = `node "${gateScriptPath}"`;
+          hook.command = buildNodeScriptCommand(gateScriptPath);
           changed = true;
         }
       }
@@ -1510,14 +1570,14 @@ export async function runDeferred(stdinData) {
   function applyStatusLine(s) {
     if (!existsSync(hudPath)) return false;
     const currentCmd = s.statusLine?.command || "";
-    if (currentCmd.includes("hud-qos-status.mjs")) return false;
+    const desiredCommand = buildNodeScriptCommand(hudPath);
+    if (currentCmd.includes("hud-qos-status.mjs")) {
+      if (currentCmd === desiredCommand) return false;
+      s.statusLine = { type: "command", command: desiredCommand };
+      return true;
+    }
 
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const hudForward = hudPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
-    const hudRef = hudForward.includes(" ") ? `"${hudForward}"` : hudForward;
-
-    s.statusLine = { type: "command", command: `${nodeRef} ${hudRef}` };
+    s.statusLine = { type: "command", command: desiredCommand };
     return true;
   }
 
@@ -1568,11 +1628,9 @@ export async function runDeferred(stdinData) {
     // ── SessionStart 훅 ──
     if (!Array.isArray(s.hooks.SessionStart)) s.hooks.SessionStart = [];
 
-    const nodePath = process.execPath.replace(/\\/g, "/");
-    const nodeRef = nodePath.includes(" ") ? `"${nodePath}"` : nodePath;
     const pluginRoot = PLUGIN_ROOT.replace(/\\/g, "/");
     const commandForScript = (scriptName) =>
-      `${nodeRef} "${pluginRoot}/scripts/${scriptName}"`;
+      buildNodeScriptCommand(`${pluginRoot}/scripts/${scriptName}`);
 
     const hasTrifluxHooks = s.hooks.SessionStart.some(
       (entry) =>
@@ -1635,6 +1693,28 @@ export async function runDeferred(stdinData) {
       if (hubIndex >= 0) entry.hooks.splice(hubIndex + 1, 0, gatewayHook);
       else entry.hooks.push(gatewayHook);
       changed = true;
+    }
+
+    for (const entry of s.hooks.SessionStart) {
+      if (!Array.isArray(entry.hooks)) continue;
+      for (const hook of entry.hooks) {
+        for (const scriptName of [
+          "setup.mjs",
+          "hub-ensure.mjs",
+          "mcp-gateway-ensure.mjs",
+          "preflight-cache.mjs",
+        ]) {
+          if (
+            refreshHookCommandForScript(
+              hook,
+              scriptName,
+              `${pluginRoot}/scripts/${scriptName}`,
+            )
+          ) {
+            changed = true;
+          }
+        }
+      }
     }
 
     // ── PreToolUse 훅: headless-guard + tfx-gate-activate ──
@@ -1726,7 +1806,7 @@ export async function runDeferred(stdinData) {
           hooks: [
             {
               type: "command",
-              command: `node "${gateScriptPath}"`,
+              command: buildNodeScriptCommand(gateScriptPath),
               timeout: 2,
             },
           ],
@@ -1750,9 +1830,9 @@ export async function runDeferred(stdinData) {
         }
         if (
           h.command.includes("tfx-gate-activate") &&
-          !h.command.includes(gateScriptPath)
+          h.command !== buildNodeScriptCommand(gateScriptPath)
         ) {
-          h.command = `node "${gateScriptPath}"`;
+          h.command = buildNodeScriptCommand(gateScriptPath);
           changed = true;
         }
       }

--- a/tests/unit/setup-stable-node-command.test.mjs
+++ b/tests/unit/setup-stable-node-command.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const SETUP_URL = new URL("../../scripts/setup.mjs", import.meta.url).href;
+
+function runCriticalWithHome(home) {
+  const script = `
+    import(${JSON.stringify(SETUP_URL)}).then(async (m) => {
+      const result = await m.runCritical({ argv: [] });
+      process.stdout.write(JSON.stringify(result));
+    }).catch((err) => {
+      process.stderr.write(String(err?.stack || err?.message || err));
+      process.exit(1);
+    });
+  `;
+
+  return spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      TRIFLUX_TEST_HOME: home,
+      CI: "true",
+      TFX_CODEX_CONFIG_SYNC: "0",
+    },
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+}
+
+describe("setup stable node command (#253)", () => {
+  it("refreshes stale Homebrew Cellar node paths in persisted Claude commands", () => {
+    const home = mkdtempSync(join(tmpdir(), "tfx-setup-node-cmd-"));
+    const claudeDir = join(home, ".claude");
+    const hudPath = join(claudeDir, "hud", "hud-qos-status.mjs");
+    const gatePath = join(claudeDir, "scripts", "tfx-gate-activate.mjs");
+    const settingsPath = join(claudeDir, "settings.json");
+    const staleNode = "/opt/homebrew/Cellar/node/25.9.0_3/bin/node";
+
+    mkdirSync(join(claudeDir, "hud"), { recursive: true });
+    mkdirSync(join(claudeDir, "scripts"), { recursive: true });
+    writeFileSync(hudPath, "#!/usr/bin/env node\n", "utf8");
+    writeFileSync(gatePath, "#!/usr/bin/env node\n", "utf8");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          statusLine: {
+            type: "command",
+            command: `"${staleNode}" "${hudPath}"`,
+          },
+          hooks: {
+            SessionStart: [
+              {
+                matcher: "*",
+                hooks: [
+                  {
+                    type: "command",
+                    command: `"${staleNode}" "/Users/tellang/Projects/tools/triflux/scripts/setup.mjs"`,
+                    timeout: 10,
+                  },
+                  {
+                    type: "command",
+                    command: `"${staleNode}" "/Users/tellang/Projects/tools/triflux/scripts/hub-ensure.mjs"`,
+                    timeout: 8,
+                  },
+                ],
+              },
+            ],
+            PreToolUse: [
+              {
+                matcher: "Skill",
+                hooks: [
+                  {
+                    type: "command",
+                    command: `"${staleNode}" "${gatePath}"`,
+                    timeout: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+
+    try {
+      const result = runCriticalWithHome(home);
+      assert.equal(
+        result.status,
+        0,
+        `setup failed: stdout=${result.stdout} stderr=${result.stderr}`,
+      );
+
+      const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+      const commands = [
+        settings.statusLine.command,
+        ...settings.hooks.SessionStart.flatMap((entry) =>
+          entry.hooks.map((hook) => hook.command),
+        ),
+        ...settings.hooks.PreToolUse.flatMap((entry) =>
+          entry.hooks.map((hook) => hook.command),
+        ),
+      ];
+
+      assert.ok(
+        commands.some((command) => command.includes("hud-qos-status.mjs")),
+        "statusLine command must still point at the HUD script",
+      );
+      assert.ok(
+        commands.every((command) => !command.includes("/Cellar/node/")),
+        `stale Homebrew Cellar node path remained in: ${commands.join("\n")}`,
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tui/setup.mjs
+++ b/tui/setup.mjs
@@ -36,6 +36,31 @@ const CODEX_DIR = join(homedir(), ".codex");
 const GEMINI_DIR = join(homedir(), ".gemini");
 const SETTINGS_PATH = join(CLAUDE_DIR, "settings.json");
 
+const STABLE_NODE_COMMAND_CANDIDATES = Object.freeze([
+  "/opt/homebrew/bin/node",
+  "/usr/local/bin/node",
+  "/home/linuxbrew/.linuxbrew/bin/node",
+]);
+
+function quoteShellCommandArg(value) {
+  const normalized = String(value).replace(/\\/g, "/");
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(normalized)) return normalized;
+  return `"${normalized.replace(/(["\\$`])/gu, "\\$1")}"`;
+}
+
+function resolveStableNodeCommand() {
+  if (process.platform !== "win32") {
+    for (const candidate of STABLE_NODE_COMMAND_CANDIDATES) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return "node";
+}
+
+function buildNodeScriptCommand(scriptPath) {
+  return `${quoteShellCommandArg(resolveStableNodeCommand())} ${quoteShellCommandArg(scriptPath)}`;
+}
+
 // ── Step Definitions ──
 
 const STEPS = [
@@ -85,10 +110,23 @@ function stepHud() {
     }
 
     const hudScript = join(CLAUDE_DIR, "hud", "hud-qos-status.mjs");
-    const nodePath = process.execPath;
+    const target = {
+      type: "command",
+      command: buildNodeScriptCommand(hudScript),
+    };
+    const currentCmd = settings.statusLine?.command || "";
 
     // Check if statusLine already configured correctly
-    if (settings.statusLine?.command?.includes("hud-qos-status")) {
+    if (currentCmd.includes("hud-qos-status")) {
+      if (currentCmd !== target.command) {
+        return {
+          ok: false,
+          detail: "statusLine의 Node command가 갱신 필요",
+          action: "configure",
+          current: settings.statusLine,
+          target,
+        };
+      }
       return {
         ok: true,
         detail: "statusLine 이미 설정됨",
@@ -103,10 +141,7 @@ function stepHud() {
         : "statusLine 미설정",
       action: "configure",
       current: settings.statusLine || null,
-      target: {
-        type: "command",
-        command: `"${nodePath}" "${hudScript}"`,
-      },
+      target,
     };
   } catch (e) {
     return { ok: false, detail: e.message };


### PR DESCRIPTION
## Summary

Fixes #253 by stopping setup from persisting versioned Homebrew Cellar `process.execPath` paths into long-lived Claude settings commands.

Changes:
- Generate Claude `statusLine` and managed hook commands with a stable node entrypoint (`/opt/homebrew/bin/node`, `/usr/local/bin/node`, `/home/linuxbrew/.linuxbrew/bin/node`, then `node`).
- Refresh existing managed commands when they already contain `hud-qos-status.mjs`, `setup.mjs`, `hub-ensure.mjs`, `mcp-gateway-ensure.mjs`, `preflight-cache.mjs`, or `tfx-gate-activate.mjs` but still point at a stale node binary.
- Align TUI HUD configure target with the same stable command policy.
- Mirror `scripts/setup.mjs` into `packages/triflux/scripts/setup.mjs`.

## Regression evidence

Added `tests/unit/setup-stable-node-command.test.mjs`, which seeds Claude settings with `/opt/homebrew/Cellar/node/25.9.0_3/bin/node` and verifies setup rewrites managed persisted commands away from `/Cellar/node/` while preserving HUD/hook script targets.

## Verification

- `node --test tests/unit/setup-stable-node-command.test.mjs tests/unit/setup-sync.test.mjs tests/unit/setup-autostart.test.mjs tests/unit/setup-hud-sync.test.mjs tests/unit/setup-home-resolution.test.mjs`
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `npx --no-install biome check scripts/setup.mjs packages/triflux/scripts/setup.mjs tui/setup.mjs tests/unit/setup-stable-node-command.test.mjs`
- `git diff --check`

## Not tested

- Windows Claude runtime execution of PATH-based `node` command.
