### PR TITLE
style: fix biome lint drift blocking v10.28.0 release

### DIFF
--- a/hub/team/uds-orchestrator.mjs
+++ b/hub/team/uds-orchestrator.mjs
@@ -243,9 +243,7 @@ export function extractClaudeUdsText(text, marker) {
   if (assistantIndex >= 0) {
     const useful = lines
       .slice(assistantIndex)
-      .map((line, index) =>
-        index === 0 ? line.replace(/^\s*⏺\s*/, "") : line,
-      )
+      .map((line, index) => (index === 0 ? line.replace(/^\s*⏺\s*/, "") : line))
       .filter((line) => !isClaudeUdsNoiseLine(line));
     return useful.join("\n").trim();
   }

--- a/packages/triflux/hub/team/uds-orchestrator.mjs
+++ b/packages/triflux/hub/team/uds-orchestrator.mjs
@@ -243,9 +243,7 @@ export function extractClaudeUdsText(text, marker) {
   if (assistantIndex >= 0) {
     const useful = lines
       .slice(assistantIndex)
-      .map((line, index) =>
-        index === 0 ? line.replace(/^\s*⏺\s*/, "") : line,
-      )
+      .map((line, index) => (index === 0 ? line.replace(/^\s*⏺\s*/, "") : line))
       .filter((line) => !isClaudeUdsNoiseLine(line));
     return useful.join("\n").trim();
   }

--- a/packages/triflux/scripts/session-stale-cleanup.mjs
+++ b/packages/triflux/scripts/session-stale-cleanup.mjs
@@ -193,7 +193,9 @@ function treeKill(pid) {
       let pgid = null;
       let cmd = "";
       try {
-        const out = execSync(`ps -o pgid=,command= -p ${pid}`, { timeout: 2000 })
+        const out = execSync(`ps -o pgid=,command= -p ${pid}`, {
+          timeout: 2000,
+        })
           .toString()
           .trim();
         const m = out.match(/^(\d+)\s+(.*)$/);

--- a/scripts/session-stale-cleanup.mjs
+++ b/scripts/session-stale-cleanup.mjs
@@ -193,7 +193,9 @@ function treeKill(pid) {
       let pgid = null;
       let cmd = "";
       try {
-        const out = execSync(`ps -o pgid=,command= -p ${pid}`, { timeout: 2000 })
+        const out = execSync(`ps -o pgid=,command= -p ${pid}`, {
+          timeout: 2000,
+        })
           .toString()
           .trim();
         const m = out.match(/^(\d+)\s+(.*)$/);

--- a/tests/unit/uds-orchestrator.test.mjs
+++ b/tests/unit/uds-orchestrator.test.mjs
@@ -91,7 +91,9 @@ test("peer mode asks Claude UDS and Codex as peers, then synthesizes", async () 
 
 async function withFakeClaudeDaemon(handler, fn) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "uds-orchestrator-"));
-  const paths = deriveClaudeDaemonPaths({ configDir: path.join(dir, "claude") });
+  const paths = deriveClaudeDaemonPaths({
+    configDir: path.join(dir, "claude"),
+  });
   await fs.mkdir(paths.daemonDir, { recursive: true });
   const requests = [];
   const server = net.createServer((socket) => {
@@ -163,7 +165,10 @@ test("createClaudeUdsEndpoint dispatches with shared daemon helper, captures mar
       } else if (request.op === "subscribe") {
         writeJson(socket, { type: "snapshot", streamTail: ["boot\n"] });
         writeJson(socket, { type: "stream", line: "⏺ ANSWER_TEXT\n" });
-        writeJson(socket, { type: "stream", line: `${request.marker || ""}\n` });
+        writeJson(socket, {
+          type: "stream",
+          line: `${request.marker || ""}\n`,
+        });
       } else if (request.op === "kill") {
         writeJson(socket, { ok: true, op: "kill" }, { end: true });
       } else {
@@ -187,9 +192,14 @@ test("createClaudeUdsEndpoint dispatches with shared daemon helper, captures mar
       assert.ok(requests.find((request) => request.op === "dispatch"));
       assert.ok(requests.find((request) => request.op === "subscribe"));
       assert.ok(requests.find((request) => request.op === "kill"));
-      assert.equal(requests.find((request) => request.op === "dispatch").d.short, "fixed123");
+      assert.equal(
+        requests.find((request) => request.op === "dispatch").d.short,
+        "fixed123",
+      );
       assert.match(
-        requests.find((request) => request.op === "dispatch").d.launch.args.join(" "),
+        requests
+          .find((request) => request.op === "dispatch")
+          .d.launch.args.join(" "),
         /DONE_MARKER/,
       );
     },
@@ -214,7 +224,10 @@ test("createClaudeUdsEndpoint throws before subscribe when daemon dispatch is no
         sessionIdFactory: () => "fail1234-session",
       });
 
-      await assert.rejects(() => endpoint.ask("say answer"), /dispatch failed/u);
+      await assert.rejects(
+        () => endpoint.ask("say answer"),
+        /dispatch failed/u,
+      );
       assert.deepEqual(
         requests.map((request) => request.op),
         ["dispatch"],
@@ -229,7 +242,12 @@ test("createClaudeUdsEndpoint ignores echoed marker instructions before completi
       if (request.op === "dispatch") {
         writeJson(
           socket,
-          { ok: true, op: "dispatch", short: request.d.short, pid: process.pid },
+          {
+            ok: true,
+            op: "dispatch",
+            short: request.d.short,
+            pid: process.pid,
+          },
           { end: true },
         );
       } else if (request.op === "list") {


### PR DESCRIPTION
## What

`biome check --write` on 3 files that landed with formatting drift via #365/#366, keeping the packages/triflux mirror byte-identical.

- `hub/team/uds-orchestrator.mjs` (+ packages/triflux mirror)
- `scripts/session-stale-cleanup.mjs` (+ packages/triflux mirror)
- `tests/unit/uds-orchestrator.test.mjs` (root only, tests not mirrored)

## Why

The v10.28.0 release (`release.yml`) failed at the `prepare` step's `npm run lint` with 3 biome **format** errors. `ci.yml` does **not** run `npm run lint` (only test + check-mirror + check-sync + codex-config guard), so formatting drift accumulated on main invisibly through #362-#369 and only surfaced at release time.

Format-only changes. `npm run lint` now clean (716 files, no fixes), `release:check-mirror` OK.

## Follow-up (not in this PR)

Add a `npm run lint` step to `ci.yml` so formatting drift is caught at PR time, not release time. (Noted for a separate change.)

No AI attribution trailer (triflux policy).