### PR TITLE
Preserve Codex auth across worker sandboxes

### DIFF
--- a/hub/team/worker-sandbox.mjs
+++ b/hub/team/worker-sandbox.mjs
@@ -71,6 +71,10 @@ export function buildWorkerSandboxEnv(opts = {}) {
     XDG_CACHE_HOME: xdgCache,
     XDG_STATE_HOME: xdgState,
   };
+  const hostHome = env.HOME || env.USERPROFILE;
+  if (!env.CODEX_HOME && hostHome) {
+    overlay.CODEX_HOME = join(hostHome, ".codex");
+  }
 
   const winParts =
     windowsHomeParts(home) ||

--- a/packages/remote/hub/team/worker-sandbox.mjs
+++ b/packages/remote/hub/team/worker-sandbox.mjs
@@ -71,6 +71,10 @@ export function buildWorkerSandboxEnv(opts = {}) {
     XDG_CACHE_HOME: xdgCache,
     XDG_STATE_HOME: xdgState,
   };
+  const hostHome = env.HOME || env.USERPROFILE;
+  if (!env.CODEX_HOME && hostHome) {
+    overlay.CODEX_HOME = join(hostHome, ".codex");
+  }
 
   const winParts =
     windowsHomeParts(home) ||

--- a/packages/triflux/hub/team/worker-sandbox.mjs
+++ b/packages/triflux/hub/team/worker-sandbox.mjs
@@ -71,6 +71,10 @@ export function buildWorkerSandboxEnv(opts = {}) {
     XDG_CACHE_HOME: xdgCache,
     XDG_STATE_HOME: xdgState,
   };
+  const hostHome = env.HOME || env.USERPROFILE;
+  if (!env.CODEX_HOME && hostHome) {
+    overlay.CODEX_HOME = join(hostHome, ".codex");
+  }
 
   const winParts =
     windowsHomeParts(home) ||

--- a/tests/unit/worker-sandbox.test.mjs
+++ b/tests/unit/worker-sandbox.test.mjs
@@ -69,6 +69,22 @@ describe("worker sandbox env", () => {
     assert.equal(existsSync(result.env.XDG_STATE_HOME), true);
   });
 
+  it("preserves the host Codex home when CODEX_HOME is unset", () => {
+    const cwd = tmpRoot("worker-sandbox-cwd");
+    const hostHome = tmpRoot("worker-sandbox-host-home");
+    const result = buildWorkerSandboxEnv({
+      cwd,
+      sessionId: "codex-worker",
+      env: {
+        HOME: hostHome,
+      },
+    });
+
+    const expectedHome = join(cwd, ".triflux", "worker-home", "codex-worker");
+    assert.equal(result.env.HOME, expectedHome);
+    assert.equal(result.env.CODEX_HOME, join(hostHome, ".codex"));
+  });
+
   it("supports explicit opt-out for debugging", () => {
     const result = buildWorkerSandboxEnv({
       cwd: tmpRoot("worker-sandbox-disabled"),


### PR DESCRIPTION
## Summary\n- keep worker HOME sandboxing intact\n- automatically set CODEX_HOME to the host .codex directory when callers did not set it\n- preserve explicit CODEX_HOME overrides\n\nAddresses Gap 3 of #290. Does not close the broader four-gap issue.\n\n## Validation\n- node scripts/test-lock.mjs --test --test-force-exit tests/unit/worker-sandbox.test.mjs\n- npm run release:check-mirror\n- npm run release:check-sync\n- npx --no-install biome check hub/team/worker-sandbox.mjs packages/remote/hub/team/worker-sandbox.mjs packages/triflux/hub/team/worker-sandbox.mjs tests/unit/worker-sandbox.test.mjs\n- git diff --check