### PR TITLE
fix: make interactive native workers appear in claude agents via daemon dispatch

### DIFF
--- a/hub/team/daemon-pty-tmux-bridge.mjs
+++ b/hub/team/daemon-pty-tmux-bridge.mjs
@@ -1,0 +1,146 @@
+import { pathToFileURL } from "node:url";
+
+import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
+const SIGNAL_EXIT_CODES = new Map([
+  ["SIGHUP", 129],
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]);
+
+export function encodeBridgeConfig(config) {
+  return Buffer.from(JSON.stringify(config), "utf8").toString("base64");
+}
+
+export function parseBridgeConfig(argv = []) {
+  const index = argv.indexOf("--config");
+  if (index < 0 || !argv[index + 1]) {
+    throw new Error("--config <base64-json> is required");
+  }
+  return JSON.parse(Buffer.from(argv[index + 1], "base64").toString("utf8"));
+}
+
+export async function runBridge({
+  config,
+  stdin,
+  stdout,
+  signals,
+  createTransport = createInteractiveTuiTransport,
+} = {}) {
+  if (!config?.sessionName) throw new Error("config.sessionName is required");
+  if (!stdin) throw new Error("stdin is required");
+  if (!stdout) throw new Error("stdout is required");
+  if (!signals) throw new Error("signals is required");
+
+  const transport = createTransport({
+    sessionName: config.sessionName,
+    cwd: config.cwd,
+    launchCmd: config.launchCmd,
+    env: config.env || {},
+    onData: (chunk) => stdout.write(chunk),
+  });
+  let shutdownPromise = null;
+
+  const currentSize = () => ({
+    cols: stdout.columns || config.cols || DEFAULT_COLS,
+    rows: stdout.rows || config.rows || DEFAULT_ROWS,
+  });
+
+  const shutdown = async ({ exitCode, exitProcess = false } = {}) => {
+    if (!shutdownPromise) {
+      shutdownPromise = (async () => {
+        unregister();
+        await transport.stop();
+      })();
+    }
+    await shutdownPromise;
+    if (exitProcess && typeof signals.exit === "function") {
+      signals.exit(exitCode ?? 0);
+    }
+  };
+
+  const writeInput = (chunk) => {
+    void transport.writeInput(chunk).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const resize = () => {
+    void transport.resize(currentSize()).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const stdinEnd = () => {
+    void shutdown({ exitCode: 0, exitProcess: true });
+  };
+  const signalHandlers = new Map(
+    [...SIGNAL_EXIT_CODES].map(([signal, exitCode]) => [
+      signal,
+      () => {
+        void shutdown({ exitCode, exitProcess: true });
+      },
+    ]),
+  );
+  const uncaughtException = () => {
+    void shutdown({ exitCode: 1, exitProcess: true });
+  };
+  const beforeExit = () => {
+    void shutdown();
+  };
+  const exit = () => {
+    void shutdown();
+  };
+
+  function unregister() {
+    stdin.off?.("data", writeInput);
+    stdin.off?.("end", stdinEnd);
+    stdout.off?.("resize", resize);
+    signals.off?.("uncaughtException", uncaughtException);
+    signals.off?.("beforeExit", beforeExit);
+    signals.off?.("exit", exit);
+    for (const [signal, handler] of signalHandlers) {
+      signals.off?.(signal, handler);
+    }
+  }
+
+  stdin.on("data", writeInput);
+  stdin.on("end", stdinEnd);
+  stdout.on?.("resize", resize);
+  signals.on?.("uncaughtException", uncaughtException);
+  signals.on?.("beforeExit", beforeExit);
+  signals.on?.("exit", exit);
+  for (const [signal, handler] of signalHandlers) {
+    signals.on?.(signal, handler);
+  }
+
+  try {
+    await transport.start();
+    await transport.resize(currentSize());
+  } catch (error) {
+    await shutdown().catch(() => {});
+    throw error;
+  }
+
+  return { shutdown };
+}
+
+async function main() {
+  const config = parseBridgeConfig(process.argv.slice(2));
+  await runBridge({
+    config,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    signals: process,
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/hub/team/interactive-native-launcher.mjs
+++ b/hub/team/interactive-native-launcher.mjs
@@ -1,27 +1,17 @@
 import crypto from "node:crypto";
-import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
-  buildNativeWorkerRosterEntry,
+  buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths,
-  mergeRosterWorkers,
-  removeRosterWorkers,
-} from "./claude-native-bridge.mjs";
-import { startInteractiveNativeWorker } from "./interactive-native-worker.mjs";
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "./claude-daemon-control.mjs";
+import { encodeBridgeConfig } from "./daemon-pty-tmux-bridge.mjs";
 
-function buildWorkerSocketPaths({ configDir, sessionName, pid, short }) {
-  const hash = crypto
-    .createHash("sha256")
-    .update(`${configDir || ""}:${sessionName}:${pid}:${crypto.randomUUID()}`)
-    .digest("hex")
-    .slice(0, 10);
-  const socketRoot = path.join(os.tmpdir(), `tfx-in-${hash}`);
-  return {
-    rvSock: path.join(socketRoot, `${short}.rv.sock`),
-    ptySock: path.join(socketRoot, `${short}.pty.sock`),
-  };
-}
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
 
 export async function launchAdoptedInteractiveWorker({
   cwd = process.cwd(),
@@ -31,76 +21,85 @@ export async function launchAdoptedInteractiveWorker({
   role = "interactive",
   configDir,
   pid = process.pid,
+  env = {},
+  cols = DEFAULT_COLS,
+  rows = DEFAULT_ROWS,
   _deps = {},
 } = {}) {
-  const startWorker =
-    _deps.startInteractiveNativeWorker || startInteractiveNativeWorker;
-  const buildRosterEntry =
-    _deps.buildNativeWorkerRosterEntry || buildNativeWorkerRosterEntry;
-  const mergeWorkers = _deps.mergeRosterWorkers || mergeRosterWorkers;
   const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const encodeConfig = _deps.encodeBridgeConfig || encodeBridgeConfig;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const resolvedCwd = path.resolve(cwd);
-  const effectiveSessionName =
-    sessionName || `tfx-${cli}-${role}-${process.pid}`;
+  const effectiveSessionName = sessionName || `tfx-${cli}-${role}-${pid}`;
   const paths = derivePaths({ configDir });
-  const short = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
-  const { rvSock, ptySock } = buildWorkerSocketPaths({
-    configDir,
-    sessionName: effectiveSessionName,
-    pid,
-    short,
-  });
+  const short = crypto.randomBytes(4).toString("hex");
   const displayName = `Triflux ${cli} ${role}`;
+  const bridgePath = fileURLToPath(
+    new URL("./daemon-pty-tmux-bridge.mjs", import.meta.url),
+  );
+  const bridgeConfig = encodeConfig({
+    sessionName: effectiveSessionName,
+    launchCmd,
+    cwd: resolvedCwd,
+    env,
+    cols,
+    rows,
+  });
+  const command = `${shellQuote(process.execPath)} ${shellQuote(
+    bridgePath,
+  )} --config ${bridgeConfig}`;
+  const payload = buildPayload({
+    short,
+    cwd: resolvedCwd,
+    command,
+    name: displayName,
+    cols,
+    rows,
+  });
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
+    agent: cli,
+    name: displayName,
+    cwd: resolvedCwd,
+    dispatchTimeoutMs: 5000,
+  });
 
-  let worker;
   let closed = false;
   let closePromise = null;
 
-  try {
-    worker = await startWorker({
-      short,
-      rvSock,
-      ptySock,
-      sessionName: effectiveSessionName,
-      cwd: resolvedCwd,
-      launchCmd,
-      pid,
-    });
-    const workerShort = worker.short || short;
-    const workerPid = worker.pid || pid;
-    const entry = buildRosterEntry({
-      short: workerShort,
-      pid: workerPid,
-      cwd: resolvedCwd,
-      rendezvousSock: worker.rvSock,
-      ptySock: worker.ptySock,
-      name: displayName,
-      prompt: displayName,
-    });
-    await mergeWorkers(paths.rosterPath, { [workerShort]: entry });
+  return {
+    short,
+    displayName,
+    sessionId: dispatched.sessionId,
+    pid: dispatched.pid,
+    bridgeSessionId: dispatched.bridgeSessionId,
+    sessionProjectionPath: dispatched.sessionProjectionPath,
+    controlSock: paths.controlSock,
+    close() {
+      if (!closePromise) {
+        closePromise = (async () => {
+          if (closed) return;
+          closed = true;
+          await teardownJob({
+            controlSock: paths.controlSock,
+            paths,
+            short,
+            sessionProjectionPath: dispatched.sessionProjectionPath,
+            sessionId: dispatched.sessionId,
+          });
+        })();
+      }
+      return closePromise;
+    },
+  };
+}
 
-    return {
-      short: workerShort,
-      displayName,
-      rosterPath: paths.rosterPath,
-      close() {
-        if (!closePromise) {
-          closePromise = (async () => {
-            if (closed) return;
-            closed = true;
-            try {
-              await worker.close();
-            } finally {
-              await removeRosterWorkers(paths.rosterPath, [workerShort]);
-            }
-          })();
-        }
-        return closePromise;
-      },
-    };
-  } catch (error) {
-    if (worker) await worker.close().catch(() => {});
-    throw error;
-  }
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }

--- a/hub/team/interactive-native-launcher.mjs
+++ b/hub/team/interactive-native-launcher.mjs
@@ -60,15 +60,29 @@ export async function launchAdoptedInteractiveWorker({
     cols,
     rows,
   });
-  const dispatched = await dispatchJob({
-    paths,
-    controlSock: paths.controlSock,
-    payload,
-    agent: cli,
-    name: displayName,
-    cwd: resolvedCwd,
-    dispatchTimeoutMs: 5000,
-  });
+  let dispatched;
+  try {
+    dispatched = await dispatchJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload,
+      agent: cli,
+      name: displayName,
+      cwd: resolvedCwd,
+      dispatchTimeoutMs: 5000,
+    });
+  } catch (error) {
+    // dispatch may have started a daemon job (pid assigned) before a later
+    // step (bridge-session resolve / projection write) threw. Tear down by
+    // short + sessionId so a failed launch never leaks a running pty/tmux job.
+    await teardownJob({
+      controlSock: paths.controlSock,
+      paths,
+      short,
+      sessionId: payload.sessionId,
+    }).catch(() => {});
+    throw error;
+  }
 
   let closed = false;
   let closePromise = null;

--- a/packages/remote/hub/team/daemon-pty-tmux-bridge.mjs
+++ b/packages/remote/hub/team/daemon-pty-tmux-bridge.mjs
@@ -1,0 +1,146 @@
+import { pathToFileURL } from "node:url";
+
+import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
+const SIGNAL_EXIT_CODES = new Map([
+  ["SIGHUP", 129],
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]);
+
+export function encodeBridgeConfig(config) {
+  return Buffer.from(JSON.stringify(config), "utf8").toString("base64");
+}
+
+export function parseBridgeConfig(argv = []) {
+  const index = argv.indexOf("--config");
+  if (index < 0 || !argv[index + 1]) {
+    throw new Error("--config <base64-json> is required");
+  }
+  return JSON.parse(Buffer.from(argv[index + 1], "base64").toString("utf8"));
+}
+
+export async function runBridge({
+  config,
+  stdin,
+  stdout,
+  signals,
+  createTransport = createInteractiveTuiTransport,
+} = {}) {
+  if (!config?.sessionName) throw new Error("config.sessionName is required");
+  if (!stdin) throw new Error("stdin is required");
+  if (!stdout) throw new Error("stdout is required");
+  if (!signals) throw new Error("signals is required");
+
+  const transport = createTransport({
+    sessionName: config.sessionName,
+    cwd: config.cwd,
+    launchCmd: config.launchCmd,
+    env: config.env || {},
+    onData: (chunk) => stdout.write(chunk),
+  });
+  let shutdownPromise = null;
+
+  const currentSize = () => ({
+    cols: stdout.columns || config.cols || DEFAULT_COLS,
+    rows: stdout.rows || config.rows || DEFAULT_ROWS,
+  });
+
+  const shutdown = async ({ exitCode, exitProcess = false } = {}) => {
+    if (!shutdownPromise) {
+      shutdownPromise = (async () => {
+        unregister();
+        await transport.stop();
+      })();
+    }
+    await shutdownPromise;
+    if (exitProcess && typeof signals.exit === "function") {
+      signals.exit(exitCode ?? 0);
+    }
+  };
+
+  const writeInput = (chunk) => {
+    void transport.writeInput(chunk).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const resize = () => {
+    void transport.resize(currentSize()).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const stdinEnd = () => {
+    void shutdown({ exitCode: 0, exitProcess: true });
+  };
+  const signalHandlers = new Map(
+    [...SIGNAL_EXIT_CODES].map(([signal, exitCode]) => [
+      signal,
+      () => {
+        void shutdown({ exitCode, exitProcess: true });
+      },
+    ]),
+  );
+  const uncaughtException = () => {
+    void shutdown({ exitCode: 1, exitProcess: true });
+  };
+  const beforeExit = () => {
+    void shutdown();
+  };
+  const exit = () => {
+    void shutdown();
+  };
+
+  function unregister() {
+    stdin.off?.("data", writeInput);
+    stdin.off?.("end", stdinEnd);
+    stdout.off?.("resize", resize);
+    signals.off?.("uncaughtException", uncaughtException);
+    signals.off?.("beforeExit", beforeExit);
+    signals.off?.("exit", exit);
+    for (const [signal, handler] of signalHandlers) {
+      signals.off?.(signal, handler);
+    }
+  }
+
+  stdin.on("data", writeInput);
+  stdin.on("end", stdinEnd);
+  stdout.on?.("resize", resize);
+  signals.on?.("uncaughtException", uncaughtException);
+  signals.on?.("beforeExit", beforeExit);
+  signals.on?.("exit", exit);
+  for (const [signal, handler] of signalHandlers) {
+    signals.on?.(signal, handler);
+  }
+
+  try {
+    await transport.start();
+    await transport.resize(currentSize());
+  } catch (error) {
+    await shutdown().catch(() => {});
+    throw error;
+  }
+
+  return { shutdown };
+}
+
+async function main() {
+  const config = parseBridgeConfig(process.argv.slice(2));
+  await runBridge({
+    config,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    signals: process,
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/packages/remote/hub/team/interactive-native-launcher.mjs
+++ b/packages/remote/hub/team/interactive-native-launcher.mjs
@@ -1,27 +1,17 @@
 import crypto from "node:crypto";
-import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
-  buildNativeWorkerRosterEntry,
+  buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths,
-  mergeRosterWorkers,
-  removeRosterWorkers,
-} from "./claude-native-bridge.mjs";
-import { startInteractiveNativeWorker } from "./interactive-native-worker.mjs";
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "./claude-daemon-control.mjs";
+import { encodeBridgeConfig } from "./daemon-pty-tmux-bridge.mjs";
 
-function buildWorkerSocketPaths({ configDir, sessionName, pid, short }) {
-  const hash = crypto
-    .createHash("sha256")
-    .update(`${configDir || ""}:${sessionName}:${pid}:${crypto.randomUUID()}`)
-    .digest("hex")
-    .slice(0, 10);
-  const socketRoot = path.join(os.tmpdir(), `tfx-in-${hash}`);
-  return {
-    rvSock: path.join(socketRoot, `${short}.rv.sock`),
-    ptySock: path.join(socketRoot, `${short}.pty.sock`),
-  };
-}
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
 
 export async function launchAdoptedInteractiveWorker({
   cwd = process.cwd(),
@@ -31,76 +21,85 @@ export async function launchAdoptedInteractiveWorker({
   role = "interactive",
   configDir,
   pid = process.pid,
+  env = {},
+  cols = DEFAULT_COLS,
+  rows = DEFAULT_ROWS,
   _deps = {},
 } = {}) {
-  const startWorker =
-    _deps.startInteractiveNativeWorker || startInteractiveNativeWorker;
-  const buildRosterEntry =
-    _deps.buildNativeWorkerRosterEntry || buildNativeWorkerRosterEntry;
-  const mergeWorkers = _deps.mergeRosterWorkers || mergeRosterWorkers;
   const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const encodeConfig = _deps.encodeBridgeConfig || encodeBridgeConfig;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const resolvedCwd = path.resolve(cwd);
-  const effectiveSessionName =
-    sessionName || `tfx-${cli}-${role}-${process.pid}`;
+  const effectiveSessionName = sessionName || `tfx-${cli}-${role}-${pid}`;
   const paths = derivePaths({ configDir });
-  const short = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
-  const { rvSock, ptySock } = buildWorkerSocketPaths({
-    configDir,
-    sessionName: effectiveSessionName,
-    pid,
-    short,
-  });
+  const short = crypto.randomBytes(4).toString("hex");
   const displayName = `Triflux ${cli} ${role}`;
+  const bridgePath = fileURLToPath(
+    new URL("./daemon-pty-tmux-bridge.mjs", import.meta.url),
+  );
+  const bridgeConfig = encodeConfig({
+    sessionName: effectiveSessionName,
+    launchCmd,
+    cwd: resolvedCwd,
+    env,
+    cols,
+    rows,
+  });
+  const command = `${shellQuote(process.execPath)} ${shellQuote(
+    bridgePath,
+  )} --config ${bridgeConfig}`;
+  const payload = buildPayload({
+    short,
+    cwd: resolvedCwd,
+    command,
+    name: displayName,
+    cols,
+    rows,
+  });
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
+    agent: cli,
+    name: displayName,
+    cwd: resolvedCwd,
+    dispatchTimeoutMs: 5000,
+  });
 
-  let worker;
   let closed = false;
   let closePromise = null;
 
-  try {
-    worker = await startWorker({
-      short,
-      rvSock,
-      ptySock,
-      sessionName: effectiveSessionName,
-      cwd: resolvedCwd,
-      launchCmd,
-      pid,
-    });
-    const workerShort = worker.short || short;
-    const workerPid = worker.pid || pid;
-    const entry = buildRosterEntry({
-      short: workerShort,
-      pid: workerPid,
-      cwd: resolvedCwd,
-      rendezvousSock: worker.rvSock,
-      ptySock: worker.ptySock,
-      name: displayName,
-      prompt: displayName,
-    });
-    await mergeWorkers(paths.rosterPath, { [workerShort]: entry });
+  return {
+    short,
+    displayName,
+    sessionId: dispatched.sessionId,
+    pid: dispatched.pid,
+    bridgeSessionId: dispatched.bridgeSessionId,
+    sessionProjectionPath: dispatched.sessionProjectionPath,
+    controlSock: paths.controlSock,
+    close() {
+      if (!closePromise) {
+        closePromise = (async () => {
+          if (closed) return;
+          closed = true;
+          await teardownJob({
+            controlSock: paths.controlSock,
+            paths,
+            short,
+            sessionProjectionPath: dispatched.sessionProjectionPath,
+            sessionId: dispatched.sessionId,
+          });
+        })();
+      }
+      return closePromise;
+    },
+  };
+}
 
-    return {
-      short: workerShort,
-      displayName,
-      rosterPath: paths.rosterPath,
-      close() {
-        if (!closePromise) {
-          closePromise = (async () => {
-            if (closed) return;
-            closed = true;
-            try {
-              await worker.close();
-            } finally {
-              await removeRosterWorkers(paths.rosterPath, [workerShort]);
-            }
-          })();
-        }
-        return closePromise;
-      },
-    };
-  } catch (error) {
-    if (worker) await worker.close().catch(() => {});
-    throw error;
-  }
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }

--- a/packages/remote/hub/team/interactive-native-launcher.mjs
+++ b/packages/remote/hub/team/interactive-native-launcher.mjs
@@ -60,15 +60,29 @@ export async function launchAdoptedInteractiveWorker({
     cols,
     rows,
   });
-  const dispatched = await dispatchJob({
-    paths,
-    controlSock: paths.controlSock,
-    payload,
-    agent: cli,
-    name: displayName,
-    cwd: resolvedCwd,
-    dispatchTimeoutMs: 5000,
-  });
+  let dispatched;
+  try {
+    dispatched = await dispatchJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload,
+      agent: cli,
+      name: displayName,
+      cwd: resolvedCwd,
+      dispatchTimeoutMs: 5000,
+    });
+  } catch (error) {
+    // dispatch may have started a daemon job (pid assigned) before a later
+    // step (bridge-session resolve / projection write) threw. Tear down by
+    // short + sessionId so a failed launch never leaks a running pty/tmux job.
+    await teardownJob({
+      controlSock: paths.controlSock,
+      paths,
+      short,
+      sessionId: payload.sessionId,
+    }).catch(() => {});
+    throw error;
+  }
 
   let closed = false;
   let closePromise = null;

--- a/packages/triflux/hub/team/daemon-pty-tmux-bridge.mjs
+++ b/packages/triflux/hub/team/daemon-pty-tmux-bridge.mjs
@@ -1,0 +1,146 @@
+import { pathToFileURL } from "node:url";
+
+import { createInteractiveTuiTransport } from "./interactive-tui-transport.mjs";
+
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
+const SIGNAL_EXIT_CODES = new Map([
+  ["SIGHUP", 129],
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]);
+
+export function encodeBridgeConfig(config) {
+  return Buffer.from(JSON.stringify(config), "utf8").toString("base64");
+}
+
+export function parseBridgeConfig(argv = []) {
+  const index = argv.indexOf("--config");
+  if (index < 0 || !argv[index + 1]) {
+    throw new Error("--config <base64-json> is required");
+  }
+  return JSON.parse(Buffer.from(argv[index + 1], "base64").toString("utf8"));
+}
+
+export async function runBridge({
+  config,
+  stdin,
+  stdout,
+  signals,
+  createTransport = createInteractiveTuiTransport,
+} = {}) {
+  if (!config?.sessionName) throw new Error("config.sessionName is required");
+  if (!stdin) throw new Error("stdin is required");
+  if (!stdout) throw new Error("stdout is required");
+  if (!signals) throw new Error("signals is required");
+
+  const transport = createTransport({
+    sessionName: config.sessionName,
+    cwd: config.cwd,
+    launchCmd: config.launchCmd,
+    env: config.env || {},
+    onData: (chunk) => stdout.write(chunk),
+  });
+  let shutdownPromise = null;
+
+  const currentSize = () => ({
+    cols: stdout.columns || config.cols || DEFAULT_COLS,
+    rows: stdout.rows || config.rows || DEFAULT_ROWS,
+  });
+
+  const shutdown = async ({ exitCode, exitProcess = false } = {}) => {
+    if (!shutdownPromise) {
+      shutdownPromise = (async () => {
+        unregister();
+        await transport.stop();
+      })();
+    }
+    await shutdownPromise;
+    if (exitProcess && typeof signals.exit === "function") {
+      signals.exit(exitCode ?? 0);
+    }
+  };
+
+  const writeInput = (chunk) => {
+    void transport.writeInput(chunk).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const resize = () => {
+    void transport.resize(currentSize()).catch(() => {
+      void shutdown({ exitCode: 1, exitProcess: true });
+    });
+  };
+  const stdinEnd = () => {
+    void shutdown({ exitCode: 0, exitProcess: true });
+  };
+  const signalHandlers = new Map(
+    [...SIGNAL_EXIT_CODES].map(([signal, exitCode]) => [
+      signal,
+      () => {
+        void shutdown({ exitCode, exitProcess: true });
+      },
+    ]),
+  );
+  const uncaughtException = () => {
+    void shutdown({ exitCode: 1, exitProcess: true });
+  };
+  const beforeExit = () => {
+    void shutdown();
+  };
+  const exit = () => {
+    void shutdown();
+  };
+
+  function unregister() {
+    stdin.off?.("data", writeInput);
+    stdin.off?.("end", stdinEnd);
+    stdout.off?.("resize", resize);
+    signals.off?.("uncaughtException", uncaughtException);
+    signals.off?.("beforeExit", beforeExit);
+    signals.off?.("exit", exit);
+    for (const [signal, handler] of signalHandlers) {
+      signals.off?.(signal, handler);
+    }
+  }
+
+  stdin.on("data", writeInput);
+  stdin.on("end", stdinEnd);
+  stdout.on?.("resize", resize);
+  signals.on?.("uncaughtException", uncaughtException);
+  signals.on?.("beforeExit", beforeExit);
+  signals.on?.("exit", exit);
+  for (const [signal, handler] of signalHandlers) {
+    signals.on?.(signal, handler);
+  }
+
+  try {
+    await transport.start();
+    await transport.resize(currentSize());
+  } catch (error) {
+    await shutdown().catch(() => {});
+    throw error;
+  }
+
+  return { shutdown };
+}
+
+async function main() {
+  const config = parseBridgeConfig(process.argv.slice(2));
+  await runBridge({
+    config,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    signals: process,
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/packages/triflux/hub/team/interactive-native-launcher.mjs
+++ b/packages/triflux/hub/team/interactive-native-launcher.mjs
@@ -1,27 +1,17 @@
 import crypto from "node:crypto";
-import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
-  buildNativeWorkerRosterEntry,
+  buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths,
-  mergeRosterWorkers,
-  removeRosterWorkers,
-} from "./claude-native-bridge.mjs";
-import { startInteractiveNativeWorker } from "./interactive-native-worker.mjs";
+  dispatchClaudeDaemonJob,
+  teardownClaudeDaemonJob,
+} from "./claude-daemon-control.mjs";
+import { encodeBridgeConfig } from "./daemon-pty-tmux-bridge.mjs";
 
-function buildWorkerSocketPaths({ configDir, sessionName, pid, short }) {
-  const hash = crypto
-    .createHash("sha256")
-    .update(`${configDir || ""}:${sessionName}:${pid}:${crypto.randomUUID()}`)
-    .digest("hex")
-    .slice(0, 10);
-  const socketRoot = path.join(os.tmpdir(), `tfx-in-${hash}`);
-  return {
-    rvSock: path.join(socketRoot, `${short}.rv.sock`),
-    ptySock: path.join(socketRoot, `${short}.pty.sock`),
-  };
-}
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 40;
 
 export async function launchAdoptedInteractiveWorker({
   cwd = process.cwd(),
@@ -31,76 +21,85 @@ export async function launchAdoptedInteractiveWorker({
   role = "interactive",
   configDir,
   pid = process.pid,
+  env = {},
+  cols = DEFAULT_COLS,
+  rows = DEFAULT_ROWS,
   _deps = {},
 } = {}) {
-  const startWorker =
-    _deps.startInteractiveNativeWorker || startInteractiveNativeWorker;
-  const buildRosterEntry =
-    _deps.buildNativeWorkerRosterEntry || buildNativeWorkerRosterEntry;
-  const mergeWorkers = _deps.mergeRosterWorkers || mergeRosterWorkers;
   const derivePaths = _deps.deriveClaudeDaemonPaths || deriveClaudeDaemonPaths;
+  const encodeConfig = _deps.encodeBridgeConfig || encodeBridgeConfig;
+  const buildPayload =
+    _deps.buildDaemonExecDispatchPayload || buildDaemonExecDispatchPayload;
+  const dispatchJob = _deps.dispatchClaudeDaemonJob || dispatchClaudeDaemonJob;
+  const teardownJob = _deps.teardownClaudeDaemonJob || teardownClaudeDaemonJob;
 
   const resolvedCwd = path.resolve(cwd);
-  const effectiveSessionName =
-    sessionName || `tfx-${cli}-${role}-${process.pid}`;
+  const effectiveSessionName = sessionName || `tfx-${cli}-${role}-${pid}`;
   const paths = derivePaths({ configDir });
-  const short = crypto.randomUUID().replaceAll("-", "").slice(0, 8);
-  const { rvSock, ptySock } = buildWorkerSocketPaths({
-    configDir,
-    sessionName: effectiveSessionName,
-    pid,
-    short,
-  });
+  const short = crypto.randomBytes(4).toString("hex");
   const displayName = `Triflux ${cli} ${role}`;
+  const bridgePath = fileURLToPath(
+    new URL("./daemon-pty-tmux-bridge.mjs", import.meta.url),
+  );
+  const bridgeConfig = encodeConfig({
+    sessionName: effectiveSessionName,
+    launchCmd,
+    cwd: resolvedCwd,
+    env,
+    cols,
+    rows,
+  });
+  const command = `${shellQuote(process.execPath)} ${shellQuote(
+    bridgePath,
+  )} --config ${bridgeConfig}`;
+  const payload = buildPayload({
+    short,
+    cwd: resolvedCwd,
+    command,
+    name: displayName,
+    cols,
+    rows,
+  });
+  const dispatched = await dispatchJob({
+    paths,
+    controlSock: paths.controlSock,
+    payload,
+    agent: cli,
+    name: displayName,
+    cwd: resolvedCwd,
+    dispatchTimeoutMs: 5000,
+  });
 
-  let worker;
   let closed = false;
   let closePromise = null;
 
-  try {
-    worker = await startWorker({
-      short,
-      rvSock,
-      ptySock,
-      sessionName: effectiveSessionName,
-      cwd: resolvedCwd,
-      launchCmd,
-      pid,
-    });
-    const workerShort = worker.short || short;
-    const workerPid = worker.pid || pid;
-    const entry = buildRosterEntry({
-      short: workerShort,
-      pid: workerPid,
-      cwd: resolvedCwd,
-      rendezvousSock: worker.rvSock,
-      ptySock: worker.ptySock,
-      name: displayName,
-      prompt: displayName,
-    });
-    await mergeWorkers(paths.rosterPath, { [workerShort]: entry });
+  return {
+    short,
+    displayName,
+    sessionId: dispatched.sessionId,
+    pid: dispatched.pid,
+    bridgeSessionId: dispatched.bridgeSessionId,
+    sessionProjectionPath: dispatched.sessionProjectionPath,
+    controlSock: paths.controlSock,
+    close() {
+      if (!closePromise) {
+        closePromise = (async () => {
+          if (closed) return;
+          closed = true;
+          await teardownJob({
+            controlSock: paths.controlSock,
+            paths,
+            short,
+            sessionProjectionPath: dispatched.sessionProjectionPath,
+            sessionId: dispatched.sessionId,
+          });
+        })();
+      }
+      return closePromise;
+    },
+  };
+}
 
-    return {
-      short: workerShort,
-      displayName,
-      rosterPath: paths.rosterPath,
-      close() {
-        if (!closePromise) {
-          closePromise = (async () => {
-            if (closed) return;
-            closed = true;
-            try {
-              await worker.close();
-            } finally {
-              await removeRosterWorkers(paths.rosterPath, [workerShort]);
-            }
-          })();
-        }
-        return closePromise;
-      },
-    };
-  } catch (error) {
-    if (worker) await worker.close().catch(() => {});
-    throw error;
-  }
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
 }

--- a/packages/triflux/hub/team/interactive-native-launcher.mjs
+++ b/packages/triflux/hub/team/interactive-native-launcher.mjs
@@ -60,15 +60,29 @@ export async function launchAdoptedInteractiveWorker({
     cols,
     rows,
   });
-  const dispatched = await dispatchJob({
-    paths,
-    controlSock: paths.controlSock,
-    payload,
-    agent: cli,
-    name: displayName,
-    cwd: resolvedCwd,
-    dispatchTimeoutMs: 5000,
-  });
+  let dispatched;
+  try {
+    dispatched = await dispatchJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload,
+      agent: cli,
+      name: displayName,
+      cwd: resolvedCwd,
+      dispatchTimeoutMs: 5000,
+    });
+  } catch (error) {
+    // dispatch may have started a daemon job (pid assigned) before a later
+    // step (bridge-session resolve / projection write) threw. Tear down by
+    // short + sessionId so a failed launch never leaks a running pty/tmux job.
+    await teardownJob({
+      controlSock: paths.controlSock,
+      paths,
+      short,
+      sessionId: payload.sessionId,
+    }).catch(() => {});
+    throw error;
+  }
 
   let closed = false;
   let closePromise = null;

--- a/tests/unit/daemon-pty-tmux-bridge.test.mjs
+++ b/tests/unit/daemon-pty-tmux-bridge.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import {
+  encodeBridgeConfig,
+  parseBridgeConfig,
+  runBridge,
+} from "../../hub/team/daemon-pty-tmux-bridge.mjs";
+
+test("encodeBridgeConfig and parseBridgeConfig round-trip shell-sensitive config", () => {
+  const config = {
+    sessionName: "tfx daemon bridge",
+    launchCmd: "codex --profile 'gpt55 low'",
+    cwd: "/tmp/project with spaces",
+    env: { TFX_MODE: "daemon pty", EMPTY: "" },
+    cols: 132,
+    rows: 43,
+  };
+
+  const encoded = encodeBridgeConfig(config);
+
+  assert.match(encoded, /^[A-Za-z0-9+/]+={0,2}$/);
+  assert.deepEqual(parseBridgeConfig(["--config", encoded]), config);
+});
+
+test("runBridge starts transport, resizes, forwards input, handles resize, and stops once", async () => {
+  const calls = [];
+  const stdin = new EventEmitter();
+  const stdout = new EventEmitter();
+  const signals = new EventEmitter();
+  stdout.columns = 100;
+  stdout.rows = 31;
+  stdout.write = (chunk) => calls.push(["stdout.write", chunk]);
+
+  const transport = {
+    async start() {
+      calls.push(["start"]);
+    },
+    async resize(size) {
+      calls.push(["resize", size]);
+    },
+    async writeInput(chunk) {
+      calls.push(["writeInput", chunk]);
+    },
+    async stop() {
+      calls.push(["stop"]);
+    },
+  };
+
+  const handle = await runBridge({
+    config: {
+      sessionName: "tfx-test",
+      launchCmd: "codex",
+      cwd: "/tmp/project",
+      env: { TFX: "1" },
+      cols: 120,
+      rows: 40,
+    },
+    stdin,
+    stdout,
+    signals,
+    createTransport(options) {
+      calls.push(["createTransport", options]);
+      options.onData("hello");
+      return transport;
+    },
+  });
+
+  assert.deepEqual(calls.slice(0, 4), [
+    [
+      "createTransport",
+      {
+        sessionName: "tfx-test",
+        cwd: "/tmp/project",
+        launchCmd: "codex",
+        env: { TFX: "1" },
+        onData: calls[0][1].onData,
+      },
+    ],
+    ["stdout.write", "hello"],
+    ["start"],
+    ["resize", { cols: 100, rows: 31 }],
+  ]);
+
+  const input = Buffer.from("\u001b[A");
+  stdin.emit("data", input);
+  stdout.columns = 90;
+  stdout.rows = 28;
+  stdout.emit("resize");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls.filter(([name]) => name === "writeInput").length, 1);
+  assert.equal(calls.find(([name]) => name === "writeInput")[1], input);
+  assert.deepEqual(calls.at(-1), ["resize", { cols: 90, rows: 28 }]);
+
+  await handle.shutdown();
+  signals.emit("SIGTERM");
+  stdin.emit("end");
+  signals.emit("SIGINT");
+  signals.emit("uncaughtException", new Error("boom"));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls.filter(([name]) => name === "stop").length, 1);
+});
+
+test("runBridge falls back to config size and then default size", async () => {
+  const sizes = [];
+  const makeStream = () => {
+    const stream = new EventEmitter();
+    stream.write = () => {};
+    return stream;
+  };
+  const makeTransport = () => ({
+    async start() {},
+    async resize(size) {
+      sizes.push(size);
+    },
+    async writeInput() {},
+    async stop() {},
+  });
+
+  const first = await runBridge({
+    config: { sessionName: "one", cols: 88, rows: 22 },
+    stdin: makeStream(),
+    stdout: makeStream(),
+    signals: new EventEmitter(),
+    createTransport: makeTransport,
+  });
+  await first.shutdown();
+
+  const second = await runBridge({
+    config: { sessionName: "two" },
+    stdin: makeStream(),
+    stdout: makeStream(),
+    signals: new EventEmitter(),
+    createTransport: makeTransport,
+  });
+  await second.shutdown();
+
+  assert.deepEqual(sizes, [
+    { cols: 88, rows: 22 },
+    { cols: 120, rows: 40 },
+  ]);
+});

--- a/tests/unit/native-bridge-interactive-launcher.test.mjs
+++ b/tests/unit/native-bridge-interactive-launcher.test.mjs
@@ -1,160 +1,137 @@
 import assert from "node:assert/strict";
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { parseBridgeConfig } from "../../hub/team/daemon-pty-tmux-bridge.mjs";
 import { launchAdoptedInteractiveWorker } from "../../hub/team/interactive-native-launcher.mjs";
 
-function createLauncherFakes({ rosterPath, startedWorker } = {}) {
+function createDispatchFakes() {
   const calls = {
-    start: [],
-    build: [],
-    merge: [],
-    workerClose: 0,
+    derive: [],
+    dispatch: [],
+    teardown: [],
+    rosterWrites: [],
   };
-  const worker = {
-    pid: 4242,
-    async close() {
-      calls.workerClose += 1;
-    },
-    ...startedWorker,
+  const paths = {
+    controlSock: "/tmp/claude/control.sock",
+    rosterPath: "/tmp/claude/daemon/roster.json",
+    sessionsDir: "/tmp/claude/sessions",
+    jobsDir: "/tmp/claude/jobs",
   };
   const deps = {
-    async startInteractiveNativeWorker(options) {
-      calls.start.push(options);
+    deriveClaudeDaemonPaths(options) {
+      calls.derive.push(options);
+      return paths;
+    },
+    buildDaemonExecDispatchPayload(options) {
+      calls.payload = options;
       return {
+        proto: 1,
         short: options.short,
-        rvSock: options.rvSock,
-        ptySock: options.ptySock,
-        pid: options.pid,
-        ...worker,
+        sessionId: `${options.short}-session`,
+        cwd: options.cwd,
+        launch: {
+          mode: "exec",
+          cmd: "/bin/zsh",
+          args: ["-lc", options.command],
+        },
+        seed: { name: options.name },
+        cols: options.cols,
+        rows: options.rows,
       };
     },
-    buildNativeWorkerRosterEntry(options) {
-      calls.build.push(options);
+    async dispatchClaudeDaemonJob(options) {
+      calls.dispatch.push(options);
       return {
-        built: true,
-        short: options.short,
-        pid: options.pid,
-        rendezvousSock: options.rendezvousSock,
-        ptySock: options.ptySock,
-        name: options.name,
+        ok: true,
+        short: options.payload.short,
+        sessionId: options.payload.sessionId,
+        pid: 12345,
+        bridgeSessionId: "cse_daemon_pty",
+        sessionProjectionPath: "/tmp/claude/sessions/projection.json",
       };
     },
-    async mergeRosterWorkers(pathname, workers) {
-      calls.merge.push({ rosterPath: pathname, workers });
-      await fs.mkdir(path.dirname(pathname), { recursive: true });
-      let roster = { proto: 1, supervisorPid: 0, updatedAt: 1, workers: {} };
-      try {
-        roster = JSON.parse(await fs.readFile(pathname, "utf8"));
-      } catch (error) {
-        if (error?.code !== "ENOENT") throw error;
-      }
-      roster.workers = { ...(roster.workers || {}), ...workers };
-      await fs.writeFile(pathname, `${JSON.stringify(roster, null, 2)}\n`);
-      return roster;
+    async teardownClaudeDaemonJob(options) {
+      calls.teardown.push(options);
     },
-    deriveClaudeDaemonPaths() {
-      return { rosterPath };
+    mergeRosterWorkers(...args) {
+      calls.rosterWrites.push(args);
+      throw new Error("roster adoption path must not be used");
+    },
+    startInteractiveNativeWorker() {
+      throw new Error("roster-only worker must not be started");
     },
   };
-  return { calls, deps, worker };
+  return { calls, deps, paths };
 }
 
-test("launchAdoptedInteractiveWorker starts an interactive worker and registers a roster adoption entry", async () => {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-int-launch-"));
-  const rosterPath = path.join(tmp, "claude", "daemon", "roster.json");
-  const { calls, deps } = createLauncherFakes({ rosterPath });
+test("launchAdoptedInteractiveWorker dispatches a daemon exec job that runs the pty tmux bridge", async () => {
+  const { calls, deps, paths } = createDispatchFakes();
 
   const handle = await launchAdoptedInteractiveWorker({
-    cwd: "/tmp/project",
+    cwd: "/tmp/project with spaces",
     sessionName: "tfx-session",
     launchCmd: "codex --profile gpt55_low",
     cli: "codex",
     role: "executor",
-    configDir: path.join(tmp, "claude"),
-    pid: 4242,
+    configDir: "/tmp/claude",
     _deps: deps,
   });
 
   assert.match(handle.short, /^[a-f0-9]{8}$/);
   assert.equal(handle.displayName, "Triflux codex executor");
-  assert.equal(handle.rosterPath, rosterPath);
-  assert.equal(calls.start.length, 1);
-  assert.equal(calls.start[0].short, handle.short);
-  assert.equal(calls.start[0].sessionName, "tfx-session");
-  assert.equal(calls.start[0].cwd, "/tmp/project");
-  assert.equal(calls.start[0].launchCmd, "codex --profile gpt55_low");
-  assert.equal(calls.start[0].pid, 4242);
-  assert.ok(calls.start[0].rvSock.endsWith(`${handle.short}.rv.sock`));
-  assert.ok(calls.start[0].ptySock.endsWith(`${handle.short}.pty.sock`));
-
-  assert.deepEqual(calls.build, [
-    {
-      short: handle.short,
-      pid: 4242,
-      cwd: "/tmp/project",
-      rendezvousSock: calls.start[0].rvSock,
-      ptySock: calls.start[0].ptySock,
-      name: "Triflux codex executor",
-      prompt: "Triflux codex executor",
-    },
-  ]);
-  assert.deepEqual(calls.merge, [
-    {
-      rosterPath,
-      workers: {
-        [handle.short]: {
-          built: true,
-          short: handle.short,
-          pid: 4242,
-          rendezvousSock: calls.start[0].rvSock,
-          ptySock: calls.start[0].ptySock,
-          name: "Triflux codex executor",
-        },
-      },
-    },
-  ]);
-
-  await handle.close();
-  await fs.rm(tmp, { recursive: true, force: true });
-});
-
-test("launchAdoptedInteractiveWorker close removes only its roster key and is idempotent", async () => {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-int-close-"));
-  const rosterPath = path.join(tmp, "claude", "daemon", "roster.json");
-  await fs.mkdir(path.dirname(rosterPath), { recursive: true });
-  await fs.writeFile(
-    rosterPath,
-    `${JSON.stringify({
-      proto: 1,
-      supervisorPid: 123,
-      updatedAt: 1,
-      workers: { existing: { pid: 1, sessionId: "existing" } },
-    })}\n`,
+  assert.equal(handle.sessionId, `${handle.short}-session`);
+  assert.equal(handle.pid, 12345);
+  assert.equal(handle.bridgeSessionId, "cse_daemon_pty");
+  assert.equal(
+    handle.sessionProjectionPath,
+    "/tmp/claude/sessions/projection.json",
   );
-  const { calls, deps } = createLauncherFakes({ rosterPath });
+  assert.equal(handle.controlSock, paths.controlSock);
 
-  const handle = await launchAdoptedInteractiveWorker({
-    cwd: "/tmp/project",
+  assert.deepEqual(calls.derive, [{ configDir: "/tmp/claude" }]);
+  assert.equal(calls.dispatch.length, 1);
+  assert.equal(calls.dispatch[0].paths, paths);
+  assert.equal(calls.dispatch[0].controlSock, paths.controlSock);
+  assert.equal(calls.dispatch[0].agent, "codex");
+  assert.equal(calls.dispatch[0].name, "Triflux codex executor");
+  assert.equal(calls.dispatch[0].cwd, "/tmp/project with spaces");
+  assert.equal(calls.dispatch[0].dispatchTimeoutMs, 5000);
+
+  assert.equal(calls.payload.short, handle.short);
+  assert.equal(calls.payload.cwd, "/tmp/project with spaces");
+  assert.equal(calls.payload.name, "Triflux codex executor");
+  assert.equal(calls.payload.cols, 120);
+  assert.equal(calls.payload.rows, 40);
+  assert.match(
+    calls.payload.command,
+    /^'[^']*node' '[^']*daemon-pty-tmux-bridge\.mjs' --config [A-Za-z0-9+/]+={0,2}$/,
+  );
+
+  const [, configArg] = calls.payload.command.match(
+    / --config ([A-Za-z0-9+/]+={0,2})$/,
+  );
+  const bridgeConfig = parseBridgeConfig(["--config", configArg]);
+  assert.deepEqual(bridgeConfig, {
     sessionName: "tfx-session",
-    configDir: path.join(tmp, "claude"),
-    pid: 4242,
-    _deps: deps,
+    launchCmd: "codex --profile gpt55_low",
+    cwd: path.resolve("/tmp/project with spaces"),
+    env: {},
+    cols: 120,
+    rows: 40,
   });
-
-  let roster = JSON.parse(await fs.readFile(rosterPath, "utf8"));
-  assert.ok(roster.workers.existing);
-  assert.ok(roster.workers[handle.short]);
+  assert.equal(calls.rosterWrites.length, 0);
 
   await handle.close();
   await handle.close();
 
-  roster = JSON.parse(await fs.readFile(rosterPath, "utf8"));
-  assert.ok(roster.workers.existing);
-  assert.equal(roster.workers[handle.short], undefined);
-  assert.equal(calls.workerClose, 1);
-
-  await fs.rm(tmp, { recursive: true, force: true });
+  assert.deepEqual(calls.teardown, [
+    {
+      controlSock: paths.controlSock,
+      paths,
+      short: handle.short,
+      sessionProjectionPath: "/tmp/claude/sessions/projection.json",
+      sessionId: `${handle.short}-session`,
+    },
+  ]);
 });

--- a/tests/unit/native-bridge-interactive-launcher.test.mjs
+++ b/tests/unit/native-bridge-interactive-launcher.test.mjs
@@ -135,3 +135,34 @@ test("launchAdoptedInteractiveWorker dispatches a daemon exec job that runs the 
     },
   ]);
 });
+
+test("launchAdoptedInteractiveWorker tears down the daemon job when dispatch fails after assigning a pid", async () => {
+  const { calls, deps, paths } = createDispatchFakes();
+  deps.dispatchClaudeDaemonJob = async (options) => {
+    calls.dispatch.push(options);
+    throw new Error("bridge session resolution timed out");
+  };
+
+  await assert.rejects(
+    launchAdoptedInteractiveWorker({
+      sessionName: "tfx-session",
+      cli: "codex",
+      role: "executor",
+      configDir: "/tmp/claude",
+      _deps: deps,
+    }),
+    /bridge session resolution timed out/,
+  );
+
+  // The failed launch must not leak a running daemon pty/tmux job: teardown is
+  // called with the short + payload sessionId known before dispatch threw.
+  assert.equal(calls.teardown.length, 1);
+  assert.equal(calls.teardown[0].controlSock, paths.controlSock);
+  assert.equal(calls.teardown[0].paths, paths);
+  assert.match(calls.teardown[0].short, /^[a-f0-9]{8}$/);
+  assert.equal(
+    calls.teardown[0].sessionId,
+    `${calls.teardown[0].short}-session`,
+  );
+  assert.equal(calls.rosterWrites.length, 0);
+});


### PR DESCRIPTION
## What

Implements P1 Item 2 from `docs/prd/native-bridge-daemon-adoption.md` (Option A): interactive native workers now appear as real rows in the `claude agents` panel because they are DISPATCHED as a daemon exec job, instead of the old roster-only facade the Claude daemon never saw.

- **New** `hub/team/daemon-pty-tmux-bridge.mjs` — a thin process entrypoint whose own stdin/stdout ARE the daemon-owned pty. It reuses `createInteractiveTuiTransport` to wire: daemon-injected stdin → tmux `send-keys`, tmux `pipe-pane` output → its stdout (which the daemon streams to `claude agents`). Reverse of today's worker-owns-pty facade.
- **Rewrote** `hub/team/interactive-native-launcher.mjs` — `launchAdoptedInteractiveWorker` now builds an exec payload (`command = node <bridge> --config <base64-json>`), dispatches via the shared `dispatchClaudeDaemonJob`, and `close()` tears down via `teardownClaudeDaemonJob`. The roster-only adoption path is retired (the reusable transport/facade primitives are kept for the opt-in E2E and fallback).

## Resolved design decisions

1. **Bridge location**: new `daemon-pty-tmux-bridge.mjs` thin entrypoint reusing the transport library (not folded into interactive-tui-transport).
2. **Roster-facade**: retire the roster-only invisible-worker path, replace with dispatch+bridge. Primitives kept.
3. **raw/resize**: raw stdin passthrough → `transport.writeInput`; `process.stdout` 'resize' → `transport.resize` (tmux resize-window); initial size from `stdout.columns/rows` (fallback config → 120x40).
4. **Teardown authority split**: the bridge owns only tmux/pipe teardown (idempotent `transport.stop()` across SIGTERM/SIGINT/SIGHUP/stdin-end/uncaught/beforeExit); the dispatcher (`launchAdoptedInteractiveWorker.close()`) owns daemon job + projection cleanup via `teardownClaudeDaemonJob`.

## Commits

- `ef81c135` (Codex) — bridge + launcher + tests + mirrors.
- `ddfd4bc6` (Claude cross-review) — tear down the daemon job if dispatch throws after pid assignment (bridge-session resolve / projection write failure), so a failed launch never orphans a pty/tmux job. + failure-path test.

## Verification

- `node --test tests/unit/daemon-pty-tmux-bridge.test.mjs tests/unit/native-bridge-interactive-launcher.test.mjs` → 5/5 pass (hermetic: fake transport + EventEmitter streams + in-memory dispatch fakes; no live daemon, no real tmux). Covers config codec round-trip (shell-sensitive values), start/resize/input/idempotent-single-stop, size fallback, 8-hex short, base64 `--config` command, no-roster-write, idempotent close, and dispatch-failure teardown.
- `npx biome check` on changed files → clean (pre-existing unrelated drift in uds-orchestrator/session-stale-cleanup left untouched; lint scoped to changed files).
- `npm run release:check-mirror` → OK. Manual `diff -q` root vs packages/triflux and root vs packages/remote → byte-identical. No `@triflux/core` conversion needed (sibling imports only). New bridge file confirmed present in `npm pack` (3.9kB), no pack-size regression (3.2 MB baseline unchanged).

## Notes

- `short` uses `crypto.randomBytes(4).toString("hex")` (8 lowercase hex — daemon dispatch/kill requirement).
- No AI attribution trailer (triflux policy).