### PR TITLE
fix(codex-app-server-worker): drop global --skip-git-repo-check rejected by codex 0.135

### DIFF
--- a/hub/workers/codex-app-server-worker.mjs
+++ b/hub/workers/codex-app-server-worker.mjs
@@ -160,8 +160,11 @@ export const KIND_MAP = Object.freeze({
   configWarning: "error",
 });
 
+// NOTE: codex 0.135.0 rejects `--skip-git-repo-check` as a global option (exit 2:
+// "unexpected argument"); it lives at `codex exec` subcommand scope, and the
+// `app-server` subcommand does not need it. Empirically verified against
+// codex-cli 0.135.0. Do not re-add it as a global flag here.
 export const DEFAULT_CODEX_APP_SERVER_ARGS = Object.freeze([
-  "--skip-git-repo-check",
   "app-server",
   "--listen",
   "stdio://",

--- a/packages/remote/hub/workers/codex-app-server-worker.mjs
+++ b/packages/remote/hub/workers/codex-app-server-worker.mjs
@@ -160,8 +160,11 @@ export const KIND_MAP = Object.freeze({
   configWarning: "error",
 });
 
+// NOTE: codex 0.135.0 rejects `--skip-git-repo-check` as a global option (exit 2:
+// "unexpected argument"); it lives at `codex exec` subcommand scope, and the
+// `app-server` subcommand does not need it. Empirically verified against
+// codex-cli 0.135.0. Do not re-add it as a global flag here.
 export const DEFAULT_CODEX_APP_SERVER_ARGS = Object.freeze([
-  "--skip-git-repo-check",
   "app-server",
   "--listen",
   "stdio://",

--- a/packages/triflux/hub/workers/codex-app-server-worker.mjs
+++ b/packages/triflux/hub/workers/codex-app-server-worker.mjs
@@ -160,8 +160,11 @@ export const KIND_MAP = Object.freeze({
   configWarning: "error",
 });
 
+// NOTE: codex 0.135.0 rejects `--skip-git-repo-check` as a global option (exit 2:
+// "unexpected argument"); it lives at `codex exec` subcommand scope, and the
+// `app-server` subcommand does not need it. Empirically verified against
+// codex-cli 0.135.0. Do not re-add it as a global flag here.
 export const DEFAULT_CODEX_APP_SERVER_ARGS = Object.freeze([
-  "--skip-git-repo-check",
   "app-server",
   "--listen",
   "stdio://",

--- a/tests/unit/codex-app-server-worker.test.mjs
+++ b/tests/unit/codex-app-server-worker.test.mjs
@@ -522,6 +522,12 @@ describe("CodexAppServerWorker — AC-13 defaults", () => {
     // app-server subcommand (regression guard for the stale-arg exit-2 bug).
     assert.equal(childRef.args[0], "app-server");
     assert.equal(childRef.args[1], "--listen");
+    // Guard against re-adding the flag at ANY position — codex app-server
+    // rejects --skip-git-repo-check whether it leads or trails the argv.
+    assert.ok(
+      !childRef.args.includes("--skip-git-repo-check"),
+      "--skip-git-repo-check must not appear in app-server argv",
+    );
     emitTurnCompleted(FakeClientBase.last, "completed");
     await p;
     await worker.stop();

--- a/tests/unit/codex-app-server-worker.test.mjs
+++ b/tests/unit/codex-app-server-worker.test.mjs
@@ -507,7 +507,7 @@ describe("CodexAppServerWorker — AC-12 publish invariants", () => {
 });
 
 describe("CodexAppServerWorker — AC-13 defaults", () => {
-  it("14. default sandbox 'read-only' and args start with --skip-git-repo-check", async () => {
+  it("14. default sandbox 'read-only' and args start with app-server subcommand", async () => {
     const { worker, childRef } = makeWorker();
     const p = worker.execute("x");
     await tick();
@@ -518,8 +518,10 @@ describe("CodexAppServerWorker — AC-13 defaults", () => {
     assert.equal(ts.params.ephemeral, true);
     assert.equal(ts.params.experimentalRawEvents, false);
     assert.equal(ts.params.persistExtendedHistory, false);
-    assert.equal(childRef.args[0], "--skip-git-repo-check");
-    assert.equal(childRef.args[1], "app-server");
+    // codex 0.135.0: no global --skip-git-repo-check; args start with the
+    // app-server subcommand (regression guard for the stale-arg exit-2 bug).
+    assert.equal(childRef.args[0], "app-server");
+    assert.equal(childRef.args[1], "--listen");
     emitTurnCompleted(FakeClientBase.last, "completed");
     await p;
     await worker.stop();


### PR DESCRIPTION
## Problem

`DEFAULT_CODEX_APP_SERVER_ARGS` placed `--skip-git-repo-check` as a **global** option *before* the `app-server` subcommand:

```
codex --skip-git-repo-check app-server --listen stdio://
```

codex-cli **0.135.0 rejects** a global `--skip-git-repo-check` with `exit 2: error: unexpected argument '--skip-git-repo-check' found`. The flag now lives at `codex exec` subcommand scope, and the `app-server` subcommand never needed it (it is a server, not a repo operation).

### Why CI stayed green

- The real-codex integration test is **env-gated** (`TFX_RUN_REAL_CODEX_APP_SERVER_*`), so CI never spawned a real codex and never saw the exit 2.
- The unit test **hard-asserted** `args[0] === "--skip-git-repo-check"`, baking the stale arg into the green path.

## Fix

- Drop `--skip-git-repo-check` from `DEFAULT_CODEX_APP_SERVER_ARGS` → `["app-server", "--listen", "stdio://"]`.
- Add a NOTE comment so it is not re-added as a global flag.
- Update the unit test to guard the corrected arg order (`args[0] === "app-server"`, `args[1] === "--listen"`).
- Mirror byte-identical to `packages/{triflux,remote}` per `tfx-mirror-policy`.

The `codex exec` paths (`codex-adapter.mjs`, `cli-adapter-base.mjs`, `execution-mode.mjs`) are **unaffected** — they place the flag at subcommand scope (`codex exec --skip-git-repo-check`), which 0.135 accepts.

## Verification (codex-cli 0.135.0, empirical)

| invocation | result |
|---|---|
| `codex --skip-git-repo-check app-server --listen unix://…` (before) | **exit 2** `unexpected argument` |
| `codex app-server --listen unix://…` (after) | binds and waits (no early exit) |

- mirror 3-way `diff -q` byte-identical
- `npm run lint` (biome, 719 files): clean
- `node --test tests/unit/codex-app-server-worker.test.mjs`: 25 pass / 0 fail

## Follow-ups (not in this PR)

- Consider adding `npm run lint` to `ci.yml` so format/arg drift is caught at PR time, not release time.