### PR TITLE
fix(session-stale-cleanup): POSIX treeKill reaps process group, not bare pid

### DIFF
--- a/packages/triflux/scripts/session-stale-cleanup.mjs
+++ b/packages/triflux/scripts/session-stale-cleanup.mjs
@@ -182,7 +182,35 @@ function treeKill(pid) {
         windowsHide: true,
       });
     } else {
-      process.kill(pid, "SIGTERM");
+      // POSIX: detached 워커의 손자까지 회수하려면 프로세스 '그룹' 을 종료해야 한다
+      // (Windows `taskkill /T` 와 동일 의미). 단 PID 재사용/공유 그룹 때문에 그룹
+      // kill 이 무관한 live 프로세스 그룹을 죽일 수 있다 (Codex review PR #365 P1).
+      // 그래서 그룹 kill 은 다음을 모두 만족할 때만 한다:
+      //   - 대상이 자기 그룹의 leader (pgid === pid → 그룹 = 그 워커의 subtree 뿐)
+      //   - 여전히 triflux 가 띄운 워커처럼 보임 (command signature)
+      //   - init 류 그룹 아님 (pgid > 1)
+      // 그 외에는 기존과 동일하게 단일 PID SIGTERM 으로 폴백한다 (회귀 없음).
+      let pgid = null;
+      let cmd = "";
+      try {
+        const out = execSync(`ps -o pgid=,command= -p ${pid}`, { timeout: 2000 })
+          .toString()
+          .trim();
+        const m = out.match(/^(\d+)\s+(.*)$/);
+        if (m) {
+          pgid = parseInt(m[1], 10);
+          cmd = m[2];
+        }
+      } catch {
+        /* 조회 실패 — bare pid 폴백 */
+      }
+      const isWorker =
+        /codex|antigravity|claude|--bg-pty-host|--bg-spare|--agent-id|tfx-route/.test(
+          cmd,
+        );
+      const safeGroupKill =
+        Number.isInteger(pgid) && pgid > 1 && pgid === pid && isWorker;
+      process.kill(safeGroupKill ? -pgid : pid, "SIGTERM");
     }
   } catch {
     /* already dead */

--- a/scripts/session-stale-cleanup.mjs
+++ b/scripts/session-stale-cleanup.mjs
@@ -182,7 +182,35 @@ function treeKill(pid) {
         windowsHide: true,
       });
     } else {
-      process.kill(pid, "SIGTERM");
+      // POSIX: detached 워커의 손자까지 회수하려면 프로세스 '그룹' 을 종료해야 한다
+      // (Windows `taskkill /T` 와 동일 의미). 단 PID 재사용/공유 그룹 때문에 그룹
+      // kill 이 무관한 live 프로세스 그룹을 죽일 수 있다 (Codex review PR #365 P1).
+      // 그래서 그룹 kill 은 다음을 모두 만족할 때만 한다:
+      //   - 대상이 자기 그룹의 leader (pgid === pid → 그룹 = 그 워커의 subtree 뿐)
+      //   - 여전히 triflux 가 띄운 워커처럼 보임 (command signature)
+      //   - init 류 그룹 아님 (pgid > 1)
+      // 그 외에는 기존과 동일하게 단일 PID SIGTERM 으로 폴백한다 (회귀 없음).
+      let pgid = null;
+      let cmd = "";
+      try {
+        const out = execSync(`ps -o pgid=,command= -p ${pid}`, { timeout: 2000 })
+          .toString()
+          .trim();
+        const m = out.match(/^(\d+)\s+(.*)$/);
+        if (m) {
+          pgid = parseInt(m[1], 10);
+          cmd = m[2];
+        }
+      } catch {
+        /* 조회 실패 — bare pid 폴백 */
+      }
+      const isWorker =
+        /codex|antigravity|claude|--bg-pty-host|--bg-spare|--agent-id|tfx-route/.test(
+          cmd,
+        );
+      const safeGroupKill =
+        Number.isInteger(pgid) && pgid > 1 && pgid === pid && isWorker;
+      process.kill(safeGroupKill ? -pgid : pid, "SIGTERM");
     }
   } catch {
     /* already dead */


### PR DESCRIPTION
## Problem

`treeKill()` in `scripts/session-stale-cleanup.mjs` (the `SessionStart` orphan-worker reaper) only sent `SIGTERM` to the bare worker PID on POSIX:

```js
} else {
  process.kill(pid, "SIGTERM");
}
```

The function name promises a *tree* kill, and the Windows branch delivers one (`taskkill /T /F`), but POSIX killed only the single PID. Detached workers (codex / antigravity / claude spawned via `tfx-route.sh`) run as process-group leaders and spawn their own children. `SIGTERM` to the bare PID leaves those grandchildren orphaned (reparented to launchd/init) — exactly the accumulation `session-stale-cleanup` exists to prevent.

## Fix

POSIX branch now resolves the worker's PGID and sends `SIGTERM` to the negative PGID (`-pgid`), matching the Windows `/T` tree-kill semantics. Falls back to the bare PID if PGID lookup fails.

```js
} else {
  let pgid = null;
  try {
    pgid = parseInt(execSync(`ps -o pgid= -p ${pid}`, { timeout: 2000 }).toString().trim(), 10);
  } catch { /* pgid lookup failed — bare pid fallback */ }
  process.kill(Number.isInteger(pgid) && pgid > 1 ? -pgid : pid, "SIGTERM");
}
```

Mirrored byte-identical to `packages/triflux/scripts/session-stale-cleanup.mjs` per `tfx-mirror-policy.md`.

## Testing

- `node --check` passes on both copies
- `diff -q` confirms root and `packages/triflux` copies are byte-identical
- Validated pgid-group kill against a controlled `ppid==1` orphan that had a detached child group: group kill removes the whole subtree, bare-pid kill left the child behind

## Context

Found while investigating local orphan `claude --resume` / worker-process accumulation on a 16 GB Mac (single freeze, dozens of leftover processes). The broader root cause is upstream Claude Code orphaned subagent/background processes (anthropics/claude-code#54626, #20369, #45880); this PR only fixes triflux's own `SessionStart` reaper so it fully reaps the worker subtrees it already targets.

`SIGKILL` escalation is intentionally out of scope here — this hook stays graceful (`SIGTERM`), and a separate periodic reaper handles stragglers.
