### PR TITLE
Extract shared Claude daemon dispatch helper (P1 prep, no behavior change)

### DIFF
--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -1,8 +1,14 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
@@ -26,10 +32,21 @@ export function deriveClaudeDaemonPaths({
     hash,
     daemonDir,
     controlSock: path.join(daemonDir, "control.sock"),
+    rendezvousDir: path.join(daemonDir, "rv"),
+    ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
     jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
+}
+
+export function getProcStart(pid = process.pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    throw new Error(`invalid pid: ${pid}`);
+  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+  }).trim();
 }
 
 export function readFirstJsonLine(text) {
@@ -1127,4 +1144,155 @@ export async function sendKillBySessionId({
       error: error?.message || String(error),
     };
   }
+}
+
+/**
+ * Claude 데몬 dispatch 한 건의 공통 시퀀스를 캡슐화한다.
+ * dispatch → waitForDaemonJobPid → resolveDaemonBridgeSessionId →
+ * buildClaudeSessionProjection → writeClaudeSessionProjection.
+ *
+ * 호출 측이 reference 로 들고 있는 record 를 헬퍼가 새로 만들지 않도록
+ * plain 필드만 반환한다. caller 는 이 결과를 자기 record 에 Object.assign 한다.
+ *
+ * @returns {Promise<{ok:boolean, short:string, sessionId:string, job:object,
+ *   pid:number, bridgeSessionId:string, sessionProjectionPath:string,
+ *   controlSock:string, paths:object}>}
+ */
+export async function dispatchClaudeDaemonJob({
+  paths,
+  controlSock,
+  payload,
+  agent,
+  name,
+  cwd,
+  projection = "write",
+  dispatchTimeoutMs = 5000,
+  pidTimeoutMs,
+  bridgeTimeoutMs,
+  accessControlSock,
+  _deps = {},
+} = {}) {
+  if (!payload) throw new Error("payload is required");
+  if (!payload.short) throw new Error("payload.short is required");
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  if (!resolvedControlSock) throw new Error("controlSock is required");
+
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const resolveBridgeSessionId =
+    _deps.resolveDaemonBridgeSessionId || resolveDaemonBridgeSessionId;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const readProcStart = _deps.getProcStart || getProcStart;
+
+  const short = payload.short;
+  const sessionsDir =
+    paths?.sessionsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "sessions") : "");
+
+  // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
+  if (accessControlSock) await accessControlSock(resolvedControlSock);
+
+  const dispatch = await sendControl(
+    resolvedControlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: dispatchTimeoutMs,
+    },
+    { timeoutMs: dispatchTimeoutMs },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+  }
+
+  const pidOpts =
+    pidTimeoutMs === undefined ? undefined : { timeoutMs: pidTimeoutMs };
+  const job = await waitForPid(resolvedControlSock, short, pidOpts);
+  const pid = job.pid;
+  const bridgeSessionId = await resolveBridgeSessionId({
+    daemonPaths: paths,
+    short,
+    job,
+    ...(bridgeTimeoutMs === undefined ? {} : { timeoutMs: bridgeTimeoutMs }),
+  });
+
+  let sessionProjectionPath = "";
+  if (projection !== "skip") {
+    const projectionRecord = buildProjection({
+      pid,
+      procStart: readProcStart(pid),
+      sessionId: payload.sessionId,
+      short,
+      cwd,
+      name,
+      agent,
+      startedAt: job.startedAt || Date.now(),
+      updatedAt: Date.now(),
+      bridgeSessionId,
+    });
+    sessionProjectionPath = await writeProjection(
+      sessionsDir,
+      projectionRecord,
+    );
+  }
+
+  return {
+    ok: true,
+    short,
+    sessionId: payload.sessionId,
+    job,
+    pid,
+    bridgeSessionId,
+    sessionProjectionPath,
+    controlSock: resolvedControlSock,
+    paths,
+  };
+}
+
+/**
+ * dispatchClaudeDaemonJob 의 대칭 정리 경로.
+ * removeProjection + killDaemonJob (+ optional removeClaudeJobState) 를
+ * 모두 시도하며, 각 스텝 오류는 기존 close()/cleanupDaemonDispatches 와
+ * 동일하게 .catch 로 삼킨다.
+ */
+export async function teardownClaudeDaemonJob({
+  controlSock,
+  paths,
+  short,
+  sessionProjectionPath,
+  sessionId,
+  jobsDir,
+  removeJobState = false,
+  _deps = {},
+} = {}) {
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const removeJobStateImpl = _deps.removeClaudeJobState;
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  const resolvedJobsDir =
+    jobsDir ||
+    paths?.jobsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "jobs") : "");
+
+  const steps = [];
+  if (sessionProjectionPath) {
+    steps.push(removeProjection(sessionProjectionPath).catch(() => {}));
+  }
+  if (sessionId && (paths?.controlSock || resolvedControlSock)) {
+    const daemonPaths = paths || { controlSock: resolvedControlSock };
+    steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
+  }
+  if (resolvedControlSock && short) {
+    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+  }
+  if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
+    steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));
+  }
+  await Promise.all(steps);
 }

--- a/hub/team/claude-native-bridge.mjs
+++ b/hub/team/claude-native-bridge.mjs
@@ -1,4 +1,4 @@
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -6,9 +6,13 @@ import os from "node:os";
 import path from "node:path";
 import {
   buildDaemonExecDispatchPayload,
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  getProcStart,
   killDaemonJob,
   resolveDaemonBridgeSessionId,
   sendClaudeControlRequest,
+  teardownClaudeDaemonJob,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
 import {
@@ -17,6 +21,10 @@ import {
   writeClaudeSessionProjection,
 } from "./claude-session-projection.mjs";
 import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+// daemon-control 이 deriveClaudeDaemonPaths / getProcStart 의 단일 owner 다.
+// 기존 native-bridge import 경로 (headless 포함) 호환을 위해 re-export 한다.
+export { deriveClaudeDaemonPaths, getProcStart };
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -28,39 +36,6 @@ const ROSTER_LOCK_RETRY_MS = 10;
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
   return path.join(os.homedir(), ".claude");
-}
-
-export function deriveClaudeDaemonPaths({
-  configDir = resolveClaudeConfigDir(),
-  uid = typeof process.getuid === "function" ? process.getuid() : 0,
-  tmpRoot = "/tmp",
-} = {}) {
-  const resolvedConfigDir = path.resolve(configDir);
-  const hash = crypto
-    .createHash("sha256")
-    .update(resolvedConfigDir)
-    .digest("hex")
-    .slice(0, 8);
-  const daemonDir = path.join(tmpRoot, `cc-daemon-${uid}`, hash);
-  return {
-    configDir: resolvedConfigDir,
-    daemonDir,
-    controlSock: path.join(daemonDir, "control.sock"),
-    rendezvousDir: path.join(daemonDir, "rv"),
-    ptyDir: path.join(daemonDir, "pty"),
-    rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
-    sessionsDir: path.join(resolvedConfigDir, "sessions"),
-    jobsDir: path.join(resolvedConfigDir, "jobs"),
-  };
-}
-
-export function getProcStart(pid = process.pid) {
-  if (!Number.isInteger(pid) || pid <= 0)
-    throw new Error(`invalid pid: ${pid}`);
-  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
-    encoding: "utf8",
-    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
-  }).trim();
 }
 
 export function buildPtyDataFrame(value) {
@@ -379,6 +354,8 @@ export async function registerSwarmShard({
   const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
@@ -487,44 +464,30 @@ export async function registerSwarmShard({
     name: displayName,
   });
 
-  await accessControlSock(paths.controlSock);
-  const dispatch = await sendControl(
-    paths.controlSock,
-    {
-      proto: 1,
-      op: "dispatch",
-      d: payload,
-      timeoutMs: 1000,
-    },
-    { timeoutMs: 1000 },
-  );
-  if (dispatch?.ok !== true) {
-    throw new Error(
-      `Claude daemon dispatch failed for swarm shard ${shardName}`,
-    );
-  }
-
-  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
-  const pid = job.pid;
-  const bridgeSessionId = await resolveBridgeSessionId({
-    daemonPaths: paths,
-    short,
-    job,
-    timeoutMs: 1000,
-  });
-  const projection = buildProjection({
-    pid,
-    procStart: readProcStart(pid),
-    sessionId: payload.sessionId,
-    short,
-    cwd,
-    name: displayName,
+  // native-bridge 는 데몬이 없으면 빠르게 실패해야 하므로 1000ms 로 고정한다
+  // (headless 의 5000ms 와 다르므로 명시 전달).
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
     agent: cli,
-    startedAt: job.startedAt || Date.now(),
-    updatedAt: Date.now(),
-    bridgeSessionId,
+    name: displayName,
+    cwd,
+    dispatchTimeoutMs: 1000,
+    pidTimeoutMs: 1000,
+    bridgeTimeoutMs: 1000,
+    accessControlSock,
+    _deps: {
+      sendClaudeControlRequest: sendControl,
+      waitForDaemonJobPid: waitForPid,
+      resolveDaemonBridgeSessionId: resolveBridgeSessionId,
+      buildClaudeSessionProjection: buildProjection,
+      writeClaudeSessionProjection: writeProjection,
+      getProcStart: readProcStart,
+    },
   });
-  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  const sessionProjectionPath = dispatched.sessionProjectionPath;
+  void sessionsDir;
   let closed = false;
 
   return {
@@ -543,9 +506,18 @@ export async function registerSwarmShard({
     async close() {
       if (closed) return;
       closed = true;
-      await removeProjection(sessionProjectionPath).catch(() => {});
-      await killJob(paths.controlSock, short).catch(() => {});
-      await removeJobStateImpl(jobsDir, short).catch(() => {});
+      await teardownJob({
+        controlSock: paths.controlSock,
+        short,
+        sessionProjectionPath,
+        jobsDir,
+        removeJobState: true,
+        _deps: {
+          removeClaudeSessionProjection: removeProjection,
+          killDaemonJob: killJob,
+          removeClaudeJobState: removeJobStateImpl,
+        },
+      });
     },
   };
 }

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -28,21 +28,12 @@ import { getBackend } from "./backend.mjs";
 import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
+  dispatchClaudeDaemonJob,
   killDaemonJob,
-  resolveDaemonBridgeSessionId,
-  sendClaudeControlRequest,
   sendKillBySessionId,
-  waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
-import {
-  getProcStart,
-  startClaudeNativeBridge,
-} from "./claude-native-bridge.mjs";
-import {
-  buildClaudeSessionProjection,
-  removeClaudeSessionProjection,
-  writeClaudeSessionProjection,
-} from "./claude-session-projection.mjs";
+import { startClaudeNativeBridge } from "./claude-native-bridge.mjs";
+import { removeClaudeSessionProjection } from "./claude-session-projection.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import {
   formatHandoffForLead,
@@ -1016,40 +1007,30 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         name,
       });
       record.sessionId = payload.sessionId;
-      const dispatch = await sendClaudeControlRequest(paths.controlSock, {
-        proto: 1,
-        op: "dispatch",
-        d: payload,
-        timeoutMs: 5000,
-      });
-      if (dispatch?.ok !== true) {
-        throw new Error(
-          `[headless] Claude daemon dispatch failed for ${paneName}`,
-        );
-      }
-
-      const job = await waitForDaemonJobPid(paths.controlSock, short);
-      const bridgeSessionId = await resolveDaemonBridgeSessionId({
-        daemonPaths: paths,
-        short,
-        job,
-      });
-      const projection = buildClaudeSessionProjection({
-        pid: job.pid,
-        procStart: getProcStart(job.pid),
-        sessionId: payload.sessionId,
-        short,
-        cwd: assignment.cwd || assignment.workdir || process.cwd(),
-        name,
+      // buildDaemonWrappedCommand + token completion 시맨틱은 헬퍼 밖(headless 전용)에
+      // 남기고, dispatch→pid→bridge→projection 시퀀스만 공유 헬퍼로 위임한다.
+      // CRITICAL: waitForDaemonCompletion 이 나중에 record.daemonCompletionMatched 를
+      // 변경하고 cleanupDaemonDispatches 가 같은 record 를 읽으므로, 헬퍼가 새 객체를
+      // 반환해도 record 를 교체하지 말고 plain 필드를 Object.assign 한다.
+      const dispatched = await dispatchClaudeDaemonJob({
+        paths,
+        controlSock: paths.controlSock,
+        payload,
         agent: resolvedCli || "codex",
-        startedAt: job.startedAt || Date.now(),
-        updatedAt: Date.now(),
-        bridgeSessionId,
+        name,
+        cwd: assignment.cwd || assignment.workdir || process.cwd(),
+        dispatchTimeoutMs: 5000,
+      }).catch((error) => {
+        throw new Error(
+          `[headless] Claude daemon dispatch failed for ${paneName}: ${
+            error?.message || error
+          }`,
+        );
       });
-      record.sessionProjectionPath = await writeClaudeSessionProjection(
-        paths.sessionsDir,
-        projection,
-      );
+      Object.assign(record, {
+        sessionId: dispatched.sessionId,
+        sessionProjectionPath: dispatched.sessionProjectionPath,
+      });
       await registerHeadlessWorker(sessionName, i, resolvedCli);
       registerHeadlessSynapseWorker(workerId, assignment.prompt);
       if (safeProgress) {

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -1,8 +1,14 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
@@ -26,10 +32,21 @@ export function deriveClaudeDaemonPaths({
     hash,
     daemonDir,
     controlSock: path.join(daemonDir, "control.sock"),
+    rendezvousDir: path.join(daemonDir, "rv"),
+    ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
     jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
+}
+
+export function getProcStart(pid = process.pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    throw new Error(`invalid pid: ${pid}`);
+  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+  }).trim();
 }
 
 export function readFirstJsonLine(text) {
@@ -1127,4 +1144,155 @@ export async function sendKillBySessionId({
       error: error?.message || String(error),
     };
   }
+}
+
+/**
+ * Claude 데몬 dispatch 한 건의 공통 시퀀스를 캡슐화한다.
+ * dispatch → waitForDaemonJobPid → resolveDaemonBridgeSessionId →
+ * buildClaudeSessionProjection → writeClaudeSessionProjection.
+ *
+ * 호출 측이 reference 로 들고 있는 record 를 헬퍼가 새로 만들지 않도록
+ * plain 필드만 반환한다. caller 는 이 결과를 자기 record 에 Object.assign 한다.
+ *
+ * @returns {Promise<{ok:boolean, short:string, sessionId:string, job:object,
+ *   pid:number, bridgeSessionId:string, sessionProjectionPath:string,
+ *   controlSock:string, paths:object}>}
+ */
+export async function dispatchClaudeDaemonJob({
+  paths,
+  controlSock,
+  payload,
+  agent,
+  name,
+  cwd,
+  projection = "write",
+  dispatchTimeoutMs = 5000,
+  pidTimeoutMs,
+  bridgeTimeoutMs,
+  accessControlSock,
+  _deps = {},
+} = {}) {
+  if (!payload) throw new Error("payload is required");
+  if (!payload.short) throw new Error("payload.short is required");
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  if (!resolvedControlSock) throw new Error("controlSock is required");
+
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const resolveBridgeSessionId =
+    _deps.resolveDaemonBridgeSessionId || resolveDaemonBridgeSessionId;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const readProcStart = _deps.getProcStart || getProcStart;
+
+  const short = payload.short;
+  const sessionsDir =
+    paths?.sessionsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "sessions") : "");
+
+  // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
+  if (accessControlSock) await accessControlSock(resolvedControlSock);
+
+  const dispatch = await sendControl(
+    resolvedControlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: dispatchTimeoutMs,
+    },
+    { timeoutMs: dispatchTimeoutMs },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+  }
+
+  const pidOpts =
+    pidTimeoutMs === undefined ? undefined : { timeoutMs: pidTimeoutMs };
+  const job = await waitForPid(resolvedControlSock, short, pidOpts);
+  const pid = job.pid;
+  const bridgeSessionId = await resolveBridgeSessionId({
+    daemonPaths: paths,
+    short,
+    job,
+    ...(bridgeTimeoutMs === undefined ? {} : { timeoutMs: bridgeTimeoutMs }),
+  });
+
+  let sessionProjectionPath = "";
+  if (projection !== "skip") {
+    const projectionRecord = buildProjection({
+      pid,
+      procStart: readProcStart(pid),
+      sessionId: payload.sessionId,
+      short,
+      cwd,
+      name,
+      agent,
+      startedAt: job.startedAt || Date.now(),
+      updatedAt: Date.now(),
+      bridgeSessionId,
+    });
+    sessionProjectionPath = await writeProjection(
+      sessionsDir,
+      projectionRecord,
+    );
+  }
+
+  return {
+    ok: true,
+    short,
+    sessionId: payload.sessionId,
+    job,
+    pid,
+    bridgeSessionId,
+    sessionProjectionPath,
+    controlSock: resolvedControlSock,
+    paths,
+  };
+}
+
+/**
+ * dispatchClaudeDaemonJob 의 대칭 정리 경로.
+ * removeProjection + killDaemonJob (+ optional removeClaudeJobState) 를
+ * 모두 시도하며, 각 스텝 오류는 기존 close()/cleanupDaemonDispatches 와
+ * 동일하게 .catch 로 삼킨다.
+ */
+export async function teardownClaudeDaemonJob({
+  controlSock,
+  paths,
+  short,
+  sessionProjectionPath,
+  sessionId,
+  jobsDir,
+  removeJobState = false,
+  _deps = {},
+} = {}) {
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const removeJobStateImpl = _deps.removeClaudeJobState;
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  const resolvedJobsDir =
+    jobsDir ||
+    paths?.jobsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "jobs") : "");
+
+  const steps = [];
+  if (sessionProjectionPath) {
+    steps.push(removeProjection(sessionProjectionPath).catch(() => {}));
+  }
+  if (sessionId && (paths?.controlSock || resolvedControlSock)) {
+    const daemonPaths = paths || { controlSock: resolvedControlSock };
+    steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
+  }
+  if (resolvedControlSock && short) {
+    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+  }
+  if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
+    steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));
+  }
+  await Promise.all(steps);
 }

--- a/packages/core/hub/team/claude-session-projection.mjs
+++ b/packages/core/hub/team/claude-session-projection.mjs
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export function normalizeClaudeBridgeSessionId(bridgeSessionId, short) {
+  const value = String(bridgeSessionId || "").trim();
+  if (value.startsWith("session_")) return value;
+  if (value.startsWith("cse_")) return `session_${value.slice(4)}`;
+  if (value) return value;
+  return `session_${short}`;
+}
+
+export function buildClaudeSessionProjection({
+  pid,
+  procStart,
+  sessionId,
+  short,
+  cwd,
+  name,
+  agent,
+  startedAt = Date.now(),
+  updatedAt = Date.now(),
+  status = "busy",
+  version = "triflux-native-bridge",
+  bridgeSessionId,
+} = {}) {
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error("pid is required");
+  if (!procStart) throw new Error("procStart is required");
+  if (!sessionId) throw new Error("sessionId is required");
+  if (!short) throw new Error("short is required");
+  if (!cwd) throw new Error("cwd is required");
+  if (!name) throw new Error("name is required");
+  if (!agent) throw new Error("agent is required");
+  return {
+    pid,
+    sessionId,
+    cwd,
+    startedAt,
+    procStart,
+    version,
+    peerProtocol: 1,
+    kind: "bg",
+    entrypoint: "cli",
+    name,
+    agent,
+    jobId: short,
+    status,
+    updatedAt,
+    bridgeSessionId: normalizeClaudeBridgeSessionId(bridgeSessionId, short),
+  };
+}
+
+export async function writeClaudeSessionProjection(sessionsDir, projection) {
+  await fs.mkdir(sessionsDir, { recursive: true });
+  const sessionPath = path.join(sessionsDir, `${projection.pid}.json`);
+  const tmpPath = `${sessionPath}.${process.pid}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(projection)}\n`, "utf8");
+  await fs.rename(tmpPath, sessionPath);
+  return sessionPath;
+}
+
+export async function updateClaudeSessionProjection(sessionPath, patch) {
+  const parsed = JSON.parse(await fs.readFile(sessionPath, "utf8"));
+  const next = {
+    ...parsed,
+    ...patch,
+    updatedAt: patch.updatedAt || Date.now(),
+  };
+  await fs.writeFile(sessionPath, `${JSON.stringify(next)}\n`, "utf8");
+  return next;
+}
+
+export async function removeClaudeSessionProjection(sessionPath) {
+  await fs.rm(sessionPath, { force: true });
+}

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -1,8 +1,14 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
@@ -26,10 +32,21 @@ export function deriveClaudeDaemonPaths({
     hash,
     daemonDir,
     controlSock: path.join(daemonDir, "control.sock"),
+    rendezvousDir: path.join(daemonDir, "rv"),
+    ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
     jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
+}
+
+export function getProcStart(pid = process.pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    throw new Error(`invalid pid: ${pid}`);
+  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+  }).trim();
 }
 
 export function readFirstJsonLine(text) {
@@ -1127,4 +1144,155 @@ export async function sendKillBySessionId({
       error: error?.message || String(error),
     };
   }
+}
+
+/**
+ * Claude 데몬 dispatch 한 건의 공통 시퀀스를 캡슐화한다.
+ * dispatch → waitForDaemonJobPid → resolveDaemonBridgeSessionId →
+ * buildClaudeSessionProjection → writeClaudeSessionProjection.
+ *
+ * 호출 측이 reference 로 들고 있는 record 를 헬퍼가 새로 만들지 않도록
+ * plain 필드만 반환한다. caller 는 이 결과를 자기 record 에 Object.assign 한다.
+ *
+ * @returns {Promise<{ok:boolean, short:string, sessionId:string, job:object,
+ *   pid:number, bridgeSessionId:string, sessionProjectionPath:string,
+ *   controlSock:string, paths:object}>}
+ */
+export async function dispatchClaudeDaemonJob({
+  paths,
+  controlSock,
+  payload,
+  agent,
+  name,
+  cwd,
+  projection = "write",
+  dispatchTimeoutMs = 5000,
+  pidTimeoutMs,
+  bridgeTimeoutMs,
+  accessControlSock,
+  _deps = {},
+} = {}) {
+  if (!payload) throw new Error("payload is required");
+  if (!payload.short) throw new Error("payload.short is required");
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  if (!resolvedControlSock) throw new Error("controlSock is required");
+
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const resolveBridgeSessionId =
+    _deps.resolveDaemonBridgeSessionId || resolveDaemonBridgeSessionId;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const readProcStart = _deps.getProcStart || getProcStart;
+
+  const short = payload.short;
+  const sessionsDir =
+    paths?.sessionsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "sessions") : "");
+
+  // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
+  if (accessControlSock) await accessControlSock(resolvedControlSock);
+
+  const dispatch = await sendControl(
+    resolvedControlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: dispatchTimeoutMs,
+    },
+    { timeoutMs: dispatchTimeoutMs },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+  }
+
+  const pidOpts =
+    pidTimeoutMs === undefined ? undefined : { timeoutMs: pidTimeoutMs };
+  const job = await waitForPid(resolvedControlSock, short, pidOpts);
+  const pid = job.pid;
+  const bridgeSessionId = await resolveBridgeSessionId({
+    daemonPaths: paths,
+    short,
+    job,
+    ...(bridgeTimeoutMs === undefined ? {} : { timeoutMs: bridgeTimeoutMs }),
+  });
+
+  let sessionProjectionPath = "";
+  if (projection !== "skip") {
+    const projectionRecord = buildProjection({
+      pid,
+      procStart: readProcStart(pid),
+      sessionId: payload.sessionId,
+      short,
+      cwd,
+      name,
+      agent,
+      startedAt: job.startedAt || Date.now(),
+      updatedAt: Date.now(),
+      bridgeSessionId,
+    });
+    sessionProjectionPath = await writeProjection(
+      sessionsDir,
+      projectionRecord,
+    );
+  }
+
+  return {
+    ok: true,
+    short,
+    sessionId: payload.sessionId,
+    job,
+    pid,
+    bridgeSessionId,
+    sessionProjectionPath,
+    controlSock: resolvedControlSock,
+    paths,
+  };
+}
+
+/**
+ * dispatchClaudeDaemonJob 의 대칭 정리 경로.
+ * removeProjection + killDaemonJob (+ optional removeClaudeJobState) 를
+ * 모두 시도하며, 각 스텝 오류는 기존 close()/cleanupDaemonDispatches 와
+ * 동일하게 .catch 로 삼킨다.
+ */
+export async function teardownClaudeDaemonJob({
+  controlSock,
+  paths,
+  short,
+  sessionProjectionPath,
+  sessionId,
+  jobsDir,
+  removeJobState = false,
+  _deps = {},
+} = {}) {
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const removeJobStateImpl = _deps.removeClaudeJobState;
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  const resolvedJobsDir =
+    jobsDir ||
+    paths?.jobsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "jobs") : "");
+
+  const steps = [];
+  if (sessionProjectionPath) {
+    steps.push(removeProjection(sessionProjectionPath).catch(() => {}));
+  }
+  if (sessionId && (paths?.controlSock || resolvedControlSock)) {
+    const daemonPaths = paths || { controlSock: resolvedControlSock };
+    steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
+  }
+  if (resolvedControlSock && short) {
+    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+  }
+  if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
+    steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));
+  }
+  await Promise.all(steps);
 }

--- a/packages/remote/hub/team/claude-native-bridge.mjs
+++ b/packages/remote/hub/team/claude-native-bridge.mjs
@@ -1,4 +1,4 @@
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -6,9 +6,13 @@ import os from "node:os";
 import path from "node:path";
 import {
   buildDaemonExecDispatchPayload,
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  getProcStart,
   killDaemonJob,
   resolveDaemonBridgeSessionId,
   sendClaudeControlRequest,
+  teardownClaudeDaemonJob,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
 import {
@@ -17,6 +21,10 @@ import {
   writeClaudeSessionProjection,
 } from "./claude-session-projection.mjs";
 import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+// daemon-control 이 deriveClaudeDaemonPaths / getProcStart 의 단일 owner 다.
+// 기존 native-bridge import 경로 (headless 포함) 호환을 위해 re-export 한다.
+export { deriveClaudeDaemonPaths, getProcStart };
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -28,39 +36,6 @@ const ROSTER_LOCK_RETRY_MS = 10;
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
   return path.join(os.homedir(), ".claude");
-}
-
-export function deriveClaudeDaemonPaths({
-  configDir = resolveClaudeConfigDir(),
-  uid = typeof process.getuid === "function" ? process.getuid() : 0,
-  tmpRoot = "/tmp",
-} = {}) {
-  const resolvedConfigDir = path.resolve(configDir);
-  const hash = crypto
-    .createHash("sha256")
-    .update(resolvedConfigDir)
-    .digest("hex")
-    .slice(0, 8);
-  const daemonDir = path.join(tmpRoot, `cc-daemon-${uid}`, hash);
-  return {
-    configDir: resolvedConfigDir,
-    daemonDir,
-    controlSock: path.join(daemonDir, "control.sock"),
-    rendezvousDir: path.join(daemonDir, "rv"),
-    ptyDir: path.join(daemonDir, "pty"),
-    rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
-    sessionsDir: path.join(resolvedConfigDir, "sessions"),
-    jobsDir: path.join(resolvedConfigDir, "jobs"),
-  };
-}
-
-export function getProcStart(pid = process.pid) {
-  if (!Number.isInteger(pid) || pid <= 0)
-    throw new Error(`invalid pid: ${pid}`);
-  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
-    encoding: "utf8",
-    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
-  }).trim();
 }
 
 export function buildPtyDataFrame(value) {
@@ -379,6 +354,8 @@ export async function registerSwarmShard({
   const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
@@ -487,44 +464,30 @@ export async function registerSwarmShard({
     name: displayName,
   });
 
-  await accessControlSock(paths.controlSock);
-  const dispatch = await sendControl(
-    paths.controlSock,
-    {
-      proto: 1,
-      op: "dispatch",
-      d: payload,
-      timeoutMs: 1000,
-    },
-    { timeoutMs: 1000 },
-  );
-  if (dispatch?.ok !== true) {
-    throw new Error(
-      `Claude daemon dispatch failed for swarm shard ${shardName}`,
-    );
-  }
-
-  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
-  const pid = job.pid;
-  const bridgeSessionId = await resolveBridgeSessionId({
-    daemonPaths: paths,
-    short,
-    job,
-    timeoutMs: 1000,
-  });
-  const projection = buildProjection({
-    pid,
-    procStart: readProcStart(pid),
-    sessionId: payload.sessionId,
-    short,
-    cwd,
-    name: displayName,
+  // native-bridge 는 데몬이 없으면 빠르게 실패해야 하므로 1000ms 로 고정한다
+  // (headless 의 5000ms 와 다르므로 명시 전달).
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
     agent: cli,
-    startedAt: job.startedAt || Date.now(),
-    updatedAt: Date.now(),
-    bridgeSessionId,
+    name: displayName,
+    cwd,
+    dispatchTimeoutMs: 1000,
+    pidTimeoutMs: 1000,
+    bridgeTimeoutMs: 1000,
+    accessControlSock,
+    _deps: {
+      sendClaudeControlRequest: sendControl,
+      waitForDaemonJobPid: waitForPid,
+      resolveDaemonBridgeSessionId: resolveBridgeSessionId,
+      buildClaudeSessionProjection: buildProjection,
+      writeClaudeSessionProjection: writeProjection,
+      getProcStart: readProcStart,
+    },
   });
-  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  const sessionProjectionPath = dispatched.sessionProjectionPath;
+  void sessionsDir;
   let closed = false;
 
   return {
@@ -543,9 +506,18 @@ export async function registerSwarmShard({
     async close() {
       if (closed) return;
       closed = true;
-      await removeProjection(sessionProjectionPath).catch(() => {});
-      await killJob(paths.controlSock, short).catch(() => {});
-      await removeJobStateImpl(jobsDir, short).catch(() => {});
+      await teardownJob({
+        controlSock: paths.controlSock,
+        short,
+        sessionProjectionPath,
+        jobsDir,
+        removeJobState: true,
+        _deps: {
+          removeClaudeSessionProjection: removeProjection,
+          killDaemonJob: killJob,
+          removeClaudeJobState: removeJobStateImpl,
+        },
+      });
     },
   };
 }

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -28,21 +28,12 @@ import { getBackend } from "./backend.mjs";
 import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
+  dispatchClaudeDaemonJob,
   killDaemonJob,
-  resolveDaemonBridgeSessionId,
-  sendClaudeControlRequest,
   sendKillBySessionId,
-  waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
-import {
-  getProcStart,
-  startClaudeNativeBridge,
-} from "./claude-native-bridge.mjs";
-import {
-  buildClaudeSessionProjection,
-  removeClaudeSessionProjection,
-  writeClaudeSessionProjection,
-} from "./claude-session-projection.mjs";
+import { startClaudeNativeBridge } from "./claude-native-bridge.mjs";
+import { removeClaudeSessionProjection } from "./claude-session-projection.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import {
   formatHandoffForLead,
@@ -1016,40 +1007,30 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         name,
       });
       record.sessionId = payload.sessionId;
-      const dispatch = await sendClaudeControlRequest(paths.controlSock, {
-        proto: 1,
-        op: "dispatch",
-        d: payload,
-        timeoutMs: 5000,
-      });
-      if (dispatch?.ok !== true) {
-        throw new Error(
-          `[headless] Claude daemon dispatch failed for ${paneName}`,
-        );
-      }
-
-      const job = await waitForDaemonJobPid(paths.controlSock, short);
-      const bridgeSessionId = await resolveDaemonBridgeSessionId({
-        daemonPaths: paths,
-        short,
-        job,
-      });
-      const projection = buildClaudeSessionProjection({
-        pid: job.pid,
-        procStart: getProcStart(job.pid),
-        sessionId: payload.sessionId,
-        short,
-        cwd: assignment.cwd || assignment.workdir || process.cwd(),
-        name,
+      // buildDaemonWrappedCommand + token completion 시맨틱은 헬퍼 밖(headless 전용)에
+      // 남기고, dispatch→pid→bridge→projection 시퀀스만 공유 헬퍼로 위임한다.
+      // CRITICAL: waitForDaemonCompletion 이 나중에 record.daemonCompletionMatched 를
+      // 변경하고 cleanupDaemonDispatches 가 같은 record 를 읽으므로, 헬퍼가 새 객체를
+      // 반환해도 record 를 교체하지 말고 plain 필드를 Object.assign 한다.
+      const dispatched = await dispatchClaudeDaemonJob({
+        paths,
+        controlSock: paths.controlSock,
+        payload,
         agent: resolvedCli || "codex",
-        startedAt: job.startedAt || Date.now(),
-        updatedAt: Date.now(),
-        bridgeSessionId,
+        name,
+        cwd: assignment.cwd || assignment.workdir || process.cwd(),
+        dispatchTimeoutMs: 5000,
+      }).catch((error) => {
+        throw new Error(
+          `[headless] Claude daemon dispatch failed for ${paneName}: ${
+            error?.message || error
+          }`,
+        );
       });
-      record.sessionProjectionPath = await writeClaudeSessionProjection(
-        paths.sessionsDir,
-        projection,
-      );
+      Object.assign(record, {
+        sessionId: dispatched.sessionId,
+        sessionProjectionPath: dispatched.sessionProjectionPath,
+      });
       await registerHeadlessWorker(sessionName, i, resolvedCli);
       registerHeadlessSynapseWorker(workerId, assignment.prompt);
       if (safeProgress) {

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -1,8 +1,14 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildClaudeSessionProjection,
+  removeClaudeSessionProjection,
+  writeClaudeSessionProjection,
+} from "./claude-session-projection.mjs";
 
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
@@ -26,10 +32,21 @@ export function deriveClaudeDaemonPaths({
     hash,
     daemonDir,
     controlSock: path.join(daemonDir, "control.sock"),
+    rendezvousDir: path.join(daemonDir, "rv"),
+    ptyDir: path.join(daemonDir, "pty"),
     rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
     sessionsDir: path.join(resolvedConfigDir, "sessions"),
     jobsDir: path.join(resolvedConfigDir, "jobs"),
   };
+}
+
+export function getProcStart(pid = process.pid) {
+  if (!Number.isInteger(pid) || pid <= 0)
+    throw new Error(`invalid pid: ${pid}`);
+  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+  }).trim();
 }
 
 export function readFirstJsonLine(text) {
@@ -1127,4 +1144,155 @@ export async function sendKillBySessionId({
       error: error?.message || String(error),
     };
   }
+}
+
+/**
+ * Claude 데몬 dispatch 한 건의 공통 시퀀스를 캡슐화한다.
+ * dispatch → waitForDaemonJobPid → resolveDaemonBridgeSessionId →
+ * buildClaudeSessionProjection → writeClaudeSessionProjection.
+ *
+ * 호출 측이 reference 로 들고 있는 record 를 헬퍼가 새로 만들지 않도록
+ * plain 필드만 반환한다. caller 는 이 결과를 자기 record 에 Object.assign 한다.
+ *
+ * @returns {Promise<{ok:boolean, short:string, sessionId:string, job:object,
+ *   pid:number, bridgeSessionId:string, sessionProjectionPath:string,
+ *   controlSock:string, paths:object}>}
+ */
+export async function dispatchClaudeDaemonJob({
+  paths,
+  controlSock,
+  payload,
+  agent,
+  name,
+  cwd,
+  projection = "write",
+  dispatchTimeoutMs = 5000,
+  pidTimeoutMs,
+  bridgeTimeoutMs,
+  accessControlSock,
+  _deps = {},
+} = {}) {
+  if (!payload) throw new Error("payload is required");
+  if (!payload.short) throw new Error("payload.short is required");
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  if (!resolvedControlSock) throw new Error("controlSock is required");
+
+  const sendControl =
+    _deps.sendClaudeControlRequest || sendClaudeControlRequest;
+  const waitForPid = _deps.waitForDaemonJobPid || waitForDaemonJobPid;
+  const resolveBridgeSessionId =
+    _deps.resolveDaemonBridgeSessionId || resolveDaemonBridgeSessionId;
+  const buildProjection =
+    _deps.buildClaudeSessionProjection || buildClaudeSessionProjection;
+  const writeProjection =
+    _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
+  const readProcStart = _deps.getProcStart || getProcStart;
+
+  const short = payload.short;
+  const sessionsDir =
+    paths?.sessionsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "sessions") : "");
+
+  // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
+  if (accessControlSock) await accessControlSock(resolvedControlSock);
+
+  const dispatch = await sendControl(
+    resolvedControlSock,
+    {
+      proto: 1,
+      op: "dispatch",
+      d: payload,
+      timeoutMs: dispatchTimeoutMs,
+    },
+    { timeoutMs: dispatchTimeoutMs },
+  );
+  if (dispatch?.ok !== true) {
+    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+  }
+
+  const pidOpts =
+    pidTimeoutMs === undefined ? undefined : { timeoutMs: pidTimeoutMs };
+  const job = await waitForPid(resolvedControlSock, short, pidOpts);
+  const pid = job.pid;
+  const bridgeSessionId = await resolveBridgeSessionId({
+    daemonPaths: paths,
+    short,
+    job,
+    ...(bridgeTimeoutMs === undefined ? {} : { timeoutMs: bridgeTimeoutMs }),
+  });
+
+  let sessionProjectionPath = "";
+  if (projection !== "skip") {
+    const projectionRecord = buildProjection({
+      pid,
+      procStart: readProcStart(pid),
+      sessionId: payload.sessionId,
+      short,
+      cwd,
+      name,
+      agent,
+      startedAt: job.startedAt || Date.now(),
+      updatedAt: Date.now(),
+      bridgeSessionId,
+    });
+    sessionProjectionPath = await writeProjection(
+      sessionsDir,
+      projectionRecord,
+    );
+  }
+
+  return {
+    ok: true,
+    short,
+    sessionId: payload.sessionId,
+    job,
+    pid,
+    bridgeSessionId,
+    sessionProjectionPath,
+    controlSock: resolvedControlSock,
+    paths,
+  };
+}
+
+/**
+ * dispatchClaudeDaemonJob 의 대칭 정리 경로.
+ * removeProjection + killDaemonJob (+ optional removeClaudeJobState) 를
+ * 모두 시도하며, 각 스텝 오류는 기존 close()/cleanupDaemonDispatches 와
+ * 동일하게 .catch 로 삼킨다.
+ */
+export async function teardownClaudeDaemonJob({
+  controlSock,
+  paths,
+  short,
+  sessionProjectionPath,
+  sessionId,
+  jobsDir,
+  removeJobState = false,
+  _deps = {},
+} = {}) {
+  const removeProjection =
+    _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
+  const killJob = _deps.killDaemonJob || killDaemonJob;
+  const removeJobStateImpl = _deps.removeClaudeJobState;
+  const resolvedControlSock = controlSock || paths?.controlSock;
+  const resolvedJobsDir =
+    jobsDir ||
+    paths?.jobsDir ||
+    (paths?.configDir ? path.join(paths.configDir, "jobs") : "");
+
+  const steps = [];
+  if (sessionProjectionPath) {
+    steps.push(removeProjection(sessionProjectionPath).catch(() => {}));
+  }
+  if (sessionId && (paths?.controlSock || resolvedControlSock)) {
+    const daemonPaths = paths || { controlSock: resolvedControlSock };
+    steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
+  }
+  if (resolvedControlSock && short) {
+    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+  }
+  if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
+    steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));
+  }
+  await Promise.all(steps);
 }

--- a/packages/triflux/hub/team/claude-native-bridge.mjs
+++ b/packages/triflux/hub/team/claude-native-bridge.mjs
@@ -1,4 +1,4 @@
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -6,9 +6,13 @@ import os from "node:os";
 import path from "node:path";
 import {
   buildDaemonExecDispatchPayload,
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  getProcStart,
   killDaemonJob,
   resolveDaemonBridgeSessionId,
   sendClaudeControlRequest,
+  teardownClaudeDaemonJob,
   waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
 import {
@@ -17,6 +21,10 @@ import {
   writeClaudeSessionProjection,
 } from "./claude-session-projection.mjs";
 import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+// daemon-control 이 deriveClaudeDaemonPaths / getProcStart 의 단일 owner 다.
+// 기존 native-bridge import 경로 (headless 포함) 호환을 위해 re-export 한다.
+export { deriveClaudeDaemonPaths, getProcStart };
 
 const DEFAULT_ROWS = 40;
 const DEFAULT_COLS = 120;
@@ -28,39 +36,6 @@ const ROSTER_LOCK_RETRY_MS = 10;
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
   return path.join(os.homedir(), ".claude");
-}
-
-export function deriveClaudeDaemonPaths({
-  configDir = resolveClaudeConfigDir(),
-  uid = typeof process.getuid === "function" ? process.getuid() : 0,
-  tmpRoot = "/tmp",
-} = {}) {
-  const resolvedConfigDir = path.resolve(configDir);
-  const hash = crypto
-    .createHash("sha256")
-    .update(resolvedConfigDir)
-    .digest("hex")
-    .slice(0, 8);
-  const daemonDir = path.join(tmpRoot, `cc-daemon-${uid}`, hash);
-  return {
-    configDir: resolvedConfigDir,
-    daemonDir,
-    controlSock: path.join(daemonDir, "control.sock"),
-    rendezvousDir: path.join(daemonDir, "rv"),
-    ptyDir: path.join(daemonDir, "pty"),
-    rosterPath: path.join(resolvedConfigDir, "daemon", "roster.json"),
-    sessionsDir: path.join(resolvedConfigDir, "sessions"),
-    jobsDir: path.join(resolvedConfigDir, "jobs"),
-  };
-}
-
-export function getProcStart(pid = process.pid) {
-  if (!Number.isInteger(pid) || pid <= 0)
-    throw new Error(`invalid pid: ${pid}`);
-  return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
-    encoding: "utf8",
-    env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
-  }).trim();
 }
 
 export function buildPtyDataFrame(value) {
@@ -379,6 +354,8 @@ export async function registerSwarmShard({
   const removeJobStateImpl = _deps.removeClaudeJobState || removeClaudeJobState;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const accessControlSock = _deps.accessControlSock || fs.access;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const paths = derivePaths({ configDir, tmpRoot });
   const sessionsDir =
@@ -487,44 +464,30 @@ export async function registerSwarmShard({
     name: displayName,
   });
 
-  await accessControlSock(paths.controlSock);
-  const dispatch = await sendControl(
-    paths.controlSock,
-    {
-      proto: 1,
-      op: "dispatch",
-      d: payload,
-      timeoutMs: 1000,
-    },
-    { timeoutMs: 1000 },
-  );
-  if (dispatch?.ok !== true) {
-    throw new Error(
-      `Claude daemon dispatch failed for swarm shard ${shardName}`,
-    );
-  }
-
-  const job = await waitForPid(paths.controlSock, short, { timeoutMs: 1000 });
-  const pid = job.pid;
-  const bridgeSessionId = await resolveBridgeSessionId({
-    daemonPaths: paths,
-    short,
-    job,
-    timeoutMs: 1000,
-  });
-  const projection = buildProjection({
-    pid,
-    procStart: readProcStart(pid),
-    sessionId: payload.sessionId,
-    short,
-    cwd,
-    name: displayName,
+  // native-bridge 는 데몬이 없으면 빠르게 실패해야 하므로 1000ms 로 고정한다
+  // (headless 의 5000ms 와 다르므로 명시 전달).
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
     agent: cli,
-    startedAt: job.startedAt || Date.now(),
-    updatedAt: Date.now(),
-    bridgeSessionId,
+    name: displayName,
+    cwd,
+    dispatchTimeoutMs: 1000,
+    pidTimeoutMs: 1000,
+    bridgeTimeoutMs: 1000,
+    accessControlSock,
+    _deps: {
+      sendClaudeControlRequest: sendControl,
+      waitForDaemonJobPid: waitForPid,
+      resolveDaemonBridgeSessionId: resolveBridgeSessionId,
+      buildClaudeSessionProjection: buildProjection,
+      writeClaudeSessionProjection: writeProjection,
+      getProcStart: readProcStart,
+    },
   });
-  const sessionProjectionPath = await writeProjection(sessionsDir, projection);
+  const sessionProjectionPath = dispatched.sessionProjectionPath;
+  void sessionsDir;
   let closed = false;
 
   return {
@@ -543,9 +506,18 @@ export async function registerSwarmShard({
     async close() {
       if (closed) return;
       closed = true;
-      await removeProjection(sessionProjectionPath).catch(() => {});
-      await killJob(paths.controlSock, short).catch(() => {});
-      await removeJobStateImpl(jobsDir, short).catch(() => {});
+      await teardownJob({
+        controlSock: paths.controlSock,
+        short,
+        sessionProjectionPath,
+        jobsDir,
+        removeJobState: true,
+        _deps: {
+          removeClaudeSessionProjection: removeProjection,
+          killDaemonJob: killJob,
+          removeClaudeJobState: removeJobStateImpl,
+        },
+      });
     },
   };
 }

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -28,21 +28,12 @@ import { getBackend } from "./backend.mjs";
 import {
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
+  dispatchClaudeDaemonJob,
   killDaemonJob,
-  resolveDaemonBridgeSessionId,
-  sendClaudeControlRequest,
   sendKillBySessionId,
-  waitForDaemonJobPid,
 } from "./claude-daemon-control.mjs";
-import {
-  getProcStart,
-  startClaudeNativeBridge,
-} from "./claude-native-bridge.mjs";
-import {
-  buildClaudeSessionProjection,
-  removeClaudeSessionProjection,
-  writeClaudeSessionProjection,
-} from "./claude-session-projection.mjs";
+import { startClaudeNativeBridge } from "./claude-native-bridge.mjs";
+import { removeClaudeSessionProjection } from "./claude-session-projection.mjs";
 import { resolveDashboardLayout } from "./dashboard-layout.mjs";
 import {
   formatHandoffForLead,
@@ -1016,40 +1007,30 @@ async function dispatchDaemonBatch(sessionName, assignments, opts = {}) {
         name,
       });
       record.sessionId = payload.sessionId;
-      const dispatch = await sendClaudeControlRequest(paths.controlSock, {
-        proto: 1,
-        op: "dispatch",
-        d: payload,
-        timeoutMs: 5000,
-      });
-      if (dispatch?.ok !== true) {
-        throw new Error(
-          `[headless] Claude daemon dispatch failed for ${paneName}`,
-        );
-      }
-
-      const job = await waitForDaemonJobPid(paths.controlSock, short);
-      const bridgeSessionId = await resolveDaemonBridgeSessionId({
-        daemonPaths: paths,
-        short,
-        job,
-      });
-      const projection = buildClaudeSessionProjection({
-        pid: job.pid,
-        procStart: getProcStart(job.pid),
-        sessionId: payload.sessionId,
-        short,
-        cwd: assignment.cwd || assignment.workdir || process.cwd(),
-        name,
+      // buildDaemonWrappedCommand + token completion 시맨틱은 헬퍼 밖(headless 전용)에
+      // 남기고, dispatch→pid→bridge→projection 시퀀스만 공유 헬퍼로 위임한다.
+      // CRITICAL: waitForDaemonCompletion 이 나중에 record.daemonCompletionMatched 를
+      // 변경하고 cleanupDaemonDispatches 가 같은 record 를 읽으므로, 헬퍼가 새 객체를
+      // 반환해도 record 를 교체하지 말고 plain 필드를 Object.assign 한다.
+      const dispatched = await dispatchClaudeDaemonJob({
+        paths,
+        controlSock: paths.controlSock,
+        payload,
         agent: resolvedCli || "codex",
-        startedAt: job.startedAt || Date.now(),
-        updatedAt: Date.now(),
-        bridgeSessionId,
+        name,
+        cwd: assignment.cwd || assignment.workdir || process.cwd(),
+        dispatchTimeoutMs: 5000,
+      }).catch((error) => {
+        throw new Error(
+          `[headless] Claude daemon dispatch failed for ${paneName}: ${
+            error?.message || error
+          }`,
+        );
       });
-      record.sessionProjectionPath = await writeClaudeSessionProjection(
-        paths.sessionsDir,
-        projection,
-      );
+      Object.assign(record, {
+        sessionId: dispatched.sessionId,
+        sessionProjectionPath: dispatched.sessionProjectionPath,
+      });
       await registerHeadlessWorker(sessionName, i, resolvedCli);
       registerHeadlessSynapseWorker(workerId, assignment.prompt);
       if (safeProgress) {

--- a/packages/triflux/scripts/release/check-packages-mirror.mjs
+++ b/packages/triflux/scripts/release/check-packages-mirror.mjs
@@ -45,6 +45,10 @@ const CORE_FILE_MIRRORS = [
     source: "hub/team/claude-daemon-control.mjs",
     target: "packages/core/hub/team/claude-daemon-control.mjs",
   },
+  {
+    source: "hub/team/claude-session-projection.mjs",
+    target: "packages/core/hub/team/claude-session-projection.mjs",
+  },
 ];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 // Per-top relative paths to skip. Mirror policy excludes these via

--- a/scripts/release/check-packages-mirror.mjs
+++ b/scripts/release/check-packages-mirror.mjs
@@ -45,6 +45,10 @@ const CORE_FILE_MIRRORS = [
     source: "hub/team/claude-daemon-control.mjs",
     target: "packages/core/hub/team/claude-daemon-control.mjs",
   },
+  {
+    source: "hub/team/claude-session-projection.mjs",
+    target: "packages/core/hub/team/claude-session-projection.mjs",
+  },
 ];
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 // Per-top relative paths to skip. Mirror policy excludes these via

--- a/tests/unit/check-packages-mirror-core.test.mjs
+++ b/tests/unit/check-packages-mirror-core.test.mjs
@@ -21,6 +21,10 @@ const CORE_MIRRORS = new Map([
     "hub/team/claude-daemon-control.mjs",
     "packages/core/hub/team/claude-daemon-control.mjs",
   ],
+  [
+    "hub/team/claude-session-projection.mjs",
+    "packages/core/hub/team/claude-session-projection.mjs",
+  ],
 ]);
 
 function write(root, rel, content) {

--- a/tests/unit/claude-daemon-control-paths.test.mjs
+++ b/tests/unit/claude-daemon-control-paths.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { deriveClaudeDaemonPaths as deriveFromControl } from "../../hub/team/claude-daemon-control.mjs";
+import { deriveClaudeDaemonPaths as deriveFromBridge } from "../../hub/team/claude-native-bridge.mjs";
+
+// daemon-control 이 단일 owner 이고 native-bridge 는 그것을 re-export 한다.
+test("deriveClaudeDaemonPaths returns the superset incl rendezvousDir+ptyDir+hash", () => {
+  const configDir = path.join(os.tmpdir(), "claude-paths-superset");
+  const hash = crypto
+    .createHash("sha256")
+    .update(path.resolve(configDir))
+    .digest("hex")
+    .slice(0, 8);
+
+  const paths = deriveFromControl({ configDir, uid: 501, tmpRoot: "/tmp" });
+
+  assert.equal(paths.configDir, path.resolve(configDir));
+  assert.equal(paths.hash, hash);
+  assert.equal(paths.daemonDir, `/tmp/cc-daemon-501/${hash}`);
+  assert.equal(paths.controlSock, `/tmp/cc-daemon-501/${hash}/control.sock`);
+  // native-bridge 가 추가로 의존하던 필드들이 이제 canonical owner 에 포함된다.
+  assert.equal(paths.rendezvousDir, `/tmp/cc-daemon-501/${hash}/rv`);
+  assert.equal(paths.ptyDir, `/tmp/cc-daemon-501/${hash}/pty`);
+  assert.equal(
+    paths.rosterPath,
+    path.join(path.resolve(configDir), "daemon", "roster.json"),
+  );
+  assert.equal(
+    paths.sessionsDir,
+    path.join(path.resolve(configDir), "sessions"),
+  );
+  assert.equal(paths.jobsDir, path.join(path.resolve(configDir), "jobs"));
+});
+
+test("native-bridge re-exports the canonical deriveClaudeDaemonPaths (same implementation)", () => {
+  assert.equal(deriveFromBridge, deriveFromControl);
+});
+
+test("parity: derived field set covers what both former callsites needed", () => {
+  const paths = deriveFromControl({
+    configDir: path.join(os.tmpdir(), "claude-paths-parity"),
+    uid: 501,
+    tmpRoot: "/tmp",
+  });
+  // headless(deriveClaudeControlPaths) 가 읽던 필드
+  const headlessNeeds = ["controlSock", "sessionsDir", "jobsDir"];
+  // native-bridge 가 읽던 필드 (interactive 브랜치 포함)
+  const bridgeNeeds = [
+    "configDir",
+    "daemonDir",
+    "controlSock",
+    "rendezvousDir",
+    "ptyDir",
+    "rosterPath",
+    "sessionsDir",
+    "jobsDir",
+  ];
+  for (const key of [...headlessNeeds, ...bridgeNeeds]) {
+    assert.ok(
+      Object.hasOwn(paths, key),
+      `expected derived paths to include ${key}`,
+    );
+  }
+});

--- a/tests/unit/claude-daemon-dispatch-job.test.mjs
+++ b/tests/unit/claude-daemon-dispatch-job.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "../../hub/team/claude-daemon-control.mjs";
+
+// 데몬 control.sock 을 흉내내는 최소 서버. dispatch/list/kill 요청을 기록한다.
+async function listenDaemon(sockPath, { short, pid }) {
+  const requests = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let data = "";
+    socket.on("data", (chunk) => {
+      data += chunk;
+      if (!data.includes("\n")) return;
+      const request = JSON.parse(data.slice(0, data.indexOf("\n")));
+      requests.push(request);
+      if (request.op === "list") {
+        socket.end(
+          `${JSON.stringify({
+            ok: true,
+            jobs: [{ short, pid, startedAt: 4321 }],
+          })}\n`,
+        );
+        return;
+      }
+      socket.end(`${JSON.stringify({ ok: true })}\n`);
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(sockPath, resolve);
+  });
+  return { server, requests };
+}
+
+test("dispatchClaudeDaemonJob emits op:dispatch, resolves pid+bridge, writes projection", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-job-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const short = "abcd1234";
+  const { server, requests } = await listenDaemon(paths.controlSock, {
+    short,
+    pid: process.pid,
+  });
+
+  try {
+    const payload = {
+      proto: 1,
+      short,
+      sessionId: "abcd1234-sess",
+      cwd: "/tmp/project",
+      seed: { name: "Triflux codex worker" },
+    };
+    const result = await dispatchClaudeDaemonJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload,
+      agent: "codex",
+      name: "Triflux codex worker",
+      cwd: "/tmp/project",
+      dispatchTimeoutMs: 5000,
+      _deps: {
+        getProcStart: () => "Mon Jan 1 00:00:00 2026",
+        resolveDaemonBridgeSessionId: async () => "cse_01DispatchJob",
+      },
+    });
+
+    // op:'dispatch' 페이로드가 정확히 controlSock 으로 나갔는지
+    const dispatch = requests.find((r) => r.op === "dispatch");
+    assert.ok(dispatch, "dispatch request should be sent");
+    assert.equal(dispatch.proto, 1);
+    assert.equal(dispatch.d.short, short);
+    assert.equal(dispatch.d.sessionId, "abcd1234-sess");
+    assert.equal(dispatch.timeoutMs, 5000);
+
+    // 헬퍼는 plain 필드를 반환한다 (caller record 로 Object.assign 가능).
+    assert.equal(result.ok, true);
+    assert.equal(result.short, short);
+    assert.equal(result.sessionId, "abcd1234-sess");
+    assert.equal(result.pid, process.pid);
+    assert.equal(result.bridgeSessionId, "cse_01DispatchJob");
+    assert.equal(result.controlSock, paths.controlSock);
+    assert.ok(result.job);
+    assert.ok(result.sessionProjectionPath);
+
+    const projection = JSON.parse(
+      await fs.readFile(result.sessionProjectionPath, "utf8"),
+    );
+    assert.equal(projection.sessionId, "abcd1234-sess");
+    assert.equal(projection.agent, "codex");
+    assert.equal(projection.jobId, short);
+    assert.equal(projection.bridgeSessionId, "session_01DispatchJob");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dispatchClaudeDaemonJob projection:'skip' does not build/write a projection", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-skip-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const short = "skip5678";
+  const { server, requests } = await listenDaemon(paths.controlSock, {
+    short,
+    pid: process.pid,
+  });
+
+  let projectionBuilt = false;
+  try {
+    const result = await dispatchClaudeDaemonJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload: { proto: 1, short, sessionId: "skip5678-sess" },
+      agent: "codex",
+      name: "skip projection",
+      cwd: "/tmp/project",
+      projection: "skip",
+      _deps: {
+        getProcStart: () => "Mon Jan 1 00:00:00 2026",
+        resolveDaemonBridgeSessionId: async () => "cse_skip",
+        buildClaudeSessionProjection: () => {
+          projectionBuilt = true;
+          return {};
+        },
+      },
+    });
+
+    assert.equal(projectionBuilt, false);
+    assert.equal(result.sessionProjectionPath, "");
+    assert.equal(result.bridgeSessionId, "cse_skip");
+    assert.ok(requests.find((r) => r.op === "dispatch"));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dispatchClaudeDaemonJob throws when daemon dispatch is not ok", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-fail-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.on("data", () => socket.end(`${JSON.stringify({ ok: false })}\n`));
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(paths.controlSock, resolve);
+  });
+
+  try {
+    await assert.rejects(
+      dispatchClaudeDaemonJob({
+        paths,
+        controlSock: paths.controlSock,
+        payload: { proto: 1, short: "fail0000", sessionId: "fail0000-sess" },
+        agent: "codex",
+        name: "fail dispatch",
+        cwd: "/tmp/project",
+      }),
+      /dispatch failed/u,
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("teardownClaudeDaemonJob attempts every step even when killDaemonJob throws", async () => {
+  const calls = [];
+  await teardownClaudeDaemonJob({
+    controlSock: "/tmp/does-not-matter.sock",
+    short: "tear1234",
+    sessionProjectionPath: "/tmp/proj.json",
+    jobsDir: "/tmp/jobs",
+    removeJobState: true,
+    _deps: {
+      removeClaudeSessionProjection: async () => {
+        calls.push("removeProjection");
+      },
+      killDaemonJob: async () => {
+        calls.push("killDaemonJob");
+        throw new Error("kill exploded");
+      },
+      removeClaudeJobState: async () => {
+        calls.push("removeJobState");
+      },
+    },
+  });
+
+  // killDaemonJob 이 throw 해도 .catch 로 삼키고 모든 스텝이 시도되어야 한다.
+  assert.deepEqual(calls.sort(), [
+    "killDaemonJob",
+    "removeJobState",
+    "removeProjection",
+  ]);
+});

--- a/tests/unit/native-bridge-immediate-cleanup.test.mjs
+++ b/tests/unit/native-bridge-immediate-cleanup.test.mjs
@@ -77,3 +77,61 @@ test("cleanupDaemonDispatches removes projection and kills daemon job within 5s"
     await fs.rm(dir, { recursive: true, force: true });
   }
 });
+
+// mutation-by-reference 회귀 가드: 공유 dispatch 헬퍼로 리팩터한 뒤에도
+// dispatchDaemonBatch 가 만든 record 객체가 waitForDaemonCompletion 의 외부
+// 변경(daemonCompletionMatched=true)을 그대로 보존해야 한다. 헬퍼가 record 를
+// 새 객체로 교체하면 이 flip 이 유실되어 sendKillBySessionId(list→kill) 가 발사되지 않는다.
+test("cleanupDaemonDispatches honors an externally-flipped daemonCompletionMatched (by-reference)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "daemon-flip-"));
+  const sockPath = path.join(dir, "control.sock");
+  const projectionPath = path.join(dir, "sessions", "session-flip.json");
+  await fs.mkdir(path.dirname(projectionPath), { recursive: true });
+  await fs.writeFile(projectionPath, "{}\n", "utf8");
+
+  const { server, requests } = await listenJsonServer(sockPath, (request) => {
+    if (request.op === "list") {
+      return {
+        ok: true,
+        op: "list",
+        jobs: [{ short: "flip333", sessionId: "session-flip" }],
+      };
+    }
+    return { ok: true, op: request.op, killed: request.short };
+  });
+
+  try {
+    // record 는 dispatch 시점에 daemonCompletionMatched=false 로 생성된다.
+    const record = {
+      controlSock: sockPath,
+      daemonShort: "flip333",
+      daemonPaths: { controlSock: sockPath },
+      sessionId: "session-flip",
+      sessionProjectionPath: projectionPath,
+      daemonCompletionMatched: false,
+    };
+    const dispatches = [record];
+
+    // waitForDaemonCompletion 이 완료를 감지하면 같은 record 를 reference 로 변경한다.
+    record.daemonCompletionMatched = true;
+
+    await Promise.race([
+      cleanupDaemonDispatches(dispatches),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("cleanup timed out")), 5000),
+      ),
+    ]);
+
+    // flip 이 보존됐다면 sendKillBySessionId 경로(list→kill)가 실행돼야 한다.
+    const listCalls = requests.filter((r) => r.op === "list");
+    const killCalls = requests.filter((r) => r.op === "kill");
+    assert.equal(listCalls.length, 1, "sendKillBySessionId should list once");
+    assert.ok(
+      killCalls.length >= 1,
+      "sendKillBySessionId must still fire a kill after the flip",
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/swarm-native-bridge-registration.test.mjs
+++ b/tests/unit/swarm-native-bridge-registration.test.mjs
@@ -112,6 +112,47 @@ test("local shard registers Triflux swarm shard row with shard display name", as
   }
 });
 
+test("local shard dispatches via the shared helper with native-bridge 1000ms timeouts", async () => {
+  let captured = null;
+  const registration = await registerSwarmShard({
+    sessionId: "swarm-run42-api-feedface",
+    cli: "codex",
+    role: "executor",
+    swarmName: "run42",
+    shardIndex: 2,
+    shardCount: 5,
+    shardName: "api",
+    cwd: "/tmp/project",
+    host: "local",
+    _deps: {
+      // 데몬 control.sock 존재 체크는 통과시킨다.
+      accessControlSock: async () => {},
+      // 공유 헬퍼를 가로채 timeout 인자만 검증한다.
+      dispatchClaudeDaemonJob: async (args) => {
+        captured = args;
+        return {
+          ok: true,
+          short: args.payload.short,
+          sessionId: args.payload.sessionId,
+          job: { pid: process.pid, startedAt: 1 },
+          pid: process.pid,
+          bridgeSessionId: "cse_fast",
+          sessionProjectionPath: "/tmp/proj.json",
+          controlSock: args.controlSock,
+          paths: args.paths,
+        };
+      },
+    },
+  });
+
+  assert.equal(registration.skipped, false);
+  assert.ok(captured, "shared dispatch helper should be invoked");
+  // native-bridge 는 5000ms(headless)로 합쳐지면 안 되고 1000ms 로 고정돼야 한다.
+  assert.equal(captured.dispatchTimeoutMs, 1000);
+  assert.equal(captured.pidTimeoutMs, 1000);
+  assert.equal(captured.bridgeTimeoutMs, 1000);
+});
+
 test("remote shard skips native bridge registration and emits warning", async () => {
   const warnings = [];
   const registration = await registerSwarmShard({


### PR DESCRIPTION
## What

Prep refactor for **P1 native-bridge daemon-dispatch adoption**. Pure refactor, no behavior change: extract the shared Claude-daemon dispatch transport and consolidate the duplicated path/proc helpers, so a future interactive launcher reuses ONE dispatch impl instead of adding a 4th.

## Changes

- **New** `dispatchClaudeDaemonJob` / `teardownClaudeDaemonJob` in `hub/team/claude-daemon-control.mjs` — encapsulates `op:'dispatch'` -> `waitForDaemonJobPid` -> `resolveDaemonBridgeSessionId` -> projection write, and the symmetric teardown. Returns plain fields (no by-reference record contract leaked).
- **Consolidated** `deriveClaudeDaemonPaths` (was defined twice; the two copies returned **different field sets** — a latent bug). Single owner now returns the `rendezvousDir`/`ptyDir` superset. `getProcStart` moved to the same owner (re-exported for back-compat) to avoid a circular import.
- **Refactored** the two existing root dispatch sites onto the helper: `headless.mjs dispatchDaemonBatch` (timeout 5000, keeps its `Object.assign` by-reference record + token-completion semantics) and `claude-native-bridge.mjs registerSwarmShard` non-interactive branch (timeout 1000 — native-bridge fast-fails on absent daemon). The **interactive branch + launcher are untouched** (separate follow-up).
- Mirrored across `packages/{core,remote,triflux}` (remote keeps `@triflux/core/...` imports).

## Verification

- Full `tests/unit` suite: **3214 pass / 0 fail** / 2 pre-existing skip
- `npm run release:check-mirror`: Mirror OK; `npm run lint:skills`: pass; biome clean on changed files
- TDD red->green: 2 new test files (`claude-daemon-dispatch-job`, `claude-daemon-control-paths`) + a mutation-by-reference regression (flip `daemonCompletionMatched` -> `sendKillBySessionId` still fires) + a per-site timeout assertion (native-bridge passes 1000)
- grep: no `op:"dispatch"` outside the helper (no new 4th impl); `deriveClaudeDaemonPaths` defined once
- `npm pack --dry-run` packages/triflux: 3.2MB baseline (no leak)

## Follow-up (NOT in this PR)

- The interactive launcher conversion + a new `hub/team/daemon-pty-tmux-bridge.mjs` bridge process. A live daemon spike **confirmed** Option A is feasible: daemon-injected stdin reaches a dispatched exec job's stdin and its stdout streams back over the attach socket. Constraint found: dispatch `short` must be 8 lowercase hex (`crypto.randomBytes(4).toString('hex')`). Open decisions remain (bridge process location, retire roster-facade for interactive, raw-mode/resize contract, teardown authority).
