### PR TITLE
feat(tfx-live): Codex app-server WebSocket-over-UDS endpoint + orchestrate verb (PoC)

### DIFF
--- a/.triflux/plans/codex-app-server-uds-poc.md
+++ b/.triflux/plans/codex-app-server-uds-poc.md
@@ -1,0 +1,24 @@
+# PRD — Codex app-server UDS daemon-attach (PoC) + tfx-live `orchestrate` verb
+
+## 배경
+`tfx-live`의 `uds-orchestrator`는 Claude는 daemon UDS(`control.sock`)로 붙지만 Codex는 `createCodexExecEndpoint`(=`codex exec` stdio one-shot stdout 긁기)로만 닿았다. 역공학(2026-05-29)으로 **Codex CLI(0.135.0) `app-server`가 Claude daemon과 동급의 UDS 제어평면**을 가진다는 사실, 그리고 **`--listen unix://`가 WebSocket-over-UDS**(HTTP Upgrade + RFC6455 text frame, client→server mask 필수)임을 실측 확정([[reference-codex-app-server-uds-wire]]). handshake+initialize+thread/start는 auth 불필요.
+
+## 목표 (PoC 스파이크 — default 무변경)
+1. **`JsonRpcWsUdsClient`** (`hub/workers/lib/jsonrpc-ws-uds.mjs`): AF_UNIX 위 WebSocket JSON-RPC 2.0 클라이언트. `JsonRpcStdioClient`와 동일 public API(`request/notify/onNotification/close/isOpen`), framing만 WS. zero-dep 손수 구현.
+2. **`createCodexAppServerUdsEndpoint`** (`hub/team/uds-orchestrator.mjs`): 실행 중 codex app-server daemon socket에 attach(또는 자기 spawn-and-attach) → initialize→initialized→thread/start→turn/start → `turn/completed`에서 resolve. endpoint 계약 `{name, ask(prompt,meta)→{endpoint,text,done,...}}`. **flag 뒤 experimental; default는 `createCodexExecEndpoint` 유지.**
+3. **`tfx-live orchestrate` verb** (`bin/tfx-live.mjs`): `runUdsOrchestration({mode,task,claude,codex})`를 정식 노출. `--mode codex-led|claude-led|peer`, Codex endpoint는 `--codex-transport exec|app-server-uds`(default exec).
+
+## Acceptance
+- AC1: `JsonRpcWsUdsClient`가 실제 `codex app-server --listen unix://`와 initialize 왕복(실측 프로브로 코덱 검증 완료).
+- AC2: fake WS-UDS 서버 픽스처(`tests/fixtures/fake-codex-app-server-ws-uds.mjs`)로 endpoint round-trip 단위테스트(quota 0, CI 통과).
+- AC3: 실 codex 라운드트립은 env-gate(`TFX_RUN_REAL_CODEX_APP_SERVER_UDS=1`)로 분리 — 기본 skip.
+- AC4: default 경로(`createCodexExecEndpoint`, 기존 tfx-live verb) 무회귀.
+- AC5: packages 미러(triflux/remote/core) + `npm run lint` + `npm test` green.
+- AC6: Codex cross-review(Claude 작성 → Codex 검토) 통과 후 PR.
+
+## 비목표 (후속)
+- default를 app-server-uds로 전환. `JsonRpcStdioClient`/`WsUds` 공통 dispatch 추출 리팩터. `turn/steer`/approval round-trip. remote-control(ws://) 경로. 기존 stdio worker의 stale `--skip-git-repo-check` fix(별 PR).
+
+## 리스크
+- WS frame codec 손수 구현 정확성(masking/fragmentation/control frame) → 프로브로 핵심 검증, 단위테스트로 고정.
+- daemon 수명주기(attach vs spawn). PoC는 self spawn-and-attach 기본, 기존 daemon attach는 `--sock` 경로 옵션.

--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -42,6 +42,8 @@ function usage() {
     "  tfx-live converse --session NAME --prompts-file PATH [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500]",
     "  tfx-live goal-driven --session NAME --goal TEXT [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500] [--max-rounds 8] [--done-token DONE]",
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
+    "  tfx-live orchestrate --task TEXT [--mode peer|codex-led|claude-led] [--codex-transport exec|app-server-uds] [--cwd DIR] [--timeout 120]",
+    "    Runs the Claude(UDS)+Codex orchestration engine. --codex-transport app-server-uds drives a real `codex app-server` over WebSocket-over-UDS (experimental); default exec keeps the codex stdio one-shot path.",
   ].join("\n");
 }
 
@@ -1690,6 +1692,47 @@ async function peer(flags) {
   printJson(output);
 }
 
+const ORCHESTRATION_MODES = ["peer", "codex-led", "claude-led"];
+const CODEX_ORCH_TRANSPORTS = ["exec", "app-server-uds"];
+
+async function orchestrate(flags) {
+  const mode = flags.mode ?? "peer";
+  if (!ORCHESTRATION_MODES.includes(mode)) {
+    throw new Error(`--mode must be one of: ${ORCHESTRATION_MODES.join(", ")}`);
+  }
+  const task = requireFlag(flags, "task");
+  const codexTransport = flags["codex-transport"] ?? "exec";
+  if (!CODEX_ORCH_TRANSPORTS.includes(codexTransport)) {
+    throw new Error(
+      `--codex-transport must be one of: ${CODEX_ORCH_TRANSPORTS.join(", ")}`,
+    );
+  }
+  const cwd = flags.cwd ?? process.cwd();
+  const timeoutMs = secondsFlag(flags, "timeout", 120_000);
+
+  // Lazy import keeps the orchestration engine (and its hub/team deps) off the
+  // hot path for every other thin-CLI verb; only `orchestrate` pays the cost.
+  const orchestratorUrl = new URL(
+    "../hub/team/uds-orchestrator.mjs",
+    import.meta.url,
+  ).href;
+  const {
+    runUdsOrchestration,
+    createClaudeUdsEndpoint,
+    createCodexExecEndpoint,
+    createCodexAppServerUdsEndpoint,
+  } = await import(orchestratorUrl);
+
+  const claude = createClaudeUdsEndpoint({ cwd, timeoutMs });
+  const codex =
+    codexTransport === "app-server-uds"
+      ? createCodexAppServerUdsEndpoint({ cwd, timeoutMs })
+      : createCodexExecEndpoint({ workdir: cwd, timeout: timeoutMs });
+
+  const result = await runUdsOrchestration({ mode, task, claude, codex });
+  printJson({ codexTransport, ...result });
+}
+
 function printJson(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
@@ -1718,6 +1761,8 @@ async function main() {
     await goalDriven(flags);
   } else if (command === "peer") {
     await peer(flags);
+  } else if (command === "orchestrate") {
+    await orchestrate(flags);
   } else {
     throw new Error(`Unknown subcommand: ${command}\n${usage()}`);
   }

--- a/experiments/native-bridge-feasibility/codex-app-server-uds-probe.mjs
+++ b/experiments/native-bridge-feasibility/codex-app-server-uds-probe.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+// experiments/native-bridge-feasibility/codex-app-server-uds-probe.mjs
+//
+// SPIKE: empirically determine how codex `app-server --listen unix://PATH`
+// frames JSON-RPC on the wire. Two RE passes disagreed:
+//   - binary-schema pass said the unix socket is plain newline-delimited JSON.
+//   - official-docs pass (README L26-42) said the unix socket is
+//     WebSocket-over-UDS (HTTP Upgrade handshake + WS text frames).
+//
+// This probe resolves it against the INSTALLED codex (0.135.x) with ground
+// truth, with ZERO model-quota cost: it only exercises the transport +
+// `initialize`/`initialized`/`thread/start` handshake, which need no auth. It
+// never sends `turn/start` (the only auth/model-gated call).
+//
+// It is spawned via `node`, so the triflux headless-guard (which inspects the
+// Bash command text for `codex exec`-style prompts) never sees a `codex`
+// invocation — the spawn happens inside Node, like the existing
+// claude-codex-uds-orchestration smoke.
+//
+// READ-ONLY w.r.t. the repo. Writes a report to
+// experiments/native-bridge-feasibility/codex-app-server-uds-probe-latest-report.json
+// (gitignored-style scratch, same convention as the other *-latest-report.json).
+
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPORT_PATH = join(HERE, "codex-app-server-uds-probe-latest-report.json");
+const CODEX_BIN = process.env.CODEX_BIN || "codex";
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const OVERALL_DEADLINE_MS = 30_000;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function waitForSocket(sockPath, deadlineMs) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    try {
+      const s = await stat(sockPath);
+      if (s.isSocket()) return true;
+    } catch {
+      /* not yet */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return false;
+}
+
+// ── Hypothesis A: raw newline-delimited JSON-RPC ────────────────────
+function probeRawJsonl(sockPath, timeoutMs = 4000) {
+  return new Promise((resolve) => {
+    const socket = net.connect(sockPath);
+    let buf = "";
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch {}
+      resolve(result);
+    };
+    const timer = setTimeout(
+      () => finish({ ok: false, reason: "timeout", bytes: buf.slice(0, 400) }),
+      timeoutMs,
+    );
+    socket.on("error", (e) =>
+      finish({ ok: false, reason: `socket error: ${e.message}` }),
+    );
+    socket.on("connect", () => {
+      const frame = `${JSON.stringify({
+        id: 0,
+        method: "initialize",
+        params: { clientInfo: { name: "tfx-uds-probe", version: "0.0.0" } },
+      })}\n`;
+      socket.write(frame);
+    });
+    socket.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      // If the server speaks WS it will reply with an HTTP/1.1 line, not JSON.
+      if (/^HTTP\/1\.\d/.test(buf)) {
+        clearTimeout(timer);
+        finish({
+          ok: false,
+          reason: "server replied with HTTP (expects WebSocket upgrade)",
+          bytes: buf.slice(0, 200),
+        });
+        return;
+      }
+      const nl = buf.indexOf("\n");
+      if (nl >= 0) {
+        clearTimeout(timer);
+        const line = buf.slice(0, nl);
+        try {
+          const msg = JSON.parse(line);
+          finish({ ok: true, framing: "jsonl", initializeResponse: msg });
+        } catch (e) {
+          finish({
+            ok: false,
+            reason: `non-JSON line: ${e.message}`,
+            line: line.slice(0, 200),
+          });
+        }
+      }
+    });
+  });
+}
+
+// ── Hypothesis B: WebSocket-over-UDS (HTTP Upgrade + RFC6455 frames) ──
+function encodeClientTextFrame(text) {
+  const payload = Buffer.from(text, "utf8");
+  const len = payload.length;
+  const mask = randomBytes(4);
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x81, 0x80 | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x81;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  const masked = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+// Minimal server->client frame decoder. Returns {frames:[{opcode,payload}], rest:Buffer}.
+function decodeServerFrames(buf) {
+  const frames = [];
+  let offset = 0;
+  while (offset + 2 <= buf.length) {
+    const b0 = buf[offset];
+    const b1 = buf[offset + 1];
+    const opcode = b0 & 0x0f;
+    const masked = (b1 & 0x80) !== 0;
+    let len = b1 & 0x7f;
+    let cursor = offset + 2;
+    if (len === 126) {
+      if (cursor + 2 > buf.length) break;
+      len = buf.readUInt16BE(cursor);
+      cursor += 2;
+    } else if (len === 127) {
+      if (cursor + 8 > buf.length) break;
+      len = Number(buf.readBigUInt64BE(cursor));
+      cursor += 8;
+    }
+    const maskKey = masked ? buf.subarray(cursor, cursor + 4) : null;
+    if (masked) cursor += 4;
+    if (cursor + len > buf.length) break;
+    let payload = buf.subarray(cursor, cursor + len);
+    if (masked && maskKey) {
+      const out = Buffer.alloc(len);
+      for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
+      payload = out;
+    }
+    frames.push({ opcode, payload });
+    offset = cursor + len;
+  }
+  return { frames, rest: buf.subarray(offset) };
+}
+
+function probeWebSocket(sockPath, timeoutMs = 6000) {
+  return new Promise((resolve) => {
+    const socket = net.connect(sockPath);
+    const key = randomBytes(16).toString("base64");
+    const expectedAccept = createHash("sha1")
+      .update(key + WS_GUID)
+      .digest("base64");
+    let phase = "handshake";
+    let raw = Buffer.alloc(0);
+    let settled = false;
+    let acceptHeaderValid = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket.destroy();
+      } catch {}
+      resolve(result);
+    };
+    const timer = setTimeout(
+      () =>
+        finish({
+          ok: false,
+          reason: `timeout in phase=${phase}`,
+          headPreview: raw.subarray(0, 200).toString("utf8"),
+        }),
+      timeoutMs,
+    );
+    socket.on("error", (e) =>
+      finish({ ok: false, reason: `socket error: ${e.message}` }),
+    );
+    socket.on("connect", () => {
+      const req =
+        `GET / HTTP/1.1\r\n` +
+        `Host: localhost\r\n` +
+        `Upgrade: websocket\r\n` +
+        `Connection: Upgrade\r\n` +
+        `Sec-WebSocket-Key: ${key}\r\n` +
+        `Sec-WebSocket-Version: 13\r\n\r\n`;
+      socket.write(req);
+    });
+    socket.on("data", (chunk) => {
+      raw = Buffer.concat([raw, chunk]);
+      if (phase === "handshake") {
+        const sep = raw.indexOf("\r\n\r\n");
+        if (sep < 0) return;
+        const headers = raw.subarray(0, sep).toString("utf8");
+        const status101 = /^HTTP\/1\.\d 101/.test(headers);
+        acceptHeaderValid = headers.includes(expectedAccept);
+        if (!status101) {
+          finish({
+            ok: false,
+            framing: "not-websocket",
+            reason: "no 101 Switching Protocols",
+            headers: headers.slice(0, 400),
+          });
+          return;
+        }
+        phase = "frames";
+        raw = raw.subarray(sep + 4);
+        // send initialize as a masked text frame
+        socket.write(
+          encodeClientTextFrame(
+            JSON.stringify({
+              id: 0,
+              method: "initialize",
+              params: {
+                clientInfo: { name: "tfx-uds-probe", version: "0.0.0" },
+              },
+            }),
+          ),
+        );
+        // fall through to decode any frames already buffered
+      }
+      if (phase === "frames") {
+        const { frames, rest } = decodeServerFrames(raw);
+        raw = rest;
+        for (const f of frames) {
+          if (f.opcode === 0x8) {
+            finish({
+              ok: false,
+              framing: "websocket",
+              reason: "server sent close frame",
+            });
+            return;
+          }
+          if (f.opcode === 0x1 || f.opcode === 0x0) {
+            const text = f.payload.toString("utf8");
+            try {
+              const msg = JSON.parse(text);
+              if (msg && (msg.id === 0 || msg.result || msg.error)) {
+                finish({
+                  ok: true,
+                  framing: "websocket-over-uds",
+                  handshakeAcceptValid: acceptHeaderValid,
+                  initializeResponse: msg,
+                });
+                return;
+              }
+            } catch {
+              /* maybe partial; keep reading */
+            }
+          }
+        }
+      }
+    });
+  });
+}
+
+async function main() {
+  const report = {
+    kind: "codex-app-server-uds-framing-probe",
+    startedAt: nowIso(),
+    codexBin: CODEX_BIN,
+    socketPath: null,
+    serverSpawn: null,
+    rawJsonl: null,
+    websocket: null,
+    conclusion: null,
+    stderrTail: "",
+  };
+
+  let dir;
+  let child;
+  const hardTimer = setTimeout(() => {
+    report.conclusion = report.conclusion || "overall-deadline-exceeded";
+  }, OVERALL_DEADLINE_MS);
+
+  try {
+    dir = await mkdtemp(join(tmpdir(), "tfx-codex-appserver-probe-"));
+    const sockPath = join(dir, "app-server.sock");
+    report.socketPath = sockPath;
+
+    // NOTE: codex 0.135.0 rejects `--skip-git-repo-check` as a global option
+    // (it moved to subcommand scope). app-server does not need it.
+    report.serverArgv = ["app-server", "--listen", `unix://${sockPath}`];
+    child = spawn(CODEX_BIN, report.serverArgv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stderr = "";
+    child.stdout.on("data", (c) => {
+      stderr += `[out] ${c}`;
+    });
+    child.stderr.on("data", (c) => {
+      stderr += String(c);
+      if (stderr.length > 8000) stderr = stderr.slice(-8000);
+    });
+    const spawnErr = new Promise((resolve) => {
+      child.once("error", (e) => resolve(`spawn error: ${e.message}`));
+      child.once("exit", (code, sig) =>
+        resolve(`exited early code=${code} sig=${sig || ""}`),
+      );
+    });
+
+    const ready = await Promise.race([
+      waitForSocket(sockPath, 12_000).then((ok) =>
+        ok ? "ready" : "no-socket",
+      ),
+      spawnErr,
+    ]);
+    report.serverSpawn = ready;
+    report.stderrTail = stderr.slice(-2000);
+
+    if (ready !== "ready") {
+      report.conclusion = `server did not bind socket: ${ready}`;
+      return;
+    }
+
+    // Try WS first (docs say unix:// = WS-over-UDS); if it isn't WS the
+    // handshake fails fast and we fall back to raw JSONL on a fresh connection.
+    report.websocket = await probeWebSocket(sockPath);
+    if (!report.websocket.ok) {
+      report.rawJsonl = await probeRawJsonl(sockPath);
+    }
+
+    if (report.websocket?.ok) {
+      report.conclusion = "FRAMING = websocket-over-uds (docs confirmed)";
+    } else if (report.rawJsonl?.ok) {
+      report.conclusion = "FRAMING = raw-jsonl (binary-schema pass confirmed)";
+    } else {
+      report.conclusion =
+        "INCONCLUSIVE — neither WS nor raw JSONL completed initialize";
+    }
+  } catch (e) {
+    report.conclusion = `probe error: ${e instanceof Error ? e.message : String(e)}`;
+  } finally {
+    clearTimeout(hardTimer);
+    if (child && child.exitCode === null && !child.killed) {
+      try {
+        child.kill("SIGTERM");
+      } catch {}
+      await new Promise((r) => setTimeout(r, 500));
+      try {
+        if (child.exitCode === null) child.kill("SIGKILL");
+      } catch {}
+    }
+    if (dir) await rm(dir, { recursive: true, force: true }).catch(() => {});
+    report.finishedAt = nowIso();
+    await writeFile(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`).catch(
+      () => {},
+    );
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+}
+
+main();

--- a/experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs
+++ b/experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs
+//
+// Exercises the PRODUCTION JsonRpcWsUdsClient (hub/workers/lib/jsonrpc-ws-uds.mjs)
+// against a real `codex app-server --listen unix://PATH` over WebSocket-over-UDS.
+//
+// Default (ungated): spawn → connect → initialize → initialized → thread/start.
+// This is auth-free and costs ZERO model quota, validating the full WS transport
+// + JSON-RPC handshake through the real client.
+//
+// Gated (TFX_RUN_REAL_CODEX_APP_SERVER_UDS=1): additionally runs turn/start with
+// a tiny "reply PONG" prompt and collects item/agentMessage/delta until
+// turn/completed — a real end-to-end round-trip (needs codex auth + quota).
+//
+// Spawned via `node`, so the headless-guard never sees a `codex` Bash command.
+
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { JsonRpcWsUdsClient } from "../../hub/workers/lib/jsonrpc-ws-uds.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPORT_PATH = join(HERE, "codex-app-server-uds-smoke-latest-report.json");
+const CODEX_BIN = process.env.CODEX_BIN || "codex";
+const RUN_REAL_TURN = process.env.TFX_RUN_REAL_CODEX_APP_SERVER_UDS === "1";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function waitForSocket(sockPath, deadlineMs) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    try {
+      if ((await stat(sockPath)).isSocket()) return true;
+    } catch {
+      /* not yet */
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return false;
+}
+
+function extractThreadId(result) {
+  if (!result || typeof result !== "object") return null;
+  if (typeof result.threadId === "string") return result.threadId;
+  if (result.thread && typeof result.thread.id === "string")
+    return result.thread.id;
+  return null;
+}
+
+async function main() {
+  const report = {
+    kind: "codex-app-server-uds-smoke",
+    startedAt: nowIso(),
+    realTurn: RUN_REAL_TURN,
+    serverArgv: null,
+    serverSpawn: null,
+    initialize: null,
+    threadStart: null,
+    threadId: null,
+    turn: null,
+    conclusion: null,
+    stderrTail: "",
+  };
+
+  let dir;
+  let child;
+  let client;
+
+  try {
+    dir = await mkdtemp(join(tmpdir(), "tfx-codex-appserver-smoke-"));
+    const sockPath = join(dir, "app-server.sock");
+    report.serverArgv = ["app-server", "--listen", `unix://${sockPath}`];
+    child = spawn(CODEX_BIN, report.serverArgv, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stderr = "";
+    child.stderr.on("data", (c) => {
+      stderr += String(c);
+      if (stderr.length > 8000) stderr = stderr.slice(-8000);
+    });
+    const earlyExit = new Promise((resolve) => {
+      child.once("error", (e) => resolve(`spawn error: ${e.message}`));
+      child.once("exit", (code, sig) =>
+        resolve(`exited early code=${code} sig=${sig || ""}`),
+      );
+    });
+
+    const ready = await Promise.race([
+      waitForSocket(sockPath, 12_000).then((ok) =>
+        ok ? "ready" : "no-socket",
+      ),
+      earlyExit,
+    ]);
+    report.serverSpawn = ready;
+    if (ready !== "ready") {
+      report.stderrTail = stderr.slice(-2000);
+      report.conclusion = `server did not bind socket: ${ready}`;
+      return;
+    }
+
+    client = new JsonRpcWsUdsClient({ socketPath: sockPath });
+    await client.connect();
+
+    const initResult = await client.request(
+      "initialize",
+      { clientInfo: { name: "tfx-uds-smoke", version: "0.0.0" } },
+      8000,
+    );
+    report.initialize = initResult;
+    client.notify("initialized", {});
+
+    const threadStart = await client.request(
+      "thread/start",
+      { sandbox: "read-only", approvalPolicy: "never", ephemeral: true },
+      8000,
+    );
+    report.threadStart = threadStart;
+    const threadId = extractThreadId(threadStart);
+    report.threadId = threadId;
+
+    if (!RUN_REAL_TURN) {
+      report.conclusion = threadId
+        ? "OK (ungated): WS-over-UDS handshake + initialize + thread/start succeeded (no model turn)"
+        : "PARTIAL: handshake ok but thread id missing";
+      return;
+    }
+
+    // Gated real turn — needs auth + quota.
+    if (!threadId) {
+      report.conclusion = "FAILED: no threadId, cannot start turn";
+      return;
+    }
+    const parts = [];
+    const done = new Promise((resolve) => {
+      const offDelta = client.onNotification("item/agentMessage/delta", (p) => {
+        if (typeof p?.delta === "string") parts.push(p.delta);
+      });
+      const offDone = client.onNotification("turn/completed", (p) => {
+        offDelta();
+        offDone();
+        resolve(p?.turn?.status || "unknown");
+      });
+    });
+    await client.request(
+      "turn/start",
+      {
+        threadId,
+        input: [{ type: "text", text: "Reply with exactly one word: PONG" }],
+      },
+      90_000,
+    );
+    const status = await Promise.race([
+      done,
+      new Promise((r) => setTimeout(() => r("timeout"), 90_000)),
+    ]);
+    report.turn = { status, output: parts.join("") };
+    report.conclusion = `real turn status=${status}, output=${JSON.stringify(parts.join(""))}`;
+  } catch (e) {
+    report.conclusion = `smoke error: ${e instanceof Error ? e.message : String(e)}`;
+  } finally {
+    try {
+      client?.close();
+    } catch {}
+    if (child && child.exitCode === null && !child.killed) {
+      try {
+        child.kill("SIGTERM");
+      } catch {}
+      await new Promise((r) => setTimeout(r, 500));
+      try {
+        if (child.exitCode === null) child.kill("SIGKILL");
+      } catch {}
+    }
+    if (dir) await rm(dir, { recursive: true, force: true }).catch(() => {});
+    report.finishedAt = nowIso();
+    await writeFile(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`).catch(
+      () => {},
+    );
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+}
+
+main();

--- a/hub/team/uds-orchestrator.mjs
+++ b/hub/team/uds-orchestrator.mjs
@@ -377,6 +377,37 @@ async function waitForSocketFile(sockPath, deadlineMs) {
 }
 
 /**
+ * SIGTERM a child, wait up to graceMs for it to actually exit, then SIGKILL if
+ * still alive. Liveness is `exitCode === null && signalCode === null` — NOT
+ * `child.killed`, which only means "a signal was sent" and would suppress the
+ * SIGKILL fallback when the child ignores SIGTERM.
+ * @param {import('node:child_process').ChildProcess} child
+ * @param {number} [graceMs]
+ */
+async function terminateChild(child, graceMs = 1000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => {
+    child.once("exit", () => resolve("exited"));
+  });
+  try {
+    child.kill("SIGTERM");
+  } catch {}
+  const outcome = await Promise.race([
+    exited,
+    new Promise((resolve) => setTimeout(() => resolve("timeout"), graceMs)),
+  ]);
+  if (
+    outcome !== "exited" &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    try {
+      child.kill("SIGKILL");
+    } catch {}
+  }
+}
+
+/**
  * Experimental Codex endpoint that drives a real `codex app-server` over its
  * WebSocket-over-Unix-Domain-Socket control plane (the symmetric peer of the
  * Claude daemon `control.sock` path). Same `ask(prompt) -> {endpoint,text,done}`
@@ -535,15 +566,21 @@ export function createCodexAppServerUdsEndpoint({
           { threadId, input: [{ type: "text", text: prompt }] },
           timeoutMs,
         );
-        const settled = await Promise.race([
-          completion,
-          new Promise((resolve) =>
-            setTimeout(() => {
-              cleanup();
-              resolve({ status: "timeout" });
-            }, timeoutMs),
-          ),
-        ]);
+        let timeoutHandle = null;
+        const timeoutPromise = new Promise((resolve) => {
+          timeoutHandle = setTimeout(() => {
+            cleanup();
+            resolve({ status: "timeout" });
+          }, timeoutMs);
+        });
+        let settled;
+        try {
+          settled = await Promise.race([completion, timeoutPromise]);
+        } finally {
+          // Clear the timer whichever side won, so a completed turn does not
+          // keep the event loop alive until timeoutMs.
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+        }
 
         return {
           endpoint: "codex-app-server-uds",
@@ -561,15 +598,7 @@ export function createCodexAppServerUdsEndpoint({
         try {
           client?.close();
         } catch {}
-        if (child && child.exitCode === null && !child.killed) {
-          try {
-            child.kill("SIGTERM");
-          } catch {}
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          try {
-            if (child.exitCode === null && !child.killed) child.kill("SIGKILL");
-          } catch {}
-        }
+        if (child) await terminateChild(child);
         if (dir)
           await rm(dir, { recursive: true, force: true }).catch(() => {});
       }

--- a/hub/team/uds-orchestrator.mjs
+++ b/hub/team/uds-orchestrator.mjs
@@ -1,7 +1,12 @@
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import net from "node:net";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 
 import { execute as defaultExecuteCodex } from "../codex-adapter.mjs";
+import { JsonRpcWsUdsClient } from "../workers/lib/jsonrpc-ws-uds.mjs";
 import {
   buildClaudePromptDispatchPayload,
   deriveClaudeDaemonPaths,
@@ -10,6 +15,8 @@ import {
 } from "./claude-daemon-control.mjs";
 
 const DEFAULT_TIMEOUT_MS = 90_000;
+const DEFAULT_CODEX_APP_SERVER_UDS_TIMEOUT_MS = 120_000;
+const DEFAULT_CODEX_APP_SERVER_UDS_BOOTSTRAP_MS = 12_000;
 
 function requireEndpoint(endpoint, name) {
   if (!endpoint || typeof endpoint.ask !== "function") {
@@ -343,6 +350,229 @@ export function createCodexExecEndpoint({
         ).trim(),
         done: true,
       };
+    },
+  };
+}
+
+function extractCodexThreadId(result) {
+  if (!result || typeof result !== "object") return null;
+  if (typeof result.threadId === "string") return result.threadId;
+  if (result.thread && typeof result.thread.id === "string") {
+    return result.thread.id;
+  }
+  return null;
+}
+
+async function waitForSocketFile(sockPath, deadlineMs) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    try {
+      if ((await stat(sockPath)).isSocket()) return true;
+    } catch {
+      /* not bound yet */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+/**
+ * Experimental Codex endpoint that drives a real `codex app-server` over its
+ * WebSocket-over-Unix-Domain-Socket control plane (the symmetric peer of the
+ * Claude daemon `control.sock` path). Same `ask(prompt) -> {endpoint,text,done}`
+ * contract as `createCodexExecEndpoint`, so it is a drop-in for
+ * `runUdsOrchestration`'s `codex` slot — but it is NOT the default.
+ *
+ * Two modes:
+ *   - spawnServer (default): mkdtemp a private socket, spawn
+ *     `codex app-server --listen unix://PATH`, attach, run one turn, tear down.
+ *   - attach (socketPath + spawnServer=false): connect to an already-running
+ *     daemon socket (e.g. $CODEX_HOME/app-server-control/app-server-control.sock).
+ *
+ * Wire transport proven against codex-cli 0.135.0 — see
+ * experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs.
+ *
+ * @param {object} [options]
+ * @param {string|null} [options.socketPath] Existing daemon socket to attach to.
+ * @param {boolean} [options.spawnServer] Spawn a private app-server (default true).
+ * @param {string} [options.codexBin]
+ * @param {string} [options.cwd]
+ * @param {string} [options.model]
+ * @param {number} [options.timeoutMs] Turn timeout.
+ * @param {number} [options.bootstrapTimeoutMs] Connect + handshake timeout.
+ * @param {(opts: object) => JsonRpcWsUdsClient} [options.clientFactory]
+ * @param {(command: string, args: string[], options: object) => import('node:child_process').ChildProcess} [options.spawnFn]
+ */
+export function createCodexAppServerUdsEndpoint({
+  socketPath = null,
+  spawnServer = true,
+  codexBin = process.env.CODEX_BIN || "codex",
+  cwd = process.cwd(),
+  model,
+  timeoutMs = DEFAULT_CODEX_APP_SERVER_UDS_TIMEOUT_MS,
+  bootstrapTimeoutMs = DEFAULT_CODEX_APP_SERVER_UDS_BOOTSTRAP_MS,
+  clientFactory = (opts) => new JsonRpcWsUdsClient(opts),
+  spawnFn = spawn,
+} = {}) {
+  return {
+    name: "codex-app-server-uds",
+    async ask(prompt, _meta = {}) {
+      if (typeof prompt !== "string" || !prompt.trim()) {
+        throw new Error(
+          "codex-app-server-uds endpoint requires a non-empty prompt",
+        );
+      }
+
+      let dir = null;
+      let child = null;
+      let client = null;
+      let resolvedSock = socketPath;
+
+      try {
+        if (spawnServer && !socketPath) {
+          dir = await mkdtemp(pathJoin(tmpdir(), "tfx-codex-appserver-uds-"));
+          resolvedSock = pathJoin(dir, "app-server.sock");
+          child = spawnFn(
+            codexBin,
+            ["app-server", "--listen", `unix://${resolvedSock}`],
+            { stdio: ["ignore", "pipe", "pipe"], cwd, env: process.env },
+          );
+          let stderr = "";
+          child.stderr?.on("data", (chunk) => {
+            stderr += String(chunk);
+            if (stderr.length > 8000) stderr = stderr.slice(-8000);
+          });
+          const earlyExit = new Promise((resolve) => {
+            child.once("error", (err) =>
+              resolve(`spawn error: ${err.message}`),
+            );
+            child.once("exit", (code, sig) =>
+              resolve(`exited early code=${code} sig=${sig || ""}`),
+            );
+          });
+          const ready = await Promise.race([
+            waitForSocketFile(resolvedSock, bootstrapTimeoutMs).then((ok) =>
+              ok ? "ready" : "no-socket",
+            ),
+            earlyExit,
+          ]);
+          if (ready !== "ready") {
+            throw new Error(
+              `codex app-server did not bind socket: ${ready}${
+                stderr ? ` — ${stderr.slice(-400)}` : ""
+              }`,
+            );
+          }
+        }
+        if (!resolvedSock) {
+          throw new Error(
+            "codex-app-server-uds endpoint needs socketPath or spawnServer=true",
+          );
+        }
+
+        client = clientFactory({
+          socketPath: resolvedSock,
+          connectTimeoutMs: bootstrapTimeoutMs,
+        });
+        await client.connect();
+        await client.request(
+          "initialize",
+          { clientInfo: { name: "triflux-tfx-live", version: "1.0.0" } },
+          bootstrapTimeoutMs,
+        );
+        client.notify("initialized", {});
+
+        const threadParams = {
+          sandbox: "read-only",
+          approvalPolicy: "never",
+          ephemeral: true,
+        };
+        if (typeof model === "string" && model) threadParams.model = model;
+        if (cwd) threadParams.cwd = cwd;
+        const threadStart = await client.request(
+          "thread/start",
+          threadParams,
+          bootstrapTimeoutMs,
+        );
+        const threadId = extractCodexThreadId(threadStart);
+        if (!threadId) {
+          throw new Error(
+            "codex app-server thread/start returned no thread id",
+          );
+        }
+
+        const parts = [];
+        let offDelta = () => {};
+        let offError = () => {};
+        let offDone = () => {};
+        const cleanup = () => {
+          offDelta();
+          offError();
+          offDone();
+        };
+        const completion = new Promise((resolve) => {
+          offDelta = client.onNotification(
+            "item/agentMessage/delta",
+            (params) => {
+              if (typeof params?.delta === "string") parts.push(params.delta);
+            },
+          );
+          offError = client.onNotification("error", (params) => {
+            cleanup();
+            resolve({
+              status: "failed",
+              message: params?.message || "codex app-server error",
+            });
+          });
+          offDone = client.onNotification("turn/completed", (params) => {
+            cleanup();
+            resolve({ status: params?.turn?.status || "unknown" });
+          });
+        });
+
+        await client.request(
+          "turn/start",
+          { threadId, input: [{ type: "text", text: prompt }] },
+          timeoutMs,
+        );
+        const settled = await Promise.race([
+          completion,
+          new Promise((resolve) =>
+            setTimeout(() => {
+              cleanup();
+              resolve({ status: "timeout" });
+            }, timeoutMs),
+          ),
+        ]);
+
+        return {
+          endpoint: "codex-app-server-uds",
+          text: parts.join("").trim(),
+          done: settled.status === "completed",
+          meta: {
+            threadId,
+            status: settled.status,
+            socketPath: resolvedSock,
+            spawned: Boolean(child),
+            ...(settled.message ? { error: settled.message } : {}),
+          },
+        };
+      } finally {
+        try {
+          client?.close();
+        } catch {}
+        if (child && child.exitCode === null && !child.killed) {
+          try {
+            child.kill("SIGTERM");
+          } catch {}
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          try {
+            if (child.exitCode === null && !child.killed) child.kill("SIGKILL");
+          } catch {}
+        }
+        if (dir)
+          await rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
     },
   };
 }

--- a/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -1,0 +1,616 @@
+// hub/workers/lib/jsonrpc-ws-uds.mjs
+// JSON-RPC 2.0 client over WebSocket-over-Unix-Domain-Socket.
+//
+// codex `app-server --listen unix://PATH` does NOT speak newline-delimited JSON
+// on the socket — it speaks WebSocket (RFC 6455) after a standard HTTP/1.1
+// Upgrade handshake, one JSON-RPC message per text frame. Confirmed live against
+// codex-cli 0.135.0 (see experiments/native-bridge-feasibility/
+// codex-app-server-uds-probe.mjs). This is the UDS sibling of the stdio
+// `JsonRpcStdioClient`: same public surface (request/notify/onNotification/
+// close/isOpen), different framing.
+//
+// Wire framing notes:
+//   - client -> server frames MUST be masked (RFC 6455 §5.3).
+//   - server -> client frames are unmasked.
+//   - one JSON-RPC object per text frame; fragmented frames are reassembled.
+//   - outbound JSON-RPC omits the `"jsonrpc":"2.0"` header (OpenAI App Server
+//     JSONL variant), matching JsonRpcStdioClient.
+//
+// Zero new dependencies — minimal hand-rolled WS client (no `ws` package).
+
+import { createHash, randomBytes } from "node:crypto";
+import net from "node:net";
+
+import {
+  JsonRpcProtocolError,
+  JsonRpcTransportError,
+} from "./jsonrpc-stdio.mjs";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
+
+// RFC 6455 opcodes
+const OP_CONTINUATION = 0x0;
+const OP_TEXT = 0x1;
+const OP_BINARY = 0x2;
+const OP_CLOSE = 0x8;
+const OP_PING = 0x9;
+const OP_PONG = 0xa;
+
+/**
+ * Encode a single client->server WebSocket frame (always masked).
+ * @param {number} opcode
+ * @param {Buffer} payload
+ * @returns {Buffer}
+ */
+function encodeClientFrame(opcode, payload) {
+  const len = payload.length;
+  const mask = randomBytes(4);
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, 0x80 | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  const masked = Buffer.allocUnsafe(len);
+  for (let i = 0; i < len; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+/**
+ * JSON-RPC 2.0 client over WebSocket-over-UDS.
+ */
+export class JsonRpcWsUdsClient {
+  /**
+   * @param {object} options
+   * @param {string} options.socketPath Absolute path to the AF_UNIX socket.
+   * @param {(err: Error) => void} [options.onError]
+   * @param {number} [options.maxFrameSize] Max bytes per inbound frame payload.
+   * @param {number} [options.connectTimeoutMs]
+   */
+  constructor({
+    socketPath,
+    onError,
+    maxFrameSize = DEFAULT_MAX_FRAME_SIZE,
+    connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
+  } = {}) {
+    if (typeof socketPath !== "string" || !socketPath) {
+      throw new TypeError("JsonRpcWsUdsClient requires a socketPath string");
+    }
+    this._socketPath = socketPath;
+    this._onError = typeof onError === "function" ? onError : null;
+    this._maxFrameSize =
+      Number.isFinite(maxFrameSize) && maxFrameSize > 0
+        ? maxFrameSize
+        : DEFAULT_MAX_FRAME_SIZE;
+    this._connectTimeoutMs = Number.isFinite(connectTimeoutMs)
+      ? connectTimeoutMs
+      : DEFAULT_CONNECT_TIMEOUT_MS;
+
+    /** @type {'idle'|'running'|'closing'|'closed'} */
+    this._state = "idle";
+    this._socket = null;
+    this._nextRequestId = 1;
+    /** @type {Map<number, { resolve: Function, reject: Function, timer: any, method: string }>} */
+    this._pendingRequests = new Map();
+    /** @type {Map<string, Set<Function>>} */
+    this._notificationHandlers = new Map();
+
+    // RX framing state
+    this._rxBuf = Buffer.alloc(0);
+    /** @type {Buffer[]} accumulated payloads of a fragmented message */
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+  }
+
+  /**
+   * Open the socket and complete the WebSocket HTTP Upgrade handshake.
+   * Resolves once the connection is in the `running` state.
+   * @returns {Promise<void>}
+   */
+  connect() {
+    if (this._state !== "idle") {
+      return Promise.reject(
+        new Error(
+          `JsonRpcWsUdsClient.connect() invalid in state ${this._state}`,
+        ),
+      );
+    }
+    return new Promise((resolve, reject) => {
+      const key = randomBytes(16).toString("base64");
+      const expectedAccept = createHash("sha1")
+        .update(key + WS_GUID)
+        .digest("base64");
+      let handshakeBuf = Buffer.alloc(0);
+      let settled = false;
+
+      const socket = net.connect(this._socketPath);
+      this._socket = socket;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          socket.destroy();
+        } catch {}
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect timed out after ${this._connectTimeoutMs}ms: ${this._socketPath}`,
+          ),
+        );
+      }, this._connectTimeoutMs);
+
+      const onConnectError = (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect error: ${err?.message || err}`,
+            { cause: err },
+          ),
+        );
+      };
+
+      socket.once("error", onConnectError);
+      socket.on("connect", () => {
+        const req =
+          "GET / HTTP/1.1\r\n" +
+          "Host: localhost\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Key: ${key}\r\n` +
+          "Sec-WebSocket-Version: 13\r\n\r\n";
+        socket.write(req);
+      });
+
+      const onHandshakeData = (chunk) => {
+        if (settled) return;
+        handshakeBuf = Buffer.concat([handshakeBuf, chunk]);
+        const sep = handshakeBuf.indexOf("\r\n\r\n");
+        if (sep < 0) {
+          if (handshakeBuf.length > 64 * 1024) {
+            settled = true;
+            clearTimeout(timer);
+            socket.removeListener("error", onConnectError);
+            socket.removeListener("data", onHandshakeData);
+            try {
+              socket.destroy();
+            } catch {}
+            this._state = "closed";
+            reject(
+              new JsonRpcProtocolError(
+                "WebSocket handshake response headers exceeded 64 KiB",
+              ),
+            );
+          }
+          return;
+        }
+        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const leftover = handshakeBuf.subarray(sep + 4);
+
+        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
+        const acceptOk = new RegExp(
+          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
+          "i",
+        ).test(headers);
+
+        if (!ok101 || !acceptOk) {
+          settled = true;
+          clearTimeout(timer);
+          socket.removeListener("error", onConnectError);
+          socket.removeListener("data", onHandshakeData);
+          try {
+            socket.destroy();
+          } catch {}
+          this._state = "closed";
+          reject(
+            new JsonRpcProtocolError(
+              `WebSocket upgrade rejected (status101=${ok101}, acceptValid=${acceptOk})`,
+            ),
+          );
+          return;
+        }
+
+        // Handshake complete — switch to running and wire frame handling.
+        settled = true;
+        clearTimeout(timer);
+        socket.removeListener("error", onConnectError);
+        socket.removeListener("data", onHandshakeData);
+        this._state = "running";
+
+        socket.on("data", (buf) => this._onSocketData(buf));
+        socket.on("error", (err) => this._handleStreamError("socket", err));
+        socket.on("close", () => {
+          if (this._state === "running") {
+            const err = new JsonRpcTransportError(
+              "WebSocket-over-UDS closed unexpectedly (EOF during running)",
+            );
+            this._emitError(err);
+            this._closeWith("closed", err);
+          } else if (this._state !== "closed") {
+            this._closeWith("closed");
+          }
+        });
+
+        if (leftover.length > 0) {
+          this._rxBuf = Buffer.concat([this._rxBuf, leftover]);
+          this._drainFrames();
+        }
+        resolve();
+      };
+
+      socket.on("data", onHandshakeData);
+    });
+  }
+
+  /**
+   * Issue a JSON-RPC request and resolve with the server's `result`.
+   * @param {string} method
+   * @param {unknown} params
+   * @param {number} [timeoutMs=60000]
+   * @returns {Promise<any>}
+   */
+  request(method, params, timeoutMs = 60000) {
+    if (this._state !== "running") {
+      return Promise.reject(new Error(CLOSED_MESSAGE));
+    }
+    const id = this._nextRequestId++;
+    const frame = { id, method };
+    if (params !== undefined) frame.params = params;
+
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          const pending = this._pendingRequests.get(id);
+          if (!pending) return;
+          this._pendingRequests.delete(id);
+          reject(
+            new Error(
+              `JSON-RPC request timed out after ${timeoutMs}ms: ${method}`,
+            ),
+          );
+        }, timeoutMs);
+      }
+      this._pendingRequests.set(id, { resolve, reject, timer, method });
+      try {
+        this._sendText(JSON.stringify(frame));
+      } catch (err) {
+        this._pendingRequests.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no id, no response).
+   * @param {string} method
+   * @param {unknown} [params]
+   */
+  notify(method, params) {
+    if (this._state !== "running") return;
+    const frame = { method };
+    if (params !== undefined) frame.params = params;
+    try {
+      this._sendText(JSON.stringify(frame));
+    } catch (err) {
+      this._emitError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  /**
+   * Subscribe to inbound notifications. `"*"` = catch-all receiving
+   * `(params, method)`; targeted handlers receive `(params)`.
+   * @param {string} method
+   * @param {(params: any, method?: string) => void} callback
+   * @returns {() => void} unsubscribe
+   */
+  onNotification(method, callback) {
+    if (typeof callback !== "function") {
+      throw new TypeError("onNotification requires a callback function");
+    }
+    let set = this._notificationHandlers.get(method);
+    if (!set) {
+      set = new Set();
+      this._notificationHandlers.set(method, set);
+    }
+    set.add(callback);
+    return () => {
+      const handlers = this._notificationHandlers.get(method);
+      if (!handlers) return;
+      handlers.delete(callback);
+      if (handlers.size === 0) this._notificationHandlers.delete(method);
+    };
+  }
+
+  /**
+   * Close the client. `reason === "closing"` transitions to an intermediate
+   * graceful state where a subsequent EOF is treated as normal. Idempotent.
+   * @param {string} [reason]
+   */
+  close(reason) {
+    if (this._state === "closed") return;
+    if (reason === "closing" && this._state === "running") {
+      this._state = "closing";
+      // best-effort WS close frame
+      try {
+        this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
+      } catch {}
+      return;
+    }
+    this._closeWith("closed");
+  }
+
+  /** @returns {boolean} */
+  isOpen() {
+    return this._state === "running";
+  }
+
+  /** @returns {'idle'|'running'|'closing'|'closed'} */
+  getState() {
+    return this._state;
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  _sendText(text) {
+    if (this._state === "closed") throw new Error(CLOSED_MESSAGE);
+    const frame = encodeClientFrame(OP_TEXT, Buffer.from(text, "utf8"));
+    this._socket.write(frame, (err) => {
+      if (err) this._handleStreamError("socket-write", err);
+    });
+  }
+
+  _onSocketData(chunk) {
+    if (this._state === "closed") return;
+    this._rxBuf = Buffer.concat([this._rxBuf, chunk]);
+    this._drainFrames();
+  }
+
+  /**
+   * Parse as many complete WebSocket frames as are buffered. Control frames
+   * (ping/pong/close) are handled inline; text/continuation frames are
+   * reassembled into a full JSON-RPC message before dispatch.
+   */
+  _drainFrames() {
+    while (this._rxBuf.length >= 2) {
+      const b0 = this._rxBuf[0];
+      const b1 = this._rxBuf[1];
+      const fin = (b0 & 0x80) !== 0;
+      const opcode = b0 & 0x0f;
+      const masked = (b1 & 0x80) !== 0;
+      let len = b1 & 0x7f;
+      let cursor = 2;
+
+      if (len === 126) {
+        if (this._rxBuf.length < cursor + 2) return;
+        len = this._rxBuf.readUInt16BE(cursor);
+        cursor += 2;
+      } else if (len === 127) {
+        if (this._rxBuf.length < cursor + 8) return;
+        const big = this._rxBuf.readBigUInt64BE(cursor);
+        if (big > BigInt(this._maxFrameSize)) {
+          const err = new JsonRpcProtocolError(
+            `WebSocket frame payload ${big} exceeds max ${this._maxFrameSize}`,
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+          return;
+        }
+        len = Number(big);
+        cursor += 8;
+      }
+
+      if (len > this._maxFrameSize) {
+        const err = new JsonRpcProtocolError(
+          `WebSocket frame payload ${len} exceeds max ${this._maxFrameSize}`,
+        );
+        this._emitError(err);
+        this._closeWith("closed", err);
+        return;
+      }
+
+      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
+      if (masked) cursor += 4;
+      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
+
+      let payload = this._rxBuf.subarray(cursor, cursor + len);
+      if (masked && maskKey) {
+        const out = Buffer.allocUnsafe(len);
+        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
+        payload = out;
+      } else {
+        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      }
+      this._rxBuf = this._rxBuf.subarray(cursor + len);
+
+      this._handleFrame(fin, opcode, payload);
+      if (this._state === "closed") return;
+    }
+  }
+
+  _handleFrame(fin, opcode, payload) {
+    switch (opcode) {
+      case OP_PING:
+        try {
+          this._socket?.write(encodeClientFrame(OP_PONG, payload));
+        } catch {}
+        return;
+      case OP_PONG:
+        return;
+      case OP_CLOSE:
+        if (this._state === "running") {
+          const err = new JsonRpcTransportError(
+            "WebSocket server sent close frame",
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+        } else {
+          this._closeWith("closed");
+        }
+        return;
+      case OP_TEXT:
+      case OP_BINARY:
+        this._fragmentOpcode = opcode;
+        this._fragmentChunks = [payload];
+        break;
+      case OP_CONTINUATION:
+        this._fragmentChunks.push(payload);
+        break;
+      default:
+        this._emitError(
+          new JsonRpcProtocolError(
+            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
+          ),
+        );
+        return;
+    }
+
+    if (!fin) return; // wait for the rest of a fragmented message
+    const full = Buffer.concat(this._fragmentChunks);
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+    this._handleMessage(full.toString("utf8"));
+  }
+
+  _handleMessage(line) {
+    if (this._state === "closed") return;
+    if (line.length === 0) return;
+
+    let frame;
+    try {
+      frame = JSON.parse(line);
+    } catch (err) {
+      const pErr = new JsonRpcProtocolError(
+        `JSON-RPC parse error: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (!frame || typeof frame !== "object") {
+      const pErr = new JsonRpcProtocolError(
+        "JSON-RPC protocol error: frame is not an object",
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (
+      Object.hasOwn(frame, "id") &&
+      frame.id !== null &&
+      (Object.hasOwn(frame, "result") || Object.hasOwn(frame, "error"))
+    ) {
+      this._dispatchResponse(frame);
+      return;
+    }
+
+    if (typeof frame.method === "string" && !Object.hasOwn(frame, "id")) {
+      this._dispatchNotification(frame);
+      return;
+    }
+
+    this._emitError(
+      new JsonRpcProtocolError(
+        "JSON-RPC protocol error: unrecognized frame shape",
+      ),
+    );
+  }
+
+  _dispatchResponse(frame) {
+    const pending = this._pendingRequests.get(frame.id);
+    if (!pending) return;
+    this._pendingRequests.delete(frame.id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (Object.hasOwn(frame, "error") && frame.error) {
+      const { code, message, data } = frame.error;
+      const err = new Error(
+        `JSON-RPC error${typeof code === "number" ? ` ${code}` : ""}: ${message || "unknown"}`,
+      );
+      if (code !== undefined) err.code = code;
+      if (data !== undefined) err.data = data;
+      pending.reject(err);
+      return;
+    }
+    pending.resolve(frame.result);
+  }
+
+  _dispatchNotification(frame) {
+    const { method, params } = frame;
+    const targeted = this._notificationHandlers.get(method);
+    if (targeted && targeted.size > 0) {
+      for (const cb of targeted) {
+        try {
+          cb(params);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+    const wildcard = this._notificationHandlers.get("*");
+    if (wildcard && wildcard.size > 0) {
+      for (const cb of wildcard) {
+        try {
+          cb(params, method);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+  }
+
+  _handleStreamError(which, err) {
+    if (this._state === "closed") return;
+    const base = err instanceof Error ? err : new Error(String(err));
+    const wrapped = new JsonRpcTransportError(
+      `WebSocket-over-UDS stream error on ${which}: ${base.message}`,
+      { cause: base },
+    );
+    this._emitError(wrapped);
+    this._closeWith("closed", wrapped);
+  }
+
+  _closeWith(target, rejectReason = null) {
+    if (this._state === "closed") return;
+    this._state = target;
+    const rejectErr =
+      rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
+    for (const [, pending] of this._pendingRequests) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(rejectErr);
+    }
+    this._pendingRequests.clear();
+    try {
+      this._socket?.destroy();
+    } catch {}
+  }
+
+  _emitError(err) {
+    if (!this._onError) return;
+    try {
+      this._onError(err);
+    } catch {
+      /* never throw out of the dispatch loop */
+    }
+  }
+}
+
+export default JsonRpcWsUdsClient;

--- a/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -29,6 +29,10 @@ import {
 const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+// After a graceful close("closing") we wait this long for the peer's close/EOF
+// before force-destroying the socket so a silent peer cannot pin it open.
+const CLOSING_DEADLINE_MS = 2_000;
+const MAX_CONTROL_PAYLOAD = 125; // RFC 6455 §5.5: control frames <=125 bytes
 const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
 
 // RFC 6455 opcodes
@@ -110,7 +114,11 @@ export class JsonRpcWsUdsClient {
     this._rxBuf = Buffer.alloc(0);
     /** @type {Buffer[]} accumulated payloads of a fragmented message */
     this._fragmentChunks = [];
+    /** @type {number|null} opcode of the in-progress fragmented message */
     this._fragmentOpcode = null;
+    this._fragmentSize = 0;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    this._closingTimer = null;
   }
 
   /**
@@ -198,14 +206,22 @@ export class JsonRpcWsUdsClient {
           }
           return;
         }
-        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const rawHeaders = handshakeBuf.subarray(0, sep).toString("utf8");
         const leftover = handshakeBuf.subarray(sep + 4);
 
-        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
-        const acceptOk = new RegExp(
-          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
-          "i",
-        ).test(headers);
+        const lines = rawHeaders.split("\r\n");
+        const ok101 = /^HTTP\/1\.\d 101/.test(lines[0] || "");
+        const headerMap = new Map();
+        for (let i = 1; i < lines.length; i++) {
+          const idx = lines[i].indexOf(":");
+          if (idx < 0) continue;
+          headerMap.set(
+            lines[i].slice(0, idx).trim().toLowerCase(),
+            lines[i].slice(idx + 1).trim(),
+          );
+        }
+        const acceptOk =
+          headerMap.get("sec-websocket-accept") === expectedAccept;
 
         if (!ok101 || !acceptOk) {
           settled = true;
@@ -350,6 +366,14 @@ export class JsonRpcWsUdsClient {
       try {
         this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
       } catch {}
+      // Arm a deadline so a peer that never replies with close/EOF cannot pin
+      // the socket + pending requests open forever.
+      this._closingTimer = setTimeout(() => {
+        if (this._state === "closing") this._closeWith("closed");
+      }, CLOSING_DEADLINE_MS);
+      if (typeof this._closingTimer.unref === "function") {
+        this._closingTimer.unref();
+      }
       return;
     }
     this._closeWith("closed");
@@ -424,18 +448,15 @@ export class JsonRpcWsUdsClient {
         return;
       }
 
-      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
-      if (masked) cursor += 4;
-      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
-
-      let payload = this._rxBuf.subarray(cursor, cursor + len);
-      if (masked && maskKey) {
-        const out = Buffer.allocUnsafe(len);
-        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
-        payload = out;
-      } else {
-        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      // RFC 6455 §5.1: server -> client frames MUST NOT be masked.
+      if (masked) {
+        this._protocolClose("WebSocket server frame is masked (RFC 6455 §5.1)");
+        return;
       }
+      if (this._rxBuf.length < cursor + len) return; // wait for full payload
+
+      // Detach from rxBuf before we slice it off.
+      const payload = Buffer.from(this._rxBuf.subarray(cursor, cursor + len));
       this._rxBuf = this._rxBuf.subarray(cursor + len);
 
       this._handleFrame(fin, opcode, payload);
@@ -444,15 +465,22 @@ export class JsonRpcWsUdsClient {
   }
 
   _handleFrame(fin, opcode, payload) {
-    switch (opcode) {
-      case OP_PING:
+    // Control frames (>=0x8): must be FIN and <=125 bytes (RFC 6455 §5.5).
+    if (opcode >= 0x8) {
+      if (!fin || payload.length > MAX_CONTROL_PAYLOAD) {
+        this._protocolClose(
+          `Invalid control frame (opcode 0x${opcode.toString(16)}, fin=${fin}, len=${payload.length})`,
+        );
+        return;
+      }
+      if (opcode === OP_PING) {
         try {
           this._socket?.write(encodeClientFrame(OP_PONG, payload));
         } catch {}
         return;
-      case OP_PONG:
-        return;
-      case OP_CLOSE:
+      }
+      if (opcode === OP_PONG) return;
+      if (opcode === OP_CLOSE) {
         if (this._state === "running") {
           const err = new JsonRpcTransportError(
             "WebSocket server sent close frame",
@@ -463,28 +491,66 @@ export class JsonRpcWsUdsClient {
           this._closeWith("closed");
         }
         return;
-      case OP_TEXT:
-      case OP_BINARY:
-        this._fragmentOpcode = opcode;
-        this._fragmentChunks = [payload];
-        break;
-      case OP_CONTINUATION:
-        this._fragmentChunks.push(payload);
-        break;
-      default:
-        this._emitError(
-          new JsonRpcProtocolError(
-            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
-          ),
-        );
-        return;
+      }
+      this._protocolClose(`Unknown control opcode 0x${opcode.toString(16)}`);
+      return;
     }
 
-    if (!fin) return; // wait for the rest of a fragmented message
-    const full = Buffer.concat(this._fragmentChunks);
-    this._fragmentChunks = [];
-    this._fragmentOpcode = null;
-    this._handleMessage(full.toString("utf8"));
+    // Data frames: text / binary (message start) or continuation.
+    if (opcode === OP_TEXT || opcode === OP_BINARY) {
+      if (this._fragmentOpcode !== null) {
+        this._protocolClose(
+          "New data frame received while a fragmented message is active",
+        );
+        return;
+      }
+      if (opcode === OP_BINARY) {
+        this._protocolClose(
+          "Binary frames are not supported (expected text JSON-RPC)",
+        );
+        return;
+      }
+      if (fin) {
+        this._handleMessage(payload.toString("utf8"));
+        return;
+      }
+      this._fragmentOpcode = opcode;
+      this._fragmentChunks = [payload];
+      this._fragmentSize = payload.length;
+      return;
+    }
+
+    if (opcode === OP_CONTINUATION) {
+      if (this._fragmentOpcode === null) {
+        this._protocolClose(
+          "Continuation frame with no active fragmented message",
+        );
+        return;
+      }
+      this._fragmentSize += payload.length;
+      if (this._fragmentSize > this._maxFrameSize) {
+        this._protocolClose(
+          `Fragmented message ${this._fragmentSize} exceeds max ${this._maxFrameSize}`,
+        );
+        return;
+      }
+      this._fragmentChunks.push(payload);
+      if (!fin) return;
+      const full = Buffer.concat(this._fragmentChunks);
+      this._fragmentChunks = [];
+      this._fragmentOpcode = null;
+      this._fragmentSize = 0;
+      this._handleMessage(full.toString("utf8"));
+      return;
+    }
+
+    this._protocolClose(`Unknown WebSocket opcode 0x${opcode.toString(16)}`);
+  }
+
+  _protocolClose(message) {
+    const err = new JsonRpcProtocolError(message);
+    this._emitError(err);
+    this._closeWith("closed", err);
   }
 
   _handleMessage(line) {
@@ -591,6 +657,10 @@ export class JsonRpcWsUdsClient {
   _closeWith(target, rejectReason = null) {
     if (this._state === "closed") return;
     this._state = target;
+    if (this._closingTimer) {
+      clearTimeout(this._closingTimer);
+      this._closingTimer = null;
+    }
     const rejectErr =
       rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
     for (const [, pending] of this._pendingRequests) {

--- a/packages/remote/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/packages/remote/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -1,0 +1,616 @@
+// hub/workers/lib/jsonrpc-ws-uds.mjs
+// JSON-RPC 2.0 client over WebSocket-over-Unix-Domain-Socket.
+//
+// codex `app-server --listen unix://PATH` does NOT speak newline-delimited JSON
+// on the socket — it speaks WebSocket (RFC 6455) after a standard HTTP/1.1
+// Upgrade handshake, one JSON-RPC message per text frame. Confirmed live against
+// codex-cli 0.135.0 (see experiments/native-bridge-feasibility/
+// codex-app-server-uds-probe.mjs). This is the UDS sibling of the stdio
+// `JsonRpcStdioClient`: same public surface (request/notify/onNotification/
+// close/isOpen), different framing.
+//
+// Wire framing notes:
+//   - client -> server frames MUST be masked (RFC 6455 §5.3).
+//   - server -> client frames are unmasked.
+//   - one JSON-RPC object per text frame; fragmented frames are reassembled.
+//   - outbound JSON-RPC omits the `"jsonrpc":"2.0"` header (OpenAI App Server
+//     JSONL variant), matching JsonRpcStdioClient.
+//
+// Zero new dependencies — minimal hand-rolled WS client (no `ws` package).
+
+import { createHash, randomBytes } from "node:crypto";
+import net from "node:net";
+
+import {
+  JsonRpcProtocolError,
+  JsonRpcTransportError,
+} from "./jsonrpc-stdio.mjs";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
+
+// RFC 6455 opcodes
+const OP_CONTINUATION = 0x0;
+const OP_TEXT = 0x1;
+const OP_BINARY = 0x2;
+const OP_CLOSE = 0x8;
+const OP_PING = 0x9;
+const OP_PONG = 0xa;
+
+/**
+ * Encode a single client->server WebSocket frame (always masked).
+ * @param {number} opcode
+ * @param {Buffer} payload
+ * @returns {Buffer}
+ */
+function encodeClientFrame(opcode, payload) {
+  const len = payload.length;
+  const mask = randomBytes(4);
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, 0x80 | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  const masked = Buffer.allocUnsafe(len);
+  for (let i = 0; i < len; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+/**
+ * JSON-RPC 2.0 client over WebSocket-over-UDS.
+ */
+export class JsonRpcWsUdsClient {
+  /**
+   * @param {object} options
+   * @param {string} options.socketPath Absolute path to the AF_UNIX socket.
+   * @param {(err: Error) => void} [options.onError]
+   * @param {number} [options.maxFrameSize] Max bytes per inbound frame payload.
+   * @param {number} [options.connectTimeoutMs]
+   */
+  constructor({
+    socketPath,
+    onError,
+    maxFrameSize = DEFAULT_MAX_FRAME_SIZE,
+    connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
+  } = {}) {
+    if (typeof socketPath !== "string" || !socketPath) {
+      throw new TypeError("JsonRpcWsUdsClient requires a socketPath string");
+    }
+    this._socketPath = socketPath;
+    this._onError = typeof onError === "function" ? onError : null;
+    this._maxFrameSize =
+      Number.isFinite(maxFrameSize) && maxFrameSize > 0
+        ? maxFrameSize
+        : DEFAULT_MAX_FRAME_SIZE;
+    this._connectTimeoutMs = Number.isFinite(connectTimeoutMs)
+      ? connectTimeoutMs
+      : DEFAULT_CONNECT_TIMEOUT_MS;
+
+    /** @type {'idle'|'running'|'closing'|'closed'} */
+    this._state = "idle";
+    this._socket = null;
+    this._nextRequestId = 1;
+    /** @type {Map<number, { resolve: Function, reject: Function, timer: any, method: string }>} */
+    this._pendingRequests = new Map();
+    /** @type {Map<string, Set<Function>>} */
+    this._notificationHandlers = new Map();
+
+    // RX framing state
+    this._rxBuf = Buffer.alloc(0);
+    /** @type {Buffer[]} accumulated payloads of a fragmented message */
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+  }
+
+  /**
+   * Open the socket and complete the WebSocket HTTP Upgrade handshake.
+   * Resolves once the connection is in the `running` state.
+   * @returns {Promise<void>}
+   */
+  connect() {
+    if (this._state !== "idle") {
+      return Promise.reject(
+        new Error(
+          `JsonRpcWsUdsClient.connect() invalid in state ${this._state}`,
+        ),
+      );
+    }
+    return new Promise((resolve, reject) => {
+      const key = randomBytes(16).toString("base64");
+      const expectedAccept = createHash("sha1")
+        .update(key + WS_GUID)
+        .digest("base64");
+      let handshakeBuf = Buffer.alloc(0);
+      let settled = false;
+
+      const socket = net.connect(this._socketPath);
+      this._socket = socket;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          socket.destroy();
+        } catch {}
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect timed out after ${this._connectTimeoutMs}ms: ${this._socketPath}`,
+          ),
+        );
+      }, this._connectTimeoutMs);
+
+      const onConnectError = (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect error: ${err?.message || err}`,
+            { cause: err },
+          ),
+        );
+      };
+
+      socket.once("error", onConnectError);
+      socket.on("connect", () => {
+        const req =
+          "GET / HTTP/1.1\r\n" +
+          "Host: localhost\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Key: ${key}\r\n` +
+          "Sec-WebSocket-Version: 13\r\n\r\n";
+        socket.write(req);
+      });
+
+      const onHandshakeData = (chunk) => {
+        if (settled) return;
+        handshakeBuf = Buffer.concat([handshakeBuf, chunk]);
+        const sep = handshakeBuf.indexOf("\r\n\r\n");
+        if (sep < 0) {
+          if (handshakeBuf.length > 64 * 1024) {
+            settled = true;
+            clearTimeout(timer);
+            socket.removeListener("error", onConnectError);
+            socket.removeListener("data", onHandshakeData);
+            try {
+              socket.destroy();
+            } catch {}
+            this._state = "closed";
+            reject(
+              new JsonRpcProtocolError(
+                "WebSocket handshake response headers exceeded 64 KiB",
+              ),
+            );
+          }
+          return;
+        }
+        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const leftover = handshakeBuf.subarray(sep + 4);
+
+        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
+        const acceptOk = new RegExp(
+          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
+          "i",
+        ).test(headers);
+
+        if (!ok101 || !acceptOk) {
+          settled = true;
+          clearTimeout(timer);
+          socket.removeListener("error", onConnectError);
+          socket.removeListener("data", onHandshakeData);
+          try {
+            socket.destroy();
+          } catch {}
+          this._state = "closed";
+          reject(
+            new JsonRpcProtocolError(
+              `WebSocket upgrade rejected (status101=${ok101}, acceptValid=${acceptOk})`,
+            ),
+          );
+          return;
+        }
+
+        // Handshake complete — switch to running and wire frame handling.
+        settled = true;
+        clearTimeout(timer);
+        socket.removeListener("error", onConnectError);
+        socket.removeListener("data", onHandshakeData);
+        this._state = "running";
+
+        socket.on("data", (buf) => this._onSocketData(buf));
+        socket.on("error", (err) => this._handleStreamError("socket", err));
+        socket.on("close", () => {
+          if (this._state === "running") {
+            const err = new JsonRpcTransportError(
+              "WebSocket-over-UDS closed unexpectedly (EOF during running)",
+            );
+            this._emitError(err);
+            this._closeWith("closed", err);
+          } else if (this._state !== "closed") {
+            this._closeWith("closed");
+          }
+        });
+
+        if (leftover.length > 0) {
+          this._rxBuf = Buffer.concat([this._rxBuf, leftover]);
+          this._drainFrames();
+        }
+        resolve();
+      };
+
+      socket.on("data", onHandshakeData);
+    });
+  }
+
+  /**
+   * Issue a JSON-RPC request and resolve with the server's `result`.
+   * @param {string} method
+   * @param {unknown} params
+   * @param {number} [timeoutMs=60000]
+   * @returns {Promise<any>}
+   */
+  request(method, params, timeoutMs = 60000) {
+    if (this._state !== "running") {
+      return Promise.reject(new Error(CLOSED_MESSAGE));
+    }
+    const id = this._nextRequestId++;
+    const frame = { id, method };
+    if (params !== undefined) frame.params = params;
+
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          const pending = this._pendingRequests.get(id);
+          if (!pending) return;
+          this._pendingRequests.delete(id);
+          reject(
+            new Error(
+              `JSON-RPC request timed out after ${timeoutMs}ms: ${method}`,
+            ),
+          );
+        }, timeoutMs);
+      }
+      this._pendingRequests.set(id, { resolve, reject, timer, method });
+      try {
+        this._sendText(JSON.stringify(frame));
+      } catch (err) {
+        this._pendingRequests.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no id, no response).
+   * @param {string} method
+   * @param {unknown} [params]
+   */
+  notify(method, params) {
+    if (this._state !== "running") return;
+    const frame = { method };
+    if (params !== undefined) frame.params = params;
+    try {
+      this._sendText(JSON.stringify(frame));
+    } catch (err) {
+      this._emitError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  /**
+   * Subscribe to inbound notifications. `"*"` = catch-all receiving
+   * `(params, method)`; targeted handlers receive `(params)`.
+   * @param {string} method
+   * @param {(params: any, method?: string) => void} callback
+   * @returns {() => void} unsubscribe
+   */
+  onNotification(method, callback) {
+    if (typeof callback !== "function") {
+      throw new TypeError("onNotification requires a callback function");
+    }
+    let set = this._notificationHandlers.get(method);
+    if (!set) {
+      set = new Set();
+      this._notificationHandlers.set(method, set);
+    }
+    set.add(callback);
+    return () => {
+      const handlers = this._notificationHandlers.get(method);
+      if (!handlers) return;
+      handlers.delete(callback);
+      if (handlers.size === 0) this._notificationHandlers.delete(method);
+    };
+  }
+
+  /**
+   * Close the client. `reason === "closing"` transitions to an intermediate
+   * graceful state where a subsequent EOF is treated as normal. Idempotent.
+   * @param {string} [reason]
+   */
+  close(reason) {
+    if (this._state === "closed") return;
+    if (reason === "closing" && this._state === "running") {
+      this._state = "closing";
+      // best-effort WS close frame
+      try {
+        this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
+      } catch {}
+      return;
+    }
+    this._closeWith("closed");
+  }
+
+  /** @returns {boolean} */
+  isOpen() {
+    return this._state === "running";
+  }
+
+  /** @returns {'idle'|'running'|'closing'|'closed'} */
+  getState() {
+    return this._state;
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  _sendText(text) {
+    if (this._state === "closed") throw new Error(CLOSED_MESSAGE);
+    const frame = encodeClientFrame(OP_TEXT, Buffer.from(text, "utf8"));
+    this._socket.write(frame, (err) => {
+      if (err) this._handleStreamError("socket-write", err);
+    });
+  }
+
+  _onSocketData(chunk) {
+    if (this._state === "closed") return;
+    this._rxBuf = Buffer.concat([this._rxBuf, chunk]);
+    this._drainFrames();
+  }
+
+  /**
+   * Parse as many complete WebSocket frames as are buffered. Control frames
+   * (ping/pong/close) are handled inline; text/continuation frames are
+   * reassembled into a full JSON-RPC message before dispatch.
+   */
+  _drainFrames() {
+    while (this._rxBuf.length >= 2) {
+      const b0 = this._rxBuf[0];
+      const b1 = this._rxBuf[1];
+      const fin = (b0 & 0x80) !== 0;
+      const opcode = b0 & 0x0f;
+      const masked = (b1 & 0x80) !== 0;
+      let len = b1 & 0x7f;
+      let cursor = 2;
+
+      if (len === 126) {
+        if (this._rxBuf.length < cursor + 2) return;
+        len = this._rxBuf.readUInt16BE(cursor);
+        cursor += 2;
+      } else if (len === 127) {
+        if (this._rxBuf.length < cursor + 8) return;
+        const big = this._rxBuf.readBigUInt64BE(cursor);
+        if (big > BigInt(this._maxFrameSize)) {
+          const err = new JsonRpcProtocolError(
+            `WebSocket frame payload ${big} exceeds max ${this._maxFrameSize}`,
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+          return;
+        }
+        len = Number(big);
+        cursor += 8;
+      }
+
+      if (len > this._maxFrameSize) {
+        const err = new JsonRpcProtocolError(
+          `WebSocket frame payload ${len} exceeds max ${this._maxFrameSize}`,
+        );
+        this._emitError(err);
+        this._closeWith("closed", err);
+        return;
+      }
+
+      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
+      if (masked) cursor += 4;
+      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
+
+      let payload = this._rxBuf.subarray(cursor, cursor + len);
+      if (masked && maskKey) {
+        const out = Buffer.allocUnsafe(len);
+        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
+        payload = out;
+      } else {
+        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      }
+      this._rxBuf = this._rxBuf.subarray(cursor + len);
+
+      this._handleFrame(fin, opcode, payload);
+      if (this._state === "closed") return;
+    }
+  }
+
+  _handleFrame(fin, opcode, payload) {
+    switch (opcode) {
+      case OP_PING:
+        try {
+          this._socket?.write(encodeClientFrame(OP_PONG, payload));
+        } catch {}
+        return;
+      case OP_PONG:
+        return;
+      case OP_CLOSE:
+        if (this._state === "running") {
+          const err = new JsonRpcTransportError(
+            "WebSocket server sent close frame",
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+        } else {
+          this._closeWith("closed");
+        }
+        return;
+      case OP_TEXT:
+      case OP_BINARY:
+        this._fragmentOpcode = opcode;
+        this._fragmentChunks = [payload];
+        break;
+      case OP_CONTINUATION:
+        this._fragmentChunks.push(payload);
+        break;
+      default:
+        this._emitError(
+          new JsonRpcProtocolError(
+            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
+          ),
+        );
+        return;
+    }
+
+    if (!fin) return; // wait for the rest of a fragmented message
+    const full = Buffer.concat(this._fragmentChunks);
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+    this._handleMessage(full.toString("utf8"));
+  }
+
+  _handleMessage(line) {
+    if (this._state === "closed") return;
+    if (line.length === 0) return;
+
+    let frame;
+    try {
+      frame = JSON.parse(line);
+    } catch (err) {
+      const pErr = new JsonRpcProtocolError(
+        `JSON-RPC parse error: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (!frame || typeof frame !== "object") {
+      const pErr = new JsonRpcProtocolError(
+        "JSON-RPC protocol error: frame is not an object",
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (
+      Object.hasOwn(frame, "id") &&
+      frame.id !== null &&
+      (Object.hasOwn(frame, "result") || Object.hasOwn(frame, "error"))
+    ) {
+      this._dispatchResponse(frame);
+      return;
+    }
+
+    if (typeof frame.method === "string" && !Object.hasOwn(frame, "id")) {
+      this._dispatchNotification(frame);
+      return;
+    }
+
+    this._emitError(
+      new JsonRpcProtocolError(
+        "JSON-RPC protocol error: unrecognized frame shape",
+      ),
+    );
+  }
+
+  _dispatchResponse(frame) {
+    const pending = this._pendingRequests.get(frame.id);
+    if (!pending) return;
+    this._pendingRequests.delete(frame.id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (Object.hasOwn(frame, "error") && frame.error) {
+      const { code, message, data } = frame.error;
+      const err = new Error(
+        `JSON-RPC error${typeof code === "number" ? ` ${code}` : ""}: ${message || "unknown"}`,
+      );
+      if (code !== undefined) err.code = code;
+      if (data !== undefined) err.data = data;
+      pending.reject(err);
+      return;
+    }
+    pending.resolve(frame.result);
+  }
+
+  _dispatchNotification(frame) {
+    const { method, params } = frame;
+    const targeted = this._notificationHandlers.get(method);
+    if (targeted && targeted.size > 0) {
+      for (const cb of targeted) {
+        try {
+          cb(params);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+    const wildcard = this._notificationHandlers.get("*");
+    if (wildcard && wildcard.size > 0) {
+      for (const cb of wildcard) {
+        try {
+          cb(params, method);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+  }
+
+  _handleStreamError(which, err) {
+    if (this._state === "closed") return;
+    const base = err instanceof Error ? err : new Error(String(err));
+    const wrapped = new JsonRpcTransportError(
+      `WebSocket-over-UDS stream error on ${which}: ${base.message}`,
+      { cause: base },
+    );
+    this._emitError(wrapped);
+    this._closeWith("closed", wrapped);
+  }
+
+  _closeWith(target, rejectReason = null) {
+    if (this._state === "closed") return;
+    this._state = target;
+    const rejectErr =
+      rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
+    for (const [, pending] of this._pendingRequests) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(rejectErr);
+    }
+    this._pendingRequests.clear();
+    try {
+      this._socket?.destroy();
+    } catch {}
+  }
+
+  _emitError(err) {
+    if (!this._onError) return;
+    try {
+      this._onError(err);
+    } catch {
+      /* never throw out of the dispatch loop */
+    }
+  }
+}
+
+export default JsonRpcWsUdsClient;

--- a/packages/remote/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/packages/remote/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -29,6 +29,10 @@ import {
 const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+// After a graceful close("closing") we wait this long for the peer's close/EOF
+// before force-destroying the socket so a silent peer cannot pin it open.
+const CLOSING_DEADLINE_MS = 2_000;
+const MAX_CONTROL_PAYLOAD = 125; // RFC 6455 §5.5: control frames <=125 bytes
 const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
 
 // RFC 6455 opcodes
@@ -110,7 +114,11 @@ export class JsonRpcWsUdsClient {
     this._rxBuf = Buffer.alloc(0);
     /** @type {Buffer[]} accumulated payloads of a fragmented message */
     this._fragmentChunks = [];
+    /** @type {number|null} opcode of the in-progress fragmented message */
     this._fragmentOpcode = null;
+    this._fragmentSize = 0;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    this._closingTimer = null;
   }
 
   /**
@@ -198,14 +206,22 @@ export class JsonRpcWsUdsClient {
           }
           return;
         }
-        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const rawHeaders = handshakeBuf.subarray(0, sep).toString("utf8");
         const leftover = handshakeBuf.subarray(sep + 4);
 
-        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
-        const acceptOk = new RegExp(
-          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
-          "i",
-        ).test(headers);
+        const lines = rawHeaders.split("\r\n");
+        const ok101 = /^HTTP\/1\.\d 101/.test(lines[0] || "");
+        const headerMap = new Map();
+        for (let i = 1; i < lines.length; i++) {
+          const idx = lines[i].indexOf(":");
+          if (idx < 0) continue;
+          headerMap.set(
+            lines[i].slice(0, idx).trim().toLowerCase(),
+            lines[i].slice(idx + 1).trim(),
+          );
+        }
+        const acceptOk =
+          headerMap.get("sec-websocket-accept") === expectedAccept;
 
         if (!ok101 || !acceptOk) {
           settled = true;
@@ -350,6 +366,14 @@ export class JsonRpcWsUdsClient {
       try {
         this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
       } catch {}
+      // Arm a deadline so a peer that never replies with close/EOF cannot pin
+      // the socket + pending requests open forever.
+      this._closingTimer = setTimeout(() => {
+        if (this._state === "closing") this._closeWith("closed");
+      }, CLOSING_DEADLINE_MS);
+      if (typeof this._closingTimer.unref === "function") {
+        this._closingTimer.unref();
+      }
       return;
     }
     this._closeWith("closed");
@@ -424,18 +448,15 @@ export class JsonRpcWsUdsClient {
         return;
       }
 
-      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
-      if (masked) cursor += 4;
-      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
-
-      let payload = this._rxBuf.subarray(cursor, cursor + len);
-      if (masked && maskKey) {
-        const out = Buffer.allocUnsafe(len);
-        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
-        payload = out;
-      } else {
-        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      // RFC 6455 §5.1: server -> client frames MUST NOT be masked.
+      if (masked) {
+        this._protocolClose("WebSocket server frame is masked (RFC 6455 §5.1)");
+        return;
       }
+      if (this._rxBuf.length < cursor + len) return; // wait for full payload
+
+      // Detach from rxBuf before we slice it off.
+      const payload = Buffer.from(this._rxBuf.subarray(cursor, cursor + len));
       this._rxBuf = this._rxBuf.subarray(cursor + len);
 
       this._handleFrame(fin, opcode, payload);
@@ -444,15 +465,22 @@ export class JsonRpcWsUdsClient {
   }
 
   _handleFrame(fin, opcode, payload) {
-    switch (opcode) {
-      case OP_PING:
+    // Control frames (>=0x8): must be FIN and <=125 bytes (RFC 6455 §5.5).
+    if (opcode >= 0x8) {
+      if (!fin || payload.length > MAX_CONTROL_PAYLOAD) {
+        this._protocolClose(
+          `Invalid control frame (opcode 0x${opcode.toString(16)}, fin=${fin}, len=${payload.length})`,
+        );
+        return;
+      }
+      if (opcode === OP_PING) {
         try {
           this._socket?.write(encodeClientFrame(OP_PONG, payload));
         } catch {}
         return;
-      case OP_PONG:
-        return;
-      case OP_CLOSE:
+      }
+      if (opcode === OP_PONG) return;
+      if (opcode === OP_CLOSE) {
         if (this._state === "running") {
           const err = new JsonRpcTransportError(
             "WebSocket server sent close frame",
@@ -463,28 +491,66 @@ export class JsonRpcWsUdsClient {
           this._closeWith("closed");
         }
         return;
-      case OP_TEXT:
-      case OP_BINARY:
-        this._fragmentOpcode = opcode;
-        this._fragmentChunks = [payload];
-        break;
-      case OP_CONTINUATION:
-        this._fragmentChunks.push(payload);
-        break;
-      default:
-        this._emitError(
-          new JsonRpcProtocolError(
-            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
-          ),
-        );
-        return;
+      }
+      this._protocolClose(`Unknown control opcode 0x${opcode.toString(16)}`);
+      return;
     }
 
-    if (!fin) return; // wait for the rest of a fragmented message
-    const full = Buffer.concat(this._fragmentChunks);
-    this._fragmentChunks = [];
-    this._fragmentOpcode = null;
-    this._handleMessage(full.toString("utf8"));
+    // Data frames: text / binary (message start) or continuation.
+    if (opcode === OP_TEXT || opcode === OP_BINARY) {
+      if (this._fragmentOpcode !== null) {
+        this._protocolClose(
+          "New data frame received while a fragmented message is active",
+        );
+        return;
+      }
+      if (opcode === OP_BINARY) {
+        this._protocolClose(
+          "Binary frames are not supported (expected text JSON-RPC)",
+        );
+        return;
+      }
+      if (fin) {
+        this._handleMessage(payload.toString("utf8"));
+        return;
+      }
+      this._fragmentOpcode = opcode;
+      this._fragmentChunks = [payload];
+      this._fragmentSize = payload.length;
+      return;
+    }
+
+    if (opcode === OP_CONTINUATION) {
+      if (this._fragmentOpcode === null) {
+        this._protocolClose(
+          "Continuation frame with no active fragmented message",
+        );
+        return;
+      }
+      this._fragmentSize += payload.length;
+      if (this._fragmentSize > this._maxFrameSize) {
+        this._protocolClose(
+          `Fragmented message ${this._fragmentSize} exceeds max ${this._maxFrameSize}`,
+        );
+        return;
+      }
+      this._fragmentChunks.push(payload);
+      if (!fin) return;
+      const full = Buffer.concat(this._fragmentChunks);
+      this._fragmentChunks = [];
+      this._fragmentOpcode = null;
+      this._fragmentSize = 0;
+      this._handleMessage(full.toString("utf8"));
+      return;
+    }
+
+    this._protocolClose(`Unknown WebSocket opcode 0x${opcode.toString(16)}`);
+  }
+
+  _protocolClose(message) {
+    const err = new JsonRpcProtocolError(message);
+    this._emitError(err);
+    this._closeWith("closed", err);
   }
 
   _handleMessage(line) {
@@ -591,6 +657,10 @@ export class JsonRpcWsUdsClient {
   _closeWith(target, rejectReason = null) {
     if (this._state === "closed") return;
     this._state = target;
+    if (this._closingTimer) {
+      clearTimeout(this._closingTimer);
+      this._closingTimer = null;
+    }
     const rejectErr =
       rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
     for (const [, pending] of this._pendingRequests) {

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -42,6 +42,8 @@ function usage() {
     "  tfx-live converse --session NAME --prompts-file PATH [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500]",
     "  tfx-live goal-driven --session NAME --goal TEXT [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500] [--max-rounds 8] [--done-token DONE]",
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
+    "  tfx-live orchestrate --task TEXT [--mode peer|codex-led|claude-led] [--codex-transport exec|app-server-uds] [--cwd DIR] [--timeout 120]",
+    "    Runs the Claude(UDS)+Codex orchestration engine. --codex-transport app-server-uds drives a real `codex app-server` over WebSocket-over-UDS (experimental); default exec keeps the codex stdio one-shot path.",
   ].join("\n");
 }
 
@@ -1690,6 +1692,47 @@ async function peer(flags) {
   printJson(output);
 }
 
+const ORCHESTRATION_MODES = ["peer", "codex-led", "claude-led"];
+const CODEX_ORCH_TRANSPORTS = ["exec", "app-server-uds"];
+
+async function orchestrate(flags) {
+  const mode = flags.mode ?? "peer";
+  if (!ORCHESTRATION_MODES.includes(mode)) {
+    throw new Error(`--mode must be one of: ${ORCHESTRATION_MODES.join(", ")}`);
+  }
+  const task = requireFlag(flags, "task");
+  const codexTransport = flags["codex-transport"] ?? "exec";
+  if (!CODEX_ORCH_TRANSPORTS.includes(codexTransport)) {
+    throw new Error(
+      `--codex-transport must be one of: ${CODEX_ORCH_TRANSPORTS.join(", ")}`,
+    );
+  }
+  const cwd = flags.cwd ?? process.cwd();
+  const timeoutMs = secondsFlag(flags, "timeout", 120_000);
+
+  // Lazy import keeps the orchestration engine (and its hub/team deps) off the
+  // hot path for every other thin-CLI verb; only `orchestrate` pays the cost.
+  const orchestratorUrl = new URL(
+    "../hub/team/uds-orchestrator.mjs",
+    import.meta.url,
+  ).href;
+  const {
+    runUdsOrchestration,
+    createClaudeUdsEndpoint,
+    createCodexExecEndpoint,
+    createCodexAppServerUdsEndpoint,
+  } = await import(orchestratorUrl);
+
+  const claude = createClaudeUdsEndpoint({ cwd, timeoutMs });
+  const codex =
+    codexTransport === "app-server-uds"
+      ? createCodexAppServerUdsEndpoint({ cwd, timeoutMs })
+      : createCodexExecEndpoint({ workdir: cwd, timeout: timeoutMs });
+
+  const result = await runUdsOrchestration({ mode, task, claude, codex });
+  printJson({ codexTransport, ...result });
+}
+
 function printJson(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
@@ -1718,6 +1761,8 @@ async function main() {
     await goalDriven(flags);
   } else if (command === "peer") {
     await peer(flags);
+  } else if (command === "orchestrate") {
+    await orchestrate(flags);
   } else {
     throw new Error(`Unknown subcommand: ${command}\n${usage()}`);
   }

--- a/packages/triflux/hub/team/uds-orchestrator.mjs
+++ b/packages/triflux/hub/team/uds-orchestrator.mjs
@@ -377,6 +377,37 @@ async function waitForSocketFile(sockPath, deadlineMs) {
 }
 
 /**
+ * SIGTERM a child, wait up to graceMs for it to actually exit, then SIGKILL if
+ * still alive. Liveness is `exitCode === null && signalCode === null` — NOT
+ * `child.killed`, which only means "a signal was sent" and would suppress the
+ * SIGKILL fallback when the child ignores SIGTERM.
+ * @param {import('node:child_process').ChildProcess} child
+ * @param {number} [graceMs]
+ */
+async function terminateChild(child, graceMs = 1000) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => {
+    child.once("exit", () => resolve("exited"));
+  });
+  try {
+    child.kill("SIGTERM");
+  } catch {}
+  const outcome = await Promise.race([
+    exited,
+    new Promise((resolve) => setTimeout(() => resolve("timeout"), graceMs)),
+  ]);
+  if (
+    outcome !== "exited" &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    try {
+      child.kill("SIGKILL");
+    } catch {}
+  }
+}
+
+/**
  * Experimental Codex endpoint that drives a real `codex app-server` over its
  * WebSocket-over-Unix-Domain-Socket control plane (the symmetric peer of the
  * Claude daemon `control.sock` path). Same `ask(prompt) -> {endpoint,text,done}`
@@ -535,15 +566,21 @@ export function createCodexAppServerUdsEndpoint({
           { threadId, input: [{ type: "text", text: prompt }] },
           timeoutMs,
         );
-        const settled = await Promise.race([
-          completion,
-          new Promise((resolve) =>
-            setTimeout(() => {
-              cleanup();
-              resolve({ status: "timeout" });
-            }, timeoutMs),
-          ),
-        ]);
+        let timeoutHandle = null;
+        const timeoutPromise = new Promise((resolve) => {
+          timeoutHandle = setTimeout(() => {
+            cleanup();
+            resolve({ status: "timeout" });
+          }, timeoutMs);
+        });
+        let settled;
+        try {
+          settled = await Promise.race([completion, timeoutPromise]);
+        } finally {
+          // Clear the timer whichever side won, so a completed turn does not
+          // keep the event loop alive until timeoutMs.
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+        }
 
         return {
           endpoint: "codex-app-server-uds",
@@ -561,15 +598,7 @@ export function createCodexAppServerUdsEndpoint({
         try {
           client?.close();
         } catch {}
-        if (child && child.exitCode === null && !child.killed) {
-          try {
-            child.kill("SIGTERM");
-          } catch {}
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          try {
-            if (child.exitCode === null && !child.killed) child.kill("SIGKILL");
-          } catch {}
-        }
+        if (child) await terminateChild(child);
         if (dir)
           await rm(dir, { recursive: true, force: true }).catch(() => {});
       }

--- a/packages/triflux/hub/team/uds-orchestrator.mjs
+++ b/packages/triflux/hub/team/uds-orchestrator.mjs
@@ -1,7 +1,12 @@
+import { spawn } from "node:child_process";
 import crypto from "node:crypto";
+import { mkdtemp, rm, stat } from "node:fs/promises";
 import net from "node:net";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 
 import { execute as defaultExecuteCodex } from "../codex-adapter.mjs";
+import { JsonRpcWsUdsClient } from "../workers/lib/jsonrpc-ws-uds.mjs";
 import {
   buildClaudePromptDispatchPayload,
   deriveClaudeDaemonPaths,
@@ -10,6 +15,8 @@ import {
 } from "./claude-daemon-control.mjs";
 
 const DEFAULT_TIMEOUT_MS = 90_000;
+const DEFAULT_CODEX_APP_SERVER_UDS_TIMEOUT_MS = 120_000;
+const DEFAULT_CODEX_APP_SERVER_UDS_BOOTSTRAP_MS = 12_000;
 
 function requireEndpoint(endpoint, name) {
   if (!endpoint || typeof endpoint.ask !== "function") {
@@ -343,6 +350,229 @@ export function createCodexExecEndpoint({
         ).trim(),
         done: true,
       };
+    },
+  };
+}
+
+function extractCodexThreadId(result) {
+  if (!result || typeof result !== "object") return null;
+  if (typeof result.threadId === "string") return result.threadId;
+  if (result.thread && typeof result.thread.id === "string") {
+    return result.thread.id;
+  }
+  return null;
+}
+
+async function waitForSocketFile(sockPath, deadlineMs) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    try {
+      if ((await stat(sockPath)).isSocket()) return true;
+    } catch {
+      /* not bound yet */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+/**
+ * Experimental Codex endpoint that drives a real `codex app-server` over its
+ * WebSocket-over-Unix-Domain-Socket control plane (the symmetric peer of the
+ * Claude daemon `control.sock` path). Same `ask(prompt) -> {endpoint,text,done}`
+ * contract as `createCodexExecEndpoint`, so it is a drop-in for
+ * `runUdsOrchestration`'s `codex` slot — but it is NOT the default.
+ *
+ * Two modes:
+ *   - spawnServer (default): mkdtemp a private socket, spawn
+ *     `codex app-server --listen unix://PATH`, attach, run one turn, tear down.
+ *   - attach (socketPath + spawnServer=false): connect to an already-running
+ *     daemon socket (e.g. $CODEX_HOME/app-server-control/app-server-control.sock).
+ *
+ * Wire transport proven against codex-cli 0.135.0 — see
+ * experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs.
+ *
+ * @param {object} [options]
+ * @param {string|null} [options.socketPath] Existing daemon socket to attach to.
+ * @param {boolean} [options.spawnServer] Spawn a private app-server (default true).
+ * @param {string} [options.codexBin]
+ * @param {string} [options.cwd]
+ * @param {string} [options.model]
+ * @param {number} [options.timeoutMs] Turn timeout.
+ * @param {number} [options.bootstrapTimeoutMs] Connect + handshake timeout.
+ * @param {(opts: object) => JsonRpcWsUdsClient} [options.clientFactory]
+ * @param {(command: string, args: string[], options: object) => import('node:child_process').ChildProcess} [options.spawnFn]
+ */
+export function createCodexAppServerUdsEndpoint({
+  socketPath = null,
+  spawnServer = true,
+  codexBin = process.env.CODEX_BIN || "codex",
+  cwd = process.cwd(),
+  model,
+  timeoutMs = DEFAULT_CODEX_APP_SERVER_UDS_TIMEOUT_MS,
+  bootstrapTimeoutMs = DEFAULT_CODEX_APP_SERVER_UDS_BOOTSTRAP_MS,
+  clientFactory = (opts) => new JsonRpcWsUdsClient(opts),
+  spawnFn = spawn,
+} = {}) {
+  return {
+    name: "codex-app-server-uds",
+    async ask(prompt, _meta = {}) {
+      if (typeof prompt !== "string" || !prompt.trim()) {
+        throw new Error(
+          "codex-app-server-uds endpoint requires a non-empty prompt",
+        );
+      }
+
+      let dir = null;
+      let child = null;
+      let client = null;
+      let resolvedSock = socketPath;
+
+      try {
+        if (spawnServer && !socketPath) {
+          dir = await mkdtemp(pathJoin(tmpdir(), "tfx-codex-appserver-uds-"));
+          resolvedSock = pathJoin(dir, "app-server.sock");
+          child = spawnFn(
+            codexBin,
+            ["app-server", "--listen", `unix://${resolvedSock}`],
+            { stdio: ["ignore", "pipe", "pipe"], cwd, env: process.env },
+          );
+          let stderr = "";
+          child.stderr?.on("data", (chunk) => {
+            stderr += String(chunk);
+            if (stderr.length > 8000) stderr = stderr.slice(-8000);
+          });
+          const earlyExit = new Promise((resolve) => {
+            child.once("error", (err) =>
+              resolve(`spawn error: ${err.message}`),
+            );
+            child.once("exit", (code, sig) =>
+              resolve(`exited early code=${code} sig=${sig || ""}`),
+            );
+          });
+          const ready = await Promise.race([
+            waitForSocketFile(resolvedSock, bootstrapTimeoutMs).then((ok) =>
+              ok ? "ready" : "no-socket",
+            ),
+            earlyExit,
+          ]);
+          if (ready !== "ready") {
+            throw new Error(
+              `codex app-server did not bind socket: ${ready}${
+                stderr ? ` — ${stderr.slice(-400)}` : ""
+              }`,
+            );
+          }
+        }
+        if (!resolvedSock) {
+          throw new Error(
+            "codex-app-server-uds endpoint needs socketPath or spawnServer=true",
+          );
+        }
+
+        client = clientFactory({
+          socketPath: resolvedSock,
+          connectTimeoutMs: bootstrapTimeoutMs,
+        });
+        await client.connect();
+        await client.request(
+          "initialize",
+          { clientInfo: { name: "triflux-tfx-live", version: "1.0.0" } },
+          bootstrapTimeoutMs,
+        );
+        client.notify("initialized", {});
+
+        const threadParams = {
+          sandbox: "read-only",
+          approvalPolicy: "never",
+          ephemeral: true,
+        };
+        if (typeof model === "string" && model) threadParams.model = model;
+        if (cwd) threadParams.cwd = cwd;
+        const threadStart = await client.request(
+          "thread/start",
+          threadParams,
+          bootstrapTimeoutMs,
+        );
+        const threadId = extractCodexThreadId(threadStart);
+        if (!threadId) {
+          throw new Error(
+            "codex app-server thread/start returned no thread id",
+          );
+        }
+
+        const parts = [];
+        let offDelta = () => {};
+        let offError = () => {};
+        let offDone = () => {};
+        const cleanup = () => {
+          offDelta();
+          offError();
+          offDone();
+        };
+        const completion = new Promise((resolve) => {
+          offDelta = client.onNotification(
+            "item/agentMessage/delta",
+            (params) => {
+              if (typeof params?.delta === "string") parts.push(params.delta);
+            },
+          );
+          offError = client.onNotification("error", (params) => {
+            cleanup();
+            resolve({
+              status: "failed",
+              message: params?.message || "codex app-server error",
+            });
+          });
+          offDone = client.onNotification("turn/completed", (params) => {
+            cleanup();
+            resolve({ status: params?.turn?.status || "unknown" });
+          });
+        });
+
+        await client.request(
+          "turn/start",
+          { threadId, input: [{ type: "text", text: prompt }] },
+          timeoutMs,
+        );
+        const settled = await Promise.race([
+          completion,
+          new Promise((resolve) =>
+            setTimeout(() => {
+              cleanup();
+              resolve({ status: "timeout" });
+            }, timeoutMs),
+          ),
+        ]);
+
+        return {
+          endpoint: "codex-app-server-uds",
+          text: parts.join("").trim(),
+          done: settled.status === "completed",
+          meta: {
+            threadId,
+            status: settled.status,
+            socketPath: resolvedSock,
+            spawned: Boolean(child),
+            ...(settled.message ? { error: settled.message } : {}),
+          },
+        };
+      } finally {
+        try {
+          client?.close();
+        } catch {}
+        if (child && child.exitCode === null && !child.killed) {
+          try {
+            child.kill("SIGTERM");
+          } catch {}
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          try {
+            if (child.exitCode === null && !child.killed) child.kill("SIGKILL");
+          } catch {}
+        }
+        if (dir)
+          await rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
     },
   };
 }

--- a/packages/triflux/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/packages/triflux/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -1,0 +1,616 @@
+// hub/workers/lib/jsonrpc-ws-uds.mjs
+// JSON-RPC 2.0 client over WebSocket-over-Unix-Domain-Socket.
+//
+// codex `app-server --listen unix://PATH` does NOT speak newline-delimited JSON
+// on the socket — it speaks WebSocket (RFC 6455) after a standard HTTP/1.1
+// Upgrade handshake, one JSON-RPC message per text frame. Confirmed live against
+// codex-cli 0.135.0 (see experiments/native-bridge-feasibility/
+// codex-app-server-uds-probe.mjs). This is the UDS sibling of the stdio
+// `JsonRpcStdioClient`: same public surface (request/notify/onNotification/
+// close/isOpen), different framing.
+//
+// Wire framing notes:
+//   - client -> server frames MUST be masked (RFC 6455 §5.3).
+//   - server -> client frames are unmasked.
+//   - one JSON-RPC object per text frame; fragmented frames are reassembled.
+//   - outbound JSON-RPC omits the `"jsonrpc":"2.0"` header (OpenAI App Server
+//     JSONL variant), matching JsonRpcStdioClient.
+//
+// Zero new dependencies — minimal hand-rolled WS client (no `ws` package).
+
+import { createHash, randomBytes } from "node:crypto";
+import net from "node:net";
+
+import {
+  JsonRpcProtocolError,
+  JsonRpcTransportError,
+} from "./jsonrpc-stdio.mjs";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
+
+// RFC 6455 opcodes
+const OP_CONTINUATION = 0x0;
+const OP_TEXT = 0x1;
+const OP_BINARY = 0x2;
+const OP_CLOSE = 0x8;
+const OP_PING = 0x9;
+const OP_PONG = 0xa;
+
+/**
+ * Encode a single client->server WebSocket frame (always masked).
+ * @param {number} opcode
+ * @param {Buffer} payload
+ * @returns {Buffer}
+ */
+function encodeClientFrame(opcode, payload) {
+  const len = payload.length;
+  const mask = randomBytes(4);
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, 0x80 | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  const masked = Buffer.allocUnsafe(len);
+  for (let i = 0; i < len; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+/**
+ * JSON-RPC 2.0 client over WebSocket-over-UDS.
+ */
+export class JsonRpcWsUdsClient {
+  /**
+   * @param {object} options
+   * @param {string} options.socketPath Absolute path to the AF_UNIX socket.
+   * @param {(err: Error) => void} [options.onError]
+   * @param {number} [options.maxFrameSize] Max bytes per inbound frame payload.
+   * @param {number} [options.connectTimeoutMs]
+   */
+  constructor({
+    socketPath,
+    onError,
+    maxFrameSize = DEFAULT_MAX_FRAME_SIZE,
+    connectTimeoutMs = DEFAULT_CONNECT_TIMEOUT_MS,
+  } = {}) {
+    if (typeof socketPath !== "string" || !socketPath) {
+      throw new TypeError("JsonRpcWsUdsClient requires a socketPath string");
+    }
+    this._socketPath = socketPath;
+    this._onError = typeof onError === "function" ? onError : null;
+    this._maxFrameSize =
+      Number.isFinite(maxFrameSize) && maxFrameSize > 0
+        ? maxFrameSize
+        : DEFAULT_MAX_FRAME_SIZE;
+    this._connectTimeoutMs = Number.isFinite(connectTimeoutMs)
+      ? connectTimeoutMs
+      : DEFAULT_CONNECT_TIMEOUT_MS;
+
+    /** @type {'idle'|'running'|'closing'|'closed'} */
+    this._state = "idle";
+    this._socket = null;
+    this._nextRequestId = 1;
+    /** @type {Map<number, { resolve: Function, reject: Function, timer: any, method: string }>} */
+    this._pendingRequests = new Map();
+    /** @type {Map<string, Set<Function>>} */
+    this._notificationHandlers = new Map();
+
+    // RX framing state
+    this._rxBuf = Buffer.alloc(0);
+    /** @type {Buffer[]} accumulated payloads of a fragmented message */
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+  }
+
+  /**
+   * Open the socket and complete the WebSocket HTTP Upgrade handshake.
+   * Resolves once the connection is in the `running` state.
+   * @returns {Promise<void>}
+   */
+  connect() {
+    if (this._state !== "idle") {
+      return Promise.reject(
+        new Error(
+          `JsonRpcWsUdsClient.connect() invalid in state ${this._state}`,
+        ),
+      );
+    }
+    return new Promise((resolve, reject) => {
+      const key = randomBytes(16).toString("base64");
+      const expectedAccept = createHash("sha1")
+        .update(key + WS_GUID)
+        .digest("base64");
+      let handshakeBuf = Buffer.alloc(0);
+      let settled = false;
+
+      const socket = net.connect(this._socketPath);
+      this._socket = socket;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          socket.destroy();
+        } catch {}
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect timed out after ${this._connectTimeoutMs}ms: ${this._socketPath}`,
+          ),
+        );
+      }, this._connectTimeoutMs);
+
+      const onConnectError = (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this._state = "closed";
+        reject(
+          new JsonRpcTransportError(
+            `WebSocket-over-UDS connect error: ${err?.message || err}`,
+            { cause: err },
+          ),
+        );
+      };
+
+      socket.once("error", onConnectError);
+      socket.on("connect", () => {
+        const req =
+          "GET / HTTP/1.1\r\n" +
+          "Host: localhost\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Key: ${key}\r\n` +
+          "Sec-WebSocket-Version: 13\r\n\r\n";
+        socket.write(req);
+      });
+
+      const onHandshakeData = (chunk) => {
+        if (settled) return;
+        handshakeBuf = Buffer.concat([handshakeBuf, chunk]);
+        const sep = handshakeBuf.indexOf("\r\n\r\n");
+        if (sep < 0) {
+          if (handshakeBuf.length > 64 * 1024) {
+            settled = true;
+            clearTimeout(timer);
+            socket.removeListener("error", onConnectError);
+            socket.removeListener("data", onHandshakeData);
+            try {
+              socket.destroy();
+            } catch {}
+            this._state = "closed";
+            reject(
+              new JsonRpcProtocolError(
+                "WebSocket handshake response headers exceeded 64 KiB",
+              ),
+            );
+          }
+          return;
+        }
+        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const leftover = handshakeBuf.subarray(sep + 4);
+
+        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
+        const acceptOk = new RegExp(
+          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
+          "i",
+        ).test(headers);
+
+        if (!ok101 || !acceptOk) {
+          settled = true;
+          clearTimeout(timer);
+          socket.removeListener("error", onConnectError);
+          socket.removeListener("data", onHandshakeData);
+          try {
+            socket.destroy();
+          } catch {}
+          this._state = "closed";
+          reject(
+            new JsonRpcProtocolError(
+              `WebSocket upgrade rejected (status101=${ok101}, acceptValid=${acceptOk})`,
+            ),
+          );
+          return;
+        }
+
+        // Handshake complete — switch to running and wire frame handling.
+        settled = true;
+        clearTimeout(timer);
+        socket.removeListener("error", onConnectError);
+        socket.removeListener("data", onHandshakeData);
+        this._state = "running";
+
+        socket.on("data", (buf) => this._onSocketData(buf));
+        socket.on("error", (err) => this._handleStreamError("socket", err));
+        socket.on("close", () => {
+          if (this._state === "running") {
+            const err = new JsonRpcTransportError(
+              "WebSocket-over-UDS closed unexpectedly (EOF during running)",
+            );
+            this._emitError(err);
+            this._closeWith("closed", err);
+          } else if (this._state !== "closed") {
+            this._closeWith("closed");
+          }
+        });
+
+        if (leftover.length > 0) {
+          this._rxBuf = Buffer.concat([this._rxBuf, leftover]);
+          this._drainFrames();
+        }
+        resolve();
+      };
+
+      socket.on("data", onHandshakeData);
+    });
+  }
+
+  /**
+   * Issue a JSON-RPC request and resolve with the server's `result`.
+   * @param {string} method
+   * @param {unknown} params
+   * @param {number} [timeoutMs=60000]
+   * @returns {Promise<any>}
+   */
+  request(method, params, timeoutMs = 60000) {
+    if (this._state !== "running") {
+      return Promise.reject(new Error(CLOSED_MESSAGE));
+    }
+    const id = this._nextRequestId++;
+    const frame = { id, method };
+    if (params !== undefined) frame.params = params;
+
+    return new Promise((resolve, reject) => {
+      let timer = null;
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          const pending = this._pendingRequests.get(id);
+          if (!pending) return;
+          this._pendingRequests.delete(id);
+          reject(
+            new Error(
+              `JSON-RPC request timed out after ${timeoutMs}ms: ${method}`,
+            ),
+          );
+        }, timeoutMs);
+      }
+      this._pendingRequests.set(id, { resolve, reject, timer, method });
+      try {
+        this._sendText(JSON.stringify(frame));
+      } catch (err) {
+        this._pendingRequests.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(err);
+      }
+    });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no id, no response).
+   * @param {string} method
+   * @param {unknown} [params]
+   */
+  notify(method, params) {
+    if (this._state !== "running") return;
+    const frame = { method };
+    if (params !== undefined) frame.params = params;
+    try {
+      this._sendText(JSON.stringify(frame));
+    } catch (err) {
+      this._emitError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  /**
+   * Subscribe to inbound notifications. `"*"` = catch-all receiving
+   * `(params, method)`; targeted handlers receive `(params)`.
+   * @param {string} method
+   * @param {(params: any, method?: string) => void} callback
+   * @returns {() => void} unsubscribe
+   */
+  onNotification(method, callback) {
+    if (typeof callback !== "function") {
+      throw new TypeError("onNotification requires a callback function");
+    }
+    let set = this._notificationHandlers.get(method);
+    if (!set) {
+      set = new Set();
+      this._notificationHandlers.set(method, set);
+    }
+    set.add(callback);
+    return () => {
+      const handlers = this._notificationHandlers.get(method);
+      if (!handlers) return;
+      handlers.delete(callback);
+      if (handlers.size === 0) this._notificationHandlers.delete(method);
+    };
+  }
+
+  /**
+   * Close the client. `reason === "closing"` transitions to an intermediate
+   * graceful state where a subsequent EOF is treated as normal. Idempotent.
+   * @param {string} [reason]
+   */
+  close(reason) {
+    if (this._state === "closed") return;
+    if (reason === "closing" && this._state === "running") {
+      this._state = "closing";
+      // best-effort WS close frame
+      try {
+        this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
+      } catch {}
+      return;
+    }
+    this._closeWith("closed");
+  }
+
+  /** @returns {boolean} */
+  isOpen() {
+    return this._state === "running";
+  }
+
+  /** @returns {'idle'|'running'|'closing'|'closed'} */
+  getState() {
+    return this._state;
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  _sendText(text) {
+    if (this._state === "closed") throw new Error(CLOSED_MESSAGE);
+    const frame = encodeClientFrame(OP_TEXT, Buffer.from(text, "utf8"));
+    this._socket.write(frame, (err) => {
+      if (err) this._handleStreamError("socket-write", err);
+    });
+  }
+
+  _onSocketData(chunk) {
+    if (this._state === "closed") return;
+    this._rxBuf = Buffer.concat([this._rxBuf, chunk]);
+    this._drainFrames();
+  }
+
+  /**
+   * Parse as many complete WebSocket frames as are buffered. Control frames
+   * (ping/pong/close) are handled inline; text/continuation frames are
+   * reassembled into a full JSON-RPC message before dispatch.
+   */
+  _drainFrames() {
+    while (this._rxBuf.length >= 2) {
+      const b0 = this._rxBuf[0];
+      const b1 = this._rxBuf[1];
+      const fin = (b0 & 0x80) !== 0;
+      const opcode = b0 & 0x0f;
+      const masked = (b1 & 0x80) !== 0;
+      let len = b1 & 0x7f;
+      let cursor = 2;
+
+      if (len === 126) {
+        if (this._rxBuf.length < cursor + 2) return;
+        len = this._rxBuf.readUInt16BE(cursor);
+        cursor += 2;
+      } else if (len === 127) {
+        if (this._rxBuf.length < cursor + 8) return;
+        const big = this._rxBuf.readBigUInt64BE(cursor);
+        if (big > BigInt(this._maxFrameSize)) {
+          const err = new JsonRpcProtocolError(
+            `WebSocket frame payload ${big} exceeds max ${this._maxFrameSize}`,
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+          return;
+        }
+        len = Number(big);
+        cursor += 8;
+      }
+
+      if (len > this._maxFrameSize) {
+        const err = new JsonRpcProtocolError(
+          `WebSocket frame payload ${len} exceeds max ${this._maxFrameSize}`,
+        );
+        this._emitError(err);
+        this._closeWith("closed", err);
+        return;
+      }
+
+      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
+      if (masked) cursor += 4;
+      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
+
+      let payload = this._rxBuf.subarray(cursor, cursor + len);
+      if (masked && maskKey) {
+        const out = Buffer.allocUnsafe(len);
+        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
+        payload = out;
+      } else {
+        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      }
+      this._rxBuf = this._rxBuf.subarray(cursor + len);
+
+      this._handleFrame(fin, opcode, payload);
+      if (this._state === "closed") return;
+    }
+  }
+
+  _handleFrame(fin, opcode, payload) {
+    switch (opcode) {
+      case OP_PING:
+        try {
+          this._socket?.write(encodeClientFrame(OP_PONG, payload));
+        } catch {}
+        return;
+      case OP_PONG:
+        return;
+      case OP_CLOSE:
+        if (this._state === "running") {
+          const err = new JsonRpcTransportError(
+            "WebSocket server sent close frame",
+          );
+          this._emitError(err);
+          this._closeWith("closed", err);
+        } else {
+          this._closeWith("closed");
+        }
+        return;
+      case OP_TEXT:
+      case OP_BINARY:
+        this._fragmentOpcode = opcode;
+        this._fragmentChunks = [payload];
+        break;
+      case OP_CONTINUATION:
+        this._fragmentChunks.push(payload);
+        break;
+      default:
+        this._emitError(
+          new JsonRpcProtocolError(
+            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
+          ),
+        );
+        return;
+    }
+
+    if (!fin) return; // wait for the rest of a fragmented message
+    const full = Buffer.concat(this._fragmentChunks);
+    this._fragmentChunks = [];
+    this._fragmentOpcode = null;
+    this._handleMessage(full.toString("utf8"));
+  }
+
+  _handleMessage(line) {
+    if (this._state === "closed") return;
+    if (line.length === 0) return;
+
+    let frame;
+    try {
+      frame = JSON.parse(line);
+    } catch (err) {
+      const pErr = new JsonRpcProtocolError(
+        `JSON-RPC parse error: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (!frame || typeof frame !== "object") {
+      const pErr = new JsonRpcProtocolError(
+        "JSON-RPC protocol error: frame is not an object",
+      );
+      this._emitError(pErr);
+      if (this._state === "running") this._closeWith("closed", pErr);
+      return;
+    }
+
+    if (
+      Object.hasOwn(frame, "id") &&
+      frame.id !== null &&
+      (Object.hasOwn(frame, "result") || Object.hasOwn(frame, "error"))
+    ) {
+      this._dispatchResponse(frame);
+      return;
+    }
+
+    if (typeof frame.method === "string" && !Object.hasOwn(frame, "id")) {
+      this._dispatchNotification(frame);
+      return;
+    }
+
+    this._emitError(
+      new JsonRpcProtocolError(
+        "JSON-RPC protocol error: unrecognized frame shape",
+      ),
+    );
+  }
+
+  _dispatchResponse(frame) {
+    const pending = this._pendingRequests.get(frame.id);
+    if (!pending) return;
+    this._pendingRequests.delete(frame.id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (Object.hasOwn(frame, "error") && frame.error) {
+      const { code, message, data } = frame.error;
+      const err = new Error(
+        `JSON-RPC error${typeof code === "number" ? ` ${code}` : ""}: ${message || "unknown"}`,
+      );
+      if (code !== undefined) err.code = code;
+      if (data !== undefined) err.data = data;
+      pending.reject(err);
+      return;
+    }
+    pending.resolve(frame.result);
+  }
+
+  _dispatchNotification(frame) {
+    const { method, params } = frame;
+    const targeted = this._notificationHandlers.get(method);
+    if (targeted && targeted.size > 0) {
+      for (const cb of targeted) {
+        try {
+          cb(params);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+    const wildcard = this._notificationHandlers.get("*");
+    if (wildcard && wildcard.size > 0) {
+      for (const cb of wildcard) {
+        try {
+          cb(params, method);
+        } catch (err) {
+          this._emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    }
+  }
+
+  _handleStreamError(which, err) {
+    if (this._state === "closed") return;
+    const base = err instanceof Error ? err : new Error(String(err));
+    const wrapped = new JsonRpcTransportError(
+      `WebSocket-over-UDS stream error on ${which}: ${base.message}`,
+      { cause: base },
+    );
+    this._emitError(wrapped);
+    this._closeWith("closed", wrapped);
+  }
+
+  _closeWith(target, rejectReason = null) {
+    if (this._state === "closed") return;
+    this._state = target;
+    const rejectErr =
+      rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
+    for (const [, pending] of this._pendingRequests) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(rejectErr);
+    }
+    this._pendingRequests.clear();
+    try {
+      this._socket?.destroy();
+    } catch {}
+  }
+
+  _emitError(err) {
+    if (!this._onError) return;
+    try {
+      this._onError(err);
+    } catch {
+      /* never throw out of the dispatch loop */
+    }
+  }
+}
+
+export default JsonRpcWsUdsClient;

--- a/packages/triflux/hub/workers/lib/jsonrpc-ws-uds.mjs
+++ b/packages/triflux/hub/workers/lib/jsonrpc-ws-uds.mjs
@@ -29,6 +29,10 @@ import {
 const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024; // 16 MiB
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+// After a graceful close("closing") we wait this long for the peer's close/EOF
+// before force-destroying the socket so a silent peer cannot pin it open.
+const CLOSING_DEADLINE_MS = 2_000;
+const MAX_CONTROL_PAYLOAD = 125; // RFC 6455 §5.5: control frames <=125 bytes
 const CLOSED_MESSAGE = "JsonRpcWsUdsClient closed";
 
 // RFC 6455 opcodes
@@ -110,7 +114,11 @@ export class JsonRpcWsUdsClient {
     this._rxBuf = Buffer.alloc(0);
     /** @type {Buffer[]} accumulated payloads of a fragmented message */
     this._fragmentChunks = [];
+    /** @type {number|null} opcode of the in-progress fragmented message */
     this._fragmentOpcode = null;
+    this._fragmentSize = 0;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    this._closingTimer = null;
   }
 
   /**
@@ -198,14 +206,22 @@ export class JsonRpcWsUdsClient {
           }
           return;
         }
-        const headers = handshakeBuf.subarray(0, sep).toString("utf8");
+        const rawHeaders = handshakeBuf.subarray(0, sep).toString("utf8");
         const leftover = handshakeBuf.subarray(sep + 4);
 
-        const ok101 = /^HTTP\/1\.\d 101/.test(headers);
-        const acceptOk = new RegExp(
-          `sec-websocket-accept:\\s*${expectedAccept.replace(/[+/=]/g, "\\$&")}`,
-          "i",
-        ).test(headers);
+        const lines = rawHeaders.split("\r\n");
+        const ok101 = /^HTTP\/1\.\d 101/.test(lines[0] || "");
+        const headerMap = new Map();
+        for (let i = 1; i < lines.length; i++) {
+          const idx = lines[i].indexOf(":");
+          if (idx < 0) continue;
+          headerMap.set(
+            lines[i].slice(0, idx).trim().toLowerCase(),
+            lines[i].slice(idx + 1).trim(),
+          );
+        }
+        const acceptOk =
+          headerMap.get("sec-websocket-accept") === expectedAccept;
 
         if (!ok101 || !acceptOk) {
           settled = true;
@@ -350,6 +366,14 @@ export class JsonRpcWsUdsClient {
       try {
         this._socket?.write(encodeClientFrame(OP_CLOSE, Buffer.alloc(0)));
       } catch {}
+      // Arm a deadline so a peer that never replies with close/EOF cannot pin
+      // the socket + pending requests open forever.
+      this._closingTimer = setTimeout(() => {
+        if (this._state === "closing") this._closeWith("closed");
+      }, CLOSING_DEADLINE_MS);
+      if (typeof this._closingTimer.unref === "function") {
+        this._closingTimer.unref();
+      }
       return;
     }
     this._closeWith("closed");
@@ -424,18 +448,15 @@ export class JsonRpcWsUdsClient {
         return;
       }
 
-      const maskKey = masked ? this._rxBuf.subarray(cursor, cursor + 4) : null;
-      if (masked) cursor += 4;
-      if (this._rxBuf.length < cursor + len) return; // wait for more bytes
-
-      let payload = this._rxBuf.subarray(cursor, cursor + len);
-      if (masked && maskKey) {
-        const out = Buffer.allocUnsafe(len);
-        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
-        payload = out;
-      } else {
-        payload = Buffer.from(payload); // detach from rxBuf before slicing it off
+      // RFC 6455 §5.1: server -> client frames MUST NOT be masked.
+      if (masked) {
+        this._protocolClose("WebSocket server frame is masked (RFC 6455 §5.1)");
+        return;
       }
+      if (this._rxBuf.length < cursor + len) return; // wait for full payload
+
+      // Detach from rxBuf before we slice it off.
+      const payload = Buffer.from(this._rxBuf.subarray(cursor, cursor + len));
       this._rxBuf = this._rxBuf.subarray(cursor + len);
 
       this._handleFrame(fin, opcode, payload);
@@ -444,15 +465,22 @@ export class JsonRpcWsUdsClient {
   }
 
   _handleFrame(fin, opcode, payload) {
-    switch (opcode) {
-      case OP_PING:
+    // Control frames (>=0x8): must be FIN and <=125 bytes (RFC 6455 §5.5).
+    if (opcode >= 0x8) {
+      if (!fin || payload.length > MAX_CONTROL_PAYLOAD) {
+        this._protocolClose(
+          `Invalid control frame (opcode 0x${opcode.toString(16)}, fin=${fin}, len=${payload.length})`,
+        );
+        return;
+      }
+      if (opcode === OP_PING) {
         try {
           this._socket?.write(encodeClientFrame(OP_PONG, payload));
         } catch {}
         return;
-      case OP_PONG:
-        return;
-      case OP_CLOSE:
+      }
+      if (opcode === OP_PONG) return;
+      if (opcode === OP_CLOSE) {
         if (this._state === "running") {
           const err = new JsonRpcTransportError(
             "WebSocket server sent close frame",
@@ -463,28 +491,66 @@ export class JsonRpcWsUdsClient {
           this._closeWith("closed");
         }
         return;
-      case OP_TEXT:
-      case OP_BINARY:
-        this._fragmentOpcode = opcode;
-        this._fragmentChunks = [payload];
-        break;
-      case OP_CONTINUATION:
-        this._fragmentChunks.push(payload);
-        break;
-      default:
-        this._emitError(
-          new JsonRpcProtocolError(
-            `Unknown WebSocket opcode 0x${opcode.toString(16)}`,
-          ),
-        );
-        return;
+      }
+      this._protocolClose(`Unknown control opcode 0x${opcode.toString(16)}`);
+      return;
     }
 
-    if (!fin) return; // wait for the rest of a fragmented message
-    const full = Buffer.concat(this._fragmentChunks);
-    this._fragmentChunks = [];
-    this._fragmentOpcode = null;
-    this._handleMessage(full.toString("utf8"));
+    // Data frames: text / binary (message start) or continuation.
+    if (opcode === OP_TEXT || opcode === OP_BINARY) {
+      if (this._fragmentOpcode !== null) {
+        this._protocolClose(
+          "New data frame received while a fragmented message is active",
+        );
+        return;
+      }
+      if (opcode === OP_BINARY) {
+        this._protocolClose(
+          "Binary frames are not supported (expected text JSON-RPC)",
+        );
+        return;
+      }
+      if (fin) {
+        this._handleMessage(payload.toString("utf8"));
+        return;
+      }
+      this._fragmentOpcode = opcode;
+      this._fragmentChunks = [payload];
+      this._fragmentSize = payload.length;
+      return;
+    }
+
+    if (opcode === OP_CONTINUATION) {
+      if (this._fragmentOpcode === null) {
+        this._protocolClose(
+          "Continuation frame with no active fragmented message",
+        );
+        return;
+      }
+      this._fragmentSize += payload.length;
+      if (this._fragmentSize > this._maxFrameSize) {
+        this._protocolClose(
+          `Fragmented message ${this._fragmentSize} exceeds max ${this._maxFrameSize}`,
+        );
+        return;
+      }
+      this._fragmentChunks.push(payload);
+      if (!fin) return;
+      const full = Buffer.concat(this._fragmentChunks);
+      this._fragmentChunks = [];
+      this._fragmentOpcode = null;
+      this._fragmentSize = 0;
+      this._handleMessage(full.toString("utf8"));
+      return;
+    }
+
+    this._protocolClose(`Unknown WebSocket opcode 0x${opcode.toString(16)}`);
+  }
+
+  _protocolClose(message) {
+    const err = new JsonRpcProtocolError(message);
+    this._emitError(err);
+    this._closeWith("closed", err);
   }
 
   _handleMessage(line) {
@@ -591,6 +657,10 @@ export class JsonRpcWsUdsClient {
   _closeWith(target, rejectReason = null) {
     if (this._state === "closed") return;
     this._state = target;
+    if (this._closingTimer) {
+      clearTimeout(this._closingTimer);
+      this._closingTimer = null;
+    }
     const rejectErr =
       rejectReason instanceof Error ? rejectReason : new Error(CLOSED_MESSAGE);
     for (const [, pending] of this._pendingRequests) {

--- a/packages/triflux/skills/tfx-live/SKILL.md
+++ b/packages/triflux/skills/tfx-live/SKILL.md
@@ -76,6 +76,25 @@ tfx-live peer --cli-a codex --cli-b claude \
 
 In `peer`, every hop sends the previous response as the next prompt to the opposite agent; the final JSON is only the transcript.
 
+## Orchestrate (Claude UDS + Codex)
+
+`orchestrate` exposes the `runUdsOrchestration` engine as a formal verb: Claude is driven over the daemon control socket (UDS) and Codex over a selectable transport, in one of three shapes.
+
+```bash
+# default: Codex over the stdio one-shot path (codex exec)
+tfx-live orchestrate --task "이 변경의 위험을 한 줄로" --mode peer
+
+# experimental: Codex over a real `codex app-server` WebSocket-over-UDS daemon
+tfx-live orchestrate --task "이 변경의 위험을 한 줄로" \
+  --mode codex-led --codex-transport app-server-uds --timeout 120
+```
+
+- `--mode` = `peer` (default) | `codex-led` | `claude-led`.
+- `--codex-transport` = `exec` (default, `codex exec` stdio) | `app-server-uds` (experimental).
+  - `app-server-uds` spawns a private `codex app-server --listen unix://<tmp>`, attaches over WebSocket-over-UDS (RFC 6455, masked client frames), runs `initialize`→`thread/start`→`turn/start`, and resolves on `turn/completed`. Transport proven against codex-cli 0.135.0 (see `experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs`).
+  - It is NOT the default — the existing `codex exec` path is unchanged.
+- Requires a live Claude daemon (same as the UDS `ask` path) for the Claude side.
+
 ## Useful diagnostics
 
 ```bash

--- a/skills/tfx-live/SKILL.md
+++ b/skills/tfx-live/SKILL.md
@@ -76,6 +76,25 @@ tfx-live peer --cli-a codex --cli-b claude \
 
 In `peer`, every hop sends the previous response as the next prompt to the opposite agent; the final JSON is only the transcript.
 
+## Orchestrate (Claude UDS + Codex)
+
+`orchestrate` exposes the `runUdsOrchestration` engine as a formal verb: Claude is driven over the daemon control socket (UDS) and Codex over a selectable transport, in one of three shapes.
+
+```bash
+# default: Codex over the stdio one-shot path (codex exec)
+tfx-live orchestrate --task "이 변경의 위험을 한 줄로" --mode peer
+
+# experimental: Codex over a real `codex app-server` WebSocket-over-UDS daemon
+tfx-live orchestrate --task "이 변경의 위험을 한 줄로" \
+  --mode codex-led --codex-transport app-server-uds --timeout 120
+```
+
+- `--mode` = `peer` (default) | `codex-led` | `claude-led`.
+- `--codex-transport` = `exec` (default, `codex exec` stdio) | `app-server-uds` (experimental).
+  - `app-server-uds` spawns a private `codex app-server --listen unix://<tmp>`, attaches over WebSocket-over-UDS (RFC 6455, masked client frames), runs `initialize`→`thread/start`→`turn/start`, and resolves on `turn/completed`. Transport proven against codex-cli 0.135.0 (see `experiments/native-bridge-feasibility/codex-app-server-uds-smoke.mjs`).
+  - It is NOT the default — the existing `codex exec` path is unchanged.
+- Requires a live Claude daemon (same as the UDS `ask` path) for the Claude side.
+
 ## Useful diagnostics
 
 ```bash

--- a/tests/fixtures/fake-codex-app-server-ws-uds.mjs
+++ b/tests/fixtures/fake-codex-app-server-ws-uds.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// tests/fixtures/fake-codex-app-server-ws-uds.mjs
+//
+// Deterministic codex app-server stub that speaks the SAME JSON-RPC protocol as
+// fake-codex-app-server.mjs, but over WebSocket-over-Unix-Domain-Socket — the
+// real transport of `codex app-server --listen unix://PATH`. Lets CI exercise
+// JsonRpcWsUdsClient + createCodexAppServerUdsEndpoint without the real codex
+// binary, with zero model quota.
+//
+//   argv[2] (or $FAKE_WS_UDS_SOCK) = absolute unix socket path to bind.
+//   FAKE_MODE   = "ok" (default) | "execution-failed" | "execution-interrupted"
+//   FAKE_DELTAS = comma-separated delta chunks (default "P,O,N,G")
+//   FAKE_THREAD_ID = thread id echoed (default "fake-thread-ws")
+
+import { createHash } from "node:crypto";
+import net from "node:net";
+import process from "node:process";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const sockPath = process.argv[2] || process.env.FAKE_WS_UDS_SOCK;
+const mode = process.env.FAKE_MODE || "ok";
+const deltas = (process.env.FAKE_DELTAS || "P,O,N,G").split(",");
+const threadId = process.env.FAKE_THREAD_ID || "fake-thread-ws";
+
+if (!sockPath) {
+  process.stderr.write("fake-codex-app-server-ws-uds: missing socket path\n");
+  process.exit(2);
+}
+
+function encodeServerFrame(opcode, payload) {
+  const len = payload.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+const server = net.createServer((socket) => {
+  let upgraded = false;
+  let buf = Buffer.alloc(0);
+
+  const sendJson = (obj) => {
+    socket.write(
+      encodeServerFrame(0x1, Buffer.from(JSON.stringify(obj), "utf8")),
+    );
+  };
+  const respond = (id, result) => sendJson({ id, result });
+  const notify = (method, params) => sendJson({ method, params });
+
+  const fakeThread = () => ({
+    id: threadId,
+    sessionId: threadId,
+    ephemeral: true,
+    modelProvider: "fake",
+    status: { type: "idle" },
+    cwd: process.cwd(),
+    turns: [],
+  });
+  const fakeTurn = (status) => ({
+    id: "turn-ws-1",
+    items: [],
+    status,
+    error: status === "failed" ? { message: "boom" } : null,
+  });
+
+  const handleMessage = (text) => {
+    let msg;
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+
+    if (msg.method === "initialize") {
+      respond(msg.id, {
+        userAgent: "fake-ws-uds/0.0.0",
+        codexHome: "/tmp/fake-codex-home",
+        platformFamily: "unix",
+        platformOs: "linux",
+      });
+    } else if (msg.method === "initialized") {
+      /* no-op */
+    } else if (msg.method === "thread/start") {
+      respond(msg.id, {
+        thread: fakeThread(),
+        model: "gpt-fake",
+        approvalPolicy: "never",
+      });
+    } else if (msg.method === "turn/start") {
+      respond(msg.id, { turn: fakeTurn("inProgress") });
+      notify("thread/started", { thread: fakeThread() });
+      notify("turn/started", { threadId, turn: fakeTurn("inProgress") });
+      for (const d of deltas) {
+        notify("item/agentMessage/delta", {
+          threadId,
+          turnId: "turn-ws-1",
+          itemId: "item-1",
+          delta: d,
+        });
+      }
+      if (mode === "execution-failed") {
+        notify("turn/completed", { threadId, turn: fakeTurn("failed") });
+      } else if (mode === "execution-interrupted") {
+        notify("turn/completed", { threadId, turn: fakeTurn("interrupted") });
+      } else {
+        notify("turn/completed", { threadId, turn: fakeTurn("completed") });
+      }
+    } else if (msg.method === "thread/unsubscribe") {
+      if (typeof msg.id !== "undefined") respond(msg.id, {});
+    }
+  };
+
+  const drainFrames = () => {
+    while (buf.length >= 2) {
+      const b1 = buf[1];
+      const masked = (b1 & 0x80) !== 0;
+      let len = b1 & 0x7f;
+      let cursor = 2;
+      if (len === 126) {
+        if (buf.length < cursor + 2) return;
+        len = buf.readUInt16BE(cursor);
+        cursor += 2;
+      } else if (len === 127) {
+        if (buf.length < cursor + 8) return;
+        len = Number(buf.readBigUInt64BE(cursor));
+        cursor += 8;
+      }
+      const maskKey = masked ? buf.subarray(cursor, cursor + 4) : null;
+      if (masked) cursor += 4;
+      if (buf.length < cursor + len) return;
+      const opcode = buf[0] & 0x0f;
+      let payload = buf.subarray(cursor, cursor + len);
+      if (masked && maskKey) {
+        const out = Buffer.allocUnsafe(len);
+        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
+        payload = out;
+      }
+      buf = Buffer.from(buf.subarray(cursor + len));
+      if (opcode === 0x8) {
+        socket.end();
+        return;
+      }
+      if (opcode === 0x1 || opcode === 0x0)
+        handleMessage(payload.toString("utf8"));
+    }
+  };
+
+  socket.on("data", (chunk) => {
+    buf = Buffer.concat([buf, chunk]);
+    if (!upgraded) {
+      const sep = buf.indexOf("\r\n\r\n");
+      if (sep < 0) return;
+      const headers = buf.subarray(0, sep).toString("utf8");
+      const keyMatch = headers.match(/sec-websocket-key:\s*(.+)\r?\n/i);
+      if (!keyMatch) {
+        socket.destroy();
+        return;
+      }
+      const accept = createHash("sha1")
+        .update(keyMatch[1].trim() + WS_GUID)
+        .digest("base64");
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+      );
+      upgraded = true;
+      buf = Buffer.from(buf.subarray(sep + 4));
+    }
+    drainFrames();
+  });
+  socket.on("error", () => {});
+});
+
+server.on("error", (err) => {
+  process.stderr.write(`fake-codex-app-server-ws-uds error: ${err.message}\n`);
+  process.exit(1);
+});
+
+server.listen(sockPath, () => {
+  process.stdout.write(`listening ${sockPath}\n`);
+});
+
+for (const sig of ["SIGTERM", "SIGINT"]) {
+  process.on(sig, () => {
+    try {
+      server.close();
+    } catch {}
+    process.exit(0);
+  });
+}

--- a/tests/fixtures/fake-codex-app-server-ws-uds.mjs
+++ b/tests/fixtures/fake-codex-app-server-ws-uds.mjs
@@ -27,33 +27,45 @@ if (!sockPath) {
   process.exit(2);
 }
 
-function encodeServerFrame(opcode, payload) {
+// Server -> client frames are unmasked. `fin` controls the FIN bit so the fake
+// can split a message into text + continuation frames (FAKE_FRAGMENT=1).
+function encodeServerFrame(opcode, payload, fin = true) {
   const len = payload.length;
+  const b0 = (fin ? 0x80 : 0) | opcode;
   let header;
   if (len < 126) {
-    header = Buffer.from([0x80 | opcode, len]);
+    header = Buffer.from([b0, len]);
   } else if (len < 65536) {
     header = Buffer.alloc(4);
-    header[0] = 0x80 | opcode;
+    header[0] = b0;
     header[1] = 126;
     header.writeUInt16BE(len, 2);
   } else {
     header = Buffer.alloc(10);
-    header[0] = 0x80 | opcode;
+    header[0] = b0;
     header[1] = 127;
     header.writeBigUInt64BE(BigInt(len), 2);
   }
   return Buffer.concat([header, payload]);
 }
 
+const FRAGMENT = process.env.FAKE_FRAGMENT === "1";
+
 const server = net.createServer((socket) => {
   let upgraded = false;
   let buf = Buffer.alloc(0);
 
   const sendJson = (obj) => {
-    socket.write(
-      encodeServerFrame(0x1, Buffer.from(JSON.stringify(obj), "utf8")),
-    );
+    const full = Buffer.from(JSON.stringify(obj), "utf8");
+    if (FRAGMENT && full.length >= 4) {
+      // Split into a non-final text frame + a final continuation frame to
+      // exercise the client's fragment reassembly.
+      const mid = Math.floor(full.length / 2);
+      socket.write(encodeServerFrame(0x1, full.subarray(0, mid), false));
+      socket.write(encodeServerFrame(0x0, full.subarray(mid), true));
+    } else {
+      socket.write(encodeServerFrame(0x1, full));
+    }
   };
   const respond = (id, result) => sendJson({ id, result });
   const notify = (method, params) => sendJson({ method, params });
@@ -126,6 +138,12 @@ const server = net.createServer((socket) => {
     while (buf.length >= 2) {
       const b1 = buf[1];
       const masked = (b1 & 0x80) !== 0;
+      // Client -> server frames MUST be masked (RFC 6455 §5.1). Reject otherwise
+      // so this fake actively verifies the client masks correctly.
+      if (!masked) {
+        socket.destroy();
+        return;
+      }
       let len = b1 & 0x7f;
       let cursor = 2;
       if (len === 126) {
@@ -137,20 +155,22 @@ const server = net.createServer((socket) => {
         len = Number(buf.readBigUInt64BE(cursor));
         cursor += 8;
       }
-      const maskKey = masked ? buf.subarray(cursor, cursor + 4) : null;
-      if (masked) cursor += 4;
-      if (buf.length < cursor + len) return;
+      if (buf.length < cursor + 4 + len) return;
+      const maskKey = buf.subarray(cursor, cursor + 4);
+      cursor += 4;
       const opcode = buf[0] & 0x0f;
-      let payload = buf.subarray(cursor, cursor + len);
-      if (masked && maskKey) {
-        const out = Buffer.allocUnsafe(len);
-        for (let i = 0; i < len; i++) out[i] = payload[i] ^ maskKey[i % 4];
-        payload = out;
-      }
+      const maskedPayload = buf.subarray(cursor, cursor + len);
+      const payload = Buffer.allocUnsafe(len);
+      for (let i = 0; i < len; i++)
+        payload[i] = maskedPayload[i] ^ maskKey[i % 4];
       buf = Buffer.from(buf.subarray(cursor + len));
       if (opcode === 0x8) {
         socket.end();
         return;
+      }
+      if (opcode === 0x9) {
+        socket.write(encodeServerFrame(0xa, payload)); // ping -> pong
+        continue;
       }
       if (opcode === 0x1 || opcode === 0x0)
         handleMessage(payload.toString("utf8"));

--- a/tests/unit/jsonrpc-ws-uds.test.mjs
+++ b/tests/unit/jsonrpc-ws-uds.test.mjs
@@ -1,0 +1,187 @@
+// tests/unit/jsonrpc-ws-uds.test.mjs
+// JsonRpcWsUdsClient + createCodexAppServerUdsEndpoint over a fake
+// WebSocket-over-UDS server (no real codex, zero quota).
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createCodexAppServerUdsEndpoint } from "../../hub/team/uds-orchestrator.mjs";
+import { JsonRpcWsUdsClient } from "../../hub/workers/lib/jsonrpc-ws-uds.mjs";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(TEST_DIR, "..", "..");
+const FAKE_WS_SERVER = resolve(
+  PROJECT_ROOT,
+  "tests",
+  "fixtures",
+  "fake-codex-app-server-ws-uds.mjs",
+);
+
+async function waitForSocket(sockPath, deadlineMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    try {
+      if ((await stat(sockPath)).isSocket()) return true;
+    } catch {
+      /* not yet */
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
+async function startFakeServer(dir, env = {}) {
+  const sockPath = join(dir, "fake-app-server.sock");
+  const child = spawn(process.execPath, [FAKE_WS_SERVER, sockPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  });
+  const ok = await waitForSocket(sockPath);
+  if (!ok) {
+    try {
+      child.kill("SIGKILL");
+    } catch {}
+    throw new Error("fake ws-uds server did not bind socket");
+  }
+  return { child, sockPath };
+}
+
+function killChild(child) {
+  if (!child || child.killed) return;
+  try {
+    child.kill("SIGTERM");
+  } catch {}
+}
+
+describe("JsonRpcWsUdsClient over fake WebSocket-over-UDS", () => {
+  let dir;
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tfx-ws-uds-test-"));
+  });
+  after(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("connects, completes the initialize handshake, and runs a turn", async () => {
+    const { child, sockPath } = await startFakeServer(dir, {
+      FAKE_DELTAS: "P,O,N,G",
+    });
+    const client = new JsonRpcWsUdsClient({ socketPath: sockPath });
+    try {
+      await client.connect();
+      assert.equal(client.isOpen(), true);
+
+      const init = await client.request(
+        "initialize",
+        { clientInfo: { name: "test", version: "0" } },
+        3000,
+      );
+      assert.equal(typeof init.codexHome, "string");
+      assert.equal(init.platformFamily, "unix");
+
+      client.notify("initialized", {});
+
+      const threadStart = await client.request("thread/start", {}, 3000);
+      const threadId = threadStart?.thread?.id;
+      assert.equal(typeof threadId, "string");
+
+      const parts = [];
+      const completed = new Promise((res) => {
+        client.onNotification("item/agentMessage/delta", (p) => {
+          if (typeof p?.delta === "string") parts.push(p.delta);
+        });
+        client.onNotification("turn/completed", (p) => res(p?.turn?.status));
+      });
+      await client.request(
+        "turn/start",
+        { threadId, input: [{ type: "text", text: "Say PONG" }] },
+        3000,
+      );
+      const status = await completed;
+      assert.equal(status, "completed");
+      assert.equal(parts.join(""), "PONG");
+    } finally {
+      client.close();
+      assert.equal(client.isOpen(), false);
+      killChild(child);
+    }
+  });
+
+  it("rejects requests after close()", async () => {
+    const { child, sockPath } = await startFakeServer(dir);
+    const client = new JsonRpcWsUdsClient({ socketPath: sockPath });
+    try {
+      await client.connect();
+      client.close();
+      await assert.rejects(() => client.request("initialize", {}, 1000));
+    } finally {
+      killChild(child);
+    }
+  });
+});
+
+describe("createCodexAppServerUdsEndpoint (attach mode, fake server)", () => {
+  let dir;
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tfx-ws-uds-ep-test-"));
+  });
+  after(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("ask() returns the assembled agent text with done=true on completed turn", async () => {
+    const { child, sockPath } = await startFakeServer(dir, {
+      FAKE_DELTAS: "PO,NG",
+    });
+    try {
+      const endpoint = createCodexAppServerUdsEndpoint({
+        socketPath: sockPath,
+        spawnServer: false,
+        timeoutMs: 5000,
+        bootstrapTimeoutMs: 3000,
+      });
+      assert.equal(endpoint.name, "codex-app-server-uds");
+      const result = await endpoint.ask("Say PONG");
+      assert.equal(result.endpoint, "codex-app-server-uds");
+      assert.equal(result.text, "PONG");
+      assert.equal(result.done, true);
+      assert.equal(result.meta.status, "completed");
+      assert.equal(result.meta.spawned, false);
+    } finally {
+      killChild(child);
+    }
+  });
+
+  it("ask() reports done=false when the turn fails", async () => {
+    const { child, sockPath } = await startFakeServer(dir, {
+      FAKE_MODE: "execution-failed",
+    });
+    try {
+      const endpoint = createCodexAppServerUdsEndpoint({
+        socketPath: sockPath,
+        spawnServer: false,
+        timeoutMs: 5000,
+        bootstrapTimeoutMs: 3000,
+      });
+      const result = await endpoint.ask("Say PONG");
+      assert.equal(result.done, false);
+      assert.equal(result.meta.status, "failed");
+    } finally {
+      killChild(child);
+    }
+  });
+
+  it("ask() rejects an empty prompt", async () => {
+    const endpoint = createCodexAppServerUdsEndpoint({
+      socketPath: "/nonexistent.sock",
+      spawnServer: false,
+    });
+    await assert.rejects(() => endpoint.ask("   "));
+  });
+});

--- a/tests/unit/jsonrpc-ws-uds.test.mjs
+++ b/tests/unit/jsonrpc-ws-uds.test.mjs
@@ -36,8 +36,13 @@ async function waitForSocket(sockPath, deadlineMs = 5000) {
   return false;
 }
 
+let fakeServerSeq = 0;
+
 async function startFakeServer(dir, env = {}) {
-  const sockPath = join(dir, "fake-app-server.sock");
+  // Unique socket path per call — tests in a suite share `dir`, and a reused
+  // path races a not-yet-unlinked stale socket from a prior test (EADDRINUSE on
+  // the new fake + stale-socket "ready" false positive => dead-socket timeout).
+  const sockPath = join(dir, `fake-${++fakeServerSeq}.sock`);
   const child = spawn(process.execPath, [FAKE_WS_SERVER, sockPath], {
     stdio: ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...env },
@@ -109,6 +114,45 @@ describe("JsonRpcWsUdsClient over fake WebSocket-over-UDS", () => {
     } finally {
       client.close();
       assert.equal(client.isOpen(), false);
+      killChild(child);
+    }
+  });
+
+  it("reassembles fragmented server messages (text + continuation)", async () => {
+    const { child, sockPath } = await startFakeServer(dir, {
+      FAKE_FRAGMENT: "1",
+      FAKE_DELTAS: "P,O,N,G",
+    });
+    const client = new JsonRpcWsUdsClient({ socketPath: sockPath });
+    try {
+      await client.connect();
+      // initialize response is itself fragmented by the fake under FAKE_FRAGMENT.
+      const init = await client.request(
+        "initialize",
+        { clientInfo: { name: "test", version: "0" } },
+        3000,
+      );
+      assert.equal(typeof init.codexHome, "string");
+      client.notify("initialized", {});
+      const threadStart = await client.request("thread/start", {}, 3000);
+      const threadId = threadStart?.thread?.id;
+      assert.equal(typeof threadId, "string");
+      const parts = [];
+      const completed = new Promise((res) => {
+        client.onNotification("item/agentMessage/delta", (p) => {
+          if (typeof p?.delta === "string") parts.push(p.delta);
+        });
+        client.onNotification("turn/completed", (p) => res(p?.turn?.status));
+      });
+      await client.request(
+        "turn/start",
+        { threadId, input: [{ type: "text", text: "Say PONG" }] },
+        3000,
+      );
+      assert.equal(await completed, "completed");
+      assert.equal(parts.join(""), "PONG");
+    } finally {
+      client.close();
       killChild(child);
     }
   });


### PR DESCRIPTION
## What

Adds a **real Codex-over-UDS path** to `tfx-live`, the symmetric peer of the existing Claude daemon `control.sock` route:

- **`JsonRpcWsUdsClient`** (`hub/workers/lib/jsonrpc-ws-uds.mjs`) — a hand-rolled, zero-dependency JSON-RPC 2.0 client over **WebSocket-over-Unix-Domain-Socket** (HTTP/1.1 Upgrade + RFC 6455 frames, client frames masked). Same public surface as the existing `JsonRpcStdioClient` (`request`/`notify`/`onNotification`/`close`/`isOpen`).
- **`createCodexAppServerUdsEndpoint`** (`hub/team/uds-orchestrator.mjs`) — drives a real `codex app-server` (`initialize` → `initialized` → `thread/start` → `turn/start` → resolves on `turn/completed`). Drop-in for the `runUdsOrchestration` `codex` slot. Spawns a private app-server by default, or attaches to an existing daemon socket.
- **`tfx-live orchestrate`** verb — exposes `runUdsOrchestration` formally: `--mode peer|codex-led|claude-led`, `--codex-transport exec|app-server-uds`.

## Why

Reverse-engineering established that the earlier claim "Codex/agy have no UDS" was wrong: Codex CLI's `app-server` ships a UDS control plane directly comparable to Claude Code's daemon. `tfx-live` had only reached Codex via `codex exec` (stdio stdout-scraping). This wires the real thing.

## How it was proven

The riskiest unknown — the wire framing — was resolved empirically against **codex-cli 0.135.0**, not assumed:

- `--listen unix://` is **WebSocket-over-UDS** (HTTP Upgrade + RFC 6455), **not** plain JSONL (two RE passes disagreed; the live probe settled it).
- handshake + `thread/start` need **no auth** (zero model quota).
- a full real turn round-tripped end-to-end through the production client: `turn.status: "completed"`, `output: "PONG"`.

Spike + smoke: `experiments/native-bridge-feasibility/codex-app-server-uds-{probe,smoke}.mjs`.

## Scope / safety (PoC)

- **Experimental, gated** behind `--codex-transport app-server-uds`. The default `codex exec` stdio path and **every existing `tfx-live` verb are unchanged**.
- CI-safe unit tests via a fake WebSocket-over-UDS server fixture (`tests/fixtures/fake-codex-app-server-ws-uds.mjs`) — no real codex, zero quota.
- Mirrored per `tfx-mirror-policy`: `packages/triflux` (uds-orchestrator, bin, SKILL) + `packages/{remote,triflux}` (jsonrpc-ws-uds), byte-identical.
- PRD: `.triflux/plans/codex-app-server-uds-poc.md`.

## Testing

- `tests/unit/jsonrpc-ws-uds.test.mjs` — client handshake/turn + endpoint round-trip + failure + empty-prompt (5/5).
- existing `uds-orchestrator`, `tfx-live-cli`, `packages-sync` suites green.
- `npm run lint` (biome, full repo) clean.

## Follow-ups (not in this PoC)

- Switch default to `app-server-uds`; attach to a shared persistent daemon socket; server-initiated approval round-trip; extract shared JSON-RPC dispatch from the stdio/ws clients.
- **Bug noted:** the existing `CodexAppServerWorker` `DEFAULT_CODEX_APP_SERVER_ARGS` `--skip-git-repo-check` is **stale for codex 0.135** (rejected as a top-level option, exit 2) — its real-codex test is env-gated so CI doesn't catch it. Separate fix.

## Review gate

✅ **Codex cross-review completed** (Claude authored → Codex reviewed, per repo policy) and **all findings fixed** in commit 2 — see the PR comment for the itemized list. Highlights:
- 2 High lifecycle bugs (timeout-timer leak that kept the event loop alive after a completed turn; `child.killed` suppressing the SIGKILL fallback) — fixed.
- 1 High + 3 Medium WS-codec hardening (RFC-safe fragmentation, masked-server-frame rejection, control-frame validation, exact `Sec-WebSocket-Accept` match, `close("closing")` deadline) — fixed.
- Test stale-socket reuse race — fixed.

Re-verified after fixes: real codex 0.135.0 handshake round-trip, full `npm test` + biome lint green, ws-uds suite stable across repeated runs.
