### PR TITLE
fix: review follow-ups — escalation override guard, profile argv exposure, gemini preflight alignment

### DIFF
--- a/hub/bridge.mjs
+++ b/hub/bridge.mjs
@@ -1373,6 +1373,21 @@ function buildRetrySmFromArgs(args, snapshot) {
   return sm;
 }
 
+function buildRetryCliInvocation(cli) {
+  if (!cli) return null;
+
+  const invocation = {
+    cli: cli.cli,
+    model: cli.model,
+    argv: [],
+  };
+  if (cli.profile) invocation.profile = cli.profile;
+  if (cli.cli === "codex" && cli.profile) {
+    invocation.argv.push("--profile", cli.profile);
+  }
+  return invocation;
+}
+
 async function cmdRetryRun(args) {
   const snapshotFile = args.snapshot || args["snapshot-file"];
   const event = args.event;
@@ -1411,12 +1426,14 @@ async function cmdRetryRun(args) {
 
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   const out = {
     ok: true,
     current: snap.current,
     iterations: snap.iterations,
     cliIndex: snap.cliIndex,
     cli,
+    cliInvocation,
     done: snap.current === "DONE",
     shouldStop: terminal,
     stuckCounter: snap.stuckCounter,
@@ -1440,6 +1457,7 @@ async function cmdRetryStatus(args) {
   }
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   console.log(
     JSON.stringify({
       ok: true,
@@ -1449,6 +1467,7 @@ async function cmdRetryStatus(args) {
       maxIterations: snap.maxIterations,
       cliIndex: snap.cliIndex,
       cli,
+      cliInvocation,
       mode: snap.mode,
       shouldStop: terminal,
       stuckCounter: snap.stuckCounter,

--- a/hub/team/retry-state-machine.mjs
+++ b/hub/team/retry-state-machine.mjs
@@ -232,7 +232,10 @@ function resolveEscalationChain(options) {
   const projectRoot = options.projectRoot || process.cwd();
   return (
     loadEscalationChainOverride(projectRoot) ||
-    normalizeEscalationChain(DEFAULT_ESCALATION_CHAIN, "DEFAULT_ESCALATION_CHAIN")
+    normalizeEscalationChain(
+      DEFAULT_ESCALATION_CHAIN,
+      "DEFAULT_ESCALATION_CHAIN",
+    )
   );
 }
 
@@ -240,7 +243,16 @@ export function loadEscalationChainOverride(projectRoot = process.cwd()) {
   const configPath = join(projectRoot, ESCALATION_CHAIN_CONFIG_PATH);
   if (!existsSync(configPath)) return null;
 
-  const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  const raw = readFileSync(configPath, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `escalation-chain override 파싱 실패: ${configPath} — 원인: ${err.message} — 수정: JSON 문법 확인 또는 파일 삭제로 DEFAULT_ESCALATION_CHAIN 사용`,
+      { cause: err },
+    );
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`${configPath}: expected object`);
   }
@@ -264,7 +276,9 @@ function normalizeEscalationChainEntry(entry, index, source) {
     throw new Error(`${source}: chain[${index}] must be an object`);
   }
   if (typeof entry.cli !== "string" || entry.cli.trim() === "") {
-    throw new Error(`${source}: chain[${index}].cli must be a non-empty string`);
+    throw new Error(
+      `${source}: chain[${index}].cli must be a non-empty string`,
+    );
   }
   if (typeof entry.model !== "string" || entry.model.trim() === "") {
     throw new Error(

--- a/hub/team/swarm-preflight.mjs
+++ b/hub/team/swarm-preflight.mjs
@@ -10,7 +10,7 @@ import { planSwarm } from "./swarm-planner.mjs";
 
 const AGENT_COMMANDS = Object.freeze({
   codex: "codex",
-  gemini: "gemini",
+  gemini: "agy",
   antigravity: "agy",
   agy: "agy",
   claude: "claude",

--- a/packages/core/hub/bridge.mjs
+++ b/packages/core/hub/bridge.mjs
@@ -1373,6 +1373,21 @@ function buildRetrySmFromArgs(args, snapshot) {
   return sm;
 }
 
+function buildRetryCliInvocation(cli) {
+  if (!cli) return null;
+
+  const invocation = {
+    cli: cli.cli,
+    model: cli.model,
+    argv: [],
+  };
+  if (cli.profile) invocation.profile = cli.profile;
+  if (cli.cli === "codex" && cli.profile) {
+    invocation.argv.push("--profile", cli.profile);
+  }
+  return invocation;
+}
+
 async function cmdRetryRun(args) {
   const snapshotFile = args.snapshot || args["snapshot-file"];
   const event = args.event;
@@ -1411,12 +1426,14 @@ async function cmdRetryRun(args) {
 
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   const out = {
     ok: true,
     current: snap.current,
     iterations: snap.iterations,
     cliIndex: snap.cliIndex,
     cli,
+    cliInvocation,
     done: snap.current === "DONE",
     shouldStop: terminal,
     stuckCounter: snap.stuckCounter,
@@ -1440,6 +1457,7 @@ async function cmdRetryStatus(args) {
   }
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   console.log(
     JSON.stringify({
       ok: true,
@@ -1449,6 +1467,7 @@ async function cmdRetryStatus(args) {
       maxIterations: snap.maxIterations,
       cliIndex: snap.cliIndex,
       cli,
+      cliInvocation,
       mode: snap.mode,
       shouldStop: terminal,
       stuckCounter: snap.stuckCounter,

--- a/packages/core/hub/team/retry-state-machine.mjs
+++ b/packages/core/hub/team/retry-state-machine.mjs
@@ -232,7 +232,10 @@ function resolveEscalationChain(options) {
   const projectRoot = options.projectRoot || process.cwd();
   return (
     loadEscalationChainOverride(projectRoot) ||
-    normalizeEscalationChain(DEFAULT_ESCALATION_CHAIN, "DEFAULT_ESCALATION_CHAIN")
+    normalizeEscalationChain(
+      DEFAULT_ESCALATION_CHAIN,
+      "DEFAULT_ESCALATION_CHAIN",
+    )
   );
 }
 
@@ -240,7 +243,16 @@ export function loadEscalationChainOverride(projectRoot = process.cwd()) {
   const configPath = join(projectRoot, ESCALATION_CHAIN_CONFIG_PATH);
   if (!existsSync(configPath)) return null;
 
-  const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  const raw = readFileSync(configPath, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `escalation-chain override 파싱 실패: ${configPath} — 원인: ${err.message} — 수정: JSON 문법 확인 또는 파일 삭제로 DEFAULT_ESCALATION_CHAIN 사용`,
+      { cause: err },
+    );
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`${configPath}: expected object`);
   }
@@ -264,7 +276,9 @@ function normalizeEscalationChainEntry(entry, index, source) {
     throw new Error(`${source}: chain[${index}] must be an object`);
   }
   if (typeof entry.cli !== "string" || entry.cli.trim() === "") {
-    throw new Error(`${source}: chain[${index}].cli must be a non-empty string`);
+    throw new Error(
+      `${source}: chain[${index}].cli must be a non-empty string`,
+    );
   }
   if (typeof entry.model !== "string" || entry.model.trim() === "") {
     throw new Error(

--- a/packages/remote/hub/team/retry-state-machine.mjs
+++ b/packages/remote/hub/team/retry-state-machine.mjs
@@ -232,7 +232,10 @@ function resolveEscalationChain(options) {
   const projectRoot = options.projectRoot || process.cwd();
   return (
     loadEscalationChainOverride(projectRoot) ||
-    normalizeEscalationChain(DEFAULT_ESCALATION_CHAIN, "DEFAULT_ESCALATION_CHAIN")
+    normalizeEscalationChain(
+      DEFAULT_ESCALATION_CHAIN,
+      "DEFAULT_ESCALATION_CHAIN",
+    )
   );
 }
 
@@ -240,7 +243,16 @@ export function loadEscalationChainOverride(projectRoot = process.cwd()) {
   const configPath = join(projectRoot, ESCALATION_CHAIN_CONFIG_PATH);
   if (!existsSync(configPath)) return null;
 
-  const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  const raw = readFileSync(configPath, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `escalation-chain override 파싱 실패: ${configPath} — 원인: ${err.message} — 수정: JSON 문법 확인 또는 파일 삭제로 DEFAULT_ESCALATION_CHAIN 사용`,
+      { cause: err },
+    );
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`${configPath}: expected object`);
   }
@@ -264,7 +276,9 @@ function normalizeEscalationChainEntry(entry, index, source) {
     throw new Error(`${source}: chain[${index}] must be an object`);
   }
   if (typeof entry.cli !== "string" || entry.cli.trim() === "") {
-    throw new Error(`${source}: chain[${index}].cli must be a non-empty string`);
+    throw new Error(
+      `${source}: chain[${index}].cli must be a non-empty string`,
+    );
   }
   if (typeof entry.model !== "string" || entry.model.trim() === "") {
     throw new Error(

--- a/packages/remote/hub/team/swarm-preflight.mjs
+++ b/packages/remote/hub/team/swarm-preflight.mjs
@@ -10,7 +10,7 @@ import { planSwarm } from "./swarm-planner.mjs";
 
 const AGENT_COMMANDS = Object.freeze({
   codex: "codex",
-  gemini: "gemini",
+  gemini: "agy",
   antigravity: "agy",
   agy: "agy",
   claude: "claude",

--- a/packages/triflux/hub/bridge.mjs
+++ b/packages/triflux/hub/bridge.mjs
@@ -1373,6 +1373,21 @@ function buildRetrySmFromArgs(args, snapshot) {
   return sm;
 }
 
+function buildRetryCliInvocation(cli) {
+  if (!cli) return null;
+
+  const invocation = {
+    cli: cli.cli,
+    model: cli.model,
+    argv: [],
+  };
+  if (cli.profile) invocation.profile = cli.profile;
+  if (cli.cli === "codex" && cli.profile) {
+    invocation.argv.push("--profile", cli.profile);
+  }
+  return invocation;
+}
+
 async function cmdRetryRun(args) {
   const snapshotFile = args.snapshot || args["snapshot-file"];
   const event = args.event;
@@ -1411,12 +1426,14 @@ async function cmdRetryRun(args) {
 
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   const out = {
     ok: true,
     current: snap.current,
     iterations: snap.iterations,
     cliIndex: snap.cliIndex,
     cli,
+    cliInvocation,
     done: snap.current === "DONE",
     shouldStop: terminal,
     stuckCounter: snap.stuckCounter,
@@ -1440,6 +1457,7 @@ async function cmdRetryStatus(args) {
   }
   const terminal = ["DONE", "STUCK", "BUDGET_EXCEEDED"].includes(snap.current);
   const cli = snap.cliChain?.[snap.cliIndex] || null;
+  const cliInvocation = buildRetryCliInvocation(cli);
   console.log(
     JSON.stringify({
       ok: true,
@@ -1449,6 +1467,7 @@ async function cmdRetryStatus(args) {
       maxIterations: snap.maxIterations,
       cliIndex: snap.cliIndex,
       cli,
+      cliInvocation,
       mode: snap.mode,
       shouldStop: terminal,
       stuckCounter: snap.stuckCounter,

--- a/packages/triflux/hub/team/retry-state-machine.mjs
+++ b/packages/triflux/hub/team/retry-state-machine.mjs
@@ -232,7 +232,10 @@ function resolveEscalationChain(options) {
   const projectRoot = options.projectRoot || process.cwd();
   return (
     loadEscalationChainOverride(projectRoot) ||
-    normalizeEscalationChain(DEFAULT_ESCALATION_CHAIN, "DEFAULT_ESCALATION_CHAIN")
+    normalizeEscalationChain(
+      DEFAULT_ESCALATION_CHAIN,
+      "DEFAULT_ESCALATION_CHAIN",
+    )
   );
 }
 
@@ -240,7 +243,16 @@ export function loadEscalationChainOverride(projectRoot = process.cwd()) {
   const configPath = join(projectRoot, ESCALATION_CHAIN_CONFIG_PATH);
   if (!existsSync(configPath)) return null;
 
-  const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  const raw = readFileSync(configPath, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `escalation-chain override 파싱 실패: ${configPath} — 원인: ${err.message} — 수정: JSON 문법 확인 또는 파일 삭제로 DEFAULT_ESCALATION_CHAIN 사용`,
+      { cause: err },
+    );
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`${configPath}: expected object`);
   }
@@ -264,7 +276,9 @@ function normalizeEscalationChainEntry(entry, index, source) {
     throw new Error(`${source}: chain[${index}] must be an object`);
   }
   if (typeof entry.cli !== "string" || entry.cli.trim() === "") {
-    throw new Error(`${source}: chain[${index}].cli must be a non-empty string`);
+    throw new Error(
+      `${source}: chain[${index}].cli must be a non-empty string`,
+    );
   }
   if (typeof entry.model !== "string" || entry.model.trim() === "") {
     throw new Error(

--- a/packages/triflux/hub/team/swarm-preflight.mjs
+++ b/packages/triflux/hub/team/swarm-preflight.mjs
@@ -10,7 +10,7 @@ import { planSwarm } from "./swarm-planner.mjs";
 
 const AGENT_COMMANDS = Object.freeze({
   codex: "codex",
-  gemini: "gemini",
+  gemini: "agy",
   antigravity: "agy",
   agy: "agy",
   claude: "claude",

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1398,6 +1398,10 @@ apply_no_claude_native_mode() {
 ## stdout 으로 반환. env 미설정 시 helper 가 silent no-op (stdout empty) →
 ## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
 ## 과 의도 정합한 sh 경로 wire-up.
+## TODO(retry-profile): bridge retry-run/status now exposes
+## cliInvocation.argv for escalation-chain profile steps. This shell route has
+## no retry snapshot input yet; when adding one, append those argv before
+## running codex instead of duplicating profile resolution here.
 apply_dynamic_routing_override() {
   # set -u 환경 safe — 모든 env 변수 default 값 패턴 적용.
   local flag="${TRIFLUX_DYNAMIC_ROUTING:-}"

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1398,6 +1398,10 @@ apply_no_claude_native_mode() {
 ## stdout 으로 반환. env 미설정 시 helper 가 silent no-op (stdout empty) →
 ## 현재 CLI_TYPE 유지. conductor (sync) / swarm-hypervisor (plan-time) wire-up
 ## 과 의도 정합한 sh 경로 wire-up.
+## TODO(retry-profile): bridge retry-run/status now exposes
+## cliInvocation.argv for escalation-chain profile steps. This shell route has
+## no retry snapshot input yet; when adding one, append those argv before
+## running codex instead of duplicating profile resolution here.
 apply_dynamic_routing_override() {
   # set -u 환경 safe — 모든 env 변수 default 값 패턴 적용.
   local flag="${TRIFLUX_DYNAMIC_ROUTING:-}"

--- a/tests/unit/bridge-retry.test.mjs
+++ b/tests/unit/bridge-retry.test.mjs
@@ -3,7 +3,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -130,5 +130,43 @@ describe("bridge retry-run / retry-status — Phase 3 Step C2", () => {
         assert.equal(last.stuckCounter, 3);
       }
     }
+  });
+
+  it("retry-status 는 profile 지정 chain step 을 codex --profile argv 로 방출한다", () => {
+    const dir = makeTempDir();
+    const snapshot = join(dir, "snap.json");
+    writeFileSync(
+      snapshot,
+      JSON.stringify({
+        version: 1,
+        current: "EXECUTING",
+        iterations: 1,
+        maxIterations: 3,
+        stuckCounter: 0,
+        lastFailureReason: null,
+        cliIndex: 0,
+        cliChain: [
+          { cli: "codex", model: "gpt-5.5", profile: "gpt55_high" },
+          { cli: "claude", model: "opus-4-7" },
+        ],
+        mode: "auto-escalate",
+        sessionId: null,
+        history: [],
+      }),
+      "utf8",
+    );
+
+    const status = runBridge(["retry-status", "--snapshot", snapshot]);
+    assert.deepEqual(status.cli, {
+      cli: "codex",
+      model: "gpt-5.5",
+      profile: "gpt55_high",
+    });
+    assert.deepEqual(status.cliInvocation, {
+      cli: "codex",
+      model: "gpt-5.5",
+      profile: "gpt55_high",
+      argv: ["--profile", "gpt55_high"],
+    });
   });
 });

--- a/tests/unit/retry-state-machine.test.mjs
+++ b/tests/unit/retry-state-machine.test.mjs
@@ -209,6 +209,32 @@ describe("retry-state-machine — bounded / ralph / auto-escalate", () => {
         { cli: "claude", model: "opus-4-7" },
       ]);
     });
+
+    it("malformed escalation-chain override 는 problem/cause/fix 에러로 실패한다", () => {
+      const dir = makeTempDir();
+      const configDir = join(dir, ".triflux", "config");
+      const configPath = join(configDir, "escalation-chain.json");
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(configPath, '{"version":1,"chain":[', "utf8");
+
+      assert.throws(
+        () =>
+          createRetryStateMachine({
+            mode: "auto-escalate",
+            projectRoot: dir,
+          }),
+        (err) => {
+          assert.match(err.message, /escalation-chain override 파싱 실패/u);
+          assert.match(err.message, new RegExp(configPath));
+          assert.match(err.message, /원인:/u);
+          assert.match(
+            err.message,
+            /수정: JSON 문법 확인 또는 파일 삭제로 DEFAULT_ESCALATION_CHAIN 사용/u,
+          );
+          return true;
+        },
+      );
+    });
   });
 
   describe("compaction survival — stateFile persist / resume", () => {

--- a/tests/unit/swarm-preflight.test.mjs
+++ b/tests/unit/swarm-preflight.test.mjs
@@ -116,11 +116,16 @@ describe("swarm-preflight", () => {
     assert.match(report.errors.join("\n"), /missing local worker CLI/u);
   });
 
-  it("checks antigravity and agy shards against the agy worker CLI", () => {
+  it("checks gemini, antigravity, and agy shards against the agy worker CLI", () => {
     const repoRoot = makeTmpDir();
     const prdPath = writePrd(
       repoRoot,
       `
+## Shard: gemini-worker
+- agent: gemini
+- files: src/gemini.mjs
+- prompt: Run Gemini alias.
+
 ## Shard: antigravity-worker
 - agent: antigravity
 - files: src/antigravity.mjs
@@ -146,6 +151,12 @@ describe("swarm-preflight", () => {
     assert.equal(report.ok, true);
     assert.deepEqual(checkedCommands, ["agy"]);
     assert.deepEqual(report.checks.workerCli.present, [
+      {
+        shard: "gemini-worker",
+        agent: "gemini",
+        command: "agy",
+        path: "/usr/local/bin/agy",
+      },
       {
         shard: "antigravity-worker",
         agent: "antigravity",


### PR DESCRIPTION
## 교차리뷰 non-blocking 후속 3건

이전 PR #356 교차리뷰가 flag 한 후속. codex 작성 → Claude 교차리뷰 APPROVE. 항목별 atomic commit.

- `fix(retry)`: `loadEscalationChainOverride` JSON.parse 를 try/catch 로 가드 — malformed `.triflux/config/escalation-chain.json` 시 problem+cause+fix 에러(`파싱 실패: <path> — 원인 — 수정`). 이전엔 raw throw.
- `feat(retry)`: escalation-chain `profile` 필드를 bridge `cliInvocation.argv` (`--profile <name>`, codex)로 노출 — 더는 완전 inert metadata 아님. **tfx-route.sh shell route 소비는 retry-snapshot 입력 plumbing 필요라 TODO 주석으로 명시**(대형 bash 리팩터 회피).
- `fix(swarm-preflight)`: `AGENT_COMMANDS` 의 `gemini` 를 `"gemini"`→`"agy"` 로 정합 (agent-map `gemini→antigravity→agy` + AntigravityBackend 실제 실행과 일치). regression test 추가.

### 검증
- 미러: retry-state-machine 4-way(core/remote/triflux+root) byte-identical, bridge root+core+triflux (remote 미러 비대상), swarm-preflight 3-way.
- CI `test` (test-lock exit-code fix가 main에 있어 trustworthy) + 항목별 회귀 테스트.

base=main (1a524951).
