### PR TITLE
Count Codex rollout activity in stall detection

### DIFF
--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1565,6 +1565,36 @@ _find_fork_pids() {
   ps 2>/dev/null | awk -v p="$parent" 'NR>1 && ($2==p || ($3==p && $1!=p)) {print $1}' | sort -un | tr '\n' ' '
 }
 
+_codex_rollout_activity_bytes() {
+  [[ "${CLI_TYPE:-}" == "codex" ]] || { printf '0\n'; return 0; }
+  local codex_home="${CODEX_HOME:-${TFX_CODEX_HOME:-${HOME:-}/.codex}}"
+  [[ -n "$codex_home" && "$codex_home" != "/.codex" ]] || { printf '0\n'; return 0; }
+
+  local session_dir="${codex_home}/sessions/$(date +%Y/%m/%d)"
+  [[ -d "$session_dir" ]] || { printf '0\n'; return 0; }
+
+  local since="${TIMESTAMP:-0}"
+  [[ "$since" =~ ^[0-9]+$ ]] || since=0
+
+  local total=0 candidate mtime size
+  for candidate in "$session_dir"/rollout-*.jsonl; do
+    [[ -f "$candidate" ]] || continue
+    mtime=$(stat -f %m "$candidate" 2>/dev/null || printf '')
+    mtime="${mtime//[[:space:]]/}"
+    if ! [[ "$mtime" =~ ^[0-9]+$ ]]; then
+      mtime=$(stat -c %Y "$candidate" 2>/dev/null || printf '0')
+      mtime="${mtime//[[:space:]]/}"
+    fi
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+    [[ "$mtime" -ge "$since" ]] || continue
+    size=$(wc -c < "$candidate" 2>/dev/null || printf '0')
+    size="${size//[[:space:]]/}"
+    [[ "$size" =~ ^[0-9]+$ ]] || size=0
+    total=$((total + size))
+  done
+  printf '%s\n' "$total"
+}
+
 # heartbeat_monitor PID [INTERVAL] [STALL_THRESHOLD]
 # - PID: 감시할 워커 프로세스 PID
 # - INTERVAL: heartbeat 출력 간격 (초, 기본 10)
@@ -1605,7 +1635,10 @@ heartbeat_monitor() {
     # P3: stderr 활동도 포함하여 거짓 STALL 방지
     local stderr_size=0
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
-    current_size=$((current_size + stderr_size))
+    local codex_rollout_size=0
+    codex_rollout_size=$(_codex_rollout_activity_bytes 2>/dev/null || echo 0)
+    [[ "$codex_rollout_size" =~ ^[0-9]+$ ]] || codex_rollout_size=0
+    current_size=$((current_size + stderr_size + codex_rollout_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))
     local expected_suffix=""
     if [[ -n "$expected_duration" && "$expected_duration" =~ ^[0-9]+$ && "$expected_duration" -gt 0 ]]; then

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1569,29 +1569,47 @@ _codex_rollout_activity_bytes() {
   [[ "${CLI_TYPE:-}" == "codex" ]] || { printf '0\n'; return 0; }
   local codex_home="${CODEX_HOME:-${TFX_CODEX_HOME:-${HOME:-}/.codex}}"
   [[ -n "$codex_home" && "$codex_home" != "/.codex" ]] || { printf '0\n'; return 0; }
+  local codex_home_real="$codex_home"
+  [[ -d "$codex_home" ]] && codex_home_real=$(cd "$codex_home" 2>/dev/null && pwd -P || printf '%s' "$codex_home")
 
-  local session_dir="${codex_home}/sessions/$(date +%Y/%m/%d)"
-  [[ -d "$session_dir" ]] || { printf '0\n'; return 0; }
+  local total=0 seen="" proc_pid fd target candidate size
+  for proc_pid in "$@"; do
+    [[ "$proc_pid" =~ ^[0-9]+$ ]] || continue
 
-  local since="${TIMESTAMP:-0}"
-  [[ "$since" =~ ^[0-9]+$ ]] || since=0
-
-  local total=0 candidate mtime size
-  for candidate in "$session_dir"/rollout-*.jsonl; do
-    [[ -f "$candidate" ]] || continue
-    mtime=$(stat -f %m "$candidate" 2>/dev/null || printf '')
-    mtime="${mtime//[[:space:]]/}"
-    if ! [[ "$mtime" =~ ^[0-9]+$ ]]; then
-      mtime=$(stat -c %Y "$candidate" 2>/dev/null || printf '0')
-      mtime="${mtime//[[:space:]]/}"
+    if [[ -d "/proc/$proc_pid/fd" ]]; then
+      for fd in "/proc/$proc_pid/fd"/*; do
+        [[ -e "$fd" ]] || continue
+        target=$(readlink "$fd" 2>/dev/null || true)
+        case "$target" in
+          "$codex_home"/sessions/*/rollout-*.jsonl|"$codex_home_real"/sessions/*/rollout-*.jsonl)
+            seen="${seen}${target}"$'\n'
+            ;;
+        esac
+      done
     fi
-    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
-    [[ "$mtime" -ge "$since" ]] || continue
+
+    if command -v lsof >/dev/null 2>&1; then
+      while IFS= read -r candidate; do
+        case "$candidate" in
+          n"$codex_home"/sessions/*/rollout-*.jsonl|n"$codex_home_real"/sessions/*/rollout-*.jsonl)
+            seen="${seen}${candidate#n}"$'\n'
+            ;;
+        esac
+      done < <(lsof -Fn -p "$proc_pid" 2>/dev/null || true)
+    fi
+  done
+
+  local raw_paths="$seen"
+  seen=$'\n'
+  while IFS= read -r candidate; do
+    [[ -f "$candidate" ]] || continue
+    [[ "$seen" == *$'\n'"$candidate"$'\n'* ]] && continue
+    seen="${seen}${candidate}"$'\n'
     size=$(wc -c < "$candidate" 2>/dev/null || printf '0')
     size="${size//[[:space:]]/}"
     [[ "$size" =~ ^[0-9]+$ ]] || size=0
     total=$((total + size))
-  done
+  done <<< "$raw_paths"
   printf '%s\n' "$total"
 }
 
@@ -1636,7 +1654,7 @@ heartbeat_monitor() {
     local stderr_size=0
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
     local codex_rollout_size=0
-    codex_rollout_size=$(_codex_rollout_activity_bytes 2>/dev/null || echo 0)
+    codex_rollout_size=$(_codex_rollout_activity_bytes "$pid" $last_known_forks 2>/dev/null || echo 0)
     [[ "$codex_rollout_size" =~ ^[0-9]+$ ]] || codex_rollout_size=0
     current_size=$((current_size + stderr_size + codex_rollout_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1565,6 +1565,36 @@ _find_fork_pids() {
   ps 2>/dev/null | awk -v p="$parent" 'NR>1 && ($2==p || ($3==p && $1!=p)) {print $1}' | sort -un | tr '\n' ' '
 }
 
+_codex_rollout_activity_bytes() {
+  [[ "${CLI_TYPE:-}" == "codex" ]] || { printf '0\n'; return 0; }
+  local codex_home="${CODEX_HOME:-${TFX_CODEX_HOME:-${HOME:-}/.codex}}"
+  [[ -n "$codex_home" && "$codex_home" != "/.codex" ]] || { printf '0\n'; return 0; }
+
+  local session_dir="${codex_home}/sessions/$(date +%Y/%m/%d)"
+  [[ -d "$session_dir" ]] || { printf '0\n'; return 0; }
+
+  local since="${TIMESTAMP:-0}"
+  [[ "$since" =~ ^[0-9]+$ ]] || since=0
+
+  local total=0 candidate mtime size
+  for candidate in "$session_dir"/rollout-*.jsonl; do
+    [[ -f "$candidate" ]] || continue
+    mtime=$(stat -f %m "$candidate" 2>/dev/null || printf '')
+    mtime="${mtime//[[:space:]]/}"
+    if ! [[ "$mtime" =~ ^[0-9]+$ ]]; then
+      mtime=$(stat -c %Y "$candidate" 2>/dev/null || printf '0')
+      mtime="${mtime//[[:space:]]/}"
+    fi
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+    [[ "$mtime" -ge "$since" ]] || continue
+    size=$(wc -c < "$candidate" 2>/dev/null || printf '0')
+    size="${size//[[:space:]]/}"
+    [[ "$size" =~ ^[0-9]+$ ]] || size=0
+    total=$((total + size))
+  done
+  printf '%s\n' "$total"
+}
+
 # heartbeat_monitor PID [INTERVAL] [STALL_THRESHOLD]
 # - PID: 감시할 워커 프로세스 PID
 # - INTERVAL: heartbeat 출력 간격 (초, 기본 10)
@@ -1605,7 +1635,10 @@ heartbeat_monitor() {
     # P3: stderr 활동도 포함하여 거짓 STALL 방지
     local stderr_size=0
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
-    current_size=$((current_size + stderr_size))
+    local codex_rollout_size=0
+    codex_rollout_size=$(_codex_rollout_activity_bytes 2>/dev/null || echo 0)
+    [[ "$codex_rollout_size" =~ ^[0-9]+$ ]] || codex_rollout_size=0
+    current_size=$((current_size + stderr_size + codex_rollout_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))
     local expected_suffix=""
     if [[ -n "$expected_duration" && "$expected_duration" =~ ^[0-9]+$ && "$expected_duration" -gt 0 ]]; then

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1569,29 +1569,47 @@ _codex_rollout_activity_bytes() {
   [[ "${CLI_TYPE:-}" == "codex" ]] || { printf '0\n'; return 0; }
   local codex_home="${CODEX_HOME:-${TFX_CODEX_HOME:-${HOME:-}/.codex}}"
   [[ -n "$codex_home" && "$codex_home" != "/.codex" ]] || { printf '0\n'; return 0; }
+  local codex_home_real="$codex_home"
+  [[ -d "$codex_home" ]] && codex_home_real=$(cd "$codex_home" 2>/dev/null && pwd -P || printf '%s' "$codex_home")
 
-  local session_dir="${codex_home}/sessions/$(date +%Y/%m/%d)"
-  [[ -d "$session_dir" ]] || { printf '0\n'; return 0; }
+  local total=0 seen="" proc_pid fd target candidate size
+  for proc_pid in "$@"; do
+    [[ "$proc_pid" =~ ^[0-9]+$ ]] || continue
 
-  local since="${TIMESTAMP:-0}"
-  [[ "$since" =~ ^[0-9]+$ ]] || since=0
-
-  local total=0 candidate mtime size
-  for candidate in "$session_dir"/rollout-*.jsonl; do
-    [[ -f "$candidate" ]] || continue
-    mtime=$(stat -f %m "$candidate" 2>/dev/null || printf '')
-    mtime="${mtime//[[:space:]]/}"
-    if ! [[ "$mtime" =~ ^[0-9]+$ ]]; then
-      mtime=$(stat -c %Y "$candidate" 2>/dev/null || printf '0')
-      mtime="${mtime//[[:space:]]/}"
+    if [[ -d "/proc/$proc_pid/fd" ]]; then
+      for fd in "/proc/$proc_pid/fd"/*; do
+        [[ -e "$fd" ]] || continue
+        target=$(readlink "$fd" 2>/dev/null || true)
+        case "$target" in
+          "$codex_home"/sessions/*/rollout-*.jsonl|"$codex_home_real"/sessions/*/rollout-*.jsonl)
+            seen="${seen}${target}"$'\n'
+            ;;
+        esac
+      done
     fi
-    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
-    [[ "$mtime" -ge "$since" ]] || continue
+
+    if command -v lsof >/dev/null 2>&1; then
+      while IFS= read -r candidate; do
+        case "$candidate" in
+          n"$codex_home"/sessions/*/rollout-*.jsonl|n"$codex_home_real"/sessions/*/rollout-*.jsonl)
+            seen="${seen}${candidate#n}"$'\n'
+            ;;
+        esac
+      done < <(lsof -Fn -p "$proc_pid" 2>/dev/null || true)
+    fi
+  done
+
+  local raw_paths="$seen"
+  seen=$'\n'
+  while IFS= read -r candidate; do
+    [[ -f "$candidate" ]] || continue
+    [[ "$seen" == *$'\n'"$candidate"$'\n'* ]] && continue
+    seen="${seen}${candidate}"$'\n'
     size=$(wc -c < "$candidate" 2>/dev/null || printf '0')
     size="${size//[[:space:]]/}"
     [[ "$size" =~ ^[0-9]+$ ]] || size=0
     total=$((total + size))
-  done
+  done <<< "$raw_paths"
   printf '%s\n' "$total"
 }
 
@@ -1636,7 +1654,7 @@ heartbeat_monitor() {
     local stderr_size=0
     [[ -f "$STDERR_LOG" ]] && stderr_size=$(wc -c < "$STDERR_LOG" 2>/dev/null || echo 0)
     local codex_rollout_size=0
-    codex_rollout_size=$(_codex_rollout_activity_bytes 2>/dev/null || echo 0)
+    codex_rollout_size=$(_codex_rollout_activity_bytes "$pid" $last_known_forks 2>/dev/null || echo 0)
     [[ "$codex_rollout_size" =~ ^[0-9]+$ ]] || codex_rollout_size=0
     current_size=$((current_size + stderr_size + codex_rollout_size))
     local elapsed=$(($(date +%s) - TIMESTAMP))

--- a/tests/unit/tfx-route-stall-kill.test.mjs
+++ b/tests/unit/tfx-route-stall-kill.test.mjs
@@ -120,6 +120,7 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
   function buildStallScript({ killMode, stdoutLog, stderrLog }) {
     const hb = extractFunction("heartbeat_monitor");
     const findForks = extractFunction("_find_fork_pids");
+    const rolloutActivity = extractFunction("_codex_rollout_activity_bytes");
     // bash file 로 실행. spawnSync("bash", ["-c", script]) 는 Windows Git Bash 에서
     // 긴 script 의 line ending / argv 한도 문제로 EOF 오류를 내는 경우가 있어
     // 파일 경유가 안전하다.
@@ -136,6 +137,7 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
       "TIMESTAMP=$(date +%s)",
       "",
       findForks,
+      rolloutActivity,
       hb,
       "",
       "sleep 30 &",
@@ -163,6 +165,63 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
       "else",
       '  echo "RESULT=child_terminated" >&2',
       "fi",
+      "",
+    ].join("\n");
+  }
+
+  function buildCodexRolloutActivityScript({
+    codexHome,
+    stdoutLog,
+    stderrLog,
+  }) {
+    const hb = extractFunction("heartbeat_monitor");
+    const findForks = extractFunction("_find_fork_pids");
+    const rolloutActivity = extractFunction("_codex_rollout_activity_bytes");
+    return [
+      "#!/usr/bin/env bash",
+      "set -u",
+      "export TFX_HEARTBEAT=1",
+      "export TFX_HEARTBEAT_INTERVAL=1",
+      "export TFX_STALL_THRESHOLD=2",
+      "export TFX_STALL_KILL=kill",
+      "export TFX_STALL_KILL_GRACE=1",
+      "export CLI_TYPE=codex",
+      `export CODEX_HOME='${codexHome}'`,
+      `STDOUT_LOG='${stdoutLog}'`,
+      `STDERR_LOG='${stderrLog}'`,
+      "TIMESTAMP=$(date +%s)",
+      "",
+      findForks,
+      rolloutActivity,
+      hb,
+      "",
+      'session_dir="$CODEX_HOME/sessions/$(date +%Y/%m/%d)"',
+      'mkdir -p "$session_dir"',
+      'rollout_log="$session_dir/rollout-heartbeat-test.jsonl"',
+      ': > "$rollout_log"',
+      "(",
+      "  for i in 1 2 3 4 5; do",
+      "    sleep 1",
+      '    printf \'{"event":"tick","i":%s}\\n\' "$i" >> "$rollout_log"',
+      "  done",
+      ") &",
+      "WRITER_PID=$!",
+      "",
+      "sleep 6 &",
+      "CHILD_PID=$!",
+      'heartbeat_monitor "$CHILD_PID" 1 2 &',
+      "HB_PID=$!",
+      "",
+      'wait "$CHILD_PID"',
+      "child_status=$?",
+      'kill "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
+      'wait "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
+      "",
+      'if [[ "$child_status" -ne 0 ]]; then',
+      '  echo "RESULT=child_killed status=$child_status" >&2',
+      "  exit 1",
+      "fi",
+      'echo "RESULT=child_completed" >&2',
       "",
     ].join("\n");
   }
@@ -227,6 +286,37 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
       result.stderr,
       /SIGTERM/,
       "classify mode 에서는 SIGTERM 이 발사되면 안 됨",
+    );
+  });
+
+  it("Codex rollout jsonl activity resets stall detection when stdout/stderr stay empty (#267)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-codex-rollout-"));
+    cleanupDirs.push(dir);
+    const codexHome = path.join(dir, "codex-home");
+    const stdoutLog = path.join(dir, "stdout.log");
+    const stderrLog = path.join(dir, "stderr.log");
+    const scriptFile = path.join(dir, "run.sh");
+    writeFileSync(stdoutLog, "");
+    writeFileSync(stderrLog, "");
+    writeFileSync(
+      scriptFile,
+      buildCodexRolloutActivityScript({ codexHome, stdoutLog, stderrLog }),
+    );
+    const result = spawnSync("bash", [scriptFile], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      timeout: 20_000,
+    });
+    assert.equal(
+      result.status,
+      0,
+      `Codex worker should not be killed while rollout jsonl grows.\nstderr:\n${result.stderr}`,
+    );
+    assert.match(result.stderr, /RESULT=child_completed/);
+    assert.doesNotMatch(
+      result.stderr,
+      /status=STALL_KILL/,
+      "rollout jsonl activity must prevent STALL_KILL",
     );
   });
 });

--- a/tests/unit/tfx-route-stall-kill.test.mjs
+++ b/tests/unit/tfx-route-stall-kill.test.mjs
@@ -200,28 +200,92 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
       'rollout_log="$session_dir/rollout-heartbeat-test.jsonl"',
       ': > "$rollout_log"',
       "(",
+      '  exec 3>>"$rollout_log"',
       "  for i in 1 2 3 4 5; do",
       "    sleep 1",
-      '    printf \'{"event":"tick","i":%s}\\n\' "$i" >> "$rollout_log"',
+      '    printf \'{"event":"tick","i":%s}\\n\' "$i" >&3',
       "  done",
       ") &",
-      "WRITER_PID=$!",
-      "",
-      "sleep 6 &",
       "CHILD_PID=$!",
+      "",
       'heartbeat_monitor "$CHILD_PID" 1 2 &',
       "HB_PID=$!",
       "",
       'wait "$CHILD_PID"',
       "child_status=$?",
-      'kill "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
-      'wait "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
+      'kill "$HB_PID" 2>/dev/null || true',
+      'wait "$HB_PID" 2>/dev/null || true',
       "",
       'if [[ "$child_status" -ne 0 ]]; then',
       '  echo "RESULT=child_killed status=$child_status" >&2',
       "  exit 1",
       "fi",
       'echo "RESULT=child_completed" >&2',
+      "",
+    ].join("\n");
+  }
+
+  function buildUnrelatedCodexRolloutScript({
+    codexHome,
+    stdoutLog,
+    stderrLog,
+  }) {
+    const hb = extractFunction("heartbeat_monitor");
+    const findForks = extractFunction("_find_fork_pids");
+    const rolloutActivity = extractFunction("_codex_rollout_activity_bytes");
+    return [
+      "#!/usr/bin/env bash",
+      "set -u",
+      "export TFX_HEARTBEAT=1",
+      "export TFX_HEARTBEAT_INTERVAL=1",
+      "export TFX_STALL_THRESHOLD=2",
+      "export TFX_STALL_KILL=kill",
+      "export TFX_STALL_KILL_GRACE=1",
+      "export CLI_TYPE=codex",
+      `export CODEX_HOME='${codexHome}'`,
+      `STDOUT_LOG='${stdoutLog}'`,
+      `STDERR_LOG='${stderrLog}'`,
+      "TIMESTAMP=$(date +%s)",
+      "",
+      findForks,
+      rolloutActivity,
+      hb,
+      "",
+      'session_dir="$CODEX_HOME/sessions/$(date +%Y/%m/%d)"',
+      'mkdir -p "$session_dir"',
+      'rollout_log="$session_dir/rollout-unrelated-test.jsonl"',
+      ': > "$rollout_log"',
+      "(",
+      '  exec 3>>"$rollout_log"',
+      "  for i in 1 2 3 4 5 6 7 8; do",
+      "    sleep 1",
+      '    printf \'{"event":"unrelated","i":%s}\\n\' "$i" >&3',
+      "  done",
+      ") &",
+      "WRITER_PID=$!",
+      "",
+      "sleep 30 &",
+      "CHILD_PID=$!",
+      'heartbeat_monitor "$CHILD_PID" 1 2 &',
+      "HB_PID=$!",
+      "",
+      "for i in 1 2 3 4 5 6 7 8 9 10; do",
+      "  sleep 1",
+      '  if ! kill -0 "$CHILD_PID" 2>/dev/null; then',
+      '    echo "CHILD_KILLED_AFTER=${i}s" >&2',
+      "    break",
+      "  fi",
+      "done",
+      "",
+      'kill "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
+      'wait "$HB_PID" "$WRITER_PID" 2>/dev/null || true',
+      'kill "$CHILD_PID" 2>/dev/null || true',
+      "",
+      'if kill -0 "$CHILD_PID" 2>/dev/null; then',
+      '  echo "RESULT=child_still_alive" >&2',
+      "  exit 1",
+      "fi",
+      'echo "RESULT=child_terminated" >&2',
       "",
     ].join("\n");
   }
@@ -318,5 +382,32 @@ describe("#144/#66 heartbeat stall kill — integration", () => {
       /status=STALL_KILL/,
       "rollout jsonl activity must prevent STALL_KILL",
     );
+  });
+
+  it("unrelated Codex rollout activity does not hide a stalled worker (#267)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tfx-codex-rollout-scope-"));
+    cleanupDirs.push(dir);
+    const codexHome = path.join(dir, "codex-home");
+    const stdoutLog = path.join(dir, "stdout.log");
+    const stderrLog = path.join(dir, "stderr.log");
+    const scriptFile = path.join(dir, "run.sh");
+    writeFileSync(stdoutLog, "");
+    writeFileSync(stderrLog, "");
+    writeFileSync(
+      scriptFile,
+      buildUnrelatedCodexRolloutScript({ codexHome, stdoutLog, stderrLog }),
+    );
+    const result = spawnSync("bash", [scriptFile], {
+      encoding: "utf8",
+      cwd: REPO_ROOT,
+      timeout: 20_000,
+    });
+    assert.equal(
+      result.status,
+      0,
+      `unrelated rollout activity should not keep a stalled worker alive.\nstderr:\n${result.stderr}`,
+    );
+    assert.match(result.stderr, /status=STALL_KILL/);
+    assert.match(result.stderr, /RESULT=child_terminated/);
   });
 });


### PR DESCRIPTION
## Summary\n- include Codex rollout JSONL growth in heartbeat activity accounting\n- scope rollout accounting to Codex routes and the active CODEX_HOME session tree\n- add regression coverage for stdout/stderr-empty Codex activity avoiding STALL_KILL\n\nFixes #267.\n\n## Validation\n- node --test tests/unit/tfx-route-stall-kill.test.mjs tests/unit/heartbeat-visibility.test.mjs\n- npm run release:check-mirror\n- npm run release:check-sync\n- npx --no-install biome check scripts/tfx-route.sh packages/triflux/scripts/tfx-route.sh tests/unit/tfx-route-stall-kill.test.mjs\n- bash -n scripts/tfx-route.sh packages/triflux/scripts/tfx-route.sh\n- git diff --check\n- cmp root/package route scripts