### PR TITLE
Validate Antigravity readiness before HUD fallback

### DIFF
--- a/packages/triflux/scripts/preflight-cache.mjs
+++ b/packages/triflux/scripts/preflight-cache.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // scripts/preflight-cache.mjs — 세션 시작 시 preflight 점검 캐싱
 
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -14,18 +14,67 @@ const PKG_ROOT = join(dirname(__filename), "..");
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
+const ANTIGRAVITY_AUTH_READY_SKEW_MS = 60_000;
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
   return { ok: existsSyncFn(routePath), path: routePath };
 }
 
-function hasAntigravityCredential({ homeDir, existsSyncFn }) {
-  return [
+function checkAntigravityCredential({
+  homeDir,
+  existsSyncFn,
+  readFileSyncFn,
+  now = Date.now(),
+}) {
+  const paths = [
     join(homeDir, ".gemini", "oauth_creds.json"),
     join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
     join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
-  ].some((path) => existsSyncFn(path));
+  ];
+
+  let reason = "auth_missing";
+  for (const path of paths) {
+    if (!existsSyncFn(path)) continue;
+
+    try {
+      const credential = JSON.parse(readFileSyncFn(path, "utf8"));
+      if (
+        Number.isFinite(credential?.expiry_date) &&
+        credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS
+      ) {
+        return { ok: true, path };
+      }
+      reason = "auth_expired";
+    } catch {
+      reason = "auth_invalid";
+    }
+  }
+
+  return { ok: false, reason };
+}
+
+function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
+  try {
+    const smoke = spawnSyncFn(
+      cliPath,
+      ["--print", "--dangerously-skip-permissions", "--print-timeout=3s"],
+      {
+        encoding: "utf8",
+        input: "Return exactly AGY_OK\n",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout,
+        windowsHide: true,
+      },
+    );
+    return (
+      !smoke.error &&
+      (smoke.status == null || smoke.status === 0) &&
+      String(smoke.stdout || "").trim().length > 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 function checkAntigravityReadiness(
@@ -33,7 +82,8 @@ function checkAntigravityReadiness(
   {
     homeDir = homedir(),
     existsSyncFn = existsSync,
-    execFileSyncFn = execFileSync,
+    readFileSyncFn = readFileSync,
+    spawnSyncFn = spawnSync,
     timeout = 2000,
   } = {},
 ) {
@@ -42,14 +92,16 @@ function checkAntigravityReadiness(
 
   let helpText = "";
   try {
-    helpText = String(
-      execFileSyncFn(cliResult.path, ["--help"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout,
-        windowsHide: true,
-      }),
-    );
+    const help = spawnSyncFn(cliResult.path, ["--help"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+      windowsHide: true,
+    });
+    if (help.error || (help.status != null && help.status !== 0)) {
+      return { ok: false, path: cliResult.path, reason: "help_failed" };
+    }
+    helpText = [help.stdout, help.stderr].filter(Boolean).join("\n");
   } catch {
     return { ok: false, path: cliResult.path, reason: "help_failed" };
   }
@@ -61,8 +113,19 @@ function checkAntigravityReadiness(
     return { ok: false, path: cliResult.path, reason: "headless_unsupported" };
   }
 
-  if (!hasAntigravityCredential({ homeDir, existsSyncFn })) {
-    return { ok: false, path: cliResult.path, reason: "auth_missing" };
+  const credential = checkAntigravityCredential({
+    homeDir,
+    existsSyncFn,
+    readFileSyncFn,
+  });
+  if (!credential.ok) {
+    if (
+      credential.reason === "auth_expired" &&
+      checkAntigravitySmoke(cliResult.path, { spawnSyncFn })
+    ) {
+      return { ok: true, path: cliResult.path, reason: "ready" };
+    }
+    return { ok: false, path: cliResult.path, reason: credential.reason };
   }
 
   return { ok: true, path: cliResult.path, reason: "ready" };
@@ -75,13 +138,15 @@ async function runPreflight({
   checkRouteFn = checkRoute,
   detectCodexPlanFn = detectCodexPlan,
   existsSyncFn = existsSync,
-  execFileSyncFn = execFileSync,
+  readFileSyncFn = readFileSync,
+  spawnSyncFn = spawnSync,
 } = {}) {
   const cliChecks = await probeClisFn(["codex", "gemini", "agy"]);
   const antigravity = checkAntigravityReadiness(cliChecks.agy, {
     homeDir,
     existsSyncFn,
-    execFileSyncFn,
+    readFileSyncFn,
+    spawnSyncFn,
   });
   const result = {
     timestamp: Date.now(),

--- a/packages/triflux/scripts/preflight-cache.mjs
+++ b/packages/triflux/scripts/preflight-cache.mjs
@@ -14,7 +14,7 @@ const PKG_ROOT = join(dirname(__filename), "..");
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
-const ANTIGRAVITY_AUTH_READY_SKEW_MS = 60_000;
+const ANTIGRAVITY_AUTH_READY_SKEW_MS = CACHE_TTL_MS + 60_000;
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
@@ -69,8 +69,11 @@ function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
     );
     return (
       !smoke.error &&
+      !smoke.signal &&
       (smoke.status == null || smoke.status === 0) &&
-      String(smoke.stdout || "").trim().length > 0
+      String(smoke.stdout || "")
+        .split(/\r?\n/)
+        .some((line) => line.trim() === "AGY_OK")
     );
   } catch {
     return false;

--- a/scripts/preflight-cache.mjs
+++ b/scripts/preflight-cache.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // scripts/preflight-cache.mjs — 세션 시작 시 preflight 점검 캐싱
 
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -14,18 +14,67 @@ const PKG_ROOT = join(dirname(__filename), "..");
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
+const ANTIGRAVITY_AUTH_READY_SKEW_MS = 60_000;
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
   return { ok: existsSyncFn(routePath), path: routePath };
 }
 
-function hasAntigravityCredential({ homeDir, existsSyncFn }) {
-  return [
+function checkAntigravityCredential({
+  homeDir,
+  existsSyncFn,
+  readFileSyncFn,
+  now = Date.now(),
+}) {
+  const paths = [
     join(homeDir, ".gemini", "oauth_creds.json"),
     join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
     join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
-  ].some((path) => existsSyncFn(path));
+  ];
+
+  let reason = "auth_missing";
+  for (const path of paths) {
+    if (!existsSyncFn(path)) continue;
+
+    try {
+      const credential = JSON.parse(readFileSyncFn(path, "utf8"));
+      if (
+        Number.isFinite(credential?.expiry_date) &&
+        credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS
+      ) {
+        return { ok: true, path };
+      }
+      reason = "auth_expired";
+    } catch {
+      reason = "auth_invalid";
+    }
+  }
+
+  return { ok: false, reason };
+}
+
+function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
+  try {
+    const smoke = spawnSyncFn(
+      cliPath,
+      ["--print", "--dangerously-skip-permissions", "--print-timeout=3s"],
+      {
+        encoding: "utf8",
+        input: "Return exactly AGY_OK\n",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout,
+        windowsHide: true,
+      },
+    );
+    return (
+      !smoke.error &&
+      (smoke.status == null || smoke.status === 0) &&
+      String(smoke.stdout || "").trim().length > 0
+    );
+  } catch {
+    return false;
+  }
 }
 
 function checkAntigravityReadiness(
@@ -33,7 +82,8 @@ function checkAntigravityReadiness(
   {
     homeDir = homedir(),
     existsSyncFn = existsSync,
-    execFileSyncFn = execFileSync,
+    readFileSyncFn = readFileSync,
+    spawnSyncFn = spawnSync,
     timeout = 2000,
   } = {},
 ) {
@@ -42,14 +92,16 @@ function checkAntigravityReadiness(
 
   let helpText = "";
   try {
-    helpText = String(
-      execFileSyncFn(cliResult.path, ["--help"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout,
-        windowsHide: true,
-      }),
-    );
+    const help = spawnSyncFn(cliResult.path, ["--help"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+      windowsHide: true,
+    });
+    if (help.error || (help.status != null && help.status !== 0)) {
+      return { ok: false, path: cliResult.path, reason: "help_failed" };
+    }
+    helpText = [help.stdout, help.stderr].filter(Boolean).join("\n");
   } catch {
     return { ok: false, path: cliResult.path, reason: "help_failed" };
   }
@@ -61,8 +113,19 @@ function checkAntigravityReadiness(
     return { ok: false, path: cliResult.path, reason: "headless_unsupported" };
   }
 
-  if (!hasAntigravityCredential({ homeDir, existsSyncFn })) {
-    return { ok: false, path: cliResult.path, reason: "auth_missing" };
+  const credential = checkAntigravityCredential({
+    homeDir,
+    existsSyncFn,
+    readFileSyncFn,
+  });
+  if (!credential.ok) {
+    if (
+      credential.reason === "auth_expired" &&
+      checkAntigravitySmoke(cliResult.path, { spawnSyncFn })
+    ) {
+      return { ok: true, path: cliResult.path, reason: "ready" };
+    }
+    return { ok: false, path: cliResult.path, reason: credential.reason };
   }
 
   return { ok: true, path: cliResult.path, reason: "ready" };
@@ -75,13 +138,15 @@ async function runPreflight({
   checkRouteFn = checkRoute,
   detectCodexPlanFn = detectCodexPlan,
   existsSyncFn = existsSync,
-  execFileSyncFn = execFileSync,
+  readFileSyncFn = readFileSync,
+  spawnSyncFn = spawnSync,
 } = {}) {
   const cliChecks = await probeClisFn(["codex", "gemini", "agy"]);
   const antigravity = checkAntigravityReadiness(cliChecks.agy, {
     homeDir,
     existsSyncFn,
-    execFileSyncFn,
+    readFileSyncFn,
+    spawnSyncFn,
   });
   const result = {
     timestamp: Date.now(),

--- a/scripts/preflight-cache.mjs
+++ b/scripts/preflight-cache.mjs
@@ -14,7 +14,7 @@ const PKG_ROOT = join(dirname(__filename), "..");
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
-const ANTIGRAVITY_AUTH_READY_SKEW_MS = 60_000;
+const ANTIGRAVITY_AUTH_READY_SKEW_MS = CACHE_TTL_MS + 60_000;
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
@@ -69,8 +69,11 @@ function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
     );
     return (
       !smoke.error &&
+      !smoke.signal &&
       (smoke.status == null || smoke.status === 0) &&
-      String(smoke.stdout || "").trim().length > 0
+      String(smoke.stdout || "")
+        .split(/\r?\n/)
+        .some((line) => line.trim() === "AGY_OK")
     );
   } catch {
     return false;

--- a/tests/unit/preflight-cache-antigravity.test.mjs
+++ b/tests/unit/preflight-cache-antigravity.test.mjs
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 
-import { runPreflight } from "../../scripts/preflight-cache.mjs";
+import { CACHE_TTL_MS, runPreflight } from "../../scripts/preflight-cache.mjs";
+
+const READY_EXPIRY_MS = CACHE_TTL_MS + 120_000;
 
 function makeHome({ antigravityAuth } = {}) {
   const homeDir = mkdtempSync(join(tmpdir(), "tfx-preflight-agy-"));
@@ -17,11 +19,11 @@ function makeHome({ antigravityAuth } = {}) {
 
   if (antigravityAuth) {
     mkdirSync(join(homeDir, ".gemini"), { recursive: true });
-    writeFileSync(
-      join(homeDir, ".gemini", "oauth_creds.json"),
-      JSON.stringify(antigravityAuth),
-      "utf8",
-    );
+    const authText =
+      typeof antigravityAuth === "string"
+        ? antigravityAuth
+        : JSON.stringify(antigravityAuth);
+    writeFileSync(join(homeDir, ".gemini", "oauth_creds.json"), authText, "utf8");
   }
 
   return homeDir;
@@ -53,7 +55,7 @@ function makePreflightOptions(
 describe("preflight-cache Antigravity readiness", () => {
   it("marks Antigravity ready only when headless flags and auth file are present", async () => {
     const homeDir = makeHome({
-      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+      antigravityAuth: { expiry_date: Date.now() + READY_EXPIRY_MS },
     });
     try {
       const result = await runPreflight(
@@ -76,7 +78,7 @@ describe("preflight-cache Antigravity readiness", () => {
 
   it("does not enable Antigravity auto fallback when auth expires within the readiness window", async () => {
     const homeDir = makeHome({
-      antigravityAuth: { expiry_date: Date.now() + 30_000 },
+      antigravityAuth: { expiry_date: Date.now() + CACHE_TTL_MS - 1 },
     });
     try {
       const result = await runPreflight(
@@ -96,7 +98,7 @@ describe("preflight-cache Antigravity readiness", () => {
 
   it("accepts Antigravity headless help flags emitted on stderr", async () => {
     const homeDir = makeHome({
-      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+      antigravityAuth: { expiry_date: Date.now() + READY_EXPIRY_MS },
     });
     try {
       const result = await runPreflight(
@@ -123,13 +125,76 @@ describe("preflight-cache Antigravity readiness", () => {
         makePreflightOptions(
           homeDir,
           "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
-          { smoke: { status: 0, stdout: "AGY_OK\n", stderr: "" } },
+          {
+            smoke: {
+              status: 0,
+              stdout: "AGY_OK\nError: timed out waiting for response\n",
+              stderr: "",
+            },
+          },
         ),
       );
 
       assert.equal(result.antigravity.ok, true);
       assert.equal(result.antigravity.reason, "ready");
       assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not accept non-sentinel smoke output as Antigravity readiness", async () => {
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() - 30_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          { smoke: { status: 0, stdout: "Welcome to agy\n", stderr: "" } },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.ok(!result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not enable Antigravity auto fallback for auth files without expiry_date", async () => {
+    const homeDir = makeHome({ antigravityAuth: {} });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.ok(!result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not enable Antigravity auto fallback for malformed auth JSON", async () => {
+    const homeDir = makeHome({ antigravityAuth: "{" });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.reason, "auth_invalid");
+      assert.ok(!result.available_agents.includes("antigravity"));
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -155,7 +220,7 @@ describe("preflight-cache Antigravity readiness", () => {
 
   it("does not enable Antigravity auto fallback without headless flags", async () => {
     const homeDir = makeHome({
-      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+      antigravityAuth: { expiry_date: Date.now() + READY_EXPIRY_MS },
     });
     try {
       const result = await runPreflight(

--- a/tests/unit/preflight-cache-antigravity.test.mjs
+++ b/tests/unit/preflight-cache-antigravity.test.mjs
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 
 import { runPreflight } from "../../scripts/preflight-cache.mjs";
 
-function makeHome({ withAntigravityAuth = false } = {}) {
+function makeHome({ antigravityAuth } = {}) {
   const homeDir = mkdtempSync(join(tmpdir(), "tfx-preflight-agy-"));
   mkdirSync(join(homeDir, ".claude", "scripts"), { recursive: true });
   writeFileSync(
@@ -15,15 +15,23 @@ function makeHome({ withAntigravityAuth = false } = {}) {
     "utf8",
   );
 
-  if (withAntigravityAuth) {
+  if (antigravityAuth) {
     mkdirSync(join(homeDir, ".gemini"), { recursive: true });
-    writeFileSync(join(homeDir, ".gemini", "oauth_creds.json"), "{}", "utf8");
+    writeFileSync(
+      join(homeDir, ".gemini", "oauth_creds.json"),
+      JSON.stringify(antigravityAuth),
+      "utf8",
+    );
   }
 
   return homeDir;
 }
 
-function makePreflightOptions(homeDir, helpText) {
+function makePreflightOptions(
+  homeDir,
+  helpText,
+  { helpStderr = "", smoke = { status: 1, stdout: "", stderr: "" } } = {},
+) {
   return {
     homeDir,
     probeClisFn: async () => ({
@@ -33,13 +41,20 @@ function makePreflightOptions(homeDir, helpText) {
     }),
     checkHubFn: () => ({ ok: true, state: "healthy" }),
     detectCodexPlanFn: () => ({ plan: "pro", source: "test" }),
-    execFileSyncFn: () => helpText,
+    spawnSyncFn: (_command, args) => {
+      if (args.includes("--help")) {
+        return { status: 0, stdout: helpText, stderr: helpStderr };
+      }
+      return smoke;
+    },
   };
 }
 
 describe("preflight-cache Antigravity readiness", () => {
   it("marks Antigravity ready only when headless flags and auth file are present", async () => {
-    const homeDir = makeHome({ withAntigravityAuth: true });
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+    });
     try {
       const result = await runPreflight(
         makePreflightOptions(
@@ -53,6 +68,67 @@ describe("preflight-cache Antigravity readiness", () => {
         path: "/fake/bin/agy",
         reason: "ready",
       });
+      assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not enable Antigravity auto fallback when auth expires within the readiness window", async () => {
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() + 30_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.ok(!result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts Antigravity headless help flags emitted on stderr", async () => {
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(homeDir, "", {
+          helpStderr:
+            "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+        }),
+      );
+
+      assert.equal(result.antigravity.ok, true);
+      assert.equal(result.antigravity.reason, "ready");
+      assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts expired Antigravity auth when non-interactive smoke succeeds", async () => {
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() - 30_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          { smoke: { status: 0, stdout: "AGY_OK\n", stderr: "" } },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, true);
+      assert.equal(result.antigravity.reason, "ready");
       assert.ok(result.available_agents.includes("antigravity"));
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
@@ -78,7 +154,9 @@ describe("preflight-cache Antigravity readiness", () => {
   });
 
   it("does not enable Antigravity auto fallback without headless flags", async () => {
-    const homeDir = makeHome({ withAntigravityAuth: true });
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() + 120_000 },
+    });
     try {
       const result = await runPreflight(
         makePreflightOptions(homeDir, "Usage: agy\n  chat\n"),


### PR DESCRIPTION
## Summary\n- parse Antigravity OAuth credentials instead of accepting file existence\n- accept headless-ready agy when expired credentials refresh through bounded non-interactive smoke\n- read agy help flags from stdout and stderr so the live CLI is detected correctly\n\nFixes #306.\n\n## Validation\n- node scripts/test-lock.mjs --test --test-force-exit tests/unit/preflight-cache-antigravity.test.mjs\n- npm run release:check-mirror\n- npm run release:check-sync\n- npx --no-install biome check scripts/preflight-cache.mjs packages/triflux/scripts/preflight-cache.mjs tests/unit/preflight-cache-antigravity.test.mjs\n- git diff --check\n- live preflight: antigravity ok true, available_agents includes antigravity\n- live HUD smoke: rendered a: row instead of g: