### PR TITLE
chore: track UDS local-dev smoke harness + audit, ignore volatile reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ research/
 # 슬롭 분석 보고서
 slop-report.json
 
+# native-bridge feasibility 스모크 생성물 (휘발성 — 실행 시 재생성)
+experiments/native-bridge-feasibility/*-latest-report.json
+
 # 프로젝트 인덱스 (세션별 자동 생성)
 PROJECT_INDEX.md
 PROJECT_INDEX.json

--- a/docs/research/triflux-stale-audit-2026-05-28.md
+++ b/docs/research/triflux-stale-audit-2026-05-28.md
@@ -1,0 +1,270 @@
+# triflux stale audit — README / assets / git refs / tfx CLI
+
+Date: 2026-05-28 (Asia/Seoul)
+Scope: fact-first audit plus safe local remediation. No branch deletion, remote deletion, or runtime process cleanup was applied.
+
+## Executive findings
+
+1. README Mermaid is currently broken in both English and Korean READMEs.
+2. README skill count is stale: published package contains 34 skill files, README claims 33.
+3. README media/architecture assets are stale and several package README-relative asset paths are broken.
+4. `tfx` CLI help/schema/completion surfaces are inconsistent; some `--help` paths execute or error instead of printing help.
+5. Runtime diagnostics show real stale local state: stale teams and stale hub processes.
+6. Git refs need cleanup triage: zero open PRs, several merged remote branches, old unmerged remote branches, and local branches whose upstreams are gone.
+7. Version/tag/npm latest are aligned at 10.26.0; no current release-tag mismatch was found.
+
+
+## Remediation applied in this working tree
+
+Safe, non-destructive fixes were applied after the initial audit:
+
+- README Mermaid labels now use quoted node labels (`Auto["/tfx-auto"]`, `Remote["/tfx-remote"]`).
+- README skill count is now 34, matching packed/package skill files.
+- README, package metadata, SVGs, demo tape, and generated GIF now use the current Codex/Antigravity/Claude surface instead of stale Gemini-front-door wording. Legacy Gemini references remain only where they describe compatibility state or snapshot files.
+- `docs/assets/demo-multi.gif` was regenerated locally (960x540 GIF, 10 frames) because `vhs` was unavailable and Pillow was available.
+- Root and `packages/triflux` package metadata now include `docs/assets`; the workspace package also includes `tui` and `README.ko.md`, fixing package README media and `tfx-profile`/TUI packaging gaps.
+- `tfx update --help` now prints help before side effects; `cmdUpdate` receives `cmdArgs`.
+- `tfx auto/setup/doctor/handoff/schema/synapse/hooks/multi/notion-read/review/tray/why --help` now use explicit help paths.
+- `tfx schema` now includes implemented/help-listed commands such as `auto`, `update`, `tray`, `codex-team`, `notion-read`, `review`, and `monitor`.
+- Shell completions now advertise current commands and remove nonexistent `codex`, `gemini`, and `antigravity` top-level commands.
+- `tfx list --json` now reports all 11 deprecated skill aliases from skill frontmatter.
+- Codex profile TUI/setup defaults now point at `gpt55_*` profile files and no longer offer `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `codex53_*`, or `spark53_*` as current defaults.
+- `--cli gemini` in `tfx auto` is accepted only as a deprecated compatibility alias and normalizes to `antigravity` with a warning.
+- `release:check-mirror` now includes `tui`, so `packages/triflux` cannot silently miss TUI files again.
+
+Destructive cleanup remains intentionally unapplied: stale runtime processes, stale teams, local branches with gone upstreams, and remote branch deletion/pruning still require a separate cleanup decision.
+
+## README and rendering
+
+### Broken Mermaid
+
+Evidence:
+- `README.md:266-283` and `README.ko.md:255-272` contain the same Mermaid block.
+- The offending labels are:
+  - `README.md:270`: `Skills --> Auto[/tfx-auto]`
+  - `README.md:271`: `Skills --> Remote[/tfx-remote]`
+  - `README.ko.md:259`: `Skills --> Auto[/tfx-auto]`
+  - `README.ko.md:260`: `Skills --> Remote[/tfx-remote]`
+- GitHub's Mermaid support expects Mermaid syntax in a fenced `mermaid` block; the user-observed GitHub renderer error points at this exact label shape.
+
+Safe replacement candidate:
+
+```mermaid
+graph TD
+    Skills --> Auto["/tfx-auto"]
+    Skills --> Remote["/tfx-remote"]
+```
+
+### README skill count stale
+
+Evidence:
+- README badge/text says `skill_files-33` and "33 skill files" (`README.md:22`, `README.md:148`; same in Korean README).
+- `npm pack --dry-run --json` shows `packed_skill_count=34` and excludes only `tfx-workspace`.
+- `tfx list --json` reports `package_skills=34`.
+
+### README/package README mismatch
+
+Evidence:
+- Root README development gate says `npm run lint:skills`.
+- `packages/triflux/README.md` says `npm run gen:skill-docs`, but `package.json` has `gen:skill-manifest` and `lint:skills`, not `gen:skill-docs`.
+- `release:check-mirror` still reports OK, so README mirror policy likely excludes this file or package README is not packed.
+
+### Media and asset staleness
+
+Evidence:
+- `README.md:29` and `README.ko.md:29` reference `docs/assets/demo-multi.gif`.
+- `docs/assets/demo-multi.gif` last changed on 2026-03-29 (`0c7d96cd`).
+- `docs/demo.tape` still includes old slash examples `/implement` and `/analyze`, plus a `gemini` lane and "Codex free tier" token-savings text.
+- `docs/assets/architecture.svg` includes stale labels: `CLI (gpt-5.3)`, `Gemini`, and footer `triflux v8.4`.
+- `docs/assets/deep-vs-light.svg` footer says `triflux v8.4`.
+- `docs/assets/social-preview.svg` footer says `v2.0.0`.
+- `docs/assets/logo-*.svg` comments still describe a Gemini lane.
+
+### Packaged README image paths
+
+Evidence:
+- `npm pack --dry-run --json` includes `README.md` and `README.ko.md` but not `docs/assets/logo-dark.svg`, `docs/assets/demo-multi.gif`, or `docs/assets/architecture.svg`.
+- Therefore GitHub repo README assets exist, but package-tarball-relative README media paths are not self-contained.
+
+## tfx CLI stale / bug audit
+
+### High: `tfx update --help` performs update side effects
+
+Evidence:
+- Running `tfx update --help` executed the update path, stopped the hub, and ran `npm install -g triflux@latest`.
+- Recovery check after the accidental command: `tfx hub ensure` returned `hub: ok`, `tfx hub status --json` was healthy at PID 48098.
+- Source: `bin/triflux.mjs:7158-7159` dispatches `case "update": await cmdUpdate();` and drops `cmdArgs`.
+- Source: `cmdUpdate()` performs network checks, can stop hub, and executes npm/git update commands.
+
+### High: completion files advertise stale or nonexistent commands
+
+Evidence:
+- `scripts/completions/tfx.bash:12` and `scripts/completions/tfx.fish:4` advertise `auto codex gemini`.
+- `scripts/completions/tfx.zsh:14-17` advertises `auto codex antigravity`.
+- Live behavior:
+  - `tfx auto --help` prints `single` instead of help.
+  - `tfx codex --help` -> unknown command.
+  - `tfx gemini --help` -> unknown command.
+  - `tfx antigravity --help` -> unknown command.
+
+### High: schema is missing help-listed / implemented commands
+
+Evidence:
+- Top-level help lists `update`, `tray`, `codex-team`, `notion-read`, but `tfx schema <name>` fails for each.
+- Dispatch also implements `auto`, `monitor`, `review`, `ls`, and `nr`; these are not in `tfx schema` and mostly not in top-level help.
+- `tfx schema` command keys currently include: `doctor, handoff, hooks, hub, list, mcp, multi, schema, setup, swarm, synapse, version, why`.
+
+### Medium: subcommand `--help` is inconsistent
+
+Evidence:
+- `tfx handoff --help` exits 2 with `알 수 없는 handoff 옵션: --help`.
+- `tfx schema --help` exits 2 with `알 수 없는 schema 대상: --help`.
+- `tfx synapse --help` exits 2 with `synapse 서브커맨드 미지원: --help`.
+- `tfx hooks --help` exits 1 via hook-manager usage JSON instead of a normal top-level help path.
+- `tfx mcp --help`, `tfx hub --help`, `tfx swarm --help`, `tfx multi --help`, `tfx codex-team --help`, and `tfx notion-read --help` do print help.
+
+### Medium: alias reporting is stale/incomplete
+
+Evidence:
+- `tfx list --json` reports only 3 `skill_aliases`: `tfx-autopilot`, `tfx-persist`, `tfx-fullcycle`.
+- Actual `deprecated: true` skill dirs under `skills/*/SKILL.md`: 11 total: `tfx-autopilot`, `tfx-consensus`, `tfx-debate`, `tfx-fullcycle`, `tfx-multi`, `tfx-panel`, `tfx-persist`, `tfx-psmux-rules`, `tfx-remote-setup`, `tfx-remote-spawn`, `tfx-swarm`.
+- README says 11 deprecated compatibility aliases, which matches the skill files, not `tfx list --json` alias summary.
+
+### Medium: profile/model UI stale
+
+Evidence:
+- `tui/codex-profile.mjs` still offers `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex`.
+- `tui/setup.mjs` still requires `codex53_high`, `codex53_xhigh`, and `spark53_low`.
+- Current repo instructions prefer `gpt55_*` profiles and not reviving `codex53_*`, `gpt54_*`, or `mini54_*` defaults.
+
+### Runtime stale state surfaced by `tfx doctor --json`
+
+Evidence:
+- `tfx doctor --json` exit 0 but top-level status: `issues`.
+- Checks with issues/warnings:
+  - `omc-stale-teams`: 2 entries, fix points to `tfx doctor --fix`.
+  - `stale-teams`: active 0, stale 2, fix points to `tfx doctor --fix`.
+  - `hub-server-processes`: detached 11, stale 10.
+  - `serena-mcp`: missing project binding/context-codex/startup timeout settings.
+  - `mcp-registry`: warning, but registry rows inspected so far were largely present.
+
+No cleanup was performed because killing processes / deleting runtime state is destructive enough to require an explicit cleanup decision.
+
+## Git refs / branches / tags
+
+### Current checkout
+
+Evidence:
+- Current branch at audit start: `main...origin/main`.
+- Current working tree now contains the safe remediation changes listed above, plus pre-existing version-bump files (`10.26.1`) that were already dirty when remediation resumed.
+- No branch deletion, remote pruning, or runtime cleanup was performed.
+
+### Open PRs
+
+Evidence:
+- `gh pr list --state open --limit 200 --json ...` returned `open_pr_count=0`.
+
+### Remote branches merged into `origin/main`
+
+Evidence:
+- `git branch -r --merged origin/main` found these non-main remote-tracking branches:
+  - `origin/feat/daemon-attach-peer-return`
+  - `origin/feat/native-bridge-bc-escalation-tmpl-cleanup`
+  - `origin/feat/parallel-wave-codex-fixes`
+  - `origin/fix/hub-orphan-cleanup-instrumentation`
+  - `origin/fix/review-followups-bundle-b`
+  - `origin/native-bridge-interactive-attach`
+
+### Remote branches older than 14 days and not merged
+
+Evidence:
+- 19 remote-tracking branches are at least 14 days old and not merged into `origin/main`.
+- Oldest examples:
+  - `origin/feat/issue-10-runtime-strategy` — 50 days
+  - `origin/fix/hub-quota-refresh-safety` — 46 days
+  - `origin/feat/conductor-auth-swap-tier-fallback` — 46 days
+  - `origin/archive/pr-73-2026-05-08` — 41 days
+  - `origin/archive/feat-macos-compat-deep-2026-05-08` — 41 days
+
+### Local branches whose upstreams are gone
+
+Evidence:
+- 6 local branches show `[origin/...: gone]` and none are currently attached to a worktree:
+  - `docs/wt-macos-symptoms`
+  - `feat/doctor-wrapper-sourcing-check`
+  - `feat/mcp-antigravity-target`
+  - `feat/native-bridge-interactive-attach-e2e`
+  - `feat/native-bridge-ui-default-expansion`
+  - `security/mcp-bearer-secrets`
+
+### Remote prune anomaly
+
+Evidence:
+- `git remote prune origin --dry-run` reports `origin/feat/native-bridge-bc-escalation-tmpl-cleanup` would be pruned.
+- Exact `git ls-remote --heads origin feat/native-bridge-bc-escalation-tmpl-cleanup` returns empty.
+- A local remote-tracking ref still exists for that name.
+
+### Tags/releases
+
+Initial audit evidence:
+- Published npm/tag state was aligned at `10.26.0` (`v10.26.0`, npm latest `10.26.0`).
+- The working tree already had local version-bump changes to `10.26.1` when remediation resumed; those pre-existing version files were preserved, not introduced by the stale-audit fixes.
+
+## Suggested fix order
+
+1. Patch README Mermaid labels in both READMEs.
+2. Refresh/replace README GIF and SVG assets, or remove stale embedded demo media until regenerated.
+3. Fix README skill count to 34 or generate it from pack/list output.
+4. Normalize `tfx update --help` before any broader CLI cleanup.
+5. Bring `tfx schema`, top-level help, subcommand help, and completions from one command registry.
+6. Update `tfx list --json` alias reporting to include all deprecated skills or rename the field so it does not imply complete alias coverage.
+7. Update Codex profile TUI/setup defaults to gpt55 profile names while keeping old-name migration guards only as cleanup logic.
+8. Decide branch cleanup policy:
+   - safe local cleanup candidates: 6 local branches with gone upstream and no worktree attachment;
+   - likely remote cleanup candidates: merged remote branches and stale remote-tracking refs;
+   - policy-review candidates: old unmerged remote branches.
+9. Run runtime cleanup only after explicit confirmation: start with `tfx doctor --cleanup-stale-hubs --dry-run`, then decide `--apply`/`tfx doctor --fix` separately.
+
+## Validation commands run
+
+- `git status --short --branch`
+- `git remote -v`
+- `git branch -vv --all --sort=-committerdate`
+- `git tag --sort=-creatordate`
+- `git ls-remote --heads origin`
+- `gh pr list --state open --limit 200 --json ...`
+- `npm pack --dry-run --json`
+- `npm view triflux version dist-tags --json`
+- `npm run release:check-sync --silent`
+- `npm run release:check-mirror --silent`
+- `npm run release:check-mirror:fix --silent`
+- `tfx --help`, `tfx schema`, `tfx list --json`, `tfx version --json`
+- `tfx doctor --json`
+- targeted `tfx <command> --help` matrix
+
+## Known audit side effect
+
+During command smoke testing, `tfx update --help` unexpectedly executed the update command. It stopped the running hub and ran `npm install -g triflux@latest`; version stayed `10.26.0`. The hub was then restored with `tfx hub ensure`, and `tfx hub status --json` reported healthy.
+
+
+## Remediation validation evidence
+
+- `node --test tests/unit/triflux-help-output.test.mjs tests/integration/triflux-cli.test.mjs scripts/__tests__/skill-surface.test.mjs scripts/__tests__/tfx-route-phase1-modules.test.mjs` → 47 passed, 0 failed.
+- `node bin/triflux.mjs update --help` printed help and did not run npm/git update text.
+- `node bin/triflux.mjs schema update` and `node bin/triflux.mjs schema auto` returned command schemas.
+- `node bin/triflux.mjs list --json` returned 11 deprecated aliases, all marked `deprecated: true`.
+- `bash -n scripts/completions/tfx.bash` passed.
+- `npm pack --dry-run --json` includes `docs/assets/demo-multi.gif`, `docs/assets/architecture.svg`, `README.md`, `README.ko.md`, and completions.
+- `(cd packages/triflux && npm pack --dry-run --json)` includes `docs/assets/demo-multi.gif`, `docs/assets/architecture.svg`, `tui/codex-profile.mjs`, `README.md`, `README.ko.md`, and completions.
+- `npm run lint --silent` → 708 files checked, no fixes applied.
+- `npm run release:check-sync --silent` → Version sync OK (`10.26.1`).
+- `npm run release:check-mirror --silent` → mirror OK after `release:check-mirror:fix` copied root runtime and TUI files into `packages/triflux`.
+- `git diff --check` → no whitespace errors.
+
+## Current non-destructive cleanup candidates rechecked after remediation
+
+- `gh pr list --state open --limit 200 --json number --jq 'length'` → `0` open PRs.
+- `git branch -r --merged origin/main` still shows 6 non-main merged remote-tracking branches.
+- `git branch -vv | grep ': gone]'` still shows 6 local branches whose upstream is gone.
+- `git remote prune origin --dry-run` still reports `origin/feat/native-bridge-bc-escalation-tmpl-cleanup` as would-prune.
+- `node bin/triflux.mjs doctor --json` still reports status `issues`; current stale runtime counts are `stale-teams=2`, `hub-server-processes detached=15 stale=13`, and `serena-mcp` still lacks project binding / startup timeout.

--- a/experiments/native-bridge-feasibility/claude-uds-local-dev-smoke.mjs
+++ b/experiments/native-bridge-feasibility/claude-uds-local-dev-smoke.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  buildDispatchPayload,
+  deriveDaemonPaths,
+  redactControlResponse,
+  sendControlRequest,
+} from "./claude-daemon-dispatch-poc.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const defaultReportPath = path.join(here, "uds-local-dev-latest-report.json");
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function parseArgs(argv) {
+  const flags = {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    reportPath: defaultReportPath,
+    marker: `TFX_UDS_LOCAL_DEV_${Date.now()}`,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      flags.help = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) throw new Error(`Unexpected argument: ${arg}`);
+    const key = arg.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined) throw new Error(`Missing value for --${key}`);
+    index += 1;
+
+    if (key === "timeout") {
+      const seconds = Number(value);
+      if (!Number.isFinite(seconds) || seconds <= 0) {
+        throw new Error("--timeout must be a positive number of seconds");
+      }
+      flags.timeoutMs = Math.round(seconds * 1000);
+    } else if (key === "marker") {
+      flags.marker = value;
+    } else if (key === "report") {
+      flags.reportPath = value;
+    } else {
+      throw new Error(`Unknown flag --${key}`);
+    }
+  }
+
+  return flags;
+}
+
+export function usage() {
+  return [
+    "Usage:",
+    "  claude-uds-local-dev-smoke.mjs [--marker TEXT] [--timeout 90] [--report PATH]",
+    "",
+    "Dev-only Claude daemon UDS smoke:",
+    "  - connects to ~/.claude daemon control.sock",
+    "  - dispatches one short-lived prompt job over the Unix domain socket",
+    "  - subscribes until the marker is observed",
+    "  - kills the job for cleanup",
+  ].join("\n");
+}
+
+export function summarizeJobs(response) {
+  return redactControlResponse(response)?.jobs?.map((job) => ({
+    short: job.short,
+    pid: job.pid,
+    sessionId: job.sessionId,
+    state: job.state,
+    tempo: job.tempo,
+    cwd: job.cwd,
+    name: job.name,
+    agent: job.agent,
+    source: job.source,
+    outcome: job.outcome,
+  }));
+}
+
+export function subscribeUntilMarker(sockPath, short, marker, { timeoutMs }) {
+  return new Promise((resolve) => {
+    const socket = net.connect(sockPath);
+    let data = "";
+    let streamBytes = 0;
+    let messageCount = 0;
+    let stateCount = 0;
+    let markerSeen = false;
+    let settled = null;
+    let settledAt = null;
+    let finished = false;
+    const startedAt = Date.now();
+    const timer = setTimeout(() => finish({ timedOut: true }), timeoutMs);
+
+    function finish(extra = {}) {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve({
+        short,
+        marker,
+        markerSeen,
+        settled,
+        settledAt,
+        messageCount,
+        stateCount,
+        streamBytes,
+        elapsedMs: Date.now() - startedAt,
+        ...extra,
+      });
+    }
+
+    function scanText(text) {
+      streamBytes += Buffer.byteLength(text);
+      if (text.includes(marker)) markerSeen = true;
+    }
+
+    function handleMessage(message) {
+      messageCount += 1;
+      if (message.type === "snapshot") {
+        for (const line of message.streamTail || []) scanText(line);
+      } else if (
+        message.type === "stream" &&
+        typeof message.line === "string"
+      ) {
+        scanText(message.line);
+      } else if (message.type === "state") {
+        stateCount += 1;
+      } else if (message.type === "settled") {
+        settled = message.outcome || "settled";
+        settledAt = Date.now();
+      }
+
+      if (markerSeen) finish();
+      else if (settled) finish();
+    }
+
+    socket.on("error", (error) => finish({ error: error.message }));
+    socket.on("connect", () => {
+      socket.write(
+        `${JSON.stringify({ proto: 1, op: "subscribe", short, tail: 80 })}\n`,
+      );
+    });
+    socket.on("data", (chunk) => {
+      data += chunk.toString("utf8");
+      while (data.includes("\n")) {
+        const index = data.indexOf("\n");
+        const line = data.slice(0, index).trim();
+        data = data.slice(index + 1);
+        if (!line) continue;
+        try {
+          handleMessage(JSON.parse(line));
+        } catch (_error) {
+          messageCount += 1;
+        }
+      }
+    });
+    socket.on("close", () => finish({ closed: true }));
+  });
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const flags = parseArgs(argv);
+  if (flags.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const paths = deriveDaemonPaths();
+  const report = {
+    generatedAt: new Date().toISOString(),
+    kind: "claude-daemon-uds-local-dev-smoke",
+    controlSock: paths.controlSock,
+    marker: flags.marker,
+    listBefore: null,
+    dispatch: null,
+    subscribe: null,
+    hasAfterSubscribe: null,
+    cleanup: null,
+    hasAfterCleanup: null,
+    listAfter: null,
+    verdict: "unknown",
+  };
+
+  const prompt = `Reply with exactly ${flags.marker} and then stop.`;
+  const payload = buildDispatchPayload({
+    mode: "prompt",
+    cwd: process.cwd(),
+    prompt,
+  });
+  payload.seed.name = "tfx uds local dev marker smoke";
+  payload.seed.intent = "[redacted local dev marker prompt]";
+
+  try {
+    report.listBefore = summarizeJobs(
+      await sendControlRequest(paths.controlSock, { proto: 1, op: "list" }),
+    );
+    report.dispatch = await sendControlRequest(
+      paths.controlSock,
+      { proto: 1, op: "dispatch", d: payload, timeoutMs: 5000 },
+      { timeoutMs: 7000 },
+    );
+    report.subscribe = await subscribeUntilMarker(
+      paths.controlSock,
+      payload.short,
+      flags.marker,
+      {
+        timeoutMs: flags.timeoutMs,
+      },
+    );
+    report.hasAfterSubscribe = await sendControlRequest(paths.controlSock, {
+      proto: 1,
+      op: "has",
+      short: payload.short,
+    });
+
+    if (report.hasAfterSubscribe?.present || report.hasAfterSubscribe?.alive) {
+      report.cleanup = await sendControlRequest(paths.controlSock, {
+        proto: 1,
+        op: "kill",
+        short: payload.short,
+      });
+    }
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      report.hasAfterCleanup = await sendControlRequest(paths.controlSock, {
+        proto: 1,
+        op: "has",
+        short: payload.short,
+      });
+      if (!report.hasAfterCleanup?.present && !report.hasAfterCleanup?.alive)
+        break;
+      await sleep(250);
+    }
+
+    report.listAfter = summarizeJobs(
+      await sendControlRequest(paths.controlSock, { proto: 1, op: "list" }),
+    );
+    report.verdict =
+      report.dispatch?.ok === true && report.subscribe?.markerSeen === true
+        ? "prompt-marker-seen"
+        : report.dispatch?.ok === true
+          ? "prompt-dispatched-no-marker"
+          : "dispatch-failed";
+  } catch (error) {
+    report.verdict = "error";
+    report.error = error.message;
+  }
+
+  await fs.writeFile(flags.reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (report.verdict !== "prompt-marker-seen") process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/unit/claude-uds-local-dev-smoke.test.mjs
+++ b/tests/unit/claude-uds-local-dev-smoke.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  parseArgs,
+  subscribeUntilMarker,
+  summarizeJobs,
+  usage,
+} from "../../experiments/native-bridge-feasibility/claude-uds-local-dev-smoke.mjs";
+
+async function withUnixJsonLineServer(messages, fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uds-smoke-test-"));
+  const sockPath = path.join(dir, "control.sock");
+  const server = net.createServer((socket) => {
+    socket.on("data", () => {
+      for (const message of messages) {
+        socket.write(`${JSON.stringify(message)}\n`);
+      }
+    });
+  });
+
+  try {
+    server.listen(sockPath);
+    await once(server, "listening");
+    await fn(sockPath);
+  } finally {
+    server.close();
+    await once(server, "close").catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("parseArgs defaults to a dev-only marker/report and parses overrides", () => {
+  const defaults = parseArgs([]);
+  assert.equal(defaults.timeoutMs, 90_000);
+  assert.match(defaults.marker, /^TFX_UDS_LOCAL_DEV_/);
+  assert.match(defaults.reportPath, /uds-local-dev-latest-report\.json$/);
+
+  const parsed = parseArgs([
+    "--marker",
+    "MARKER",
+    "--timeout",
+    "1.5",
+    "--report",
+    "/tmp/uds-report.json",
+  ]);
+  assert.equal(parsed.marker, "MARKER");
+  assert.equal(parsed.timeoutMs, 1500);
+  assert.equal(parsed.reportPath, "/tmp/uds-report.json");
+});
+
+test("parseArgs rejects unknown flags and invalid timeouts", () => {
+  assert.throws(() => parseArgs(["--unknown", "x"]), /Unknown flag/);
+  assert.throws(() => parseArgs(["--timeout", "0"]), /positive number/);
+  assert.throws(() => parseArgs(["unexpected"]), /Unexpected argument/);
+  assert.throws(() => parseArgs(["--marker"]), /Missing value/);
+});
+
+test("usage documents UDS control socket dispatch semantics", () => {
+  const text = usage();
+  assert.match(text, /Unix domain socket/);
+  assert.match(text, /control\.sock/);
+  assert.match(text, /dispatches one short-lived prompt job/);
+});
+
+test("summarizeJobs redacts daemon list records to stable fields", () => {
+  const summary = summarizeJobs({
+    ok: true,
+    jobs: [
+      {
+        short: "abcd1234",
+        pid: 123,
+        sessionId: "abcd",
+        state: "running",
+        tempo: "active",
+        cwd: "/tmp/project",
+        name: "smoke",
+        agent: "claude",
+        source: "shell",
+        outcome: "done",
+        detail: "should be dropped",
+        intent: "should be dropped",
+      },
+    ],
+  });
+
+  assert.deepEqual(summary, [
+    {
+      short: "abcd1234",
+      pid: 123,
+      sessionId: "abcd",
+      state: "running",
+      tempo: "active",
+      cwd: "/tmp/project",
+      name: "smoke",
+      agent: "claude",
+      source: "shell",
+      outcome: "done",
+    },
+  ]);
+});
+
+test("subscribeUntilMarker resolves when marker appears in stream output", async () => {
+  await withUnixJsonLineServer(
+    [
+      { type: "snapshot", streamTail: ["booting\n"] },
+      { type: "state", patch: { tempo: "active" } },
+      { type: "stream", line: "TFX_UDS_LOCAL_DEV_TEST\n" },
+    ],
+    async (sockPath) => {
+      const result = await subscribeUntilMarker(
+        sockPath,
+        "shorty",
+        "TFX_UDS_LOCAL_DEV_TEST",
+        {
+          timeoutMs: 1000,
+        },
+      );
+
+      assert.equal(result.markerSeen, true);
+      assert.equal(result.short, "shorty");
+      assert.equal(result.messageCount, 3);
+      assert.equal(result.stateCount, 1);
+      assert.equal(result.streamBytes > 0, true);
+    },
+  );
+});
+
+test("subscribeUntilMarker resolves on settled even without marker", async () => {
+  await withUnixJsonLineServer(
+    [
+      { type: "snapshot", streamTail: ["booting\n"] },
+      { type: "settled", outcome: "done" },
+    ],
+    async (sockPath) => {
+      const result = await subscribeUntilMarker(
+        sockPath,
+        "shorty",
+        "MISSING_MARKER",
+        {
+          timeoutMs: 1000,
+        },
+      );
+
+      assert.equal(result.markerSeen, false);
+      assert.equal(result.settled, "done");
+      assert.equal(result.messageCount, 2);
+    },
+  );
+});


### PR DESCRIPTION
## What

Houses the leftover untracked artifacts from the UDS orchestration work (post-#366) into version control or .gitignore.

- **Add** `experiments/native-bridge-feasibility/claude-uds-local-dev-smoke.mjs` — hermetic UDS control-socket smoke harness (parseArgs / subscribeUntilMarker / summarizeJobs / usage).
- **Add** `tests/unit/claude-uds-local-dev-smoke.test.mjs` — 6 unit tests, in-process Unix socket mock, no live daemon dependency, 1s timeouts. Passes locally (6/6, ~67ms).
- **Add** `docs/research/triflux-stale-audit-2026-05-28.md` — 2026-05-28 stale audit (README / assets / git refs / tfx CLI).
- **Ignore** `experiments/native-bridge-feasibility/*-latest-report.json` — volatile reports the harness regenerates each run (`daemon-dispatch-latest-report.json`, `uds-local-dev-latest-report.json`).

## Why

These sat untracked on `main` after the #366 line landed. The harness+test are reusable; the audit doc is reference; the JSON reports are generated noise.

## Notes

- No mirror obligation: `tests/` is mirror-excluded and `experiments/` is not in the mirror set (`.claude/rules/tfx-mirror-policy.md`).
- No AI attribution trailer (triflux policy).