### PR TITLE
Adopt shared Claude daemon control for UDS orchestration + P2 fixes

### DIFF
--- a/experiments/native-bridge-feasibility/claude-codex-uds-orchestration-smoke.mjs
+++ b/experiments/native-bridge-feasibility/claude-codex-uds-orchestration-smoke.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createClaudeUdsEndpoint,
+  createCodexExecEndpoint,
+  runUdsOrchestration,
+} from "../../hub/team/uds-orchestrator.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const defaultReportPath = path.join(
+  here,
+  "uds-orchestration-latest-report.json",
+);
+
+function parseArgs(argv) {
+  const flags = {
+    mode: "all",
+    codexBackend: "echo",
+    report: defaultReportPath,
+    task: "Validate Claude-Codex orchestration. Keep every answer under ten words.",
+    timeoutMs: 90_000,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      flags.help = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) throw new Error(`Unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined) throw new Error(`Missing value for --${key}`);
+    index += 1;
+    if (key === "mode") flags.mode = value;
+    else if (key === "codex-backend") flags.codexBackend = value;
+    else if (key === "report") flags.report = value;
+    else if (key === "task") flags.task = value;
+    else if (key === "timeout") flags.timeoutMs = Number(value) * 1000;
+    else throw new Error(`Unknown flag --${key}`);
+  }
+  return flags;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  claude-codex-uds-orchestration-smoke.mjs [--mode all|codex-led|claude-led|peer] [--codex-backend echo|exec] [--task TEXT] [--report PATH]",
+    "",
+    "Runs dev-only Claude<->Codex orchestration with Claude transported over UDS.",
+  ].join("\n");
+}
+
+function createEchoCodexEndpoint() {
+  let count = 0;
+  return {
+    name: "codex",
+    async ask(prompt) {
+      count += 1;
+      return {
+        endpoint: "codex",
+        text: `CODEX_ECHO_${count}: ${String(prompt).split("\n")[0]}`,
+        done: true,
+      };
+    },
+  };
+}
+
+function buildCodexEndpoint(flags) {
+  if (flags.codexBackend === "echo") return createEchoCodexEndpoint();
+  if (flags.codexBackend === "exec") {
+    return createCodexExecEndpoint({
+      workdir: process.cwd(),
+      timeout: 180_000,
+    });
+  }
+  throw new Error("--codex-backend must be echo or exec");
+}
+
+function compactTurn(turn) {
+  return {
+    role: turn.role,
+    endpoint: turn.endpoint,
+    done: turn.done,
+    text: String(turn.text || "").slice(0, 500),
+    meta: turn.meta,
+  };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const flags = parseArgs(argv);
+  if (flags.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const modes =
+    flags.mode === "all" ? ["codex-led", "claude-led", "peer"] : [flags.mode];
+  const report = {
+    generatedAt: new Date().toISOString(),
+    kind: "claude-codex-uds-orchestration-smoke",
+    codexBackend: flags.codexBackend,
+    task: flags.task,
+    modes: [],
+    verdict: "unknown",
+  };
+
+  try {
+    for (const mode of modes) {
+      const claude = createClaudeUdsEndpoint({ timeoutMs: flags.timeoutMs });
+      const codex = buildCodexEndpoint(flags);
+      const result = await runUdsOrchestration({
+        mode,
+        task: flags.task,
+        claude,
+        codex,
+      });
+      report.modes.push({
+        mode,
+        ok: result.turns.every((turn) => turn.done === true),
+        final: compactTurn(result.final),
+        turns: result.turns.map(compactTurn),
+      });
+    }
+    report.verdict = report.modes.every((mode) => mode.ok)
+      ? "all-modes-ok"
+      : "mode-failed";
+  } catch (error) {
+    report.verdict = "error";
+    report.error = error?.stack || error?.message || String(error);
+  }
+
+  await fs.writeFile(flags.report, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (report.verdict !== "all-modes-ok") process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -1008,6 +1008,52 @@ export function buildDaemonExecDispatchPayload({
   };
 }
 
+export function buildClaudePromptDispatchPayload({
+  short = crypto.randomBytes(4).toString("hex"),
+  sessionId,
+  cwd = process.cwd(),
+  prompt,
+  name = "tfx uds claude prompt",
+  createdAt = Date.now(),
+  cols = 120,
+  rows = 40,
+} = {}) {
+  if (!prompt) throw new Error("prompt is required");
+  const uuid = crypto.randomUUID();
+  const resolvedSessionId = sessionId || `${short}${uuid.slice(8)}`;
+  return {
+    proto: 1,
+    short,
+    sessionId: resolvedSessionId,
+    createdAt,
+    source: "shell",
+    cwd,
+    agent: "claude",
+    launch: {
+      mode: "prompt",
+      args: [
+        "--session-id",
+        resolvedSessionId,
+        "--agent",
+        "claude",
+        "--permission-mode",
+        "auto",
+        "--",
+        prompt,
+      ],
+    },
+    env: {},
+    isolation: "none",
+    respawnFlags: [],
+    seed: {
+      intent: "[redacted uds orchestration prompt]",
+      name,
+    },
+    cols,
+    rows,
+  };
+}
+
 export function findDaemonJobByShort(listResponse, short) {
   if (!Array.isArray(listResponse?.jobs)) return null;
   return listResponse.jobs.find((job) => job?.short === short) || null;

--- a/hub/team/uds-orchestrator.mjs
+++ b/hub/team/uds-orchestrator.mjs
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+import net from "node:net";
+
+import { execute as defaultExecuteCodex } from "../codex-adapter.mjs";
+import {
+  buildClaudePromptDispatchPayload,
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "./claude-daemon-control.mjs";
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+function requireEndpoint(endpoint, name) {
+  if (!endpoint || typeof endpoint.ask !== "function") {
+    throw new Error(`${name} endpoint with ask(prompt) is required`);
+  }
+  return endpoint;
+}
+
+function turn(endpoint, response, role) {
+  return {
+    role,
+    endpoint: response.endpoint || endpoint.name || role,
+    text: response.text || "",
+    done: response.done === true,
+    meta: response.meta || undefined,
+  };
+}
+
+function codexLeadPrompt(task) {
+  return `Lead as Codex. Create a concise plan for this task, then stop.\n\nTask:\n${task}`;
+}
+
+function claudeLeadPrompt(task) {
+  return `Lead as Claude. Create a concise plan for this task, then stop.\n\nTask:\n${task}`;
+}
+
+function claudeReviewCodexPrompt(task, codexPlan) {
+  return `Review Codex's plan for this task. Return risks and one improvement.\n\nTask:\n${task}\n\nCodex plan:\n${codexPlan}`;
+}
+
+function codexReviewClaudePrompt(task, claudePlan) {
+  return `Review Claude's plan for this task. Return risks and one improvement.\n\nTask:\n${task}\n\nClaude plan:\n${claudePlan}`;
+}
+
+function codexFinalPrompt(task, codexPlan, claudeReview) {
+  return `Finalize as Codex using Claude's review. Return the final orchestration decision.\n\nTask:\n${task}\n\nCodex plan:\n${codexPlan}\n\nClaude review:\n${claudeReview}`;
+}
+
+function claudeFinalPrompt(task, claudePlan, codexReview) {
+  return `Finalize as Claude using Codex's review. Return the final orchestration decision.\n\nTask:\n${task}\n\nClaude plan:\n${claudePlan}\n\nCodex review:\n${codexReview}`;
+}
+
+function peerPrompt(agentName, task) {
+  return `Act as a peer collaborator named ${agentName}. Independently answer this task in a concise way.\n\nTask:\n${task}`;
+}
+
+function peerSynthesisPrompt(task, claudeAnswer, codexAnswer) {
+  return `Synthesize peer answers from Claude and Codex. Return the agreed next action and conflicts.\n\nTask:\n${task}\n\nClaude answer:\n${claudeAnswer}\n\nCodex answer:\n${codexAnswer}`;
+}
+
+export async function runUdsOrchestration({ mode, task, claude, codex } = {}) {
+  const selectedMode = mode || "peer";
+  const claudeEndpoint = requireEndpoint(claude, "claude");
+  const codexEndpoint = requireEndpoint(codex, "codex");
+  if (!task || typeof task !== "string") throw new Error("task is required");
+
+  const turns = [];
+  if (selectedMode === "codex-led") {
+    const codexPlan = await codexEndpoint.ask(codexLeadPrompt(task), {
+      mode: selectedMode,
+      phase: "lead",
+    });
+    turns.push(turn(codexEndpoint, codexPlan, "lead"));
+
+    const claudeReview = await claudeEndpoint.ask(
+      claudeReviewCodexPrompt(task, codexPlan.text),
+      { mode: selectedMode, phase: "review" },
+    );
+    turns.push(turn(claudeEndpoint, claudeReview, "review"));
+
+    const final = await codexEndpoint.ask(
+      codexFinalPrompt(task, codexPlan.text, claudeReview.text),
+      { mode: selectedMode, phase: "final" },
+    );
+    turns.push(turn(codexEndpoint, final, "final"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  if (selectedMode === "claude-led") {
+    const claudePlan = await claudeEndpoint.ask(claudeLeadPrompt(task), {
+      mode: selectedMode,
+      phase: "lead",
+    });
+    turns.push(turn(claudeEndpoint, claudePlan, "lead"));
+
+    const codexReview = await codexEndpoint.ask(
+      codexReviewClaudePrompt(task, claudePlan.text),
+      { mode: selectedMode, phase: "review" },
+    );
+    turns.push(turn(codexEndpoint, codexReview, "review"));
+
+    const final = await claudeEndpoint.ask(
+      claudeFinalPrompt(task, claudePlan.text, codexReview.text),
+      { mode: selectedMode, phase: "final" },
+    );
+    turns.push(turn(claudeEndpoint, final, "final"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  if (selectedMode === "peer") {
+    const [claudePeer, codexPeer] = await Promise.all([
+      claudeEndpoint.ask(peerPrompt("Claude", task), {
+        mode: selectedMode,
+        phase: "peer",
+      }),
+      codexEndpoint.ask(peerPrompt("Codex", task), {
+        mode: selectedMode,
+        phase: "peer",
+      }),
+    ]);
+    turns.push(turn(claudeEndpoint, claudePeer, "peer"));
+    turns.push(turn(codexEndpoint, codexPeer, "peer"));
+
+    const final = await claudeEndpoint.ask(
+      peerSynthesisPrompt(task, claudePeer.text, codexPeer.text),
+      { mode: selectedMode, phase: "synthesis" },
+    );
+    turns.push(turn(claudeEndpoint, final, "synthesis"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  throw new Error(`Unsupported UDS orchestration mode: ${selectedMode}`);
+}
+
+function scanMessage(message, marker, state) {
+  const scan = (text) => {
+    state.streamBytes += Buffer.byteLength(text);
+    state.stream.push(text);
+    if (/⏺/.test(stripAnsi(text))) state.assistantStarted = true;
+    if (state.assistantStarted && text.includes(marker)) {
+      state.markerSeen = true;
+    }
+  };
+
+  state.messageCount += 1;
+  if (message.type === "snapshot") {
+    for (const line of message.streamTail || []) scan(line);
+  } else if (message.type === "stream" && typeof message.line === "string") {
+    scan(message.line);
+  } else if (message.type === "state") {
+    state.stateCount += 1;
+  } else if (message.type === "settled") {
+    state.settled = message.outcome || "settled";
+  }
+}
+
+export function subscribeClaudeUntilMarker(
+  controlSock,
+  short,
+  marker,
+  { timeoutMs = DEFAULT_TIMEOUT_MS } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = net.connect(controlSock);
+    let data = "";
+    let finished = false;
+    const startedAt = Date.now();
+    const state = {
+      short,
+      marker,
+      markerSeen: false,
+      settled: null,
+      messageCount: 0,
+      stateCount: 0,
+      streamBytes: 0,
+      stream: [],
+      assistantStarted: false,
+    };
+    const timer = setTimeout(() => finish({ timedOut: true }), timeoutMs);
+
+    function finish(extra = {}) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve({ ...state, elapsedMs: Date.now() - startedAt, ...extra });
+    }
+
+    socket.on("error", (error) => finish({ error: error.message }));
+    socket.on("connect", () => {
+      socket.write(
+        `${JSON.stringify({ proto: 1, op: "subscribe", short, tail: 80, marker })}\n`,
+      );
+    });
+    socket.on("data", (chunk) => {
+      data += chunk.toString("utf8");
+      while (data.includes("\n")) {
+        const index = data.indexOf("\n");
+        const line = data.slice(0, index).trim();
+        data = data.slice(index + 1);
+        if (!line) continue;
+        try {
+          scanMessage(JSON.parse(line), marker, state);
+        } catch (_error) {
+          state.messageCount += 1;
+        }
+        if (state.markerSeen || state.settled) finish();
+      }
+    });
+    socket.on("close", () => finish({ closed: true }));
+  });
+}
+
+export function stripAnsi(text) {
+  return String(text)
+    .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/g, "")
+    .replace(/\x1B[78]/g, "")
+    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+function isClaudeUdsNoiseLine(line) {
+  return (
+    /Claude Code|Opus|remote-control|Brewed|Baked|Cogitated|Crunched|▐|▛|▜|▝|▘|Max|context/.test(
+      line,
+    ) ||
+    /^[╭╮╰╯│─┌┐└┘├┤┬┴┼\s]+$/.test(line) ||
+    /^\s*[❯✳✻]\s*/.test(line)
+  );
+}
+
+export function extractClaudeUdsText(text, marker) {
+  const cleaned = stripAnsi(String(text).replaceAll(marker, "")).replace(
+    /\r/g,
+    "\n",
+  );
+  const lines = cleaned
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  const assistantIndex = lines.findLastIndex((line) => /^\s*⏺\s*/.test(line));
+  if (assistantIndex >= 0) {
+    const useful = lines
+      .slice(assistantIndex)
+      .map((line, index) =>
+        index === 0 ? line.replace(/^\s*⏺\s*/, "") : line,
+      )
+      .filter((line) => !isClaudeUdsNoiseLine(line));
+    return useful.join("\n").trim();
+  }
+  const useful = lines.filter((line) => !isClaudeUdsNoiseLine(line));
+  return useful.at(-1)?.trim() || cleaned.trim();
+}
+
+export function createClaudeUdsEndpoint({
+  controlSock,
+  daemonPaths = deriveClaudeDaemonPaths(),
+  cwd = process.cwd(),
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  markerFactory = () =>
+    `TFX_UDS_ORCH_DONE_${crypto.randomBytes(6).toString("hex")}`,
+  shortFactory,
+  sessionIdFactory,
+  dispatchDaemonJob = dispatchClaudeDaemonJob,
+  teardownDaemonJob = teardownClaudeDaemonJob,
+} = {}) {
+  const sock = controlSock || daemonPaths.controlSock;
+  return {
+    name: "claude-uds",
+    async ask(prompt, meta = {}) {
+      const marker = markerFactory();
+      const wrappedPrompt = `${prompt}\n\nWhen finished, print this exact completion marker on its own line: ${marker}`;
+      const name =
+        meta.name ||
+        `tfx uds ${meta.mode || "orchestration"} ${meta.phase || "ask"}`;
+      const payload = buildClaudePromptDispatchPayload({
+        short: shortFactory?.(),
+        sessionId: sessionIdFactory?.(),
+        cwd,
+        prompt: wrappedPrompt,
+        name,
+      });
+      const dispatch = await dispatchDaemonJob({
+        paths: daemonPaths,
+        controlSock: sock,
+        payload,
+        agent: "claude",
+        name,
+        cwd,
+        dispatchTimeoutMs: 5000,
+      });
+      const subscription = await subscribeClaudeUntilMarker(
+        sock,
+        payload.short,
+        marker,
+        { timeoutMs },
+      );
+      await teardownDaemonJob({
+        controlSock: sock,
+        paths: daemonPaths,
+        short: payload.short,
+        sessionProjectionPath: dispatch.sessionProjectionPath,
+        sessionId: payload.sessionId,
+      });
+      return {
+        endpoint: "claude-uds",
+        text: extractClaudeUdsText(subscription.stream.join(""), marker),
+        done: subscription.markerSeen === true,
+        dispatch,
+        subscription: {
+          markerSeen: subscription.markerSeen,
+          elapsedMs: subscription.elapsedMs,
+          messageCount: subscription.messageCount,
+          streamBytes: subscription.streamBytes,
+          timedOut: subscription.timedOut === true,
+          settled: subscription.settled,
+        },
+        cleanup: { ok: true },
+        meta: { short: payload.short, marker },
+      };
+    },
+  };
+}
+
+export function createCodexExecEndpoint({
+  executeCodex = defaultExecuteCodex,
+  workdir = process.cwd(),
+  timeout = 120_000,
+  profile,
+} = {}) {
+  return {
+    name: "codex",
+    async ask(prompt) {
+      const result = await executeCodex({ prompt, workdir, timeout, profile });
+      if (result?.ok === false) {
+        throw new Error(
+          `Codex exec failed: ${result.stderr || result.error || "unknown error"}`,
+        );
+      }
+      return {
+        endpoint: "codex",
+        text: String(
+          result?.output ?? result?.stdout ?? result?.text ?? "",
+        ).trim(),
+        done: true,
+      };
+    },
+  };
+}

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -1008,6 +1008,52 @@ export function buildDaemonExecDispatchPayload({
   };
 }
 
+export function buildClaudePromptDispatchPayload({
+  short = crypto.randomBytes(4).toString("hex"),
+  sessionId,
+  cwd = process.cwd(),
+  prompt,
+  name = "tfx uds claude prompt",
+  createdAt = Date.now(),
+  cols = 120,
+  rows = 40,
+} = {}) {
+  if (!prompt) throw new Error("prompt is required");
+  const uuid = crypto.randomUUID();
+  const resolvedSessionId = sessionId || `${short}${uuid.slice(8)}`;
+  return {
+    proto: 1,
+    short,
+    sessionId: resolvedSessionId,
+    createdAt,
+    source: "shell",
+    cwd,
+    agent: "claude",
+    launch: {
+      mode: "prompt",
+      args: [
+        "--session-id",
+        resolvedSessionId,
+        "--agent",
+        "claude",
+        "--permission-mode",
+        "auto",
+        "--",
+        prompt,
+      ],
+    },
+    env: {},
+    isolation: "none",
+    respawnFlags: [],
+    seed: {
+      intent: "[redacted uds orchestration prompt]",
+      name,
+    },
+    cols,
+    rows,
+  };
+}
+
 export function findDaemonJobByShort(listResponse, short) {
   if (!Array.isArray(listResponse?.jobs)) return null;
   return listResponse.jobs.find((job) => job?.short === short) || null;

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -10,6 +10,52 @@ import {
   writeClaudeSessionProjection,
 } from "./claude-session-projection.mjs";
 
+export function buildClaudePromptDispatchPayload({
+  short = crypto.randomBytes(4).toString("hex"),
+  sessionId,
+  cwd = process.cwd(),
+  prompt,
+  name = "tfx uds claude prompt",
+  createdAt = Date.now(),
+  cols = 120,
+  rows = 40,
+} = {}) {
+  if (!prompt) throw new Error("prompt is required");
+  const uuid = crypto.randomUUID();
+  const resolvedSessionId = sessionId || `${short}${uuid.slice(8)}`;
+  return {
+    proto: 1,
+    short,
+    sessionId: resolvedSessionId,
+    createdAt,
+    source: "shell",
+    cwd,
+    agent: "claude",
+    launch: {
+      mode: "prompt",
+      args: [
+        "--session-id",
+        resolvedSessionId,
+        "--agent",
+        "claude",
+        "--permission-mode",
+        "auto",
+        "--",
+        prompt,
+      ],
+    },
+    env: {},
+    isolation: "none",
+    respawnFlags: [],
+    seed: {
+      intent: "[redacted uds orchestration prompt]",
+      name,
+    },
+    cols,
+    rows,
+  };
+}
+
 export function resolveClaudeConfigDir(env = process.env) {
   if (env.CLAUDE_CONFIG_DIR) return path.resolve(env.CLAUDE_CONFIG_DIR);
   return path.join(os.homedir(), ".claude");

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -1008,6 +1008,52 @@ export function buildDaemonExecDispatchPayload({
   };
 }
 
+export function buildClaudePromptDispatchPayload({
+  short = crypto.randomBytes(4).toString("hex"),
+  sessionId,
+  cwd = process.cwd(),
+  prompt,
+  name = "tfx uds claude prompt",
+  createdAt = Date.now(),
+  cols = 120,
+  rows = 40,
+} = {}) {
+  if (!prompt) throw new Error("prompt is required");
+  const uuid = crypto.randomUUID();
+  const resolvedSessionId = sessionId || `${short}${uuid.slice(8)}`;
+  return {
+    proto: 1,
+    short,
+    sessionId: resolvedSessionId,
+    createdAt,
+    source: "shell",
+    cwd,
+    agent: "claude",
+    launch: {
+      mode: "prompt",
+      args: [
+        "--session-id",
+        resolvedSessionId,
+        "--agent",
+        "claude",
+        "--permission-mode",
+        "auto",
+        "--",
+        prompt,
+      ],
+    },
+    env: {},
+    isolation: "none",
+    respawnFlags: [],
+    seed: {
+      intent: "[redacted uds orchestration prompt]",
+      name,
+    },
+    cols,
+    rows,
+  };
+}
+
 export function findDaemonJobByShort(listResponse, short) {
   if (!Array.isArray(listResponse?.jobs)) return null;
   return listResponse.jobs.find((job) => job?.short === short) || null;

--- a/packages/triflux/hub/team/uds-orchestrator.mjs
+++ b/packages/triflux/hub/team/uds-orchestrator.mjs
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+import net from "node:net";
+
+import { execute as defaultExecuteCodex } from "../codex-adapter.mjs";
+import {
+  buildClaudePromptDispatchPayload,
+  deriveClaudeDaemonPaths,
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "./claude-daemon-control.mjs";
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+function requireEndpoint(endpoint, name) {
+  if (!endpoint || typeof endpoint.ask !== "function") {
+    throw new Error(`${name} endpoint with ask(prompt) is required`);
+  }
+  return endpoint;
+}
+
+function turn(endpoint, response, role) {
+  return {
+    role,
+    endpoint: response.endpoint || endpoint.name || role,
+    text: response.text || "",
+    done: response.done === true,
+    meta: response.meta || undefined,
+  };
+}
+
+function codexLeadPrompt(task) {
+  return `Lead as Codex. Create a concise plan for this task, then stop.\n\nTask:\n${task}`;
+}
+
+function claudeLeadPrompt(task) {
+  return `Lead as Claude. Create a concise plan for this task, then stop.\n\nTask:\n${task}`;
+}
+
+function claudeReviewCodexPrompt(task, codexPlan) {
+  return `Review Codex's plan for this task. Return risks and one improvement.\n\nTask:\n${task}\n\nCodex plan:\n${codexPlan}`;
+}
+
+function codexReviewClaudePrompt(task, claudePlan) {
+  return `Review Claude's plan for this task. Return risks and one improvement.\n\nTask:\n${task}\n\nClaude plan:\n${claudePlan}`;
+}
+
+function codexFinalPrompt(task, codexPlan, claudeReview) {
+  return `Finalize as Codex using Claude's review. Return the final orchestration decision.\n\nTask:\n${task}\n\nCodex plan:\n${codexPlan}\n\nClaude review:\n${claudeReview}`;
+}
+
+function claudeFinalPrompt(task, claudePlan, codexReview) {
+  return `Finalize as Claude using Codex's review. Return the final orchestration decision.\n\nTask:\n${task}\n\nClaude plan:\n${claudePlan}\n\nCodex review:\n${codexReview}`;
+}
+
+function peerPrompt(agentName, task) {
+  return `Act as a peer collaborator named ${agentName}. Independently answer this task in a concise way.\n\nTask:\n${task}`;
+}
+
+function peerSynthesisPrompt(task, claudeAnswer, codexAnswer) {
+  return `Synthesize peer answers from Claude and Codex. Return the agreed next action and conflicts.\n\nTask:\n${task}\n\nClaude answer:\n${claudeAnswer}\n\nCodex answer:\n${codexAnswer}`;
+}
+
+export async function runUdsOrchestration({ mode, task, claude, codex } = {}) {
+  const selectedMode = mode || "peer";
+  const claudeEndpoint = requireEndpoint(claude, "claude");
+  const codexEndpoint = requireEndpoint(codex, "codex");
+  if (!task || typeof task !== "string") throw new Error("task is required");
+
+  const turns = [];
+  if (selectedMode === "codex-led") {
+    const codexPlan = await codexEndpoint.ask(codexLeadPrompt(task), {
+      mode: selectedMode,
+      phase: "lead",
+    });
+    turns.push(turn(codexEndpoint, codexPlan, "lead"));
+
+    const claudeReview = await claudeEndpoint.ask(
+      claudeReviewCodexPrompt(task, codexPlan.text),
+      { mode: selectedMode, phase: "review" },
+    );
+    turns.push(turn(claudeEndpoint, claudeReview, "review"));
+
+    const final = await codexEndpoint.ask(
+      codexFinalPrompt(task, codexPlan.text, claudeReview.text),
+      { mode: selectedMode, phase: "final" },
+    );
+    turns.push(turn(codexEndpoint, final, "final"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  if (selectedMode === "claude-led") {
+    const claudePlan = await claudeEndpoint.ask(claudeLeadPrompt(task), {
+      mode: selectedMode,
+      phase: "lead",
+    });
+    turns.push(turn(claudeEndpoint, claudePlan, "lead"));
+
+    const codexReview = await codexEndpoint.ask(
+      codexReviewClaudePrompt(task, claudePlan.text),
+      { mode: selectedMode, phase: "review" },
+    );
+    turns.push(turn(codexEndpoint, codexReview, "review"));
+
+    const final = await claudeEndpoint.ask(
+      claudeFinalPrompt(task, claudePlan.text, codexReview.text),
+      { mode: selectedMode, phase: "final" },
+    );
+    turns.push(turn(claudeEndpoint, final, "final"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  if (selectedMode === "peer") {
+    const [claudePeer, codexPeer] = await Promise.all([
+      claudeEndpoint.ask(peerPrompt("Claude", task), {
+        mode: selectedMode,
+        phase: "peer",
+      }),
+      codexEndpoint.ask(peerPrompt("Codex", task), {
+        mode: selectedMode,
+        phase: "peer",
+      }),
+    ]);
+    turns.push(turn(claudeEndpoint, claudePeer, "peer"));
+    turns.push(turn(codexEndpoint, codexPeer, "peer"));
+
+    const final = await claudeEndpoint.ask(
+      peerSynthesisPrompt(task, claudePeer.text, codexPeer.text),
+      { mode: selectedMode, phase: "synthesis" },
+    );
+    turns.push(turn(claudeEndpoint, final, "synthesis"));
+    return { mode: selectedMode, task, turns, final: turns.at(-1) };
+  }
+
+  throw new Error(`Unsupported UDS orchestration mode: ${selectedMode}`);
+}
+
+function scanMessage(message, marker, state) {
+  const scan = (text) => {
+    state.streamBytes += Buffer.byteLength(text);
+    state.stream.push(text);
+    if (/⏺/.test(stripAnsi(text))) state.assistantStarted = true;
+    if (state.assistantStarted && text.includes(marker)) {
+      state.markerSeen = true;
+    }
+  };
+
+  state.messageCount += 1;
+  if (message.type === "snapshot") {
+    for (const line of message.streamTail || []) scan(line);
+  } else if (message.type === "stream" && typeof message.line === "string") {
+    scan(message.line);
+  } else if (message.type === "state") {
+    state.stateCount += 1;
+  } else if (message.type === "settled") {
+    state.settled = message.outcome || "settled";
+  }
+}
+
+export function subscribeClaudeUntilMarker(
+  controlSock,
+  short,
+  marker,
+  { timeoutMs = DEFAULT_TIMEOUT_MS } = {},
+) {
+  return new Promise((resolve) => {
+    const socket = net.connect(controlSock);
+    let data = "";
+    let finished = false;
+    const startedAt = Date.now();
+    const state = {
+      short,
+      marker,
+      markerSeen: false,
+      settled: null,
+      messageCount: 0,
+      stateCount: 0,
+      streamBytes: 0,
+      stream: [],
+      assistantStarted: false,
+    };
+    const timer = setTimeout(() => finish({ timedOut: true }), timeoutMs);
+
+    function finish(extra = {}) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve({ ...state, elapsedMs: Date.now() - startedAt, ...extra });
+    }
+
+    socket.on("error", (error) => finish({ error: error.message }));
+    socket.on("connect", () => {
+      socket.write(
+        `${JSON.stringify({ proto: 1, op: "subscribe", short, tail: 80, marker })}\n`,
+      );
+    });
+    socket.on("data", (chunk) => {
+      data += chunk.toString("utf8");
+      while (data.includes("\n")) {
+        const index = data.indexOf("\n");
+        const line = data.slice(0, index).trim();
+        data = data.slice(index + 1);
+        if (!line) continue;
+        try {
+          scanMessage(JSON.parse(line), marker, state);
+        } catch (_error) {
+          state.messageCount += 1;
+        }
+        if (state.markerSeen || state.settled) finish();
+      }
+    });
+    socket.on("close", () => finish({ closed: true }));
+  });
+}
+
+export function stripAnsi(text) {
+  return String(text)
+    .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/g, "")
+    .replace(/\x1B[78]/g, "")
+    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+function isClaudeUdsNoiseLine(line) {
+  return (
+    /Claude Code|Opus|remote-control|Brewed|Baked|Cogitated|Crunched|▐|▛|▜|▝|▘|Max|context/.test(
+      line,
+    ) ||
+    /^[╭╮╰╯│─┌┐└┘├┤┬┴┼\s]+$/.test(line) ||
+    /^\s*[❯✳✻]\s*/.test(line)
+  );
+}
+
+export function extractClaudeUdsText(text, marker) {
+  const cleaned = stripAnsi(String(text).replaceAll(marker, "")).replace(
+    /\r/g,
+    "\n",
+  );
+  const lines = cleaned
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  const assistantIndex = lines.findLastIndex((line) => /^\s*⏺\s*/.test(line));
+  if (assistantIndex >= 0) {
+    const useful = lines
+      .slice(assistantIndex)
+      .map((line, index) =>
+        index === 0 ? line.replace(/^\s*⏺\s*/, "") : line,
+      )
+      .filter((line) => !isClaudeUdsNoiseLine(line));
+    return useful.join("\n").trim();
+  }
+  const useful = lines.filter((line) => !isClaudeUdsNoiseLine(line));
+  return useful.at(-1)?.trim() || cleaned.trim();
+}
+
+export function createClaudeUdsEndpoint({
+  controlSock,
+  daemonPaths = deriveClaudeDaemonPaths(),
+  cwd = process.cwd(),
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  markerFactory = () =>
+    `TFX_UDS_ORCH_DONE_${crypto.randomBytes(6).toString("hex")}`,
+  shortFactory,
+  sessionIdFactory,
+  dispatchDaemonJob = dispatchClaudeDaemonJob,
+  teardownDaemonJob = teardownClaudeDaemonJob,
+} = {}) {
+  const sock = controlSock || daemonPaths.controlSock;
+  return {
+    name: "claude-uds",
+    async ask(prompt, meta = {}) {
+      const marker = markerFactory();
+      const wrappedPrompt = `${prompt}\n\nWhen finished, print this exact completion marker on its own line: ${marker}`;
+      const name =
+        meta.name ||
+        `tfx uds ${meta.mode || "orchestration"} ${meta.phase || "ask"}`;
+      const payload = buildClaudePromptDispatchPayload({
+        short: shortFactory?.(),
+        sessionId: sessionIdFactory?.(),
+        cwd,
+        prompt: wrappedPrompt,
+        name,
+      });
+      const dispatch = await dispatchDaemonJob({
+        paths: daemonPaths,
+        controlSock: sock,
+        payload,
+        agent: "claude",
+        name,
+        cwd,
+        dispatchTimeoutMs: 5000,
+      });
+      const subscription = await subscribeClaudeUntilMarker(
+        sock,
+        payload.short,
+        marker,
+        { timeoutMs },
+      );
+      await teardownDaemonJob({
+        controlSock: sock,
+        paths: daemonPaths,
+        short: payload.short,
+        sessionProjectionPath: dispatch.sessionProjectionPath,
+        sessionId: payload.sessionId,
+      });
+      return {
+        endpoint: "claude-uds",
+        text: extractClaudeUdsText(subscription.stream.join(""), marker),
+        done: subscription.markerSeen === true,
+        dispatch,
+        subscription: {
+          markerSeen: subscription.markerSeen,
+          elapsedMs: subscription.elapsedMs,
+          messageCount: subscription.messageCount,
+          streamBytes: subscription.streamBytes,
+          timedOut: subscription.timedOut === true,
+          settled: subscription.settled,
+        },
+        cleanup: { ok: true },
+        meta: { short: payload.short, marker },
+      };
+    },
+  };
+}
+
+export function createCodexExecEndpoint({
+  executeCodex = defaultExecuteCodex,
+  workdir = process.cwd(),
+  timeout = 120_000,
+  profile,
+} = {}) {
+  return {
+    name: "codex",
+    async ask(prompt) {
+      const result = await executeCodex({ prompt, workdir, timeout, profile });
+      if (result?.ok === false) {
+        throw new Error(
+          `Codex exec failed: ${result.stderr || result.error || "unknown error"}`,
+        );
+      }
+      return {
+        endpoint: "codex",
+        text: String(
+          result?.output ?? result?.stdout ?? result?.text ?? "",
+        ).trim(),
+        done: true,
+      };
+    },
+  };
+}

--- a/tests/unit/uds-orchestrator.test.mjs
+++ b/tests/unit/uds-orchestrator.test.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { deriveClaudeDaemonPaths } from "../../hub/team/claude-daemon-control.mjs";
+import {
+  createClaudeUdsEndpoint,
+  createCodexExecEndpoint,
+  extractClaudeUdsText,
+  runUdsOrchestration,
+} from "../../hub/team/uds-orchestrator.mjs";
+
+function scriptedEndpoint(name, replies) {
+  const calls = [];
+  return {
+    name,
+    calls,
+    async ask(prompt, meta = {}) {
+      calls.push({ prompt, meta });
+      return { endpoint: name, text: replies.shift(), done: true };
+    },
+  };
+}
+
+test("codex-led mode asks Codex, then Claude UDS, then Codex final", async () => {
+  const codex = scriptedEndpoint("codex", ["CODEX_PLAN", "CODEX_FINAL"]);
+  const claude = scriptedEndpoint("claude-uds", ["CLAUDE_REVIEW"]);
+
+  const result = await runUdsOrchestration({
+    mode: "codex-led",
+    task: "demo task",
+    codex,
+    claude,
+  });
+
+  assert.equal(result.mode, "codex-led");
+  assert.equal(result.final.text, "CODEX_FINAL");
+  assert.deepEqual(
+    result.turns.map((turn) => turn.endpoint),
+    ["codex", "claude-uds", "codex"],
+  );
+  assert.match(codex.calls[0].prompt, /Lead as Codex/);
+  assert.match(claude.calls[0].prompt, /Review Codex/);
+});
+
+test("claude-led mode asks Claude UDS, then Codex, then Claude final", async () => {
+  const codex = scriptedEndpoint("codex", ["CODEX_REVIEW"]);
+  const claude = scriptedEndpoint("claude-uds", [
+    "CLAUDE_PLAN",
+    "CLAUDE_FINAL",
+  ]);
+
+  const result = await runUdsOrchestration({
+    mode: "claude-led",
+    task: "demo task",
+    codex,
+    claude,
+  });
+
+  assert.equal(result.final.text, "CLAUDE_FINAL");
+  assert.deepEqual(
+    result.turns.map((turn) => turn.endpoint),
+    ["claude-uds", "codex", "claude-uds"],
+  );
+  assert.match(claude.calls[0].prompt, /Lead as Claude/);
+  assert.match(codex.calls[0].prompt, /Review Claude/);
+});
+
+test("peer mode asks Claude UDS and Codex as peers, then synthesizes", async () => {
+  const codex = scriptedEndpoint("codex", ["CODEX_PEER"]);
+  const claude = scriptedEndpoint("claude-uds", ["CLAUDE_PEER", "PEER_FINAL"]);
+
+  const result = await runUdsOrchestration({
+    mode: "peer",
+    task: "demo task",
+    codex,
+    claude,
+  });
+
+  assert.equal(result.final.text, "PEER_FINAL");
+  assert.deepEqual(
+    result.turns.map((turn) => turn.endpoint),
+    ["claude-uds", "codex", "claude-uds"],
+  );
+  assert.match(claude.calls[1].prompt, /Synthesize peer answers/);
+});
+
+async function withFakeClaudeDaemon(handler, fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uds-orchestrator-"));
+  const paths = deriveClaudeDaemonPaths({ configDir: path.join(dir, "claude") });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const requests = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let data = "";
+    socket.on("data", (chunk) => {
+      data += chunk;
+      while (data.includes("\n")) {
+        const index = data.indexOf("\n");
+        const line = data.slice(0, index).trim();
+        data = data.slice(index + 1);
+        if (!line) continue;
+        const request = JSON.parse(line);
+        requests.push(request);
+        handler(request, socket);
+      }
+    });
+  });
+
+  try {
+    server.listen(paths.controlSock);
+    await once(server, "listening");
+    await fn(paths, requests);
+  } finally {
+    server.close();
+    await once(server, "close").catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJson(socket, value, { end = false } = {}) {
+  const line = `${JSON.stringify(value)}\n`;
+  if (end) socket.end(line);
+  else socket.write(line);
+}
+
+test("createClaudeUdsEndpoint dispatches with shared daemon helper, captures marker text, and tears down", async () => {
+  await withFakeClaudeDaemon(
+    (request, socket) => {
+      if (request.op === "dispatch") {
+        writeJson(
+          socket,
+          {
+            ok: true,
+            op: "dispatch",
+            short: request.d.short,
+            via: "spare",
+            pid: process.pid,
+          },
+          { end: true },
+        );
+      } else if (request.op === "list") {
+        writeJson(
+          socket,
+          {
+            ok: true,
+            jobs: [
+              {
+                short: "fixed123",
+                pid: process.pid,
+                sessionId: "fixed123-session",
+                bridgeSessionId: "cse_uds_orch",
+                startedAt: 1234,
+              },
+            ],
+          },
+          { end: true },
+        );
+      } else if (request.op === "subscribe") {
+        writeJson(socket, { type: "snapshot", streamTail: ["boot\n"] });
+        writeJson(socket, { type: "stream", line: "⏺ ANSWER_TEXT\n" });
+        writeJson(socket, { type: "stream", line: `${request.marker || ""}\n` });
+      } else if (request.op === "kill") {
+        writeJson(socket, { ok: true, op: "kill" }, { end: true });
+      } else {
+        writeJson(socket, { ok: true, op: request.op }, { end: true });
+      }
+    },
+    async (paths, requests) => {
+      const endpoint = createClaudeUdsEndpoint({
+        daemonPaths: paths,
+        markerFactory: () => "DONE_MARKER",
+        timeoutMs: 1000,
+        shortFactory: () => "fixed123",
+        sessionIdFactory: () => "fixed123-session",
+      });
+
+      const result = await endpoint.ask("say answer");
+
+      assert.equal(result.done, true);
+      assert.equal(result.text, "ANSWER_TEXT");
+      assert.equal(result.dispatch?.ok, true);
+      assert.ok(requests.find((request) => request.op === "dispatch"));
+      assert.ok(requests.find((request) => request.op === "subscribe"));
+      assert.ok(requests.find((request) => request.op === "kill"));
+      assert.equal(requests.find((request) => request.op === "dispatch").d.short, "fixed123");
+      assert.match(
+        requests.find((request) => request.op === "dispatch").d.launch.args.join(" "),
+        /DONE_MARKER/,
+      );
+    },
+  );
+});
+
+test("createClaudeUdsEndpoint throws before subscribe when daemon dispatch is not ok", async () => {
+  await withFakeClaudeDaemon(
+    (request, socket) => {
+      if (request.op === "dispatch") {
+        writeJson(socket, { ok: false, op: "dispatch" }, { end: true });
+        return;
+      }
+      writeJson(socket, { ok: true, op: request.op }, { end: true });
+    },
+    async (paths, requests) => {
+      const endpoint = createClaudeUdsEndpoint({
+        daemonPaths: paths,
+        markerFactory: () => "DONE_MARKER",
+        timeoutMs: 1000,
+        shortFactory: () => "fail1234",
+        sessionIdFactory: () => "fail1234-session",
+      });
+
+      await assert.rejects(() => endpoint.ask("say answer"), /dispatch failed/u);
+      assert.deepEqual(
+        requests.map((request) => request.op),
+        ["dispatch"],
+      );
+    },
+  );
+});
+
+test("createClaudeUdsEndpoint ignores echoed marker instructions before completion", async () => {
+  await withFakeClaudeDaemon(
+    (request, socket) => {
+      if (request.op === "dispatch") {
+        writeJson(
+          socket,
+          { ok: true, op: "dispatch", short: request.d.short, pid: process.pid },
+          { end: true },
+        );
+      } else if (request.op === "list") {
+        writeJson(
+          socket,
+          {
+            ok: true,
+            jobs: [
+              {
+                short: "echo1234",
+                pid: process.pid,
+                sessionId: "echo1234-session",
+                bridgeSessionId: "cse_echo",
+                startedAt: 1234,
+              },
+            ],
+          },
+          { end: true },
+        );
+      } else if (request.op === "subscribe") {
+        writeJson(socket, {
+          type: "snapshot",
+          streamTail: [
+            "When finished, print this exact completion marker on its own line: DONE_MARKER\n",
+          ],
+        });
+        writeJson(socket, { type: "stream", line: "⏺ ACTUAL_ANSWER\n" });
+        writeJson(socket, { type: "stream", line: "DONE_MARKER\n" });
+      } else if (request.op === "kill") {
+        writeJson(socket, { ok: true, op: "kill" }, { end: true });
+      } else {
+        writeJson(socket, { ok: true, op: request.op }, { end: true });
+      }
+    },
+    async (paths) => {
+      const endpoint = createClaudeUdsEndpoint({
+        daemonPaths: paths,
+        markerFactory: () => "DONE_MARKER",
+        timeoutMs: 1000,
+        shortFactory: () => "echo1234",
+        sessionIdFactory: () => "echo1234-session",
+      });
+
+      const result = await endpoint.ask("say answer");
+
+      assert.equal(result.done, true);
+      assert.equal(result.text, "ACTUAL_ANSWER");
+    },
+  );
+});
+
+test("extractClaudeUdsText filters status noise after assistant marker", () => {
+  const text = [
+    "Claude Code",
+    "⏺ FINAL_ANSWER",
+    "✳ Crunching tokens",
+    "Opus",
+    "╭────────╮",
+    "DONE_MARKER",
+  ].join("\n");
+
+  assert.equal(extractClaudeUdsText(text, "DONE_MARKER"), "FINAL_ANSWER");
+});
+
+test("createCodexExecEndpoint normalizes Codex exec success and failure", async () => {
+  const success = createCodexExecEndpoint({
+    executeCodex: async ({ prompt }) => ({
+      ok: true,
+      output: `codex:${prompt}`,
+    }),
+  });
+  assert.deepEqual(await success.ask("ping"), {
+    endpoint: "codex",
+    text: "codex:ping",
+    done: true,
+  });
+
+  const stdoutFallback = createCodexExecEndpoint({
+    executeCodex: async () => ({ ok: true, stdout: "legacy stdout" }),
+  });
+  assert.equal((await stdoutFallback.ask("ping")).text, "legacy stdout");
+
+  const failure = createCodexExecEndpoint({
+    executeCodex: async () => ({ ok: false, stderr: "boom" }),
+  });
+  await assert.rejects(() => failure.ask("ping"), /Codex exec failed: boom/);
+});


### PR DESCRIPTION
## What

`uds-orchestrator`를 현재 main(PR #364 이후) 위로 재작성해 **shared daemon-control 을 채택**하고, codex+agy 전수조사가 지적한 **P2 결함 2건**을 수정합니다.

## Background

기존 `.worktrees/uds-orchestration-peer` 의 WIP 는 PR #364(shared `dispatchClaudeDaemonJob`/`teardownClaudeDaemonJob` 통합) 이전 base 라, shared helper 없이 자체 `op:"dispatch"` 직접 호출과 자체 `buildClaudePromptDispatchPayload` 를 구현 → #364 가 통합한 dispatch owner 를 다시 분산시켰습니다.

## Changes

- `createClaudeUdsEndpoint` 가 shared `dispatchClaudeDaemonJob` / `teardownClaudeDaemonJob` 를 사용 (자체 `op:"dispatch"` / `op:"kill"` 직접 호출 제거)
- **P2-1**: dispatch `ok === false` 시 subscribe 로 진행하지 않고 throw
- **P2-2**: `extractClaudeUdsText` 가 `⏺` 마커 경로에서도 spinner/token/status noise 를 필터 (이전엔 마커 없는 경로에만 필터 적용 → done:true 텍스트에 noise 혼입)
- 로컬 `buildClaudePromptDispatchPayload` 제거 → shared helper 로 단일화. main 의 `claude-daemon-control.mjs` 에는 exec-mode builder(`buildDaemonExecDispatchPayload`)만 있어 prompt-mode `buildClaudePromptDispatchPayload` 를 shared helper 에 신규 추가하고 4-layer(root/core/triflux/remote) 미러

## Test

- `node --test tests/unit/uds-orchestrator.test.mjs` → 9/9 pass (dispatch ok-fail / 마커 noise 필터 2 케이스 포함)
- `npm run release:check-mirror` → Mirror OK (0 mismatch)

## Not-tested

- live Claude daemon smoke (offline 리뷰 환경)
