### PR TITLE
Preserve MCP gateway daemon while moving local MCP to Streamable HTTP

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -4864,10 +4864,9 @@ async function cmdDoctor(options = {}) {
     // skip 된 server 를 잡는다. 로그가 없으면 gateway 미설치/미실행으로 침묵.
     section("MCP Gateway Health");
     {
-      const { checkMcpGatewayHealth, summarizeMcpGatewayHealth } = await import(
-        "../scripts/lib/mcp-gateway-health-check.mjs"
-      );
-      const gatewayHealth = checkMcpGatewayHealth();
+      const { checkMcpGatewayHealthLive, summarizeMcpGatewayHealth } =
+        await import("../scripts/lib/mcp-gateway-health-check.mjs");
+      const gatewayHealth = await checkMcpGatewayHealthLive();
       const summary = summarizeMcpGatewayHealth(gatewayHealth);
       addDoctorCheck(report, {
         name: "mcp-gateway-health",
@@ -4875,6 +4874,7 @@ async function cmdDoctor(options = {}) {
         log_path: gatewayHealth.logPath,
         findings: gatewayHealth.findings,
         started: gatewayHealth.started,
+        live: gatewayHealth.live,
         skipped: gatewayHealth.skipped,
         ...(summary.fix ? { fix: summary.fix } : {}),
       });

--- a/config/mcp-registry.json
+++ b/config/mcp-registry.json
@@ -7,8 +7,8 @@
     "hub_base": "http://127.0.0.1:27888"
   },
   "policy_notes": {
-    "policy": "Server policy is the SSOT for client sync shape: hosted writes url+headers, gateway-sse writes http://127.0.0.1:81XX/sse with SSE metadata, and stdio writes command/args/env.",
-    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers. Gateway-backed stdio upstreams use policy:\"gateway-sse\" plus gateway_port so clients receive URL/SSE config.",
+    "policy": "Server policy is the SSOT for client sync shape: hosted writes url+headers, gateway-sse writes http://127.0.0.1:81XX/sse with SSE metadata, gateway-http writes http://127.0.0.1:81XX/mcp with HTTP metadata, and stdio writes command/args/env.",
+    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers. Gateway-backed stdio upstreams should use policy:\"gateway-http\" plus gateway_port/gateway_path so clients receive reconnect-safe HTTP MCP config; legacy policy:\"gateway-sse\" remains supported only for backward compatibility.",
     "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
     "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
     "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
@@ -42,18 +42,22 @@
       "description": "Exa neural/semantic web search — 학술/기술 깊이. Key 발급: https://exa.ai/dashboard → secrets.env의 EXA_API_KEY"
     },
     "serena": {
-      "policy": "gateway-sse",
+      "policy": "gateway-http",
+      "transport": "http",
       "gateway_port": 8105,
+      "gateway_path": "/mcp",
       "safe": true,
       "targets": ["claude", "gemini", "codex", "antigravity"],
-      "description": "Serena MCP — supergateway singleton SSE endpoint (:8105)"
+      "description": "Serena MCP — local supergateway stateful Streamable HTTP endpoint (:8105/mcp)"
     },
     "brave-search": {
-      "policy": "gateway-sse",
+      "policy": "gateway-http",
+      "transport": "http",
       "gateway_port": 8101,
+      "gateway_path": "/mcp",
       "safe": true,
       "targets": ["claude", "gemini", "codex", "antigravity"],
-      "description": "Brave Search MCP — supergateway singleton SSE endpoint (:8101). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
+      "description": "Brave Search MCP — local supergateway stateful Streamable HTTP endpoint (:8101/mcp). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
     },
     "tavily": {
       "policy": "hosted",

--- a/docs/research/mcp-orphan-process-analysis.md
+++ b/docs/research/mcp-orphan-process-analysis.md
@@ -41,8 +41,15 @@ Windows 환경에서 프로세스 트리를 강제 종료하는 데는 다음과
 - **cc-reaper 활용**: 커뮤니티 도구인 `cc-reaper`와 같은 전문 프로세스 관리 유틸리티의 도입 검토.
 
 ### 5.3 장기적 아키텍처 (Long-term)
-- **트랜스포트 전환**: 불안정한 stdio 방식 대신 HTTP/SSE 트랜스포트로 전환.
-- **Gateway 도입**: `supergateway` 등을 사용하여 MCP 서버를 영속적인 서비스 형태로 관리하고, Claude Code는 클라이언트로서 접속만 수행하는 구조로 변경.
+- **트랜스포트 전환**: 불안정한 직접 stdio 클라이언트 연결 대신 gateway-backed HTTP MCP 트랜스포트로 전환.
+- **Gateway 도입**: `supergateway` 등을 사용하여 MCP 서버를 영속적인 서비스 형태로 관리하고, Claude Code/Codex/Gemini/Antigravity는 클라이언트로서 접속만 수행하는 구조로 변경.
+- **현재 표준**: gateway가 stdio upstream을 감싸야 하는 서버는 `gateway-http` 정책과 `/mcp` 경로를 사용한다. `supergateway`는 `--outputTransport streamableHttp --stateful --streamableHttpPath /mcp`로 실행한다.
+
+### 5.4 SSE Gateway를 기본값으로 쓰지 않는 이유
+- 기존 `gateway-sse`는 직접 stdio spawn을 줄이고 registry SSOT를 유지하기 위해 도입된 과도기적 형태였다. 설계 목적 자체는 여전히 유효하다.
+- 그러나 `supergateway`의 stdio→SSE 래핑은 단일 stdio transport를 공유하는 형태라, 같은 포트에 두 번째 SSE GET/reconnect가 들어오면 `Already connected to a transport`로 gateway process가 종료될 수 있다.
+- 따라서 해결 방향은 gateway daemon을 제거하거나 직접 stdio로 되돌리는 것이 아니라, 동일한 gateway daemon 경계 안에서 reconnect-safe한 stateful Streamable HTTP로 노출하는 것이다.
+- `gateway-sse` 정책은 과거 설정을 읽기 위한 backward compatibility로만 남긴다. 신규 registry sync와 setup 안내는 `gateway-http`를 기본값으로 사용해야 한다.
 
 ## 6. 참고 자료
 - **GitHub Issues**: #1935, #15211, #28126, #11778, #29058, #30267

--- a/packages/core/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/core/scripts/lib/mcp-gateway-health-check.mjs
@@ -14,6 +14,7 @@
 // 침묵한다 (false-positive 방지).
 
 import { readFileSync, statSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -32,6 +33,27 @@ const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+function probePortListening(
+  port,
+  { host = "127.0.0.1", timeoutMs = 800 } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    }
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
 
 export function checkMcpGatewayHealth({
   fs = { readFileSync, statSync },
@@ -130,6 +152,40 @@ export function checkMcpGatewayHealth({
   };
 }
 
+export async function checkMcpGatewayHealthLive({
+  probePort = probePortListening,
+  ...options
+} = {}) {
+  const result = checkMcpGatewayHealth(options);
+  if (!result.available || result.started.length === 0) {
+    return {
+      ...result,
+      live: [],
+    };
+  }
+
+  const live = [];
+  const findings = [...result.findings];
+  for (const entry of result.started) {
+    const listening = await probePort(entry.port);
+    live.push({ ...entry, listening });
+    if (!listening) {
+      findings.push({
+        server: entry.server,
+        reason: "port-down",
+        detail: `expected listener on :${entry.port}`,
+        port: entry.port,
+      });
+    }
+  }
+
+  return {
+    ...result,
+    findings,
+    live,
+  };
+}
+
 export function summarizeMcpGatewayHealth(result) {
   if (!result?.available) {
     return {
@@ -150,6 +206,15 @@ export function summarizeMcpGatewayHealth(result) {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
       fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  const portDown = result.findings.filter((f) => f.reason === "port-down");
+  if (portDown.length > 0) {
+    const list = portDown.map((f) => `${f.server} (:${f.port})`).join(", ");
+    return {
+      level: "warn",
+      message: `${portDown.length}개 MCP gateway port down: ${list}`,
+      fix: "gateway 를 재기동하세요: `node scripts/mcp-gateway-start.mjs` 또는 macOS `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway`",
     };
   }
   return {

--- a/packages/core/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/core/scripts/lib/mcp-guard-engine.mjs
@@ -22,7 +22,12 @@ const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
-const SERVER_POLICIES = new Set(["hosted", "gateway-sse", "stdio"]);
+const SERVER_POLICIES = new Set([
+  "hosted",
+  "gateway-sse",
+  "gateway-http",
+  "stdio",
+]);
 const GATEWAY_PORTS = Object.freeze({
   context7: 8100,
   "brave-search": 8101,
@@ -792,6 +797,23 @@ function gatewaySseUrl(name, serverConfig = {}) {
   return `http://127.0.0.1:${port}/sse`;
 }
 
+function gatewayHttpUrl(name, serverConfig = {}) {
+  if (typeof serverConfig.url === "string" && serverConfig.url.trim()) {
+    return normalizeUrl(serverConfig.url);
+  }
+  const port =
+    Number(serverConfig.gateway_port || serverConfig.port || 0) ||
+    GATEWAY_PORTS[name];
+  if (!Number.isFinite(port) || port <= 0) return "";
+  const path =
+    typeof serverConfig.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : "/mcp";
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `http://127.0.0.1:${port}${normalizedPath}`;
+}
+
 function syncDenylistEntries(policy = {}) {
   if (!Array.isArray(policy?.sync_denylist)) return new Set();
   return new Set(
@@ -836,9 +858,11 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     policy === "gateway-sse"
       ? gatewaySseUrl(name, serverConfig)
-      : serverConfig?.transport === "hub-url"
-        ? resolveHubUrl()
-        : normalizeUrl(serverConfig?.url || "");
+      : policy === "gateway-http"
+        ? gatewayHttpUrl(name, serverConfig)
+        : serverConfig?.transport === "hub-url"
+          ? resolveHubUrl()
+          : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
   const resolvedHeaders = resolveHeaderDescriptors(
     name,
@@ -848,6 +872,26 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const headerConfig = hasOwnEntries(resolvedHeaders.headers)
     ? { headers: resolvedHeaders.headers }
     : {};
+
+  if (policy === "gateway-http") {
+    if (isCodexConfig(filePath)) {
+      return {
+        name,
+        config: { url },
+        headerDescriptors: {},
+        codex: {},
+        warnings: [],
+      };
+    }
+
+    return {
+      name,
+      config: { type: "http", url },
+      headerDescriptors: {},
+      codex: {},
+      warnings: [],
+    };
+  }
 
   if (policy === "gateway-sse") {
     if (isCodexConfig(filePath)) {
@@ -1237,7 +1281,7 @@ export function validateRegistry(registry) {
         !SERVER_POLICIES.has(server.policy)
       ) {
         errors.push(
-          `registry.servers.${name}.policy must be hosted, gateway-sse, or stdio`,
+          `registry.servers.${name}.policy must be hosted, gateway-sse, gateway-http, or stdio`,
         );
       }
       const transport = server.transport || registry.defaults?.transport;
@@ -1252,7 +1296,7 @@ export function validateRegistry(registry) {
       ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      if (policy === "gateway-sse") {
+      if (policy === "gateway-sse" || policy === "gateway-http") {
         const port = Number(server.gateway_port || server.port || 0);
         const hasGatewayUrl =
           typeof server.url === "string" && server.url.trim().length > 0;
@@ -1261,7 +1305,7 @@ export function validateRegistry(registry) {
           (!Number.isInteger(port) || port <= 0 || port > 65535)
         ) {
           errors.push(
-            `registry.servers.${name}.gateway_port must be a valid TCP port for gateway-sse`,
+            `registry.servers.${name}.gateway_port must be a valid TCP port for ${policy}`,
           );
         }
       }
@@ -1913,7 +1957,7 @@ export function addRegistryServer(name, url, options = {}) {
     (transport === "stdio"
       ? "stdio"
       : options.gateway_port || options.port
-        ? "gateway-sse"
+        ? "gateway-http"
         : "hosted");
 
   registry.servers[trimmedName] = {

--- a/packages/remote/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/remote/scripts/lib/mcp-gateway-health-check.mjs
@@ -14,6 +14,7 @@
 // 침묵한다 (false-positive 방지).
 
 import { readFileSync, statSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -32,6 +33,27 @@ const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+function probePortListening(
+  port,
+  { host = "127.0.0.1", timeoutMs = 800 } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    }
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
 
 export function checkMcpGatewayHealth({
   fs = { readFileSync, statSync },
@@ -130,6 +152,40 @@ export function checkMcpGatewayHealth({
   };
 }
 
+export async function checkMcpGatewayHealthLive({
+  probePort = probePortListening,
+  ...options
+} = {}) {
+  const result = checkMcpGatewayHealth(options);
+  if (!result.available || result.started.length === 0) {
+    return {
+      ...result,
+      live: [],
+    };
+  }
+
+  const live = [];
+  const findings = [...result.findings];
+  for (const entry of result.started) {
+    const listening = await probePort(entry.port);
+    live.push({ ...entry, listening });
+    if (!listening) {
+      findings.push({
+        server: entry.server,
+        reason: "port-down",
+        detail: `expected listener on :${entry.port}`,
+        port: entry.port,
+      });
+    }
+  }
+
+  return {
+    ...result,
+    findings,
+    live,
+  };
+}
+
 export function summarizeMcpGatewayHealth(result) {
   if (!result?.available) {
     return {
@@ -150,6 +206,15 @@ export function summarizeMcpGatewayHealth(result) {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
       fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  const portDown = result.findings.filter((f) => f.reason === "port-down");
+  if (portDown.length > 0) {
+    const list = portDown.map((f) => `${f.server} (:${f.port})`).join(", ");
+    return {
+      level: "warn",
+      message: `${portDown.length}개 MCP gateway port down: ${list}`,
+      fix: "gateway 를 재기동하세요: `node scripts/mcp-gateway-start.mjs` 또는 macOS `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway`",
     };
   }
   return {

--- a/packages/remote/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/remote/scripts/lib/mcp-guard-engine.mjs
@@ -22,7 +22,12 @@ const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
-const SERVER_POLICIES = new Set(["hosted", "gateway-sse", "stdio"]);
+const SERVER_POLICIES = new Set([
+  "hosted",
+  "gateway-sse",
+  "gateway-http",
+  "stdio",
+]);
 const GATEWAY_PORTS = Object.freeze({
   context7: 8100,
   "brave-search": 8101,
@@ -792,6 +797,23 @@ function gatewaySseUrl(name, serverConfig = {}) {
   return `http://127.0.0.1:${port}/sse`;
 }
 
+function gatewayHttpUrl(name, serverConfig = {}) {
+  if (typeof serverConfig.url === "string" && serverConfig.url.trim()) {
+    return normalizeUrl(serverConfig.url);
+  }
+  const port =
+    Number(serverConfig.gateway_port || serverConfig.port || 0) ||
+    GATEWAY_PORTS[name];
+  if (!Number.isFinite(port) || port <= 0) return "";
+  const path =
+    typeof serverConfig.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : "/mcp";
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `http://127.0.0.1:${port}${normalizedPath}`;
+}
+
 function syncDenylistEntries(policy = {}) {
   if (!Array.isArray(policy?.sync_denylist)) return new Set();
   return new Set(
@@ -836,9 +858,11 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     policy === "gateway-sse"
       ? gatewaySseUrl(name, serverConfig)
-      : serverConfig?.transport === "hub-url"
-        ? resolveHubUrl()
-        : normalizeUrl(serverConfig?.url || "");
+      : policy === "gateway-http"
+        ? gatewayHttpUrl(name, serverConfig)
+        : serverConfig?.transport === "hub-url"
+          ? resolveHubUrl()
+          : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
   const resolvedHeaders = resolveHeaderDescriptors(
     name,
@@ -848,6 +872,26 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const headerConfig = hasOwnEntries(resolvedHeaders.headers)
     ? { headers: resolvedHeaders.headers }
     : {};
+
+  if (policy === "gateway-http") {
+    if (isCodexConfig(filePath)) {
+      return {
+        name,
+        config: { url },
+        headerDescriptors: {},
+        codex: {},
+        warnings: [],
+      };
+    }
+
+    return {
+      name,
+      config: { type: "http", url },
+      headerDescriptors: {},
+      codex: {},
+      warnings: [],
+    };
+  }
 
   if (policy === "gateway-sse") {
     if (isCodexConfig(filePath)) {
@@ -1237,7 +1281,7 @@ export function validateRegistry(registry) {
         !SERVER_POLICIES.has(server.policy)
       ) {
         errors.push(
-          `registry.servers.${name}.policy must be hosted, gateway-sse, or stdio`,
+          `registry.servers.${name}.policy must be hosted, gateway-sse, gateway-http, or stdio`,
         );
       }
       const transport = server.transport || registry.defaults?.transport;
@@ -1252,7 +1296,7 @@ export function validateRegistry(registry) {
       ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      if (policy === "gateway-sse") {
+      if (policy === "gateway-sse" || policy === "gateway-http") {
         const port = Number(server.gateway_port || server.port || 0);
         const hasGatewayUrl =
           typeof server.url === "string" && server.url.trim().length > 0;
@@ -1261,7 +1305,7 @@ export function validateRegistry(registry) {
           (!Number.isInteger(port) || port <= 0 || port > 65535)
         ) {
           errors.push(
-            `registry.servers.${name}.gateway_port must be a valid TCP port for gateway-sse`,
+            `registry.servers.${name}.gateway_port must be a valid TCP port for ${policy}`,
           );
         }
       }
@@ -1913,7 +1957,7 @@ export function addRegistryServer(name, url, options = {}) {
     (transport === "stdio"
       ? "stdio"
       : options.gateway_port || options.port
-        ? "gateway-sse"
+        ? "gateway-http"
         : "hosted");
 
   registry.servers[trimmedName] = {

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -4864,10 +4864,9 @@ async function cmdDoctor(options = {}) {
     // skip 된 server 를 잡는다. 로그가 없으면 gateway 미설치/미실행으로 침묵.
     section("MCP Gateway Health");
     {
-      const { checkMcpGatewayHealth, summarizeMcpGatewayHealth } = await import(
-        "../scripts/lib/mcp-gateway-health-check.mjs"
-      );
-      const gatewayHealth = checkMcpGatewayHealth();
+      const { checkMcpGatewayHealthLive, summarizeMcpGatewayHealth } =
+        await import("../scripts/lib/mcp-gateway-health-check.mjs");
+      const gatewayHealth = await checkMcpGatewayHealthLive();
       const summary = summarizeMcpGatewayHealth(gatewayHealth);
       addDoctorCheck(report, {
         name: "mcp-gateway-health",
@@ -4875,6 +4874,7 @@ async function cmdDoctor(options = {}) {
         log_path: gatewayHealth.logPath,
         findings: gatewayHealth.findings,
         started: gatewayHealth.started,
+        live: gatewayHealth.live,
         skipped: gatewayHealth.skipped,
         ...(summary.fix ? { fix: summary.fix } : {}),
       });

--- a/packages/triflux/config/mcp-registry.json
+++ b/packages/triflux/config/mcp-registry.json
@@ -7,8 +7,8 @@
     "hub_base": "http://127.0.0.1:27888"
   },
   "policy_notes": {
-    "policy": "Server policy is the SSOT for client sync shape: hosted writes url+headers, gateway-sse writes http://127.0.0.1:81XX/sse with SSE metadata, and stdio writes command/args/env.",
-    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers. Gateway-backed stdio upstreams use policy:\"gateway-sse\" plus gateway_port so clients receive URL/SSE config.",
+    "policy": "Server policy is the SSOT for client sync shape: hosted writes url+headers, gateway-sse writes http://127.0.0.1:81XX/sse with SSE metadata, gateway-http writes http://127.0.0.1:81XX/mcp with HTTP metadata, and stdio writes command/args/env.",
+    "transport": "Server transport accepts \"hub-url\" for triflux Hub URL flow, \"http\" for direct Streamable HTTP MCP endpoints, or \"stdio\" for upstream-stdio-only MCP servers. Gateway-backed stdio upstreams should use policy:\"gateway-http\" plus gateway_port/gateway_path so clients receive reconnect-safe HTTP MCP config; legacy policy:\"gateway-sse\" remains supported only for backward compatibility.",
     "headers": "Optional headers are allowed only for HTTP-compatible transports. Each header value must be a descriptor: {\"value\":\"literal\"} for non-secret static values, {\"env\":\"ENV_VAR_NAME\"} for secrets resolved at sync/runtime, or {\"env\":\"ENV_VAR_NAME\",\"prefix\":\"Bearer \"} for common authorization formats.",
     "secret_safety": "Resolved secret values must not be written back to this registry file. Missing env vars warn during sync and do not emit empty secret headers.",
     "sync_denylist": "Array of client:server strings skipped by proactive registry sync, for example gemini:tfx-hub."
@@ -42,18 +42,22 @@
       "description": "Exa neural/semantic web search — 학술/기술 깊이. Key 발급: https://exa.ai/dashboard → secrets.env의 EXA_API_KEY"
     },
     "serena": {
-      "policy": "gateway-sse",
+      "policy": "gateway-http",
+      "transport": "http",
       "gateway_port": 8105,
+      "gateway_path": "/mcp",
       "safe": true,
       "targets": ["claude", "gemini", "codex", "antigravity"],
-      "description": "Serena MCP — supergateway singleton SSE endpoint (:8105)"
+      "description": "Serena MCP — local supergateway stateful Streamable HTTP endpoint (:8105/mcp)"
     },
     "brave-search": {
-      "policy": "gateway-sse",
+      "policy": "gateway-http",
+      "transport": "http",
       "gateway_port": 8101,
+      "gateway_path": "/mcp",
       "safe": true,
       "targets": ["claude", "gemini", "codex", "antigravity"],
-      "description": "Brave Search MCP — supergateway singleton SSE endpoint (:8101). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
+      "description": "Brave Search MCP — local supergateway stateful Streamable HTTP endpoint (:8101/mcp). BRAVE_API_KEY 환경변수 필요 (https://brave.com/search/api/). secrets.env 의 BRAVE_API_KEY 참조."
     },
     "tavily": {
       "policy": "hosted",

--- a/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   checkMcpGatewayHealth,
+  checkMcpGatewayHealthLive,
   summarizeMcpGatewayHealth,
 } from "../lib/mcp-gateway-health-check.mjs";
 
@@ -204,5 +205,57 @@ describe("mcp-gateway-health-check", () => {
     );
     assert.equal(summary.level, "ok");
     assert.match(summary.message, /healthy/);
+  });
+
+  it("live probe: START 로그가 있어도 port 가 닫혀 있으면 stale 로 경고한다", async () => {
+    const result = await checkMcpGatewayHealthLive({
+      fs: makeFs({ logBody: HEALTHY_LOG }),
+      logPath: "/fake/log",
+      probePort: async (port) => port === 8100,
+    });
+
+    assert.deepEqual(result.live, [
+      {
+        server: "brave-search",
+        port: 8101,
+        preExisting: false,
+        listening: false,
+      },
+      {
+        server: "context7",
+        port: 8100,
+        preExisting: true,
+        listening: true,
+      },
+      {
+        server: "serena",
+        port: 8105,
+        preExisting: false,
+        listening: false,
+      },
+    ]);
+    assert.deepEqual(
+      result.findings.filter((finding) => finding.reason === "port-down"),
+      [
+        {
+          server: "brave-search",
+          reason: "port-down",
+          detail: "expected listener on :8101",
+          port: 8101,
+        },
+        {
+          server: "serena",
+          reason: "port-down",
+          detail: "expected listener on :8105",
+          port: 8105,
+        },
+      ],
+    );
+
+    const summary = summarizeMcpGatewayHealth(result);
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /brave-search \(:8101\)/);
+    assert.match(summary.message, /serena \(:8105\)/);
+    assert.match(summary.fix, /mcp-gateway-start\.mjs/);
   });
 });

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs
@@ -62,7 +62,7 @@ function policyRegistry(homeDir) {
         targets: ["claude", "gemini", "codex", "antigravity"],
       },
       serena: {
-        policy: "gateway-sse",
+        policy: "gateway-http",
         gateway_port: 8105,
         safe: true,
         targets: ["claude", "gemini", "codex", "antigravity"],
@@ -96,7 +96,7 @@ function policyRegistry(homeDir) {
 afterEach(restoreEnv);
 
 describe("mcp guard policy sync", () => {
-  it("validates explicit hosted, gateway-sse, and stdio server policies", () => {
+  it("validates explicit hosted, gateway-http, and stdio server policies", () => {
     const homeDir = createHomeDir();
     assert.deepEqual(validateRegistry(policyRegistry(homeDir)), []);
   });
@@ -153,8 +153,8 @@ describe("mcp guard policy sync", () => {
       headers: { Authorization: "Bearer test-exa-key" },
     });
     assert.deepEqual(claudeUser.mcpServers.serena, {
-      type: "sse",
-      url: "http://127.0.0.1:8105/sse",
+      type: "http",
+      url: "http://127.0.0.1:8105/mcp",
     });
     assert.deepEqual(claudeUser.mcpServers["brave-search"], {
       command: "npx",
@@ -177,8 +177,8 @@ describe("mcp guard policy sync", () => {
         config.mcpServers.exa.headers.Authorization,
         "Bearer test-exa-key",
       );
-      assert.equal(config.mcpServers.serena.url, "http://127.0.0.1:8105/sse");
-      assert.equal(config.mcpServers.serena.type, "sse");
+      assert.equal(config.mcpServers.serena.url, "http://127.0.0.1:8105/mcp");
+      assert.equal(config.mcpServers.serena.type, "http");
       assert.equal(config.mcpServers["brave-search"].command, "npx");
       assert.deepEqual(config.mcpServers["brave-search"].env, {
         BRAVE_API_KEY: "test-brave-key",
@@ -194,8 +194,8 @@ describe("mcp guard policy sync", () => {
     assert.match(codexToml, /\[mcp_servers\.exa\]/);
     assert.match(codexToml, /bearer_token_env_var = "EXA_API_KEY"/);
     assert.match(codexToml, /\[mcp_servers\.serena\]/);
-    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8105\/sse"/);
-    assert.match(codexToml, /transport = "sse"/);
+    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8105\/mcp"/);
+    assert.doesNotMatch(codexToml, /transport = "sse"/);
     assert.match(codexToml, /\[mcp_servers\.brave-search\]/);
     assert.match(codexToml, /command = "npx"/);
     assert.match(codexToml, /env = \{ "BRAVE_API_KEY" = "test-brave-key" \}/);

--- a/packages/triflux/scripts/codex-gateway-preflight.mjs
+++ b/packages/triflux/scripts/codex-gateway-preflight.mjs
@@ -8,54 +8,104 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  SERVERS,
+  serversWithSatisfiedEnv,
+} from "./lib/mcp-gateway-servers.mjs";
+import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PROBE_PORT = 8100;
 const PROBE_TIMEOUT_MS = 2000;
 const STARTUP_WAIT_MS = 6000;
 const POLL_MS = 500;
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5분
 const CACHE_FILE = join(tmpdir(), "tfx-gateway-alive.json");
 
-function readCache() {
+function ensureGatewayManifest() {
+  const manifest = readManifest();
+  if (manifest) return manifest;
+
+  const envReadyServers = serversWithSatisfiedEnv()
+    .filter((server) => server.envVars.length > 0)
+    .map((server) => server.name);
+  return writeManifest(envReadyServers);
+}
+
+function configuredServers(manifest) {
+  const enabled = new Set(manifest?.enabled || []);
+  return SERVERS.filter((server) => {
+    if (!enabled.has(server.name)) return false;
+    return server.envVars.every((envName) => Boolean(process.env[envName]));
+  });
+}
+
+function configuredPorts(servers) {
+  return servers.map((server) => server.port).sort((a, b) => a - b);
+}
+
+function samePorts(left, right) {
+  if (!Array.isArray(left) || left.length !== right.length) return false;
+  return left.every((port, index) => port === right[index]);
+}
+
+function readCache(servers) {
+  const ports = configuredPorts(servers);
   try {
     if (!existsSync(CACHE_FILE)) return null;
     const data = JSON.parse(readFileSync(CACHE_FILE, "utf8"));
-    if (Date.now() - data.ts < CACHE_TTL_MS) return data;
+    if (Date.now() - data.ts >= CACHE_TTL_MS) return null;
+    return samePorts(data.ports, ports) ? data : null;
   } catch {
     /* ignore */
   }
   return null;
 }
 
-function writeCache() {
+function writeCache(servers) {
   try {
-    writeFileSync(CACHE_FILE, JSON.stringify({ ts: Date.now(), alive: true }));
+    writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({
+        ts: Date.now(),
+        alive: true,
+        ports: configuredPorts(servers),
+      }),
+    );
   } catch {
     /* ignore */
   }
 }
 
-async function isGatewayAlive() {
-  // B) Preflight 캐시: 5분 이내 확인했으면 프로브 스킵
-  const cached = readCache();
-  if (cached) return true;
-
+async function isPortHealthy(port) {
   try {
-    const res = await fetch(`http://127.0.0.1:${PROBE_PORT}/healthz`, {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`, {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
-    if (res.ok) {
-      writeCache();
-      return true;
-    }
-    return false;
+    return res.ok;
   } catch {
     return false;
   }
 }
 
-async function startGateway() {
+async function gatewayReadiness(servers, { useCache = true } = {}) {
+  if (servers.length === 0) return { ready: true, entries: [] };
+
+  // B) Preflight 캐시: 5분 이내 같은 configured port set을 확인했으면 프로브 스킵
+  if (useCache && readCache(servers)) return { ready: true, entries: [] };
+
+  const entries = await Promise.all(
+    servers.map(async (server) => ({
+      name: server.name,
+      port: server.port,
+      healthy: await isPortHealthy(server.port),
+    })),
+  );
+  const ready = entries.every((entry) => entry.healthy);
+  if (ready) writeCache(servers);
+  return { ready, entries };
+}
+
+async function startGateway(servers) {
   const script = join(PLUGIN_ROOT, "scripts", "mcp-gateway-start.mjs");
   if (!existsSync(script)) {
     process.stderr.write(
@@ -78,7 +128,9 @@ async function startGateway() {
   // 헬스체크 대기
   const deadline = Date.now() + STARTUP_WAIT_MS;
   while (Date.now() < deadline) {
-    if (await isGatewayAlive()) return true;
+    if ((await gatewayReadiness(servers, { useCache: false })).ready) {
+      return true;
+    }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
   return false;
@@ -88,10 +140,18 @@ async function startGateway() {
 
 async function main() {
   // 1) gateway 보장
-  const alive = await isGatewayAlive();
-  if (!alive) {
-    process.stderr.write("[gateway-preflight] gateway down, starting...\n");
-    const ok = await startGateway();
+  const manifest = ensureGatewayManifest();
+  const servers = configuredServers(manifest);
+  const readiness = await gatewayReadiness(servers);
+  if (!readiness.ready) {
+    const downPorts = readiness.entries
+      .filter((entry) => !entry.healthy)
+      .map((entry) => `${entry.name}:${entry.port}`)
+      .join(", ");
+    process.stderr.write(
+      `[gateway-preflight] gateway down (${downPorts}), starting...\n`,
+    );
+    const ok = await startGateway(servers);
     process.stderr.write(
       ok
         ? "[gateway-preflight] gateway started\n"

--- a/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
+++ b/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
@@ -55,17 +55,27 @@ function parseTomlMcpServers(content) {
 
     const hasUrl = /^url\s*=/m.test(block);
     const hasCommand = /^command\s*=/m.test(block);
+    const urlMatch = block.match(/^url\s*=\s*["']([^"']*)["']/m);
+    const url = urlMatch ? urlMatch[1] : null;
 
     servers.set(name, {
       block,
       hasUrl,
       hasCommand,
+      url,
       startIdx,
       headerIdx: match.index,
     });
   }
 
   return servers;
+}
+
+// 블록의 url 값이 이 서버의 기대 gateway /mcp endpoint 와 일치하는지 판정.
+// /sse 등 stale endpoint 는 false → enableGateway 가 강제 재작성, getStatus 는
+// "needs-migration" 으로 분류한다.
+function isCurrentGatewayUrl(srv, expectedUrl) {
+  return Boolean(srv) && srv.url === expectedUrl;
 }
 
 function buildHttpEntry(name, url) {
@@ -89,24 +99,24 @@ function shouldSkipCodexConfigMutation() {
 
 // ── enable: stdio → Streamable HTTP ──
 
-export function enableGateway() {
+export function enableGateway(configPath = CODEX_CONFIG) {
   if (shouldSkipCodexConfigMutation()) {
     console.log("[SKIP] protected environment; config.toml not modified");
     return { changed: 0, skipped: 0, reason: "protected-env" };
   }
 
-  if (!existsSync(CODEX_CONFIG)) {
+  if (!existsSync(configPath)) {
     console.log("[SKIP] ~/.codex/config.toml not found");
     return { changed: 0, skipped: 0 };
   }
 
-  const original = readFileSync(CODEX_CONFIG, "utf8");
+  const original = readFileSync(configPath, "utf8");
   const servers = parseTomlMcpServers(original);
 
   // 백업 (최초 1회만)
-  const backupPath = CODEX_CONFIG + BACKUP_SUFFIX;
+  const backupPath = configPath + BACKUP_SUFFIX;
   if (!existsSync(backupPath)) {
-    copyFileSync(CODEX_CONFIG, backupPath);
+    copyFileSync(configPath, backupPath);
     console.log(`[BACKUP] ${backupPath}`);
   }
 
@@ -126,8 +136,18 @@ export function enableGateway() {
     }
 
     if (srv.hasUrl) {
-      // 이미 URL 기반 → 스킵
-      skipped++;
+      if (isCurrentGatewayUrl(srv, url)) {
+        // 이미 올바른 /mcp gateway URL → 스킵
+        skipped++;
+        continue;
+      }
+      // stale URL (예: v10.27.0 이 남긴 /sse) → 올바른 /mcp 로 강제 재작성.
+      // 데몬이 streamableHttp /mcp 만 서빙하므로 그대로 두면 dead path 가 된다.
+      const oldSection = `[mcp_servers.${name}]\n${srv.block}`;
+      const newSection = buildHttpEntry(name, url).trim();
+      content = content.replace(oldSection, newSection);
+      changed++;
+      console.log(`[MIGRATE] ${name}: ${srv.url} → ${url}`);
       continue;
     }
 
@@ -154,7 +174,7 @@ export function enableGateway() {
   }
 
   if (changed > 0) {
-    writeFileSync(CODEX_CONFIG, content, "utf8");
+    writeFileSync(configPath, content, "utf8");
     console.log(
       `\n[DONE] ${changed} servers converted, ${skipped} already HTTP`,
     );
@@ -186,12 +206,12 @@ export function disableGateway() {
 
 // ── status: 현재 상태 확인 ──
 
-export function getStatus() {
-  if (!existsSync(CODEX_CONFIG)) {
+export function getStatus(configPath = CODEX_CONFIG) {
+  if (!existsSync(configPath)) {
     return { exists: false, servers: [] };
   }
 
-  const content = readFileSync(CODEX_CONFIG, "utf8");
+  const content = readFileSync(configPath, "utf8");
   const servers = parseTomlMcpServers(content);
   const result = [];
 
@@ -199,8 +219,11 @@ export function getStatus() {
     const srv = servers.get(name);
     if (!srv) {
       result.push({ name, mode: "missing", url });
-    } else if (srv.hasUrl) {
+    } else if (isCurrentGatewayUrl(srv, url)) {
       result.push({ name, mode: "http", url });
+    } else if (srv.hasUrl) {
+      // url 은 있으나 기대 /mcp endpoint 가 아님 (stale /sse 등) → 마이그레이션 필요
+      result.push({ name, mode: "needs-migration", url, currentUrl: srv.url });
     } else {
       result.push({ name, mode: "stdio", url });
     }
@@ -226,10 +249,19 @@ if (arg === "--enable") {
   console.log("\nCodex MCP Gateway Status:");
   console.log("─".repeat(50));
   for (const s of servers) {
-    const icon = s.mode === "http" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
-    console.log(
-      `${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(8)} ${s.mode === "stdio" ? "← zombie risk" : ""}`,
-    );
+    const icon =
+      s.mode === "http"
+        ? "✅"
+        : s.mode === "stdio" || s.mode === "needs-migration"
+          ? "⚠️"
+          : "❌";
+    const note =
+      s.mode === "stdio"
+        ? "← zombie risk"
+        : s.mode === "needs-migration"
+          ? `← stale endpoint (${s.currentUrl}) — run --enable`
+          : "";
+    console.log(`${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(15)} ${note}`);
   }
 } else {
   console.log(

--- a/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
+++ b/packages/triflux/scripts/codex-mcp-gateway-sync.mjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-// scripts/codex-mcp-gateway-sync.mjs — Codex config.toml MCP를 gateway SSE로 전환
+// scripts/codex-mcp-gateway-sync.mjs — Codex config.toml MCP를 gateway Streamable HTTP로 전환
 // Usage: node codex-mcp-gateway-sync.mjs [--enable|--disable|--status]
 //
 // 문제: Codex CLI가 매 호출마다 MCP 서버를 stdio로 spawn → 좀비 Node.js 프로세스
-// 해결: mcp-gateway-start.mjs의 싱글톤 SSE 데몬을 재사용하도록 config.toml 전환
+// 해결: mcp-gateway-start.mjs의 싱글톤 Streamable HTTP 데몬을 재사용하도록 config.toml 전환
 //
 // before: [mcp_servers.context7]
 //         command = "npx"
 //         args = ["-y", "@upstash/context7-mcp@latest"]
 //
 // after:  [mcp_servers.context7]
-//         url = "http://127.0.0.1:8100/sse"
+//         url = "http://127.0.0.1:8100/mcp"
 
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -23,9 +23,9 @@ const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const BACKUP_SUFFIX = ".pre-gateway.bak";
 const CODEX_CONFIG_SYNC_OPT_IN = "TFX_CODEX_CONFIG_SYNC";
 
-// gateway 서버 → SSE URL 매핑
+// gateway 서버 → Streamable HTTP URL 매핑
 const GATEWAY_MAP = new Map(
-  SERVERS.map((s) => [s.name, `http://127.0.0.1:${s.port}/sse`]),
+  SERVERS.map((s) => [s.name, `http://127.0.0.1:${s.port}/mcp`]),
 );
 
 // stdio 정의를 보존해야 하는 MCP 서버 (gateway 대상 아님)
@@ -68,7 +68,7 @@ function parseTomlMcpServers(content) {
   return servers;
 }
 
-function buildSseEntry(name, url) {
+function buildHttpEntry(name, url) {
   return `[mcp_servers.${name}]\nurl = "${url}"\n`;
 }
 
@@ -87,7 +87,7 @@ function shouldSkipCodexConfigMutation() {
   );
 }
 
-// ── enable: stdio → SSE ──
+// ── enable: stdio → Streamable HTTP ──
 
 export function enableGateway() {
   if (shouldSkipCodexConfigMutation()) {
@@ -118,8 +118,8 @@ export function enableGateway() {
     const srv = servers.get(name);
 
     if (!srv) {
-      // 서버 미등록 → SSE entry 추가
-      content += `\n${buildSseEntry(name, url)}`;
+      // 서버 미등록 → HTTP entry 추가
+      content += `\n${buildHttpEntry(name, url)}`;
       changed++;
       console.log(`[ADD] ${name} → ${url}`);
       continue;
@@ -132,9 +132,9 @@ export function enableGateway() {
     }
 
     if (srv.hasCommand) {
-      // stdio → SSE 전환: 기존 블록을 URL로 교체
+      // stdio → Streamable HTTP 전환: 기존 블록을 URL로 교체
       const oldSection = `[mcp_servers.${name}]\n${srv.block}`;
-      const newSection = buildSseEntry(name, url).trim();
+      const newSection = buildHttpEntry(name, url).trim();
       content = content.replace(oldSection, newSection);
       changed++;
       console.log(`[CONVERT] ${name}: stdio → ${url}`);
@@ -156,16 +156,16 @@ export function enableGateway() {
   if (changed > 0) {
     writeFileSync(CODEX_CONFIG, content, "utf8");
     console.log(
-      `\n[DONE] ${changed} servers converted, ${skipped} already SSE`,
+      `\n[DONE] ${changed} servers converted, ${skipped} already HTTP`,
     );
   } else {
-    console.log(`\n[DONE] No changes needed (${skipped} already SSE)`);
+    console.log(`\n[DONE] No changes needed (${skipped} already HTTP)`);
   }
 
   return { changed, skipped };
 }
 
-// ── disable: SSE → stdio 복원 ──
+// ── disable: HTTP → stdio 복원 ──
 
 export function disableGateway() {
   if (shouldSkipCodexConfigMutation()) {
@@ -200,7 +200,7 @@ export function getStatus() {
     if (!srv) {
       result.push({ name, mode: "missing", url });
     } else if (srv.hasUrl) {
-      result.push({ name, mode: "sse", url });
+      result.push({ name, mode: "http", url });
     } else {
       result.push({ name, mode: "stdio", url });
     }
@@ -226,7 +226,7 @@ if (arg === "--enable") {
   console.log("\nCodex MCP Gateway Status:");
   console.log("─".repeat(50));
   for (const s of servers) {
-    const icon = s.mode === "sse" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
+    const icon = s.mode === "http" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
     console.log(
       `${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(8)} ${s.mode === "stdio" ? "← zombie risk" : ""}`,
     );
@@ -235,7 +235,9 @@ if (arg === "--enable") {
   console.log(
     "Usage: codex-mcp-gateway-sync.mjs [--enable|--disable|--status]",
   );
-  console.log("  --enable   Convert stdio MCP servers to SSE gateway URLs");
+  console.log(
+    "  --enable   Convert stdio MCP servers to Streamable HTTP gateway URLs",
+  );
   console.log("  --disable  Restore original stdio config from backup");
   console.log("  --status   Show current MCP connection mode per server");
 }

--- a/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
+++ b/packages/triflux/scripts/lib/mcp-gateway-health-check.mjs
@@ -14,6 +14,7 @@
 // 침묵한다 (false-positive 방지).
 
 import { readFileSync, statSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -32,6 +33,27 @@ const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+function probePortListening(
+  port,
+  { host = "127.0.0.1", timeoutMs = 800 } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    }
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
 
 export function checkMcpGatewayHealth({
   fs = { readFileSync, statSync },
@@ -130,6 +152,40 @@ export function checkMcpGatewayHealth({
   };
 }
 
+export async function checkMcpGatewayHealthLive({
+  probePort = probePortListening,
+  ...options
+} = {}) {
+  const result = checkMcpGatewayHealth(options);
+  if (!result.available || result.started.length === 0) {
+    return {
+      ...result,
+      live: [],
+    };
+  }
+
+  const live = [];
+  const findings = [...result.findings];
+  for (const entry of result.started) {
+    const listening = await probePort(entry.port);
+    live.push({ ...entry, listening });
+    if (!listening) {
+      findings.push({
+        server: entry.server,
+        reason: "port-down",
+        detail: `expected listener on :${entry.port}`,
+        port: entry.port,
+      });
+    }
+  }
+
+  return {
+    ...result,
+    findings,
+    live,
+  };
+}
+
 export function summarizeMcpGatewayHealth(result) {
   if (!result?.available) {
     return {
@@ -150,6 +206,15 @@ export function summarizeMcpGatewayHealth(result) {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
       fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  const portDown = result.findings.filter((f) => f.reason === "port-down");
+  if (portDown.length > 0) {
+    const list = portDown.map((f) => `${f.server} (:${f.port})`).join(", ");
+    return {
+      level: "warn",
+      message: `${portDown.length}개 MCP gateway port down: ${list}`,
+      fix: "gateway 를 재기동하세요: `node scripts/mcp-gateway-start.mjs` 또는 macOS `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway`",
     };
   }
   return {

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -22,7 +22,12 @@ const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
-const SERVER_POLICIES = new Set(["hosted", "gateway-sse", "stdio"]);
+const SERVER_POLICIES = new Set([
+  "hosted",
+  "gateway-sse",
+  "gateway-http",
+  "stdio",
+]);
 const GATEWAY_PORTS = Object.freeze({
   context7: 8100,
   "brave-search": 8101,
@@ -792,6 +797,23 @@ function gatewaySseUrl(name, serverConfig = {}) {
   return `http://127.0.0.1:${port}/sse`;
 }
 
+function gatewayHttpUrl(name, serverConfig = {}) {
+  if (typeof serverConfig.url === "string" && serverConfig.url.trim()) {
+    return normalizeUrl(serverConfig.url);
+  }
+  const port =
+    Number(serverConfig.gateway_port || serverConfig.port || 0) ||
+    GATEWAY_PORTS[name];
+  if (!Number.isFinite(port) || port <= 0) return "";
+  const path =
+    typeof serverConfig.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : "/mcp";
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `http://127.0.0.1:${port}${normalizedPath}`;
+}
+
 function syncDenylistEntries(policy = {}) {
   if (!Array.isArray(policy?.sync_denylist)) return new Set();
   return new Set(
@@ -836,9 +858,11 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     policy === "gateway-sse"
       ? gatewaySseUrl(name, serverConfig)
-      : serverConfig?.transport === "hub-url"
-        ? resolveHubUrl()
-        : normalizeUrl(serverConfig?.url || "");
+      : policy === "gateway-http"
+        ? gatewayHttpUrl(name, serverConfig)
+        : serverConfig?.transport === "hub-url"
+          ? resolveHubUrl()
+          : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
   const resolvedHeaders = resolveHeaderDescriptors(
     name,
@@ -848,6 +872,26 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const headerConfig = hasOwnEntries(resolvedHeaders.headers)
     ? { headers: resolvedHeaders.headers }
     : {};
+
+  if (policy === "gateway-http") {
+    if (isCodexConfig(filePath)) {
+      return {
+        name,
+        config: { url },
+        headerDescriptors: {},
+        codex: {},
+        warnings: [],
+      };
+    }
+
+    return {
+      name,
+      config: { type: "http", url },
+      headerDescriptors: {},
+      codex: {},
+      warnings: [],
+    };
+  }
 
   if (policy === "gateway-sse") {
     if (isCodexConfig(filePath)) {
@@ -1237,7 +1281,7 @@ export function validateRegistry(registry) {
         !SERVER_POLICIES.has(server.policy)
       ) {
         errors.push(
-          `registry.servers.${name}.policy must be hosted, gateway-sse, or stdio`,
+          `registry.servers.${name}.policy must be hosted, gateway-sse, gateway-http, or stdio`,
         );
       }
       const transport = server.transport || registry.defaults?.transport;
@@ -1252,7 +1296,7 @@ export function validateRegistry(registry) {
       ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      if (policy === "gateway-sse") {
+      if (policy === "gateway-sse" || policy === "gateway-http") {
         const port = Number(server.gateway_port || server.port || 0);
         const hasGatewayUrl =
           typeof server.url === "string" && server.url.trim().length > 0;
@@ -1261,7 +1305,7 @@ export function validateRegistry(registry) {
           (!Number.isInteger(port) || port <= 0 || port > 65535)
         ) {
           errors.push(
-            `registry.servers.${name}.gateway_port must be a valid TCP port for gateway-sse`,
+            `registry.servers.${name}.gateway_port must be a valid TCP port for ${policy}`,
           );
         }
       }
@@ -1913,7 +1957,7 @@ export function addRegistryServer(name, url, options = {}) {
     (transport === "stdio"
       ? "stdio"
       : options.gateway_port || options.port
-        ? "gateway-sse"
+        ? "gateway-http"
         : "hosted");
 
   registry.servers[trimmedName] = {

--- a/packages/triflux/scripts/mcp-gateway-config.mjs
+++ b/packages/triflux/scripts/mcp-gateway-config.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// mcp-gateway-config.mjs — Claude Code MCP stdio↔SSE 전환
-// Usage: node mcp-gateway-config.mjs --enable   # stdio → SSE
-//        node mcp-gateway-config.mjs --disable  # SSE → stdio (복원)
+// mcp-gateway-config.mjs — Claude Code MCP stdio↔Streamable HTTP 전환
+// Usage: node mcp-gateway-config.mjs --enable   # stdio → Streamable HTTP
+//        node mcp-gateway-config.mjs --disable  # Streamable HTTP → stdio (복원)
 
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -92,10 +92,10 @@ function loadBackup() {
   }
 }
 
-// ── enable: 스냅샷 → remove → SSE add (실패 시 rollback) ──
+// ── enable: 스냅샷 → remove → HTTP add (실패 시 rollback) ──
 
-function enableSse() {
-  console.log("Switching MCP servers to SSE mode...\n");
+function enableHttp() {
+  console.log("Switching MCP servers to Streamable HTTP mode...\n");
 
   // 1) 현재 상태 스냅샷
   const snapshot = captureCurrentMcpState();
@@ -112,13 +112,13 @@ function enableSse() {
     }
 
     removeMcp(name);
-    const url = `http://localhost:${port}/sse`;
+    const url = `http://localhost:${port}/mcp`;
     const success = run(
-      `claude mcp add --transport sse -s user "${name}" ${url}`,
+      `claude mcp add --transport http -s user "${name}" ${url}`,
     );
 
     if (success) {
-      console.log(`  [SSE] ${name} → ${url}`);
+      console.log(`  [HTTP] ${name} → ${url}`);
       ok++;
     } else {
       // add 실패 → 원본 복원 시도
@@ -141,7 +141,7 @@ function enableSse() {
 
 // ── disable: 백업에서 서버별 원복 ──
 
-function disableSse() {
+function disableHttp() {
   console.log("Restoring MCP servers from backup...\n");
   const backup = loadBackup();
 
@@ -202,7 +202,7 @@ function disableSse() {
 function printUsage() {
   console.log(`Usage: node mcp-gateway-config.mjs [--enable|--disable]
 
-  --enable   Switch Claude Code MCP servers from stdio to SSE (supergateway)
+  --enable   Switch Claude Code MCP servers from stdio to Streamable HTTP (supergateway)
   --disable  Restore Claude Code MCP servers to original stdio mode
 
 Servers managed: ${GATEWAY_SERVERS.map((s) => s.name).join(", ")}
@@ -213,9 +213,9 @@ Servers skipped: ${[...SKIP_SERVERS].join(", ")}`);
 const flag = process.argv[2];
 
 if (flag === "--enable") {
-  enableSse();
+  enableHttp();
 } else if (flag === "--disable") {
-  disableSse();
+  disableHttp();
 } else {
   printUsage();
   process.exit(flag ? 1 : 0);

--- a/packages/triflux/scripts/mcp-gateway-ensure.mjs
+++ b/packages/triflux/scripts/mcp-gateway-ensure.mjs
@@ -14,14 +14,13 @@ import {
 import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PROBE_PORT = 8100; // context7 — 첫 번째 게이트웨이 포트로 alive 프로브
 const PROBE_TIMEOUT_MS = 1500;
 const STARTUP_WAIT_MS = 4000;
 const POLL_INTERVAL_MS = 500;
 
-async function isGatewayAlive() {
+async function isPortHealthy(port) {
   try {
-    const res = await fetch(`http://127.0.0.1:${PROBE_PORT}/healthz`, {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`, {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
     return res.ok;
@@ -40,12 +39,27 @@ function ensureGatewayManifest() {
   return writeManifest(envReadyServers);
 }
 
-function hasConfiguredGatewayServer(manifest) {
+function configuredServers(manifest) {
   const enabled = new Set(manifest?.enabled || []);
-  return SERVERS.some((server) => {
+  return SERVERS.filter((server) => {
     if (!enabled.has(server.name)) return false;
     return server.envVars.every((envName) => Boolean(process.env[envName]));
   });
+}
+
+async function gatewayReadiness(servers) {
+  const entries = await Promise.all(
+    servers.map(async (server) => ({
+      name: server.name,
+      port: server.port,
+      healthy: await isPortHealthy(server.port),
+    })),
+  );
+
+  return {
+    ready: entries.length > 0 && entries.every((entry) => entry.healthy),
+    entries,
+  };
 }
 
 function startGateway() {
@@ -72,10 +86,10 @@ function startGateway() {
   }
 }
 
-async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
+async function waitForGatewayReady(servers, maxWaitMs = STARTUP_WAIT_MS) {
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
-    if (await isGatewayAlive()) return true;
+    if ((await gatewayReadiness(servers)).ready) return true;
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
   return false;
@@ -84,13 +98,14 @@ async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
 export async function run(stdinData) {
   void stdinData;
   const manifest = ensureGatewayManifest();
+  const servers = configuredServers(manifest);
 
-  if (hasConfiguredGatewayServer(manifest) && (await isGatewayAlive())) {
-    return { code: 0, stdout: "gateway: ok", stderr: "" };
+  if (servers.length === 0) {
+    return { code: 0, stdout: "gateway: not configured", stderr: "" };
   }
 
-  if (!hasConfiguredGatewayServer(manifest)) {
-    return { code: 0, stdout: "gateway: not configured", stderr: "" };
+  if ((await gatewayReadiness(servers)).ready) {
+    return { code: 0, stdout: "gateway: ok", stderr: "" };
   }
 
   const started = startGateway();
@@ -98,7 +113,7 @@ export async function run(stdinData) {
     return { code: 0, stdout: "", stderr: "[gateway-ensure] start failed" };
   }
 
-  const ready = await waitForGatewayReady();
+  const ready = await waitForGatewayReady(servers);
   return {
     code: 0,
     stdout: ready ? "gateway: ok" : "gateway: starting",

--- a/packages/triflux/scripts/mcp-gateway-integration-test.mjs
+++ b/packages/triflux/scripts/mcp-gateway-integration-test.mjs
@@ -178,43 +178,49 @@ async function main() {
     );
   }
 
-  // STEP 3: Switch Claude Code config to SSE
-  console.log("\n[STEP 3] Switching Claude Code config to SSE mode...");
+  // STEP 3: Switch Claude Code config to Streamable HTTP
+  console.log(
+    "\n[STEP 3] Switching Claude Code config to Streamable HTTP mode...",
+  );
   try {
     runScript(CONFIG_SCRIPT, "--enable");
-    pass("Config switch to SSE (--enable)");
+    pass("Config switch to Streamable HTTP (--enable)");
   } catch (err) {
-    fail("Config switch to SSE", err.message);
+    fail("Config switch to Streamable HTTP", err.message);
   }
 
-  // STEP 4: Verify SSE endpoints respond on each active port
-  console.log("\n[STEP 4] Verifying SSE endpoints (/healthz)...");
-  const sseResults = await Promise.allSettled(
+  // STEP 4: Verify Streamable HTTP gateways respond on each active port
+  console.log("\n[STEP 4] Verifying Streamable HTTP gateways (/healthz)...");
+  const httpResults = await Promise.allSettled(
     SERVERS.map(async (srv) => ({
       ...srv,
       alive: await checkHealth(srv.port),
     })),
   );
 
-  let sseOk = 0;
-  for (const r of sseResults) {
+  let httpOk = 0;
+  for (const r of httpResults) {
     if (r.status !== "fulfilled") continue;
     const { name, port, alive } = r.value;
     if (alive) {
       console.log(`  [ok]   ${name.padEnd(16)} :${port}`);
-      sseOk++;
+      httpOk++;
     } else {
       console.log(`  [skip] ${name.padEnd(16)} :${port}  (not running)`);
     }
   }
 
-  if (sseOk === 0 && healthOk > 0) {
-    fail("SSE endpoint verification — servers went down after config switch");
-  } else if (sseOk > 0) {
-    pass(`SSE endpoint verification — ${sseOk} endpoint(s) healthy`);
+  if (httpOk === 0 && healthOk > 0) {
+    fail(
+      "Streamable HTTP gateway verification — servers went down after config switch",
+    );
+  } else if (httpOk > 0) {
+    pass(
+      `Streamable HTTP gateway verification — ${httpOk} endpoint(s) healthy`,
+    );
   } else {
     pass(
-      "SSE endpoint verification — no servers running (all skipped due to missing env)",
+      "Streamable HTTP gateway verification — no servers running (all skipped due to missing env)",
     );
   }
 

--- a/packages/triflux/scripts/mcp-gateway-start.mjs
+++ b/packages/triflux/scripts/mcp-gateway-start.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// mcp-gateway-start.mjs — supergateway MCP SSE 영속 서비스 관리
+// mcp-gateway-start.mjs — supergateway MCP Streamable HTTP 영속 서비스 관리
 // Usage: node mcp-gateway-start.mjs          # 시작
 //        node mcp-gateway-start.mjs --stop   # 중지
 //        node mcp-gateway-start.mjs --status # 상태 확인
@@ -57,7 +57,7 @@ function sleep(ms) {
 function spawnGateway(srv) {
   if (process.platform === "win32") {
     // 임시 .cmd 파일로 quoting 문제 회피
-    const cmdContent = `@echo off\nnpx -y supergateway --stdio "${srv.cmd}" --port ${srv.port} --outputTransport sse --healthEndpoint /healthz --cors "http://localhost"`;
+    const cmdContent = `@echo off\nnpx -y supergateway --stdio "${srv.cmd}" --port ${srv.port} --outputTransport streamableHttp --stateful --streamableHttpPath /mcp --healthEndpoint /healthz --cors "http://localhost"`;
     const cmdFile = join(tmpdir(), `tfx-sg-${srv.name}.cmd`);
     writeFileSync(cmdFile, cmdContent);
 
@@ -79,7 +79,10 @@ function spawnGateway(srv) {
     "--port",
     String(srv.port),
     "--outputTransport",
-    "sse",
+    "streamableHttp",
+    "--stateful",
+    "--streamableHttpPath",
+    "/mcp",
     "--healthEndpoint",
     "/healthz",
     "--cors",

--- a/packages/triflux/scripts/mcp-gateway-start.ps1
+++ b/packages/triflux/scripts/mcp-gateway-start.ps1
@@ -1,5 +1,5 @@
-# mcp-gateway-start.ps1 — supergateway MCP SSE 영속 서비스 관리
-# 각 MCP 서버를 supergateway로 래핑하여 SSE 엔드포인트로 노출한다.
+# mcp-gateway-start.ps1 — supergateway MCP Streamable HTTP 영속 서비스 관리
+# 각 MCP 서버를 supergateway로 래핑하여 Streamable HTTP 엔드포인트로 노출한다.
 # Usage: .\mcp-gateway-start.ps1          # 시작
 #        .\mcp-gateway-start.ps1 -Stop    # 중지
 
@@ -88,7 +88,7 @@ function Start-AllGateways {
 
     # supergateway 기동 — npx는 .cmd 파일이므로 cmd.exe /c 로 래핑
     $stdioCmdEscaped = $srv.Cmd -replace '"', '\"'
-    $sgCmd = "npx -y supergateway --stdio `"$stdioCmdEscaped`" --port $port --outputTransport sse --healthEndpoint /healthz"
+    $sgCmd = "npx -y supergateway --stdio `"$stdioCmdEscaped`" --port $port --outputTransport streamableHttp --stateful --streamableHttpPath /mcp --healthEndpoint /healthz"
 
     try {
       $proc = Start-Process -FilePath 'cmd.exe' -ArgumentList "/c $sgCmd" `

--- a/packages/triflux/scripts/mcp-gateway-verify.mjs
+++ b/packages/triflux/scripts/mcp-gateway-verify.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// mcp-gateway-verify.mjs — supergateway SSE 엔드포인트 헬스체크
+// mcp-gateway-verify.mjs — supergateway Streamable HTTP 엔드포인트 헬스체크
 
 import { readManifest } from "./lib/mcp-manifest.mjs";
 

--- a/packages/triflux/scripts/sync-hub-mcp-settings.mjs
+++ b/packages/triflux/scripts/sync-hub-mcp-settings.mjs
@@ -317,7 +317,7 @@ function setCodexMcpServerBody(raw, sectionName, body) {
   return `${raw.slice(0, section.bodyStart)}${body}${raw.slice(section.sectionEnd)}`;
 }
 
-function gatewaySseUrl(serverName, serverConfig) {
+function gatewayUrl(serverName, serverConfig) {
   if (typeof serverConfig?.url === "string" && serverConfig.url.trim()) {
     return serverConfig.url.trim();
   }
@@ -325,7 +325,14 @@ function gatewaySseUrl(serverName, serverConfig) {
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     return "";
   }
-  return `http://127.0.0.1:${port}/sse`;
+  const fallbackPath = serverConfig?.policy === "gateway-sse" ? "/sse" : "/mcp";
+  const rawPath =
+    typeof serverConfig?.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : fallbackPath;
+  const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  return `http://127.0.0.1:${port}${path}`;
 }
 
 async function loadGatewaySseServers({ registryPath, client, logger }) {
@@ -349,19 +356,25 @@ async function loadGatewaySseServers({ registryPath, client, logger }) {
 
   return Object.entries(servers)
     .filter(([, server]) => {
-      if (server?.policy !== "gateway-sse") return false;
+      if (!["gateway-sse", "gateway-http"].includes(server?.policy))
+        return false;
       if (!Array.isArray(server.targets)) return true;
       return server.targets.includes(client);
     })
-    .map(([name, server]) => ({ name, url: gatewaySseUrl(name, server) }))
+    .map(([name, server]) => ({
+      name,
+      url: gatewayUrl(name, server),
+      policy: server.policy,
+    }))
     .filter((server) => server.url.length > 0);
 }
 
-function desiredJsonGatewayConfig(client, url) {
-  if (client === "antigravity") {
-    return { serverUrl: url };
+function desiredJsonGatewayConfig(client, gatewayServer) {
+  if (gatewayServer.policy === "gateway-sse") {
+    if (client === "antigravity") return { serverUrl: gatewayServer.url };
+    return { type: "sse", url: gatewayServer.url };
   }
-  return { type: "sse", url };
+  return { type: "http", url: gatewayServer.url };
 }
 
 function sameJsonValue(left, right) {
@@ -476,7 +489,7 @@ async function syncGatewayJsonFile({
       if (servers[gatewayServer.name] === undefined) {
         continue;
       }
-      const nextConfig = desiredJsonGatewayConfig(client, gatewayServer.url);
+      const nextConfig = desiredJsonGatewayConfig(client, gatewayServer);
       if (sameJsonValue(servers[gatewayServer.name], nextConfig)) {
         continue;
       }
@@ -645,11 +658,14 @@ async function syncCodexGatewayConfigFile({
         continue;
       }
       const beforeRaw = nextRaw;
-      nextRaw = setCodexMcpServerBody(
-        nextRaw,
-        gatewayServer.name,
-        `url = ${formatTomlString(gatewayServer.url)}\ntransport = "sse"\n`,
-      );
+      const body =
+        gatewayServer.policy === "gateway-sse"
+          ? `url = ${formatTomlString(gatewayServer.url)}
+transport = "sse"
+`
+          : `url = ${formatTomlString(gatewayServer.url)}
+`;
+      nextRaw = setCodexMcpServerBody(nextRaw, gatewayServer.name, body);
       if (nextRaw !== beforeRaw) {
         changedServers.push(gatewayServer);
       }

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -150,20 +150,20 @@ Bash("triflux setup")
 #### 단계 3.6: Codex MCP Gateway 싱글톤 전환
 
 Codex CLI가 매 호출마다 MCP 서버를 stdio로 spawn하면 좀비 Node.js 프로세스가 생긴다.
-gateway SSE 싱글톤을 사용하도록 config.toml을 전환한다.
+gateway Streamable HTTP 싱글톤을 사용하도록 config.toml을 전환한다.
 
 ```bash
 node scripts/codex-mcp-gateway-sync.mjs --status
 ```
 
-- 전부 `sse` → ✅ 이미 전환됨
+- 전부 `http` → ✅ 이미 전환됨
 - `stdio` 또는 `missing` 있으면 → AskUserQuestion:
   ```
-  question: "Codex MCP 서버를 gateway 싱글톤(SSE)으로 전환하시겠습니까? 매 호출마다 MCP를 새로 spawn하는 대신, 영속 gateway 데몬을 공유합니다. (좀비 Node.js 방지)"
+  question: "Codex MCP 서버를 gateway 싱글톤(Streamable HTTP)으로 전환하시겠습니까? 매 호출마다 MCP를 새로 spawn하는 대신, 영속 gateway 데몬을 공유합니다. (좀비 Node.js 방지)"
   header: "MCP Gateway"
   options:
     - label: "전환 (Recommended)"
-      description: "stdio → SSE URL 전환. 좀비 프로세스 방지"
+      description: "stdio → Streamable HTTP URL 전환. 좀비 프로세스 방지"
     - label: "건너뛰기"
       description: "현재 stdio 방식 유지"
   ```

--- a/scripts/__tests__/mcp-gateway-health-check.test.mjs
+++ b/scripts/__tests__/mcp-gateway-health-check.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   checkMcpGatewayHealth,
+  checkMcpGatewayHealthLive,
   summarizeMcpGatewayHealth,
 } from "../lib/mcp-gateway-health-check.mjs";
 
@@ -204,5 +205,57 @@ describe("mcp-gateway-health-check", () => {
     );
     assert.equal(summary.level, "ok");
     assert.match(summary.message, /healthy/);
+  });
+
+  it("live probe: START 로그가 있어도 port 가 닫혀 있으면 stale 로 경고한다", async () => {
+    const result = await checkMcpGatewayHealthLive({
+      fs: makeFs({ logBody: HEALTHY_LOG }),
+      logPath: "/fake/log",
+      probePort: async (port) => port === 8100,
+    });
+
+    assert.deepEqual(result.live, [
+      {
+        server: "brave-search",
+        port: 8101,
+        preExisting: false,
+        listening: false,
+      },
+      {
+        server: "context7",
+        port: 8100,
+        preExisting: true,
+        listening: true,
+      },
+      {
+        server: "serena",
+        port: 8105,
+        preExisting: false,
+        listening: false,
+      },
+    ]);
+    assert.deepEqual(
+      result.findings.filter((finding) => finding.reason === "port-down"),
+      [
+        {
+          server: "brave-search",
+          reason: "port-down",
+          detail: "expected listener on :8101",
+          port: 8101,
+        },
+        {
+          server: "serena",
+          reason: "port-down",
+          detail: "expected listener on :8105",
+          port: 8105,
+        },
+      ],
+    );
+
+    const summary = summarizeMcpGatewayHealth(result);
+    assert.equal(summary.level, "warn");
+    assert.match(summary.message, /brave-search \(:8101\)/);
+    assert.match(summary.message, /serena \(:8105\)/);
+    assert.match(summary.fix, /mcp-gateway-start\.mjs/);
   });
 });

--- a/scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs
@@ -62,7 +62,7 @@ function policyRegistry(homeDir) {
         targets: ["claude", "gemini", "codex", "antigravity"],
       },
       serena: {
-        policy: "gateway-sse",
+        policy: "gateway-http",
         gateway_port: 8105,
         safe: true,
         targets: ["claude", "gemini", "codex", "antigravity"],
@@ -96,7 +96,7 @@ function policyRegistry(homeDir) {
 afterEach(restoreEnv);
 
 describe("mcp guard policy sync", () => {
-  it("validates explicit hosted, gateway-sse, and stdio server policies", () => {
+  it("validates explicit hosted, gateway-http, and stdio server policies", () => {
     const homeDir = createHomeDir();
     assert.deepEqual(validateRegistry(policyRegistry(homeDir)), []);
   });
@@ -153,8 +153,8 @@ describe("mcp guard policy sync", () => {
       headers: { Authorization: "Bearer test-exa-key" },
     });
     assert.deepEqual(claudeUser.mcpServers.serena, {
-      type: "sse",
-      url: "http://127.0.0.1:8105/sse",
+      type: "http",
+      url: "http://127.0.0.1:8105/mcp",
     });
     assert.deepEqual(claudeUser.mcpServers["brave-search"], {
       command: "npx",
@@ -177,8 +177,8 @@ describe("mcp guard policy sync", () => {
         config.mcpServers.exa.headers.Authorization,
         "Bearer test-exa-key",
       );
-      assert.equal(config.mcpServers.serena.url, "http://127.0.0.1:8105/sse");
-      assert.equal(config.mcpServers.serena.type, "sse");
+      assert.equal(config.mcpServers.serena.url, "http://127.0.0.1:8105/mcp");
+      assert.equal(config.mcpServers.serena.type, "http");
       assert.equal(config.mcpServers["brave-search"].command, "npx");
       assert.deepEqual(config.mcpServers["brave-search"].env, {
         BRAVE_API_KEY: "test-brave-key",
@@ -194,8 +194,8 @@ describe("mcp guard policy sync", () => {
     assert.match(codexToml, /\[mcp_servers\.exa\]/);
     assert.match(codexToml, /bearer_token_env_var = "EXA_API_KEY"/);
     assert.match(codexToml, /\[mcp_servers\.serena\]/);
-    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8105\/sse"/);
-    assert.match(codexToml, /transport = "sse"/);
+    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8105\/mcp"/);
+    assert.doesNotMatch(codexToml, /transport = "sse"/);
     assert.match(codexToml, /\[mcp_servers\.brave-search\]/);
     assert.match(codexToml, /command = "npx"/);
     assert.match(codexToml, /env = \{ "BRAVE_API_KEY" = "test-brave-key" \}/);

--- a/scripts/codex-gateway-preflight.mjs
+++ b/scripts/codex-gateway-preflight.mjs
@@ -8,54 +8,104 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  SERVERS,
+  serversWithSatisfiedEnv,
+} from "./lib/mcp-gateway-servers.mjs";
+import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PROBE_PORT = 8100;
 const PROBE_TIMEOUT_MS = 2000;
 const STARTUP_WAIT_MS = 6000;
 const POLL_MS = 500;
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5분
 const CACHE_FILE = join(tmpdir(), "tfx-gateway-alive.json");
 
-function readCache() {
+function ensureGatewayManifest() {
+  const manifest = readManifest();
+  if (manifest) return manifest;
+
+  const envReadyServers = serversWithSatisfiedEnv()
+    .filter((server) => server.envVars.length > 0)
+    .map((server) => server.name);
+  return writeManifest(envReadyServers);
+}
+
+function configuredServers(manifest) {
+  const enabled = new Set(manifest?.enabled || []);
+  return SERVERS.filter((server) => {
+    if (!enabled.has(server.name)) return false;
+    return server.envVars.every((envName) => Boolean(process.env[envName]));
+  });
+}
+
+function configuredPorts(servers) {
+  return servers.map((server) => server.port).sort((a, b) => a - b);
+}
+
+function samePorts(left, right) {
+  if (!Array.isArray(left) || left.length !== right.length) return false;
+  return left.every((port, index) => port === right[index]);
+}
+
+function readCache(servers) {
+  const ports = configuredPorts(servers);
   try {
     if (!existsSync(CACHE_FILE)) return null;
     const data = JSON.parse(readFileSync(CACHE_FILE, "utf8"));
-    if (Date.now() - data.ts < CACHE_TTL_MS) return data;
+    if (Date.now() - data.ts >= CACHE_TTL_MS) return null;
+    return samePorts(data.ports, ports) ? data : null;
   } catch {
     /* ignore */
   }
   return null;
 }
 
-function writeCache() {
+function writeCache(servers) {
   try {
-    writeFileSync(CACHE_FILE, JSON.stringify({ ts: Date.now(), alive: true }));
+    writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({
+        ts: Date.now(),
+        alive: true,
+        ports: configuredPorts(servers),
+      }),
+    );
   } catch {
     /* ignore */
   }
 }
 
-async function isGatewayAlive() {
-  // B) Preflight 캐시: 5분 이내 확인했으면 프로브 스킵
-  const cached = readCache();
-  if (cached) return true;
-
+async function isPortHealthy(port) {
   try {
-    const res = await fetch(`http://127.0.0.1:${PROBE_PORT}/healthz`, {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`, {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
-    if (res.ok) {
-      writeCache();
-      return true;
-    }
-    return false;
+    return res.ok;
   } catch {
     return false;
   }
 }
 
-async function startGateway() {
+async function gatewayReadiness(servers, { useCache = true } = {}) {
+  if (servers.length === 0) return { ready: true, entries: [] };
+
+  // B) Preflight 캐시: 5분 이내 같은 configured port set을 확인했으면 프로브 스킵
+  if (useCache && readCache(servers)) return { ready: true, entries: [] };
+
+  const entries = await Promise.all(
+    servers.map(async (server) => ({
+      name: server.name,
+      port: server.port,
+      healthy: await isPortHealthy(server.port),
+    })),
+  );
+  const ready = entries.every((entry) => entry.healthy);
+  if (ready) writeCache(servers);
+  return { ready, entries };
+}
+
+async function startGateway(servers) {
   const script = join(PLUGIN_ROOT, "scripts", "mcp-gateway-start.mjs");
   if (!existsSync(script)) {
     process.stderr.write(
@@ -78,7 +128,9 @@ async function startGateway() {
   // 헬스체크 대기
   const deadline = Date.now() + STARTUP_WAIT_MS;
   while (Date.now() < deadline) {
-    if (await isGatewayAlive()) return true;
+    if ((await gatewayReadiness(servers, { useCache: false })).ready) {
+      return true;
+    }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
   return false;
@@ -88,10 +140,18 @@ async function startGateway() {
 
 async function main() {
   // 1) gateway 보장
-  const alive = await isGatewayAlive();
-  if (!alive) {
-    process.stderr.write("[gateway-preflight] gateway down, starting...\n");
-    const ok = await startGateway();
+  const manifest = ensureGatewayManifest();
+  const servers = configuredServers(manifest);
+  const readiness = await gatewayReadiness(servers);
+  if (!readiness.ready) {
+    const downPorts = readiness.entries
+      .filter((entry) => !entry.healthy)
+      .map((entry) => `${entry.name}:${entry.port}`)
+      .join(", ");
+    process.stderr.write(
+      `[gateway-preflight] gateway down (${downPorts}), starting...\n`,
+    );
+    const ok = await startGateway(servers);
     process.stderr.write(
       ok
         ? "[gateway-preflight] gateway started\n"

--- a/scripts/codex-mcp-gateway-sync.mjs
+++ b/scripts/codex-mcp-gateway-sync.mjs
@@ -55,17 +55,27 @@ function parseTomlMcpServers(content) {
 
     const hasUrl = /^url\s*=/m.test(block);
     const hasCommand = /^command\s*=/m.test(block);
+    const urlMatch = block.match(/^url\s*=\s*["']([^"']*)["']/m);
+    const url = urlMatch ? urlMatch[1] : null;
 
     servers.set(name, {
       block,
       hasUrl,
       hasCommand,
+      url,
       startIdx,
       headerIdx: match.index,
     });
   }
 
   return servers;
+}
+
+// 블록의 url 값이 이 서버의 기대 gateway /mcp endpoint 와 일치하는지 판정.
+// /sse 등 stale endpoint 는 false → enableGateway 가 강제 재작성, getStatus 는
+// "needs-migration" 으로 분류한다.
+function isCurrentGatewayUrl(srv, expectedUrl) {
+  return Boolean(srv) && srv.url === expectedUrl;
 }
 
 function buildHttpEntry(name, url) {
@@ -89,24 +99,24 @@ function shouldSkipCodexConfigMutation() {
 
 // ── enable: stdio → Streamable HTTP ──
 
-export function enableGateway() {
+export function enableGateway(configPath = CODEX_CONFIG) {
   if (shouldSkipCodexConfigMutation()) {
     console.log("[SKIP] protected environment; config.toml not modified");
     return { changed: 0, skipped: 0, reason: "protected-env" };
   }
 
-  if (!existsSync(CODEX_CONFIG)) {
+  if (!existsSync(configPath)) {
     console.log("[SKIP] ~/.codex/config.toml not found");
     return { changed: 0, skipped: 0 };
   }
 
-  const original = readFileSync(CODEX_CONFIG, "utf8");
+  const original = readFileSync(configPath, "utf8");
   const servers = parseTomlMcpServers(original);
 
   // 백업 (최초 1회만)
-  const backupPath = CODEX_CONFIG + BACKUP_SUFFIX;
+  const backupPath = configPath + BACKUP_SUFFIX;
   if (!existsSync(backupPath)) {
-    copyFileSync(CODEX_CONFIG, backupPath);
+    copyFileSync(configPath, backupPath);
     console.log(`[BACKUP] ${backupPath}`);
   }
 
@@ -126,8 +136,18 @@ export function enableGateway() {
     }
 
     if (srv.hasUrl) {
-      // 이미 URL 기반 → 스킵
-      skipped++;
+      if (isCurrentGatewayUrl(srv, url)) {
+        // 이미 올바른 /mcp gateway URL → 스킵
+        skipped++;
+        continue;
+      }
+      // stale URL (예: v10.27.0 이 남긴 /sse) → 올바른 /mcp 로 강제 재작성.
+      // 데몬이 streamableHttp /mcp 만 서빙하므로 그대로 두면 dead path 가 된다.
+      const oldSection = `[mcp_servers.${name}]\n${srv.block}`;
+      const newSection = buildHttpEntry(name, url).trim();
+      content = content.replace(oldSection, newSection);
+      changed++;
+      console.log(`[MIGRATE] ${name}: ${srv.url} → ${url}`);
       continue;
     }
 
@@ -154,7 +174,7 @@ export function enableGateway() {
   }
 
   if (changed > 0) {
-    writeFileSync(CODEX_CONFIG, content, "utf8");
+    writeFileSync(configPath, content, "utf8");
     console.log(
       `\n[DONE] ${changed} servers converted, ${skipped} already HTTP`,
     );
@@ -186,12 +206,12 @@ export function disableGateway() {
 
 // ── status: 현재 상태 확인 ──
 
-export function getStatus() {
-  if (!existsSync(CODEX_CONFIG)) {
+export function getStatus(configPath = CODEX_CONFIG) {
+  if (!existsSync(configPath)) {
     return { exists: false, servers: [] };
   }
 
-  const content = readFileSync(CODEX_CONFIG, "utf8");
+  const content = readFileSync(configPath, "utf8");
   const servers = parseTomlMcpServers(content);
   const result = [];
 
@@ -199,8 +219,11 @@ export function getStatus() {
     const srv = servers.get(name);
     if (!srv) {
       result.push({ name, mode: "missing", url });
-    } else if (srv.hasUrl) {
+    } else if (isCurrentGatewayUrl(srv, url)) {
       result.push({ name, mode: "http", url });
+    } else if (srv.hasUrl) {
+      // url 은 있으나 기대 /mcp endpoint 가 아님 (stale /sse 등) → 마이그레이션 필요
+      result.push({ name, mode: "needs-migration", url, currentUrl: srv.url });
     } else {
       result.push({ name, mode: "stdio", url });
     }
@@ -226,10 +249,19 @@ if (arg === "--enable") {
   console.log("\nCodex MCP Gateway Status:");
   console.log("─".repeat(50));
   for (const s of servers) {
-    const icon = s.mode === "http" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
-    console.log(
-      `${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(8)} ${s.mode === "stdio" ? "← zombie risk" : ""}`,
-    );
+    const icon =
+      s.mode === "http"
+        ? "✅"
+        : s.mode === "stdio" || s.mode === "needs-migration"
+          ? "⚠️"
+          : "❌";
+    const note =
+      s.mode === "stdio"
+        ? "← zombie risk"
+        : s.mode === "needs-migration"
+          ? `← stale endpoint (${s.currentUrl}) — run --enable`
+          : "";
+    console.log(`${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(15)} ${note}`);
   }
 } else {
   console.log(

--- a/scripts/codex-mcp-gateway-sync.mjs
+++ b/scripts/codex-mcp-gateway-sync.mjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-// scripts/codex-mcp-gateway-sync.mjs — Codex config.toml MCP를 gateway SSE로 전환
+// scripts/codex-mcp-gateway-sync.mjs — Codex config.toml MCP를 gateway Streamable HTTP로 전환
 // Usage: node codex-mcp-gateway-sync.mjs [--enable|--disable|--status]
 //
 // 문제: Codex CLI가 매 호출마다 MCP 서버를 stdio로 spawn → 좀비 Node.js 프로세스
-// 해결: mcp-gateway-start.mjs의 싱글톤 SSE 데몬을 재사용하도록 config.toml 전환
+// 해결: mcp-gateway-start.mjs의 싱글톤 Streamable HTTP 데몬을 재사용하도록 config.toml 전환
 //
 // before: [mcp_servers.context7]
 //         command = "npx"
 //         args = ["-y", "@upstash/context7-mcp@latest"]
 //
 // after:  [mcp_servers.context7]
-//         url = "http://127.0.0.1:8100/sse"
+//         url = "http://127.0.0.1:8100/mcp"
 
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -23,9 +23,9 @@ const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const BACKUP_SUFFIX = ".pre-gateway.bak";
 const CODEX_CONFIG_SYNC_OPT_IN = "TFX_CODEX_CONFIG_SYNC";
 
-// gateway 서버 → SSE URL 매핑
+// gateway 서버 → Streamable HTTP URL 매핑
 const GATEWAY_MAP = new Map(
-  SERVERS.map((s) => [s.name, `http://127.0.0.1:${s.port}/sse`]),
+  SERVERS.map((s) => [s.name, `http://127.0.0.1:${s.port}/mcp`]),
 );
 
 // stdio 정의를 보존해야 하는 MCP 서버 (gateway 대상 아님)
@@ -68,7 +68,7 @@ function parseTomlMcpServers(content) {
   return servers;
 }
 
-function buildSseEntry(name, url) {
+function buildHttpEntry(name, url) {
   return `[mcp_servers.${name}]\nurl = "${url}"\n`;
 }
 
@@ -87,7 +87,7 @@ function shouldSkipCodexConfigMutation() {
   );
 }
 
-// ── enable: stdio → SSE ──
+// ── enable: stdio → Streamable HTTP ──
 
 export function enableGateway() {
   if (shouldSkipCodexConfigMutation()) {
@@ -118,8 +118,8 @@ export function enableGateway() {
     const srv = servers.get(name);
 
     if (!srv) {
-      // 서버 미등록 → SSE entry 추가
-      content += `\n${buildSseEntry(name, url)}`;
+      // 서버 미등록 → HTTP entry 추가
+      content += `\n${buildHttpEntry(name, url)}`;
       changed++;
       console.log(`[ADD] ${name} → ${url}`);
       continue;
@@ -132,9 +132,9 @@ export function enableGateway() {
     }
 
     if (srv.hasCommand) {
-      // stdio → SSE 전환: 기존 블록을 URL로 교체
+      // stdio → Streamable HTTP 전환: 기존 블록을 URL로 교체
       const oldSection = `[mcp_servers.${name}]\n${srv.block}`;
-      const newSection = buildSseEntry(name, url).trim();
+      const newSection = buildHttpEntry(name, url).trim();
       content = content.replace(oldSection, newSection);
       changed++;
       console.log(`[CONVERT] ${name}: stdio → ${url}`);
@@ -156,16 +156,16 @@ export function enableGateway() {
   if (changed > 0) {
     writeFileSync(CODEX_CONFIG, content, "utf8");
     console.log(
-      `\n[DONE] ${changed} servers converted, ${skipped} already SSE`,
+      `\n[DONE] ${changed} servers converted, ${skipped} already HTTP`,
     );
   } else {
-    console.log(`\n[DONE] No changes needed (${skipped} already SSE)`);
+    console.log(`\n[DONE] No changes needed (${skipped} already HTTP)`);
   }
 
   return { changed, skipped };
 }
 
-// ── disable: SSE → stdio 복원 ──
+// ── disable: HTTP → stdio 복원 ──
 
 export function disableGateway() {
   if (shouldSkipCodexConfigMutation()) {
@@ -200,7 +200,7 @@ export function getStatus() {
     if (!srv) {
       result.push({ name, mode: "missing", url });
     } else if (srv.hasUrl) {
-      result.push({ name, mode: "sse", url });
+      result.push({ name, mode: "http", url });
     } else {
       result.push({ name, mode: "stdio", url });
     }
@@ -226,7 +226,7 @@ if (arg === "--enable") {
   console.log("\nCodex MCP Gateway Status:");
   console.log("─".repeat(50));
   for (const s of servers) {
-    const icon = s.mode === "sse" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
+    const icon = s.mode === "http" ? "✅" : s.mode === "stdio" ? "⚠️" : "❌";
     console.log(
       `${icon} ${s.name.padEnd(15)} ${s.mode.padEnd(8)} ${s.mode === "stdio" ? "← zombie risk" : ""}`,
     );
@@ -235,7 +235,9 @@ if (arg === "--enable") {
   console.log(
     "Usage: codex-mcp-gateway-sync.mjs [--enable|--disable|--status]",
   );
-  console.log("  --enable   Convert stdio MCP servers to SSE gateway URLs");
+  console.log(
+    "  --enable   Convert stdio MCP servers to Streamable HTTP gateway URLs",
+  );
   console.log("  --disable  Restore original stdio config from backup");
   console.log("  --status   Show current MCP connection mode per server");
 }

--- a/scripts/lib/mcp-gateway-health-check.mjs
+++ b/scripts/lib/mcp-gateway-health-check.mjs
@@ -14,6 +14,7 @@
 // 침묵한다 (false-positive 방지).
 
 import { readFileSync, statSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -32,6 +33,27 @@ const MISSING_ENV_RE = /^\[WARN\]\s+(\S+)\s+skipped\s+—\s+missing env:\s+(.+)$
 const START_RE = /^\[START\]\s+(\S+)\s+on\s+:(\d+)$/;
 const SKIP_RUNNING_RE = /^\[SKIP\]\s+(\S+)\s+already running on\s+:(\d+)$/;
 const SKIP_DISABLED_RE = /^\[SKIP\]\s+(\S+)\s+—\s+manifest에서 비활성$/;
+
+function probePortListening(
+  port,
+  { host = "127.0.0.1", timeoutMs = 800 } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+
+    function finish(value) {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    }
+
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(timeoutMs, () => finish(false));
+  });
+}
 
 export function checkMcpGatewayHealth({
   fs = { readFileSync, statSync },
@@ -130,6 +152,40 @@ export function checkMcpGatewayHealth({
   };
 }
 
+export async function checkMcpGatewayHealthLive({
+  probePort = probePortListening,
+  ...options
+} = {}) {
+  const result = checkMcpGatewayHealth(options);
+  if (!result.available || result.started.length === 0) {
+    return {
+      ...result,
+      live: [],
+    };
+  }
+
+  const live = [];
+  const findings = [...result.findings];
+  for (const entry of result.started) {
+    const listening = await probePort(entry.port);
+    live.push({ ...entry, listening });
+    if (!listening) {
+      findings.push({
+        server: entry.server,
+        reason: "port-down",
+        detail: `expected listener on :${entry.port}`,
+        port: entry.port,
+      });
+    }
+  }
+
+  return {
+    ...result,
+    findings,
+    live,
+  };
+}
+
 export function summarizeMcpGatewayHealth(result) {
   if (!result?.available) {
     return {
@@ -150,6 +206,15 @@ export function summarizeMcpGatewayHealth(result) {
       level: "warn",
       message: `${missingEnv.length}개 MCP 서버가 missing env 로 skip: ${list}`,
       fix: "secrets 를 ~/.config/triflux/secrets.env 에 추가하고 `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway` (macOS) 또는 `systemctl --user restart mcp-gateway` (linux)",
+    };
+  }
+  const portDown = result.findings.filter((f) => f.reason === "port-down");
+  if (portDown.length > 0) {
+    const list = portDown.map((f) => `${f.server} (:${f.port})`).join(", ");
+    return {
+      level: "warn",
+      message: `${portDown.length}개 MCP gateway port down: ${list}`,
+      fix: "gateway 를 재기동하세요: `node scripts/mcp-gateway-start.mjs` 또는 macOS `launchctl kickstart -k gui/$(id -u)/com.tellang.mcp-gateway`",
     };
   }
   return {

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -22,7 +22,12 @@ const PROJECT_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const DEFAULT_REGISTRY_PATH = join(PROJECT_ROOT, "config", "mcp-registry.json");
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
 const DEFAULT_HUB_PATH = "/mcp";
-const SERVER_POLICIES = new Set(["hosted", "gateway-sse", "stdio"]);
+const SERVER_POLICIES = new Set([
+  "hosted",
+  "gateway-sse",
+  "gateway-http",
+  "stdio",
+]);
 const GATEWAY_PORTS = Object.freeze({
   context7: 8100,
   "brave-search": 8101,
@@ -792,6 +797,23 @@ function gatewaySseUrl(name, serverConfig = {}) {
   return `http://127.0.0.1:${port}/sse`;
 }
 
+function gatewayHttpUrl(name, serverConfig = {}) {
+  if (typeof serverConfig.url === "string" && serverConfig.url.trim()) {
+    return normalizeUrl(serverConfig.url);
+  }
+  const port =
+    Number(serverConfig.gateway_port || serverConfig.port || 0) ||
+    GATEWAY_PORTS[name];
+  if (!Number.isFinite(port) || port <= 0) return "";
+  const path =
+    typeof serverConfig.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : "/mcp";
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `http://127.0.0.1:${port}${normalizedPath}`;
+}
+
 function syncDenylistEntries(policy = {}) {
   if (!Array.isArray(policy?.sync_denylist)) return new Set();
   return new Set(
@@ -836,9 +858,11 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const url =
     policy === "gateway-sse"
       ? gatewaySseUrl(name, serverConfig)
-      : serverConfig?.transport === "hub-url"
-        ? resolveHubUrl()
-        : normalizeUrl(serverConfig?.url || "");
+      : policy === "gateway-http"
+        ? gatewayHttpUrl(name, serverConfig)
+        : serverConfig?.transport === "hub-url"
+          ? resolveHubUrl()
+          : normalizeUrl(serverConfig?.url || "");
   const basenameValue = pathBasename(filePath);
   const resolvedHeaders = resolveHeaderDescriptors(
     name,
@@ -848,6 +872,26 @@ export function buildDesiredServerRecord(name, serverConfig, filePath) {
   const headerConfig = hasOwnEntries(resolvedHeaders.headers)
     ? { headers: resolvedHeaders.headers }
     : {};
+
+  if (policy === "gateway-http") {
+    if (isCodexConfig(filePath)) {
+      return {
+        name,
+        config: { url },
+        headerDescriptors: {},
+        codex: {},
+        warnings: [],
+      };
+    }
+
+    return {
+      name,
+      config: { type: "http", url },
+      headerDescriptors: {},
+      codex: {},
+      warnings: [],
+    };
+  }
 
   if (policy === "gateway-sse") {
     if (isCodexConfig(filePath)) {
@@ -1237,7 +1281,7 @@ export function validateRegistry(registry) {
         !SERVER_POLICIES.has(server.policy)
       ) {
         errors.push(
-          `registry.servers.${name}.policy must be hosted, gateway-sse, or stdio`,
+          `registry.servers.${name}.policy must be hosted, gateway-sse, gateway-http, or stdio`,
         );
       }
       const transport = server.transport || registry.defaults?.transport;
@@ -1252,7 +1296,7 @@ export function validateRegistry(registry) {
       ) {
         errors.push(`registry.servers.${name}.url must be a non-empty string`);
       }
-      if (policy === "gateway-sse") {
+      if (policy === "gateway-sse" || policy === "gateway-http") {
         const port = Number(server.gateway_port || server.port || 0);
         const hasGatewayUrl =
           typeof server.url === "string" && server.url.trim().length > 0;
@@ -1261,7 +1305,7 @@ export function validateRegistry(registry) {
           (!Number.isInteger(port) || port <= 0 || port > 65535)
         ) {
           errors.push(
-            `registry.servers.${name}.gateway_port must be a valid TCP port for gateway-sse`,
+            `registry.servers.${name}.gateway_port must be a valid TCP port for ${policy}`,
           );
         }
       }
@@ -1913,7 +1957,7 @@ export function addRegistryServer(name, url, options = {}) {
     (transport === "stdio"
       ? "stdio"
       : options.gateway_port || options.port
-        ? "gateway-sse"
+        ? "gateway-http"
         : "hosted");
 
   registry.servers[trimmedName] = {

--- a/scripts/mcp-gateway-config.mjs
+++ b/scripts/mcp-gateway-config.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// mcp-gateway-config.mjs — Claude Code MCP stdio↔SSE 전환
-// Usage: node mcp-gateway-config.mjs --enable   # stdio → SSE
-//        node mcp-gateway-config.mjs --disable  # SSE → stdio (복원)
+// mcp-gateway-config.mjs — Claude Code MCP stdio↔Streamable HTTP 전환
+// Usage: node mcp-gateway-config.mjs --enable   # stdio → Streamable HTTP
+//        node mcp-gateway-config.mjs --disable  # Streamable HTTP → stdio (복원)
 
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -92,10 +92,10 @@ function loadBackup() {
   }
 }
 
-// ── enable: 스냅샷 → remove → SSE add (실패 시 rollback) ──
+// ── enable: 스냅샷 → remove → HTTP add (실패 시 rollback) ──
 
-function enableSse() {
-  console.log("Switching MCP servers to SSE mode...\n");
+function enableHttp() {
+  console.log("Switching MCP servers to Streamable HTTP mode...\n");
 
   // 1) 현재 상태 스냅샷
   const snapshot = captureCurrentMcpState();
@@ -112,13 +112,13 @@ function enableSse() {
     }
 
     removeMcp(name);
-    const url = `http://localhost:${port}/sse`;
+    const url = `http://localhost:${port}/mcp`;
     const success = run(
-      `claude mcp add --transport sse -s user "${name}" ${url}`,
+      `claude mcp add --transport http -s user "${name}" ${url}`,
     );
 
     if (success) {
-      console.log(`  [SSE] ${name} → ${url}`);
+      console.log(`  [HTTP] ${name} → ${url}`);
       ok++;
     } else {
       // add 실패 → 원본 복원 시도
@@ -141,7 +141,7 @@ function enableSse() {
 
 // ── disable: 백업에서 서버별 원복 ──
 
-function disableSse() {
+function disableHttp() {
   console.log("Restoring MCP servers from backup...\n");
   const backup = loadBackup();
 
@@ -202,7 +202,7 @@ function disableSse() {
 function printUsage() {
   console.log(`Usage: node mcp-gateway-config.mjs [--enable|--disable]
 
-  --enable   Switch Claude Code MCP servers from stdio to SSE (supergateway)
+  --enable   Switch Claude Code MCP servers from stdio to Streamable HTTP (supergateway)
   --disable  Restore Claude Code MCP servers to original stdio mode
 
 Servers managed: ${GATEWAY_SERVERS.map((s) => s.name).join(", ")}
@@ -213,9 +213,9 @@ Servers skipped: ${[...SKIP_SERVERS].join(", ")}`);
 const flag = process.argv[2];
 
 if (flag === "--enable") {
-  enableSse();
+  enableHttp();
 } else if (flag === "--disable") {
-  disableSse();
+  disableHttp();
 } else {
   printUsage();
   process.exit(flag ? 1 : 0);

--- a/scripts/mcp-gateway-ensure.mjs
+++ b/scripts/mcp-gateway-ensure.mjs
@@ -14,14 +14,13 @@ import {
 import { readManifest, writeManifest } from "./lib/mcp-manifest.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const PROBE_PORT = 8100; // context7 — 첫 번째 게이트웨이 포트로 alive 프로브
 const PROBE_TIMEOUT_MS = 1500;
 const STARTUP_WAIT_MS = 4000;
 const POLL_INTERVAL_MS = 500;
 
-async function isGatewayAlive() {
+async function isPortHealthy(port) {
   try {
-    const res = await fetch(`http://127.0.0.1:${PROBE_PORT}/healthz`, {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`, {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
     return res.ok;
@@ -40,12 +39,27 @@ function ensureGatewayManifest() {
   return writeManifest(envReadyServers);
 }
 
-function hasConfiguredGatewayServer(manifest) {
+function configuredServers(manifest) {
   const enabled = new Set(manifest?.enabled || []);
-  return SERVERS.some((server) => {
+  return SERVERS.filter((server) => {
     if (!enabled.has(server.name)) return false;
     return server.envVars.every((envName) => Boolean(process.env[envName]));
   });
+}
+
+async function gatewayReadiness(servers) {
+  const entries = await Promise.all(
+    servers.map(async (server) => ({
+      name: server.name,
+      port: server.port,
+      healthy: await isPortHealthy(server.port),
+    })),
+  );
+
+  return {
+    ready: entries.length > 0 && entries.every((entry) => entry.healthy),
+    entries,
+  };
 }
 
 function startGateway() {
@@ -72,10 +86,10 @@ function startGateway() {
   }
 }
 
-async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
+async function waitForGatewayReady(servers, maxWaitMs = STARTUP_WAIT_MS) {
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
-    if (await isGatewayAlive()) return true;
+    if ((await gatewayReadiness(servers)).ready) return true;
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
   return false;
@@ -84,13 +98,14 @@ async function waitForGatewayReady(maxWaitMs = STARTUP_WAIT_MS) {
 export async function run(stdinData) {
   void stdinData;
   const manifest = ensureGatewayManifest();
+  const servers = configuredServers(manifest);
 
-  if (hasConfiguredGatewayServer(manifest) && (await isGatewayAlive())) {
-    return { code: 0, stdout: "gateway: ok", stderr: "" };
+  if (servers.length === 0) {
+    return { code: 0, stdout: "gateway: not configured", stderr: "" };
   }
 
-  if (!hasConfiguredGatewayServer(manifest)) {
-    return { code: 0, stdout: "gateway: not configured", stderr: "" };
+  if ((await gatewayReadiness(servers)).ready) {
+    return { code: 0, stdout: "gateway: ok", stderr: "" };
   }
 
   const started = startGateway();
@@ -98,7 +113,7 @@ export async function run(stdinData) {
     return { code: 0, stdout: "", stderr: "[gateway-ensure] start failed" };
   }
 
-  const ready = await waitForGatewayReady();
+  const ready = await waitForGatewayReady(servers);
   return {
     code: 0,
     stdout: ready ? "gateway: ok" : "gateway: starting",

--- a/scripts/mcp-gateway-integration-test.mjs
+++ b/scripts/mcp-gateway-integration-test.mjs
@@ -178,43 +178,49 @@ async function main() {
     );
   }
 
-  // STEP 3: Switch Claude Code config to SSE
-  console.log("\n[STEP 3] Switching Claude Code config to SSE mode...");
+  // STEP 3: Switch Claude Code config to Streamable HTTP
+  console.log(
+    "\n[STEP 3] Switching Claude Code config to Streamable HTTP mode...",
+  );
   try {
     runScript(CONFIG_SCRIPT, "--enable");
-    pass("Config switch to SSE (--enable)");
+    pass("Config switch to Streamable HTTP (--enable)");
   } catch (err) {
-    fail("Config switch to SSE", err.message);
+    fail("Config switch to Streamable HTTP", err.message);
   }
 
-  // STEP 4: Verify SSE endpoints respond on each active port
-  console.log("\n[STEP 4] Verifying SSE endpoints (/healthz)...");
-  const sseResults = await Promise.allSettled(
+  // STEP 4: Verify Streamable HTTP gateways respond on each active port
+  console.log("\n[STEP 4] Verifying Streamable HTTP gateways (/healthz)...");
+  const httpResults = await Promise.allSettled(
     SERVERS.map(async (srv) => ({
       ...srv,
       alive: await checkHealth(srv.port),
     })),
   );
 
-  let sseOk = 0;
-  for (const r of sseResults) {
+  let httpOk = 0;
+  for (const r of httpResults) {
     if (r.status !== "fulfilled") continue;
     const { name, port, alive } = r.value;
     if (alive) {
       console.log(`  [ok]   ${name.padEnd(16)} :${port}`);
-      sseOk++;
+      httpOk++;
     } else {
       console.log(`  [skip] ${name.padEnd(16)} :${port}  (not running)`);
     }
   }
 
-  if (sseOk === 0 && healthOk > 0) {
-    fail("SSE endpoint verification — servers went down after config switch");
-  } else if (sseOk > 0) {
-    pass(`SSE endpoint verification — ${sseOk} endpoint(s) healthy`);
+  if (httpOk === 0 && healthOk > 0) {
+    fail(
+      "Streamable HTTP gateway verification — servers went down after config switch",
+    );
+  } else if (httpOk > 0) {
+    pass(
+      `Streamable HTTP gateway verification — ${httpOk} endpoint(s) healthy`,
+    );
   } else {
     pass(
-      "SSE endpoint verification — no servers running (all skipped due to missing env)",
+      "Streamable HTTP gateway verification — no servers running (all skipped due to missing env)",
     );
   }
 

--- a/scripts/mcp-gateway-start.mjs
+++ b/scripts/mcp-gateway-start.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// mcp-gateway-start.mjs — supergateway MCP SSE 영속 서비스 관리
+// mcp-gateway-start.mjs — supergateway MCP Streamable HTTP 영속 서비스 관리
 // Usage: node mcp-gateway-start.mjs          # 시작
 //        node mcp-gateway-start.mjs --stop   # 중지
 //        node mcp-gateway-start.mjs --status # 상태 확인
@@ -57,7 +57,7 @@ function sleep(ms) {
 function spawnGateway(srv) {
   if (process.platform === "win32") {
     // 임시 .cmd 파일로 quoting 문제 회피
-    const cmdContent = `@echo off\nnpx -y supergateway --stdio "${srv.cmd}" --port ${srv.port} --outputTransport sse --healthEndpoint /healthz --cors "http://localhost"`;
+    const cmdContent = `@echo off\nnpx -y supergateway --stdio "${srv.cmd}" --port ${srv.port} --outputTransport streamableHttp --stateful --streamableHttpPath /mcp --healthEndpoint /healthz --cors "http://localhost"`;
     const cmdFile = join(tmpdir(), `tfx-sg-${srv.name}.cmd`);
     writeFileSync(cmdFile, cmdContent);
 
@@ -79,7 +79,10 @@ function spawnGateway(srv) {
     "--port",
     String(srv.port),
     "--outputTransport",
-    "sse",
+    "streamableHttp",
+    "--stateful",
+    "--streamableHttpPath",
+    "/mcp",
     "--healthEndpoint",
     "/healthz",
     "--cors",

--- a/scripts/mcp-gateway-start.ps1
+++ b/scripts/mcp-gateway-start.ps1
@@ -1,5 +1,5 @@
-# mcp-gateway-start.ps1 — supergateway MCP SSE 영속 서비스 관리
-# 각 MCP 서버를 supergateway로 래핑하여 SSE 엔드포인트로 노출한다.
+# mcp-gateway-start.ps1 — supergateway MCP Streamable HTTP 영속 서비스 관리
+# 각 MCP 서버를 supergateway로 래핑하여 Streamable HTTP 엔드포인트로 노출한다.
 # Usage: .\mcp-gateway-start.ps1          # 시작
 #        .\mcp-gateway-start.ps1 -Stop    # 중지
 
@@ -88,7 +88,7 @@ function Start-AllGateways {
 
     # supergateway 기동 — npx는 .cmd 파일이므로 cmd.exe /c 로 래핑
     $stdioCmdEscaped = $srv.Cmd -replace '"', '\"'
-    $sgCmd = "npx -y supergateway --stdio `"$stdioCmdEscaped`" --port $port --outputTransport sse --healthEndpoint /healthz"
+    $sgCmd = "npx -y supergateway --stdio `"$stdioCmdEscaped`" --port $port --outputTransport streamableHttp --stateful --streamableHttpPath /mcp --healthEndpoint /healthz"
 
     try {
       $proc = Start-Process -FilePath 'cmd.exe' -ArgumentList "/c $sgCmd" `

--- a/scripts/mcp-gateway-verify.mjs
+++ b/scripts/mcp-gateway-verify.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// mcp-gateway-verify.mjs — supergateway SSE 엔드포인트 헬스체크
+// mcp-gateway-verify.mjs — supergateway Streamable HTTP 엔드포인트 헬스체크
 
 import { readManifest } from "./lib/mcp-manifest.mjs";
 

--- a/scripts/sync-hub-mcp-settings.mjs
+++ b/scripts/sync-hub-mcp-settings.mjs
@@ -317,7 +317,7 @@ function setCodexMcpServerBody(raw, sectionName, body) {
   return `${raw.slice(0, section.bodyStart)}${body}${raw.slice(section.sectionEnd)}`;
 }
 
-function gatewaySseUrl(serverName, serverConfig) {
+function gatewayUrl(serverName, serverConfig) {
   if (typeof serverConfig?.url === "string" && serverConfig.url.trim()) {
     return serverConfig.url.trim();
   }
@@ -325,7 +325,14 @@ function gatewaySseUrl(serverName, serverConfig) {
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     return "";
   }
-  return `http://127.0.0.1:${port}/sse`;
+  const fallbackPath = serverConfig?.policy === "gateway-sse" ? "/sse" : "/mcp";
+  const rawPath =
+    typeof serverConfig?.gateway_path === "string" &&
+    serverConfig.gateway_path.trim()
+      ? serverConfig.gateway_path.trim()
+      : fallbackPath;
+  const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  return `http://127.0.0.1:${port}${path}`;
 }
 
 async function loadGatewaySseServers({ registryPath, client, logger }) {
@@ -349,19 +356,25 @@ async function loadGatewaySseServers({ registryPath, client, logger }) {
 
   return Object.entries(servers)
     .filter(([, server]) => {
-      if (server?.policy !== "gateway-sse") return false;
+      if (!["gateway-sse", "gateway-http"].includes(server?.policy))
+        return false;
       if (!Array.isArray(server.targets)) return true;
       return server.targets.includes(client);
     })
-    .map(([name, server]) => ({ name, url: gatewaySseUrl(name, server) }))
+    .map(([name, server]) => ({
+      name,
+      url: gatewayUrl(name, server),
+      policy: server.policy,
+    }))
     .filter((server) => server.url.length > 0);
 }
 
-function desiredJsonGatewayConfig(client, url) {
-  if (client === "antigravity") {
-    return { serverUrl: url };
+function desiredJsonGatewayConfig(client, gatewayServer) {
+  if (gatewayServer.policy === "gateway-sse") {
+    if (client === "antigravity") return { serverUrl: gatewayServer.url };
+    return { type: "sse", url: gatewayServer.url };
   }
-  return { type: "sse", url };
+  return { type: "http", url: gatewayServer.url };
 }
 
 function sameJsonValue(left, right) {
@@ -476,7 +489,7 @@ async function syncGatewayJsonFile({
       if (servers[gatewayServer.name] === undefined) {
         continue;
       }
-      const nextConfig = desiredJsonGatewayConfig(client, gatewayServer.url);
+      const nextConfig = desiredJsonGatewayConfig(client, gatewayServer);
       if (sameJsonValue(servers[gatewayServer.name], nextConfig)) {
         continue;
       }
@@ -645,11 +658,14 @@ async function syncCodexGatewayConfigFile({
         continue;
       }
       const beforeRaw = nextRaw;
-      nextRaw = setCodexMcpServerBody(
-        nextRaw,
-        gatewayServer.name,
-        `url = ${formatTomlString(gatewayServer.url)}\ntransport = "sse"\n`,
-      );
+      const body =
+        gatewayServer.policy === "gateway-sse"
+          ? `url = ${formatTomlString(gatewayServer.url)}
+transport = "sse"
+`
+          : `url = ${formatTomlString(gatewayServer.url)}
+`;
+      nextRaw = setCodexMcpServerBody(nextRaw, gatewayServer.name, body);
       if (nextRaw !== beforeRaw) {
         changedServers.push(gatewayServer);
       }

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -150,20 +150,20 @@ Bash("triflux setup")
 #### 단계 3.6: Codex MCP Gateway 싱글톤 전환
 
 Codex CLI가 매 호출마다 MCP 서버를 stdio로 spawn하면 좀비 Node.js 프로세스가 생긴다.
-gateway SSE 싱글톤을 사용하도록 config.toml을 전환한다.
+gateway Streamable HTTP 싱글톤을 사용하도록 config.toml을 전환한다.
 
 ```bash
 node scripts/codex-mcp-gateway-sync.mjs --status
 ```
 
-- 전부 `sse` → ✅ 이미 전환됨
+- 전부 `http` → ✅ 이미 전환됨
 - `stdio` 또는 `missing` 있으면 → AskUserQuestion:
   ```
-  question: "Codex MCP 서버를 gateway 싱글톤(SSE)으로 전환하시겠습니까? 매 호출마다 MCP를 새로 spawn하는 대신, 영속 gateway 데몬을 공유합니다. (좀비 Node.js 방지)"
+  question: "Codex MCP 서버를 gateway 싱글톤(Streamable HTTP)으로 전환하시겠습니까? 매 호출마다 MCP를 새로 spawn하는 대신, 영속 gateway 데몬을 공유합니다. (좀비 Node.js 방지)"
   header: "MCP Gateway"
   options:
     - label: "전환 (Recommended)"
-      description: "stdio → SSE URL 전환. 좀비 프로세스 방지"
+      description: "stdio → Streamable HTTP URL 전환. 좀비 프로세스 방지"
     - label: "건너뛰기"
       description: "현재 stdio 방식 유지"
   ```

--- a/tests/unit/codex-mcp-gateway-sync.test.mjs
+++ b/tests/unit/codex-mcp-gateway-sync.test.mjs
@@ -1,0 +1,112 @@
+// tests/unit/codex-mcp-gateway-sync.test.mjs
+// codex-mcp-gateway-sync.mjs — /sse → /mcp 업그레이드 마이그레이션 회귀 가드
+//
+// 회귀 시나리오: v10.27.0 이하에서 gateway 가 /sse URL 을 config.toml 에 썼다.
+// 데몬은 이제 streamableHttp /mcp 만 서빙하므로, 업그레이드 후에는 stale /sse 가
+// 반드시 /mcp 로 재작성돼야 한다. hasUrl 만 보고 스킵하면 dead /sse 가 남는다.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+
+const ROOT = process.cwd();
+const SYNC_PATH = join(ROOT, "scripts", "codex-mcp-gateway-sync.mjs");
+
+const syncModule = await import(`${SYNC_PATH}?t=${Date.now()}`);
+const serversModule = await import(
+  `${join(ROOT, "scripts", "lib", "mcp-gateway-servers.mjs")}?t=${Date.now()}`
+);
+
+const { enableGateway, getStatus } = syncModule;
+const { SERVERS } = serversModule;
+
+// context7 는 8100 → http://127.0.0.1:8100/mcp 가 기대 endpoint.
+const CONTEXT7 = SERVERS.find((s) => s.name === "context7");
+const EXPECTED_MCP_URL = `http://127.0.0.1:${CONTEXT7.port}/mcp`;
+const STALE_SSE_URL = `http://127.0.0.1:${CONTEXT7.port}/sse`;
+
+describe("codex-mcp-gateway-sync — stale /sse upgrade migration", () => {
+  let workDir;
+  let configPath;
+  let prevOptIn;
+
+  before(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tfx-gateway-sync-test-"));
+    configPath = join(workDir, "config.toml");
+    // 보호 환경(NODE_ENV=test) 가드를 우회해 실제 재작성 로직을 실행한다.
+    prevOptIn = process.env.TFX_CODEX_CONFIG_SYNC;
+    process.env.TFX_CODEX_CONFIG_SYNC = "1";
+  });
+
+  after(() => {
+    if (prevOptIn === undefined) delete process.env.TFX_CODEX_CONFIG_SYNC;
+    else process.env.TFX_CODEX_CONFIG_SYNC = prevOptIn;
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("enableGateway rewrites a stale /sse url to the /mcp endpoint instead of skipping", () => {
+    // v10.27.0 이 남긴 stale /sse URL 블록
+    writeFileSync(
+      configPath,
+      `[mcp_servers.context7]\nurl = "${STALE_SSE_URL}"\n`,
+      "utf8",
+    );
+
+    const result = enableGateway(configPath);
+
+    const after = readFileSync(configPath, "utf8");
+    assert.ok(
+      after.includes(`url = "${EXPECTED_MCP_URL}"`),
+      `stale /sse must be rewritten to ${EXPECTED_MCP_URL}; got:\n${after}`,
+    );
+    assert.doesNotMatch(
+      after,
+      /url\s*=\s*"[^"]*\/sse"/,
+      `no /sse url may survive enableGateway; got:\n${after}`,
+    );
+    // 스킵이 아니라 변경(또는 마이그레이션)으로 카운트돼야 한다.
+    assert.ok(
+      result.changed >= 1,
+      `stale /sse block must count as changed, not skipped: ${JSON.stringify(result)}`,
+    );
+  });
+
+  it("getStatus does not report a stale /sse url as a healthy http server", () => {
+    writeFileSync(
+      configPath,
+      `[mcp_servers.context7]\nurl = "${STALE_SSE_URL}"\n`,
+      "utf8",
+    );
+
+    const { servers } = getStatus(configPath);
+    const ctx = servers.find((s) => s.name === "context7");
+    assert.ok(ctx, "context7 must appear in status");
+    assert.notStrictEqual(
+      ctx.mode,
+      "http",
+      `stale /sse must not be classified as a healthy http server; got mode=${ctx.mode}`,
+    );
+  });
+
+  it("enableGateway leaves a correct /mcp url untouched (no false migration)", () => {
+    writeFileSync(
+      configPath,
+      `[mcp_servers.context7]\nurl = "${EXPECTED_MCP_URL}"\n`,
+      "utf8",
+    );
+
+    const result = enableGateway(configPath);
+    const after = readFileSync(configPath, "utf8");
+    assert.ok(
+      after.includes(`url = "${EXPECTED_MCP_URL}"`),
+      "correct /mcp url must remain present",
+    );
+    // preflight 추가는 changed 를 올릴 수 있으므로 context7 자체는 skip 으로 분류돼야 한다.
+    assert.ok(
+      result.skipped >= 1,
+      `correct /mcp url should be skipped, not migrated: ${JSON.stringify(result)}`,
+    );
+  });
+});

--- a/tests/unit/mcp-gateway.test.mjs
+++ b/tests/unit/mcp-gateway.test.mjs
@@ -22,6 +22,8 @@ const ROOT = join(process.cwd());
 const START_PATH = join(ROOT, "scripts", "mcp-gateway-start.mjs");
 const CONFIG_PATH = join(ROOT, "scripts", "mcp-gateway-config.mjs");
 const VERIFY_PATH = join(ROOT, "scripts", "mcp-gateway-verify.mjs");
+const ENSURE_PATH = join(ROOT, "scripts", "mcp-gateway-ensure.mjs");
+const PREFLIGHT_PATH = join(ROOT, "scripts", "codex-gateway-preflight.mjs");
 const SERVERS_LIB_PATH = join(
   ROOT,
   "scripts",
@@ -431,16 +433,53 @@ describe("source file structural integrity", () => {
     );
   });
 
-  it("mcp-gateway-ensure.mjs does not use gateway PID files as configuration state", () => {
-    const src = readFileSync(
-      join(ROOT, "scripts", "mcp-gateway-ensure.mjs"),
-      "utf8",
+  it("mcp-gateway-start.mjs exposes stdio upstreams as stateful Streamable HTTP on /mcp", () => {
+    const src = readFileSync(START_PATH, "utf8");
+    assert.match(src, /--outputTransport/);
+    assert.match(src, /streamableHttp/);
+    assert.match(src, /--stateful/);
+    assert.match(src, /--streamableHttpPath/);
+    assert.match(src, /\/mcp/);
+    assert.doesNotMatch(
+      src,
+      /--outputTransport(?:\s*["',`]+|\s+)sse\b/,
+      "gateway start must not expose shared stdio upstreams through SSE",
     );
+  });
+
+  it("mcp-gateway-config.mjs writes Claude Streamable HTTP MCP URLs, not SSE URLs", () => {
+    const src = readFileSync(CONFIG_PATH, "utf8");
+    assert.match(src, /--transport http/);
+    assert.match(src, /\/mcp/);
+    assert.doesNotMatch(src, /--transport sse/);
+    assert.doesNotMatch(src, /\/sse/);
+  });
+
+  it("mcp-gateway-ensure.mjs does not use gateway PID files as configuration state", () => {
+    const src = readFileSync(ENSURE_PATH, "utf8");
     assert.doesNotMatch(
       src,
       /tfx-gateway-pids\.json|PID_FILE|hasManifest/,
       "ensure must use MCP manifest/registry lifecycle instead of PID files",
     );
+  });
+
+  it("mcp-gateway-ensure.mjs probes every configured gateway port, not a single sentinel port", () => {
+    const src = readFileSync(ENSURE_PATH, "utf8");
+    assert.doesNotMatch(src, /PROBE_PORT/);
+    assert.match(src, /function configuredServers/);
+    assert.match(src, /async function gatewayReadiness/);
+    assert.match(src, /servers\.map/);
+    assert.match(src, /entries\.every/);
+  });
+
+  it("codex-gateway-preflight.mjs caches only the configured gateway port set", () => {
+    const src = readFileSync(PREFLIGHT_PATH, "utf8");
+    assert.doesNotMatch(src, /PROBE_PORT/);
+    assert.match(src, /function configuredPorts/);
+    assert.match(src, /samePorts/);
+    assert.match(src, /ports: configuredPorts\(servers\)/);
+    assert.match(src, /async function gatewayReadiness/);
   });
 
   it("setup.mjs legacy direct SessionStart hook includes gateway ensure", () => {

--- a/tests/unit/sync-hub-mcp-settings.test.mjs
+++ b/tests/unit/sync-hub-mcp-settings.test.mjs
@@ -19,7 +19,7 @@ import {
 } from "../../scripts/sync-hub-mcp-settings.mjs";
 
 const HUB_URL = "http://127.0.0.1:27888/mcp";
-const BRAVE_GATEWAY_URL = "http://127.0.0.1:8101/sse";
+const BRAVE_GATEWAY_URL = "http://127.0.0.1:8101/mcp";
 
 function createLogger() {
   return {
@@ -266,7 +266,7 @@ describe("sync-hub-mcp-settings", () => {
     });
   });
 
-  it("case 9: registry gateway-sse 서버를 Gemini와 Antigravity 양식으로 동기화한다", async () => {
+  it("case 9: registry gateway-http 서버를 Gemini와 Antigravity 양식으로 동기화한다", async () => {
     const geminiPath = settingsPath(".gemini", "settings.json");
     const antigravityPath = settingsPath(
       ".gemini",
@@ -305,7 +305,7 @@ describe("sync-hub-mcp-settings", () => {
     assert.deepEqual(
       JSON.parse(readFileSync(geminiPath, "utf8")).mcpServers["brave-search"],
       {
-        type: "sse",
+        type: "http",
         url: BRAVE_GATEWAY_URL,
       },
     );
@@ -314,7 +314,8 @@ describe("sync-hub-mcp-settings", () => {
         "brave-search"
       ],
       {
-        serverUrl: BRAVE_GATEWAY_URL,
+        type: "http",
+        url: BRAVE_GATEWAY_URL,
       },
     );
   });
@@ -549,7 +550,7 @@ describe("syncCodexHubUrl", () => {
     }
   });
 
-  it("case 8: registry gateway-sse 서버를 Codex url/transport 양식으로 동기화한다", async () => {
+  it("case 8: registry gateway-http 서버를 Codex url 양식으로 동기화한다", async () => {
     const configPath = codexPath(".codex", "config.toml");
     writeRaw(
       configPath,
@@ -571,8 +572,8 @@ describe("syncCodexHubUrl", () => {
     assert.deepEqual(result.updated, [configPath]);
     const codexToml = readFileSync(configPath, "utf8");
     assert.match(codexToml, /\[mcp_servers\.brave-search\]/);
-    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8101\/sse"/);
-    assert.match(codexToml, /transport = "sse"/);
+    assert.match(codexToml, /url = "http:\/\/127\.0\.0\.1:8101\/mcp"/);
+    assert.doesNotMatch(codexToml, /transport = "sse"/);
     assert.doesNotMatch(codexToml, /command = "npx"/);
   });
 });


### PR DESCRIPTION
## Summary
- Preserve the MCP gateway daemon/registry SSOT design, but move gateway-backed stdio upstreams from SSE (`/sse`) to stateful Streamable HTTP (`/mcp`).
- Add `gateway-http` policy rendering for Codex, Gemini, Claude, Antigravity, legacy sync helpers, setup docs, and package mirrors.
- Make gateway readiness and doctor health check live configured ports instead of trusting stale `[START]` logs or probing only 8100.
- Document why the old gateway/SSE design existed and why `gateway-http` is now the default architecture.

## Validation
- `node --test scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs packages/triflux/scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs tests/unit/sync-hub-mcp-settings.test.mjs tests/unit/mcp-gateway.test.mjs scripts/__tests__/mcp-gateway-health-check.test.mjs packages/triflux/scripts/__tests__/mcp-gateway-health-check.test.mjs scripts/__tests__/session-start-fast.test.mjs packages/triflux/scripts/__tests__/session-start-fast.test.mjs`
- `npx biome check bin config hooks hub hud mesh scripts tests .claude-plugin .github package.json package-lock.json biome.json`
- `npm run release:check-mirror`
- `npm run lint:skills`
- `node bin/triflux.mjs doctor --json`
- Local smoke: `tfx mcp sync`; `node scripts/mcp-gateway-start.mjs`; repeated `/mcp` initialize against brave-search and serena.

## Notes
- Full `npm test` was started, but I interrupted the long-running integration batch after the relevant suites had already passed; this PR relies on the targeted MCP/registry/doctor/lint coverage above.
