### PR TITLE
fix(swarm): reject invalid redundant completions before preempting primary

### DIFF
--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -903,26 +903,45 @@ export function createSwarmHypervisor(opts) {
     const completedWorker = isRedundant
       ? redundantWorkers.get(shardName)
       : workers.get(shardName);
-    if (completedWorker) {
-      void closeNativeBridgeRegistration(
-        completedWorker,
-        shardName,
-        "completed",
-      );
-    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
     // don't emit a structured payload keep the F6 integration-time guard.
-    if (!isRedundant && completionPayload !== undefined) {
+    if (completionPayload !== undefined) {
       const verdict = validateWorkerCompletion(completionPayload);
       if (!verdict.ok) {
         const reason = verdict.reason || "invalid_completion_payload";
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
         eventLog.append("no_worker_commit_report", {
           shard: shardName,
           sessionId,
           reason,
         });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
         failures.set(shardName, {
           mode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
           reason,
@@ -968,6 +987,14 @@ export function createSwarmHypervisor(opts) {
         checkAllShardsCompleted();
         return;
       }
+    }
+
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
     }
 
     completedShards.add(shardName);

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -903,26 +903,45 @@ export function createSwarmHypervisor(opts) {
     const completedWorker = isRedundant
       ? redundantWorkers.get(shardName)
       : workers.get(shardName);
-    if (completedWorker) {
-      void closeNativeBridgeRegistration(
-        completedWorker,
-        shardName,
-        "completed",
-      );
-    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
     // don't emit a structured payload keep the F6 integration-time guard.
-    if (!isRedundant && completionPayload !== undefined) {
+    if (completionPayload !== undefined) {
       const verdict = validateWorkerCompletion(completionPayload);
       if (!verdict.ok) {
         const reason = verdict.reason || "invalid_completion_payload";
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
         eventLog.append("no_worker_commit_report", {
           shard: shardName,
           sessionId,
           reason,
         });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
         failures.set(shardName, {
           mode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
           reason,
@@ -968,6 +987,14 @@ export function createSwarmHypervisor(opts) {
         checkAllShardsCompleted();
         return;
       }
+    }
+
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
     }
 
     completedShards.add(shardName);

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -903,26 +903,45 @@ export function createSwarmHypervisor(opts) {
     const completedWorker = isRedundant
       ? redundantWorkers.get(shardName)
       : workers.get(shardName);
-    if (completedWorker) {
-      void closeNativeBridgeRegistration(
-        completedWorker,
-        shardName,
-        "completed",
-      );
-    }
 
     // F7 — worker self-reported completion must include commits_made.
     // Only enforce when payload is actually provided; legacy workers that
     // don't emit a structured payload keep the F6 integration-time guard.
-    if (!isRedundant && completionPayload !== undefined) {
+    if (completionPayload !== undefined) {
       const verdict = validateWorkerCompletion(completionPayload);
       if (!verdict.ok) {
         const reason = verdict.reason || "invalid_completion_payload";
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
         eventLog.append("no_worker_commit_report", {
           shard: shardName,
           sessionId,
           reason,
         });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
         failures.set(shardName, {
           mode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
           reason,
@@ -968,6 +987,14 @@ export function createSwarmHypervisor(opts) {
         checkAllShardsCompleted();
         return;
       }
+    }
+
+    if (completedWorker) {
+      void closeNativeBridgeRegistration(
+        completedWorker,
+        shardName,
+        "completed",
+      );
     }
 
     completedShards.add(shardName);

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -74,6 +74,17 @@ const CRITICAL_PRD = `
 - prompt: normal work
 `;
 
+const CRITICAL_NO_FILES_PRD = `
+## Shard: critical-shard
+- agent: codex
+- critical: true
+- prompt: critical work
+
+## Shard: normal-shard
+- agent: codex
+- prompt: normal work
+`;
+
 const SINGLE_PRD = `
 ## Shard: worker-a
 - agent: claude
@@ -499,6 +510,93 @@ describe("swarm-hypervisor", () => {
 
       await hv.launch(plan);
       assert.deepEqual(plan.criticalShards, ["critical-shard"]);
+    });
+
+    it("does not let an invalid redundant completion kill a healthy primary", async () => {
+      const plan = planSwarm(null, { content: CRITICAL_NO_FILES_PRD });
+      const { createConductor, conductors } = createMockConductorFactory();
+      const rebaseCalls = [];
+
+      hv = createSwarmHypervisor({
+        workdir,
+        logsDir,
+        runId: "redundant-invalid-completion",
+        _deps: {
+          createConductor,
+          ensureWorktree: async ({ slug, runId }) => ({
+            worktreePath: `${workdir}/.codex-swarm/wt-${slug}`,
+            branchName: `swarm/${runId}/${slug}`,
+          }),
+          prepareIntegrationBranch: async () => ({
+            integrationBranch: "swarm/redundant-invalid-completion/merge",
+            baseCommit: "abc123",
+          }),
+          rebaseShardOntoIntegration: async ({ shardName, shardBranch }) => {
+            rebaseCalls.push({ shardName, shardBranch });
+            return {
+              ok: true,
+              headCommit: `head:${shardBranch}`,
+              strategy: "cherry-pick",
+              commits: 1,
+              notes: "test integration",
+            };
+          },
+          cleanupWorktree: async () => {},
+        },
+      });
+
+      await hv.launch(plan);
+      assert.equal(conductors.length, 3);
+
+      const primary = conductors.find(
+        (item) =>
+          item.sessionConfig.worktreePath.includes("wt-critical-shard") &&
+          !item.sessionConfig.worktreePath.includes("redundant"),
+      );
+      const redundant = conductors.find((item) =>
+        item.sessionConfig.worktreePath.includes("wt-critical-shard-redundant"),
+      );
+      assert.ok(primary, "primary conductor expected");
+      assert.ok(redundant, "redundant conductor expected");
+
+      redundant.complete(undefined, {
+        status: "failed",
+        reason: "OAuth timeout",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      assert.equal(
+        primary.getSnapshot()[0].state,
+        "healthy",
+        "invalid redundant completion must not stop the primary",
+      );
+      assert.equal(hv.getStatus().completedShards, 0);
+
+      primary.complete(undefined, {
+        status: "ok",
+        commits_made: [{ sha: "abc1234", message: "fix: primary result" }],
+      });
+      conductors
+        .find((item) => item.sessionConfig.id.includes("normal-shard"))
+        .complete();
+
+      const result = await hv.integrationComplete();
+      assert.deepEqual(result.failed, []);
+      assert.deepEqual(result.integrated, ["critical-shard", "normal-shard"]);
+      assert.ok(rebaseCalls[0].shardBranch.endsWith("/critical-shard"));
+
+      const events = readEventLog(hv.eventLogPath);
+      assert.ok(
+        events.some(
+          (entry) =>
+            entry.event === "redundant_completion_rejected" &&
+            entry.reason === "worker_self_reported_failure:OAuth timeout",
+        ),
+      );
+      assert.equal(
+        events.some((entry) => entry.event === "redundant_wins"),
+        false,
+      );
     });
 
     it("wires ensureWorktree metadata into spawned session configs", async () => {


### PR DESCRIPTION
## What

Fixes a swarm critical-shard race where a redundant worker with an invalid/failed completion payload could be treated as the winner and shut down a still-healthy primary worker.

The observed failure was:

- primary codex worker: healthy, doing real work
- redundant agy worker: self-reported/terminated with OAuth timeout
- hypervisor: treated redundant completion as authoritative and called `shutdown("redundant_completed_first")` on the primary

## Change

- Validate redundant completion payloads with the same worker completion validator before allowing the redundant worker to win.
- If redundant completion is invalid/failed, emit `redundant_completion_rejected`, remove the redundant entry, close native bridge registration as failed, and leave the primary running.
- Keep existing primary F7 behavior intact.
- Mirror the hypervisor change to `packages/triflux` and `packages/remote`.
- Add a regression test that proves an OAuth-timeout redundant payload cannot kill a healthy primary and that the primary can still complete/integrate.

## Evidence

- `node --test tests/unit/swarm-hypervisor.test.mjs --test-name-pattern 'invalid redundant completion|fails shard with F7|launches redundant workers'` — pass, including new regression.
- `node --test tests/unit/worker-completion-validator.test.mjs` — 8 pass / 0 fail.
- `npx biome check hub/team/swarm-hypervisor.mjs packages/triflux/hub/team/swarm-hypervisor.mjs packages/remote/hub/team/swarm-hypervisor.mjs tests/unit/swarm-hypervisor.test.mjs` — pass.
- `npm run release:check-mirror` — Mirror OK.
- `git diff --check` — pass.

## Not tested

- Full `npm test` not run in this lane; scoped hypervisor/validator tests and mirror checks were run.
