### PR TITLE
ci: run biome lint in CI to catch format/arg drift at PR time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
         # npm install fallback. deterministic 손실 trade-off 있으나 CI 미실행 보다 낫다.
         run: npm ci || npm install --no-audit --no-fund
 
+      - name: Biome lint
+        # ci.yml 이 `npm run lint` (biome) 를 안 돌려서 format/arg drift 가 main 에
+        # invisible 하게 누적되고 release prepare 단계에서만 터졌다 (v10.28.0 release
+        # blocker, PR #371). PR 시점에 fast-fail 로 잡는다.
+        # NOTE: `lint` 스크립트는 packages/ 를 제외한다 — packages 미러는 아래
+        # release:check-mirror 가 byte-identical 로 보증하므로 중복 검사 불필요.
+        run: npm run lint
+
       - name: packages/triflux mirror byte-identical
         # packages-mirror.test.mjs 가 transitive 로 같은 검사를 돌지만, drift 시
         # unit test 실행 전에 fast-fail 로 끊어주면 원인 파악이 명확해진다.


### PR DESCRIPTION
## Problem

`ci.yml` ran the test suite (via `test:guard-codex-config` → `npm test`, which includes `lint:skills`) but **never `npm run lint` (biome)**. So biome format and stale-arg drift accumulated invisibly on `main` and only surfaced at **release prepare** time:

- v10.28.0 release blocker: pre-existing biome drift (`uds-orchestrator.mjs` #366, `session-stale-cleanup.mjs` #365) failed `release.yml` prepare, fixed by PR #371.
- Same class of gap that let the codex 0.135 stale-arg bug ride green CI (#373).

## Fix

Add a fast-fail **Biome lint** step right after `Install dependencies`:

```yaml
- name: Biome lint
  run: npm run lint
```

Drift now fails the **PR**, not the release.

## Notes

- The `lint` script (`biome check bin config hooks hub hud mesh scripts tests .claude-plugin .github ...`) **excludes `packages/`** by design — the packages mirrors are byte-identical-guarded by the existing `release:check-mirror` step, so re-linting them would be redundant.
- Placed before the mirror/sync/config-guard steps so a format issue fails fast with a clear cause.

## Verification

- `npm run lint` on current main (`ae4340af`): clean, 719 files — the new step does not insta-fail.
- ci.yml parsed with the `yaml` lib: `test` job, 7 steps, Biome lint at position 4, `run: npm run lint`.