### PR TITLE
Cover Antigravity sandbox flag absorption

### DIFF
--- a/tests/integration/agy-stdout-pipe.test.mjs
+++ b/tests/integration/agy-stdout-pipe.test.mjs
@@ -248,6 +248,27 @@ test("agy --print prompt-passing regression tests", {
       );
     },
   );
+
+  await t.test(
+    "6. flag absorption guard: --print + --sandbox + positional -> timeout/failure",
+    { timeout: 100000 },
+    () => {
+      const result = spawnSync(
+        AGY_PATH,
+        ["--print", "--sandbox", "/tmp", TEST_PROMPT],
+        {
+          encoding: "utf8",
+          timeout: 90000,
+          env: { ...process.env, PAGER: "cat" },
+        },
+      );
+      const combined = (result.stdout || "") + (result.stderr || "");
+      assert.ok(
+        !hasHi(combined) || hasWelcomeOrFailure(combined),
+        `--print + --sandbox + positional should NOT pass prompt cleanly. status=${result.status} signal=${result.signal} output: ${combined}`,
+      );
+    },
+  );
 });
 
 test("tfx-route.sh routes Antigravity through agy --print stdin", () => {


### PR DESCRIPTION
## Summary
- add the missing T9 live agy matrix case for --print --sandbox /tmp <prompt>
- keep the live case under the existing TFX_AGY_LIVE=1 opt-in gate
- leave always-on fixture-backed route tests unchanged

Fixes #308.

## Validation
- node --test tests/integration/agy-stdout-pipe.test.mjs
- npx --no-install biome check tests/integration/agy-stdout-pipe.test.mjs
- git diff --check
- npm run release:check-mirror
- npm run release:check-sync

Note: I did not run TFX_AGY_LIVE=1 to avoid OAuth/token spend in this default validation pass.