### PR TITLE
fix(context-guard): default context monitor + Stop hook to 1M window

### DIFF
--- a/hooks/pipeline-stop.mjs
+++ b/hooks/pipeline-stop.mjs
@@ -142,7 +142,7 @@ function contextPercentsFromObject(value) {
   ];
 
   const currentUsage = value.current_usage ?? value.currentUsage ?? {};
-  const maxTokens =
+  const explicitMaxTokens =
     value.context_window_size ??
     value.contextWindowSize ??
     value.max_context_tokens ??
@@ -151,6 +151,18 @@ function contextPercentsFromObject(value) {
     value.maxTokens ??
     value.total_tokens ??
     value.totalTokens;
+  // Fall back to a 1M context window when the payload omits one — Opus 4.x
+  // [1M] and Codex gpt-5.5 both run on a 1M window, and assuming 200K there
+  // false-positives at ~15% real usage. Override via
+  // TFX_CONTEXT_DEFAULT_MAX_TOKENS for narrower setups.
+  const envFallback = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const fallbackMaxTokens =
+    Number.isFinite(envFallback) && envFallback > 0 ? envFallback : 1_000_000;
+  const explicitNumeric = Number(explicitMaxTokens);
+  const maxTokens =
+    Number.isFinite(explicitNumeric) && explicitNumeric > 0
+      ? explicitNumeric
+      : fallbackMaxTokens;
   candidates.push(
     tokenPercent(value.used_tokens ?? value.usedTokens, maxTokens),
     tokenPercent(

--- a/hud/context-monitor.mjs
+++ b/hud/context-monitor.mjs
@@ -288,11 +288,16 @@ export function buildContextUsageView(stdin, snapshot = null) {
   const modelHintLimit = resolveModelLimit(modelId);
   const monitorLimit = Number(monitor?.limitTokens || 0);
   const stdinLimit = stdinUsage?.limitTokens;
+  // When a model id is known it is the authoritative per-model ceiling: the
+  // monitor's cached limitTokens is just a default-derived accumulator (now 1M
+  // by default) and must not override a known model's real window in either
+  // direction — it would inflate a 200K model (Sonnet 4.5 / Haiku) up to 1M.
+  // The model hint already upgrades a stale-low monitor on its own (#88).
   const limitTokens =
     stdinLimit != null && stdinLimit > 0
       ? Math.max(1, stdinLimit)
       : modelId
-        ? Math.max(1, monitorLimit, modelHintLimit)
+        ? Math.max(1, modelHintLimit)
         : Math.max(1, monitorLimit || modelHintLimit);
 
   const usedTokens = stdinUsage?.usedTokens ?? Number(monitor?.usedTokens || 0);
@@ -324,7 +329,19 @@ export function buildContextUsageView(stdin, snapshot = null) {
 }
 
 export function createContextMonitor(options = {}) {
-  const limitTokens = Number(options.limitTokens || DEFAULT_CONTEXT_LIMIT);
+  // Default to a 1M context window (Opus 4.x [1M] / Codex gpt-5.5 both run on
+  // a 1M window) when no explicit limit is supplied, so the cached percent the
+  // Stop hook reads is not inflated against a 200K assumption — assuming 200K
+  // there false-positives at ~15% real usage and blocks legitimate stops.
+  // Narrower setups override via TFX_CONTEXT_DEFAULT_MAX_TOKENS.
+  const explicitLimit = Number(options.limitTokens);
+  const envLimit = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const limitTokens =
+    Number.isFinite(explicitLimit) && explicitLimit > 0
+      ? explicitLimit
+      : Number.isFinite(envLimit) && envLimit > 0
+        ? envLimit
+        : MILLION_CONTEXT_LIMIT;
   const cachePath = options.cachePath || CONTEXT_MONITOR_CACHE_PATH;
   const logsDir = options.logsDir || CONTEXT_MONITOR_LOG_DIR;
   const sessionId = options.sessionId || randomUUID().slice(0, 8);

--- a/packages/core/hooks/pipeline-stop.mjs
+++ b/packages/core/hooks/pipeline-stop.mjs
@@ -142,7 +142,7 @@ function contextPercentsFromObject(value) {
   ];
 
   const currentUsage = value.current_usage ?? value.currentUsage ?? {};
-  const maxTokens =
+  const explicitMaxTokens =
     value.context_window_size ??
     value.contextWindowSize ??
     value.max_context_tokens ??
@@ -151,6 +151,18 @@ function contextPercentsFromObject(value) {
     value.maxTokens ??
     value.total_tokens ??
     value.totalTokens;
+  // Fall back to a 1M context window when the payload omits one — Opus 4.x
+  // [1M] and Codex gpt-5.5 both run on a 1M window, and assuming 200K there
+  // false-positives at ~15% real usage. Override via
+  // TFX_CONTEXT_DEFAULT_MAX_TOKENS for narrower setups.
+  const envFallback = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const fallbackMaxTokens =
+    Number.isFinite(envFallback) && envFallback > 0 ? envFallback : 1_000_000;
+  const explicitNumeric = Number(explicitMaxTokens);
+  const maxTokens =
+    Number.isFinite(explicitNumeric) && explicitNumeric > 0
+      ? explicitNumeric
+      : fallbackMaxTokens;
   candidates.push(
     tokenPercent(value.used_tokens ?? value.usedTokens, maxTokens),
     tokenPercent(

--- a/packages/core/hud/context-monitor.mjs
+++ b/packages/core/hud/context-monitor.mjs
@@ -288,11 +288,16 @@ export function buildContextUsageView(stdin, snapshot = null) {
   const modelHintLimit = resolveModelLimit(modelId);
   const monitorLimit = Number(monitor?.limitTokens || 0);
   const stdinLimit = stdinUsage?.limitTokens;
+  // When a model id is known it is the authoritative per-model ceiling: the
+  // monitor's cached limitTokens is just a default-derived accumulator (now 1M
+  // by default) and must not override a known model's real window in either
+  // direction — it would inflate a 200K model (Sonnet 4.5 / Haiku) up to 1M.
+  // The model hint already upgrades a stale-low monitor on its own (#88).
   const limitTokens =
     stdinLimit != null && stdinLimit > 0
       ? Math.max(1, stdinLimit)
       : modelId
-        ? Math.max(1, monitorLimit, modelHintLimit)
+        ? Math.max(1, modelHintLimit)
         : Math.max(1, monitorLimit || modelHintLimit);
 
   const usedTokens = stdinUsage?.usedTokens ?? Number(monitor?.usedTokens || 0);
@@ -324,7 +329,19 @@ export function buildContextUsageView(stdin, snapshot = null) {
 }
 
 export function createContextMonitor(options = {}) {
-  const limitTokens = Number(options.limitTokens || DEFAULT_CONTEXT_LIMIT);
+  // Default to a 1M context window (Opus 4.x [1M] / Codex gpt-5.5 both run on
+  // a 1M window) when no explicit limit is supplied, so the cached percent the
+  // Stop hook reads is not inflated against a 200K assumption — assuming 200K
+  // there false-positives at ~15% real usage and blocks legitimate stops.
+  // Narrower setups override via TFX_CONTEXT_DEFAULT_MAX_TOKENS.
+  const explicitLimit = Number(options.limitTokens);
+  const envLimit = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const limitTokens =
+    Number.isFinite(explicitLimit) && explicitLimit > 0
+      ? explicitLimit
+      : Number.isFinite(envLimit) && envLimit > 0
+        ? envLimit
+        : MILLION_CONTEXT_LIMIT;
   const cachePath = options.cachePath || CONTEXT_MONITOR_CACHE_PATH;
   const logsDir = options.logsDir || CONTEXT_MONITOR_LOG_DIR;
   const sessionId = options.sessionId || randomUUID().slice(0, 8);

--- a/packages/triflux/hooks/pipeline-stop.mjs
+++ b/packages/triflux/hooks/pipeline-stop.mjs
@@ -142,7 +142,7 @@ function contextPercentsFromObject(value) {
   ];
 
   const currentUsage = value.current_usage ?? value.currentUsage ?? {};
-  const maxTokens =
+  const explicitMaxTokens =
     value.context_window_size ??
     value.contextWindowSize ??
     value.max_context_tokens ??
@@ -151,6 +151,18 @@ function contextPercentsFromObject(value) {
     value.maxTokens ??
     value.total_tokens ??
     value.totalTokens;
+  // Fall back to a 1M context window when the payload omits one — Opus 4.x
+  // [1M] and Codex gpt-5.5 both run on a 1M window, and assuming 200K there
+  // false-positives at ~15% real usage. Override via
+  // TFX_CONTEXT_DEFAULT_MAX_TOKENS for narrower setups.
+  const envFallback = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const fallbackMaxTokens =
+    Number.isFinite(envFallback) && envFallback > 0 ? envFallback : 1_000_000;
+  const explicitNumeric = Number(explicitMaxTokens);
+  const maxTokens =
+    Number.isFinite(explicitNumeric) && explicitNumeric > 0
+      ? explicitNumeric
+      : fallbackMaxTokens;
   candidates.push(
     tokenPercent(value.used_tokens ?? value.usedTokens, maxTokens),
     tokenPercent(

--- a/packages/triflux/hud/context-monitor.mjs
+++ b/packages/triflux/hud/context-monitor.mjs
@@ -288,11 +288,16 @@ export function buildContextUsageView(stdin, snapshot = null) {
   const modelHintLimit = resolveModelLimit(modelId);
   const monitorLimit = Number(monitor?.limitTokens || 0);
   const stdinLimit = stdinUsage?.limitTokens;
+  // When a model id is known it is the authoritative per-model ceiling: the
+  // monitor's cached limitTokens is just a default-derived accumulator (now 1M
+  // by default) and must not override a known model's real window in either
+  // direction — it would inflate a 200K model (Sonnet 4.5 / Haiku) up to 1M.
+  // The model hint already upgrades a stale-low monitor on its own (#88).
   const limitTokens =
     stdinLimit != null && stdinLimit > 0
       ? Math.max(1, stdinLimit)
       : modelId
-        ? Math.max(1, monitorLimit, modelHintLimit)
+        ? Math.max(1, modelHintLimit)
         : Math.max(1, monitorLimit || modelHintLimit);
 
   const usedTokens = stdinUsage?.usedTokens ?? Number(monitor?.usedTokens || 0);
@@ -324,7 +329,19 @@ export function buildContextUsageView(stdin, snapshot = null) {
 }
 
 export function createContextMonitor(options = {}) {
-  const limitTokens = Number(options.limitTokens || DEFAULT_CONTEXT_LIMIT);
+  // Default to a 1M context window (Opus 4.x [1M] / Codex gpt-5.5 both run on
+  // a 1M window) when no explicit limit is supplied, so the cached percent the
+  // Stop hook reads is not inflated against a 200K assumption — assuming 200K
+  // there false-positives at ~15% real usage and blocks legitimate stops.
+  // Narrower setups override via TFX_CONTEXT_DEFAULT_MAX_TOKENS.
+  const explicitLimit = Number(options.limitTokens);
+  const envLimit = Number(process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS);
+  const limitTokens =
+    Number.isFinite(explicitLimit) && explicitLimit > 0
+      ? explicitLimit
+      : Number.isFinite(envLimit) && envLimit > 0
+        ? envLimit
+        : MILLION_CONTEXT_LIMIT;
   const cachePath = options.cachePath || CONTEXT_MONITOR_CACHE_PATH;
   const logsDir = options.logsDir || CONTEXT_MONITOR_LOG_DIR;
   const sessionId = options.sessionId || randomUUID().slice(0, 8);

--- a/tests/unit/context-monitor.test.mjs
+++ b/tests/unit/context-monitor.test.mjs
@@ -201,6 +201,101 @@ describe("hud/context-monitor.mjs", () => {
     rmSync(logsDir, { recursive: true, force: true });
   });
 
+  it("limitTokens 옵션이 없으면 기본 1M 컨텍스트 윈도우를 사용한다", () => {
+    const cachePath = makeTmpPath("context-monitor-cache");
+    const logsDir = makeTmpPath("context-monitor-logs");
+    const monitor = createContextMonitor({
+      cachePath,
+      logsDir,
+      registerExitHooks: false,
+      sessionId: "default-1m-window",
+    });
+
+    const summary = monitor.record({
+      requestBody: '{"method":"tools/call","params":{"name":"read_file"}}',
+      responseBody:
+        '{"result":{"usage":{"input_tokens":150000,"output_tokens":0}}}',
+    });
+
+    // 150K used against a 1M default = 15%, not the 75%+ a 200K default would
+    // report and which would false-block a stop on 1M-context models.
+    assert.equal(summary.limitTokens, 1_000_000);
+    assert.equal(summary.warningLevel, "ok");
+
+    monitor.flush("default-1m");
+    rmSync(cachePath, { force: true });
+    rmSync(logsDir, { recursive: true, force: true });
+  });
+
+  it("TFX_CONTEXT_DEFAULT_MAX_TOKENS로 기본 컨텍스트 윈도우를 좁힐 수 있다", () => {
+    const cachePath = makeTmpPath("context-monitor-cache");
+    const logsDir = makeTmpPath("context-monitor-logs");
+    const previous = process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS;
+    process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS = "300000";
+    try {
+      const monitor = createContextMonitor({
+        cachePath,
+        logsDir,
+        registerExitHooks: false,
+        sessionId: "env-override-window",
+      });
+
+      const summary = monitor.record({
+        requestBody: '{"method":"tools/call","params":{"name":"read_file"}}',
+        responseBody:
+          '{"result":{"usage":{"input_tokens":150000,"output_tokens":0}}}',
+      });
+
+      assert.equal(summary.limitTokens, 300_000);
+
+      monitor.flush("env-override");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS;
+      } else {
+        process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS = previous;
+      }
+      rmSync(cachePath, { force: true });
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("TFX_CONTEXT_DEFAULT_MAX_TOKENS가 음수/비유한값이면 1M 기본값으로 폴백한다", () => {
+    const cachePath = makeTmpPath("context-monitor-cache");
+    const logsDir = makeTmpPath("context-monitor-logs");
+    const previous = process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS;
+    process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS = "-1";
+    try {
+      const monitor = createContextMonitor({
+        cachePath,
+        logsDir,
+        registerExitHooks: false,
+        sessionId: "negative-env-window",
+      });
+
+      const summary = monitor.record({
+        requestBody: '{"method":"tools/call","params":{"name":"read_file"}}',
+        responseBody:
+          '{"result":{"usage":{"input_tokens":150000,"output_tokens":0}}}',
+      });
+
+      // A malformed (-1) env must not poison the limit to -1, which would
+      // report percent 0 / "ok" and silently disable the guard signal.
+      assert.equal(summary.limitTokens, 1_000_000);
+      assert.equal(summary.warningLevel, "ok");
+
+      monitor.flush("negative-env");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS;
+      } else {
+        process.env.TFX_CONTEXT_DEFAULT_MAX_TOKENS = previous;
+      }
+      rmSync(cachePath, { force: true });
+      rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
   it("임계값 경계값(소수 포함)을 정확히 분류한다", () => {
     assert.equal(classifyContextThreshold(59.9).level, "ok");
     assert.equal(classifyContextThreshold(60.0).level, "info");

--- a/tests/unit/pipeline-stop.test.mjs
+++ b/tests/unit/pipeline-stop.test.mjs
@@ -329,4 +329,83 @@ describe("pipeline-stop hook", { skip: SQLITE_SKIP }, () => {
     assert.equal(afterCap.decision, "block");
     assert.match(afterCap.reason, /project-active-team/);
   });
+
+  it("window 없는 raw-token payload는 기본 1M 윈도우로 false-block을 피한다", () => {
+    // 170K tokens with no explicit context window. Under the old implicit 200K
+    // assumption this is 85% and false-blocks; with the 1M default it is 17%
+    // and the stop is silently allowed.
+    const result = runHook({
+      cwd: projectRoot,
+      homeDir,
+      pluginRoot,
+      input: {
+        hook_event_name: "Stop",
+        session_id: "windowless-1m-default-allows",
+        stop_reason: "end_turn",
+        context_window: {
+          current_usage: { input_tokens: 170_000 },
+        },
+      },
+      env: { TRIFLUX_CONTEXT_GUARD_STATE_DIR: guardStateDir },
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), "");
+    assert.equal(result.stderr.trim(), "");
+  });
+
+  it("TFX_CONTEXT_DEFAULT_MAX_TOKENS를 좁히면 동일 raw-token payload가 다시 block한다", () => {
+    // Same windowless 170K payload, but a 200K fallback window makes it 85%,
+    // so the guard blocks — proving the fallback denominator is the only knob.
+    const output = parseStdout(
+      runHook({
+        cwd: projectRoot,
+        homeDir,
+        pluginRoot,
+        input: {
+          hook_event_name: "Stop",
+          session_id: "windowless-200k-blocks",
+          stop_reason: "end_turn",
+          context_window: {
+            current_usage: { input_tokens: 170_000 },
+          },
+        },
+        env: {
+          TRIFLUX_CONTEXT_GUARD_STATE_DIR: guardStateDir,
+          TFX_CONTEXT_DEFAULT_MAX_TOKENS: "200000",
+        },
+      }),
+    );
+
+    assert.equal(output.decision, "block");
+    assert.match(output.reason, /context/i);
+  });
+
+  it("TFX_CONTEXT_DEFAULT_MAX_TOKENS가 음수면 1M 폴백으로 guard를 유지한다", () => {
+    // A malformed (-1) env must not make the fallback denominator negative,
+    // which would drop the token candidate and silently skip the guard. It
+    // must fall back to 1M: 800K raw tokens = 80% and still blocks.
+    const output = parseStdout(
+      runHook({
+        cwd: projectRoot,
+        homeDir,
+        pluginRoot,
+        input: {
+          hook_event_name: "Stop",
+          session_id: "windowless-negative-env-blocks",
+          stop_reason: "end_turn",
+          context_window: {
+            current_usage: { input_tokens: 800_000 },
+          },
+        },
+        env: {
+          TRIFLUX_CONTEXT_GUARD_STATE_DIR: guardStateDir,
+          TFX_CONTEXT_DEFAULT_MAX_TOKENS: "-1",
+        },
+      }),
+    );
+
+    assert.equal(output.decision, "block");
+    assert.match(output.reason, /context/i);
+  });
 });


### PR DESCRIPTION
## Problem

The Stop-hook context guard (`hooks/pipeline-stop.mjs`) blocks a session stop when context usage crosses a threshold. It reads a pre-computed `percent` from the hub context-monitor cache (`~/.claude/cache/tfx-hub/context-monitor.json`), which `createContextMonitor` (`hud/context-monitor.mjs`) writes against a hardcoded **200K** window.

On 1M-context models (Opus 4.x `[1m]`, Codex gpt-5.5) this false-blocks legitimate stops at ~15% real usage. Reproduced live: a cache snapshot showed `usedTokens: 309056, limitTokens: 200000, percent: 100` — 309K tokens (≈31% of a 1M window) recorded as 100%.

`buildContextUsageView` (the HUD statusline path) was already model-aware, so the HUD *display* was correct; only the Stop hook trusted the raw 200K-based cached percent.

## Why the cache, not just the Stop hook

`contextPercent()` consumes the cache's pre-computed `percent` via `Math.max`, so a Stop-hook-only token fallback cannot override an inflated `percent`. The fix has to make the cached number correct at the writer. The hub (`request-logger.mjs`) instantiates the monitor with no model id (MCP requests do not carry one), and the Stop payload has no model id either — so an env-defined default is the available knob.

## Fix

A single env knob `TFX_CONTEXT_DEFAULT_MAX_TOKENS` (default **1M**), applied at two points:

- **Source** — `createContextMonitor` defaults its limit to `TFX_CONTEXT_DEFAULT_MAX_TOKENS || 1M` (was 200K). The cached percent the Stop hook reads is now correct on 1M models.
- **Defense** — the Stop hook's `contextPercentsFromObject` falls back to the same 1M default when a payload omits an explicit window (windowless payloads / transcript tails).

Both env reads are validated `Number.isFinite(v) && v > 0`, so a malformed value (negative/Infinity) falls back to 1M instead of poisoning the limit.

### Tradeoff

A genuinely 200K-window model (Sonnet 4.5 / Haiku) running against the hub now needs `TFX_CONTEXT_DEFAULT_MAX_TOKENS=200000` to restore the Stop-guard nudge. The HUD display stays model-accurate regardless (`buildContextUsageView` re-derives from the model id). This is the same default-1M / override-for-narrow-setups tradeoff the Stop-hook fallback already takes.

## Tests

- `context-monitor.test.mjs`: monitor defaults to 1M, env override narrows it, negative-env falls back to 1M.
- `pipeline-stop.test.mjs`: windowless payload allowed under the 1M default, blocked under a 200K override, still blocked under a malformed negative env.
- 40/40 affected unit tests pass; full `npm run lint` clean (719 files).

## Mirror

`hud/context-monitor.mjs` and `hooks/pipeline-stop.mjs` mirrored byte-identical to `packages/core` and `packages/triflux` (not `packages/remote`, which carries neither).

## Review

Codex cross-review (`tfx review --base origin/main`): verdict COMMENT, one MEDIUM (env validation) — addressed in this branch with the `Number.isFinite && > 0` guards and negative-env regression tests.
