### PR TITLE
revert(hud): drop Claude Sonnet/Opus weekly split, keep unified 5h/1w

### DIFF
--- a/hud/providers/claude.mjs
+++ b/hud/providers/claude.mjs
@@ -395,7 +395,7 @@ export function parseClaudeUsageResponse(response) {
   // 키 자체가 부재하면 percent=null (HUD --% placeholder), utilization=null 만 0%로 처리
   const fiveHourPresent = response.five_hour != null;
   const sevenDayPresent = response.seven_day != null;
-  const result = {
+  return {
     fiveHourPercent: fiveHourPresent
       ? clampPercent(response.five_hour.utilization ?? 0)
       : null,
@@ -405,19 +405,6 @@ export function parseClaudeUsageResponse(response) {
     fiveHourResetsAt: response.five_hour?.resets_at || null,
     weeklyResetsAt: response.seven_day?.resets_at || null,
   };
-  if (response.seven_day_sonnet != null) {
-    result.sonnetWeeklyPercent = clampPercent(
-      response.seven_day_sonnet.utilization ?? 0,
-    );
-    result.sonnetWeeklyResetsAt = response.seven_day_sonnet.resets_at || null;
-  }
-  if (response.seven_day_opus != null) {
-    result.opusWeeklyPercent = clampPercent(
-      response.seven_day_opus.utilization ?? 0,
-    );
-    result.opusWeeklyResetsAt = response.seven_day_opus.resets_at || null;
-  }
-  return result;
 }
 
 // stale 캐시의 과거 resetsAt → 다음 주기로 순환 추정 (null 대신 다음 reset 시간 계산)
@@ -435,20 +422,6 @@ export function stripStaleResets(data) {
     const t = new Date(copy.weeklyResetsAt).getTime();
     if (!Number.isNaN(t))
       copy.weeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.sonnetWeeklyResetsAt) {
-    const t = new Date(copy.sonnetWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.sonnetWeeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.opusWeeklyResetsAt) {
-    const t = new Date(copy.opusWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.opusWeeklyResetsAt = new Date(
         advanceToNextCycle(t, SEVEN_DAY_MS),
       ).toISOString();
   }

--- a/hud/renderers.mjs
+++ b/hud/renderers.mjs
@@ -375,34 +375,6 @@ export function getClaudeRows(
       : tierDimBar(currentTier);
   const fTime = formatTimeCell(fiveHourReset);
   const wTime = formatTimeCellDH(weeklyReset);
-  const modelWeeklyPart = (label, percent, resetsAt, { includeTime }) => {
-    if (!hasData || percent == null || percent <= 0) return null;
-    const value = colorByProvider(
-      percent,
-      formatPercentCell(percent),
-      claudeOrange,
-    );
-    const reset = resetsAt
-      ? formatResetRemainingDayHour(resetsAt, SEVEN_DAY_MS)
-      : null;
-    const time = includeTime && reset ? ` ${dim(formatTimeCellDH(reset))}` : "";
-    return `${dim(`${label}:`)}${value}${time}`;
-  };
-  const modelWeeklyParts = ({ includeTime = false } = {}) =>
-    [
-      modelWeeklyPart(
-        "Sn",
-        claudeUsage?.sonnetWeeklyPercent,
-        claudeUsage?.sonnetWeeklyResetsAt,
-        { includeTime },
-      ),
-      modelWeeklyPart(
-        "Op",
-        claudeUsage?.opusWeeklyPercent,
-        claudeUsage?.opusWeeklyResetsAt,
-        { includeTime },
-      ),
-    ].filter(Boolean);
 
   if (currentTier === "nano" || currentTier === "micro") {
     const fShort =
@@ -419,18 +391,14 @@ export function getClaudeRows(
 
   if (currentTier === "minimal") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${staleTag}`;
     const right = `${dim("CTX:")}${colorByPercent(ctxView.percent, ctxView.display)}`;
     return [{ prefix, left: quotaSection, right }];
   }
 
   if (currentTier === "compact") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${staleTag}`;
     const warning = ctxView.warningTag
       ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
       : "";
@@ -440,9 +408,7 @@ export function getClaudeRows(
 
   // full tier (>= 120 cols)
   const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-  const modelSection = modelWeeklyParts({ includeTime: true });
-  const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${staleTag}`;
   const warning = ctxView.warningTag
     ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
     : "";

--- a/packages/core/hud/providers/claude.mjs
+++ b/packages/core/hud/providers/claude.mjs
@@ -395,7 +395,7 @@ export function parseClaudeUsageResponse(response) {
   // 키 자체가 부재하면 percent=null (HUD --% placeholder), utilization=null 만 0%로 처리
   const fiveHourPresent = response.five_hour != null;
   const sevenDayPresent = response.seven_day != null;
-  const result = {
+  return {
     fiveHourPercent: fiveHourPresent
       ? clampPercent(response.five_hour.utilization ?? 0)
       : null,
@@ -405,19 +405,6 @@ export function parseClaudeUsageResponse(response) {
     fiveHourResetsAt: response.five_hour?.resets_at || null,
     weeklyResetsAt: response.seven_day?.resets_at || null,
   };
-  if (response.seven_day_sonnet != null) {
-    result.sonnetWeeklyPercent = clampPercent(
-      response.seven_day_sonnet.utilization ?? 0,
-    );
-    result.sonnetWeeklyResetsAt = response.seven_day_sonnet.resets_at || null;
-  }
-  if (response.seven_day_opus != null) {
-    result.opusWeeklyPercent = clampPercent(
-      response.seven_day_opus.utilization ?? 0,
-    );
-    result.opusWeeklyResetsAt = response.seven_day_opus.resets_at || null;
-  }
-  return result;
 }
 
 // stale 캐시의 과거 resetsAt → 다음 주기로 순환 추정 (null 대신 다음 reset 시간 계산)
@@ -435,20 +422,6 @@ export function stripStaleResets(data) {
     const t = new Date(copy.weeklyResetsAt).getTime();
     if (!Number.isNaN(t))
       copy.weeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.sonnetWeeklyResetsAt) {
-    const t = new Date(copy.sonnetWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.sonnetWeeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.opusWeeklyResetsAt) {
-    const t = new Date(copy.opusWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.opusWeeklyResetsAt = new Date(
         advanceToNextCycle(t, SEVEN_DAY_MS),
       ).toISOString();
   }

--- a/packages/core/hud/renderers.mjs
+++ b/packages/core/hud/renderers.mjs
@@ -375,34 +375,6 @@ export function getClaudeRows(
       : tierDimBar(currentTier);
   const fTime = formatTimeCell(fiveHourReset);
   const wTime = formatTimeCellDH(weeklyReset);
-  const modelWeeklyPart = (label, percent, resetsAt, { includeTime }) => {
-    if (!hasData || percent == null || percent <= 0) return null;
-    const value = colorByProvider(
-      percent,
-      formatPercentCell(percent),
-      claudeOrange,
-    );
-    const reset = resetsAt
-      ? formatResetRemainingDayHour(resetsAt, SEVEN_DAY_MS)
-      : null;
-    const time = includeTime && reset ? ` ${dim(formatTimeCellDH(reset))}` : "";
-    return `${dim(`${label}:`)}${value}${time}`;
-  };
-  const modelWeeklyParts = ({ includeTime = false } = {}) =>
-    [
-      modelWeeklyPart(
-        "Sn",
-        claudeUsage?.sonnetWeeklyPercent,
-        claudeUsage?.sonnetWeeklyResetsAt,
-        { includeTime },
-      ),
-      modelWeeklyPart(
-        "Op",
-        claudeUsage?.opusWeeklyPercent,
-        claudeUsage?.opusWeeklyResetsAt,
-        { includeTime },
-      ),
-    ].filter(Boolean);
 
   if (currentTier === "nano" || currentTier === "micro") {
     const fShort =
@@ -419,18 +391,14 @@ export function getClaudeRows(
 
   if (currentTier === "minimal") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${staleTag}`;
     const right = `${dim("CTX:")}${colorByPercent(ctxView.percent, ctxView.display)}`;
     return [{ prefix, left: quotaSection, right }];
   }
 
   if (currentTier === "compact") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${staleTag}`;
     const warning = ctxView.warningTag
       ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
       : "";
@@ -440,9 +408,7 @@ export function getClaudeRows(
 
   // full tier (>= 120 cols)
   const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-  const modelSection = modelWeeklyParts({ includeTime: true });
-  const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${staleTag}`;
   const warning = ctxView.warningTag
     ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
     : "";

--- a/packages/triflux/hud/providers/claude.mjs
+++ b/packages/triflux/hud/providers/claude.mjs
@@ -395,7 +395,7 @@ export function parseClaudeUsageResponse(response) {
   // 키 자체가 부재하면 percent=null (HUD --% placeholder), utilization=null 만 0%로 처리
   const fiveHourPresent = response.five_hour != null;
   const sevenDayPresent = response.seven_day != null;
-  const result = {
+  return {
     fiveHourPercent: fiveHourPresent
       ? clampPercent(response.five_hour.utilization ?? 0)
       : null,
@@ -405,19 +405,6 @@ export function parseClaudeUsageResponse(response) {
     fiveHourResetsAt: response.five_hour?.resets_at || null,
     weeklyResetsAt: response.seven_day?.resets_at || null,
   };
-  if (response.seven_day_sonnet != null) {
-    result.sonnetWeeklyPercent = clampPercent(
-      response.seven_day_sonnet.utilization ?? 0,
-    );
-    result.sonnetWeeklyResetsAt = response.seven_day_sonnet.resets_at || null;
-  }
-  if (response.seven_day_opus != null) {
-    result.opusWeeklyPercent = clampPercent(
-      response.seven_day_opus.utilization ?? 0,
-    );
-    result.opusWeeklyResetsAt = response.seven_day_opus.resets_at || null;
-  }
-  return result;
 }
 
 // stale 캐시의 과거 resetsAt → 다음 주기로 순환 추정 (null 대신 다음 reset 시간 계산)
@@ -435,20 +422,6 @@ export function stripStaleResets(data) {
     const t = new Date(copy.weeklyResetsAt).getTime();
     if (!Number.isNaN(t))
       copy.weeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.sonnetWeeklyResetsAt) {
-    const t = new Date(copy.sonnetWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.sonnetWeeklyResetsAt = new Date(
-        advanceToNextCycle(t, SEVEN_DAY_MS),
-      ).toISOString();
-  }
-  if (copy.opusWeeklyResetsAt) {
-    const t = new Date(copy.opusWeeklyResetsAt).getTime();
-    if (!Number.isNaN(t))
-      copy.opusWeeklyResetsAt = new Date(
         advanceToNextCycle(t, SEVEN_DAY_MS),
       ).toISOString();
   }

--- a/packages/triflux/hud/renderers.mjs
+++ b/packages/triflux/hud/renderers.mjs
@@ -375,34 +375,6 @@ export function getClaudeRows(
       : tierDimBar(currentTier);
   const fTime = formatTimeCell(fiveHourReset);
   const wTime = formatTimeCellDH(weeklyReset);
-  const modelWeeklyPart = (label, percent, resetsAt, { includeTime }) => {
-    if (!hasData || percent == null || percent <= 0) return null;
-    const value = colorByProvider(
-      percent,
-      formatPercentCell(percent),
-      claudeOrange,
-    );
-    const reset = resetsAt
-      ? formatResetRemainingDayHour(resetsAt, SEVEN_DAY_MS)
-      : null;
-    const time = includeTime && reset ? ` ${dim(formatTimeCellDH(reset))}` : "";
-    return `${dim(`${label}:`)}${value}${time}`;
-  };
-  const modelWeeklyParts = ({ includeTime = false } = {}) =>
-    [
-      modelWeeklyPart(
-        "Sn",
-        claudeUsage?.sonnetWeeklyPercent,
-        claudeUsage?.sonnetWeeklyResetsAt,
-        { includeTime },
-      ),
-      modelWeeklyPart(
-        "Op",
-        claudeUsage?.opusWeeklyPercent,
-        claudeUsage?.opusWeeklyResetsAt,
-        { includeTime },
-      ),
-    ].filter(Boolean);
 
   if (currentTier === "nano" || currentTier === "micro") {
     const fShort =
@@ -419,18 +391,14 @@ export function getClaudeRows(
 
   if (currentTier === "minimal") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim("1w:")}${wStr}${staleTag}`;
     const right = `${dim("CTX:")}${colorByPercent(ctxView.percent, ctxView.display)}`;
     return [{ prefix, left: quotaSection, right }];
   }
 
   if (currentTier === "compact") {
     const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-    const modelSection = modelWeeklyParts();
-    const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+    const quotaSection = `${dim("5h:")}${fStr} ${dim(fTime)} ${dim("1w:")}${wStr} ${dim(wTime)}${staleTag}`;
     const warning = ctxView.warningTag
       ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
       : "";
@@ -440,9 +408,7 @@ export function getClaudeRows(
 
   // full tier (>= 120 cols)
   const staleTag = claudeUsage?.stale ? ` ${dim("[stale]")}` : "";
-  const modelSection = modelWeeklyParts({ includeTime: true });
-  const modelSuffix = modelSection.length ? ` ${modelSection.join(" ")}` : "";
-  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${modelSuffix}${staleTag}`;
+  const quotaSection = `${dim("5h:")}${fBar}${fStr} ${dim(fTime)} ${dim("1w:")}${wBar}${wStr} ${dim(wTime)}${staleTag}`;
   const warning = ctxView.warningTag
     ? ` ${dim("|")} ${yellow(ctxView.warningTag)}`
     : "";

--- a/tests/unit/hud-backoff.test.mjs
+++ b/tests/unit/hud-backoff.test.mjs
@@ -110,45 +110,9 @@ describe("hud stale marker", () => {
   });
 });
 
-describe("Claude model-specific weekly markers", () => {
-  it("shows positive Sonnet and Opus weekly usage as secondary compact markers", () => {
-    const rows = getClaudeRows(
-      "compact",
-      { percent: 42, display: "42%" },
-      {
-        fiveHourPercent: 11,
-        weeklyPercent: 22,
-        sonnetWeeklyPercent: 33,
-        opusWeeklyPercent: 44,
-      },
-      0,
-    );
-
-    const left = stripAnsi(rows[0].left);
-    assert.match(left, /1w:/);
-    assert.match(left, /Sn:33%/);
-    assert.match(left, /Op:44%/);
-  });
-
-  it("hides zero or absent model-specific weekly usage", () => {
-    const rows = getClaudeRows(
-      "minimal",
-      { percent: 42, display: "42%" },
-      {
-        fiveHourPercent: 11,
-        weeklyPercent: 22,
-        sonnetWeeklyPercent: 0,
-      },
-      0,
-    );
-
-    const left = stripAnsi(rows[0].left);
-    assert.doesNotMatch(left, /Sn:/);
-    assert.doesNotMatch(left, /Op:/);
-  });
-
-  it("does not show model-specific weekly usage in nano or micro tiers", () => {
-    for (const tier of ["nano", "micro"]) {
+describe("Claude unified weekly markers", () => {
+  it("does not render Sonnet or Opus weekly markers in any Claude row tier", () => {
+    for (const tier of ["nano", "micro", "minimal", "compact", "full"]) {
       const rows = getClaudeRows(
         tier,
         { percent: 42, display: "42%" },
@@ -162,6 +126,10 @@ describe("Claude model-specific weekly markers", () => {
       );
 
       const left = stripAnsi(rows[0].left);
+      assert.match(
+        left,
+        tier === "nano" || tier === "micro" ? /11%\/22%/ : /1w:/,
+      );
       assert.doesNotMatch(left, /Sn:/);
       assert.doesNotMatch(left, /Op:/);
     }

--- a/tests/unit/hud-claude-parse.test.mjs
+++ b/tests/unit/hud-claude-parse.test.mjs
@@ -25,7 +25,7 @@ describe("parseClaudeUsageResponse", () => {
     assert.equal(result.opusWeeklyPercent, undefined);
   });
 
-  it("conditionally parses Sonnet weekly usage and omits null Opus bucket keys", () => {
+  it("ignores model-specific weekly buckets and keeps unified weekly usage", () => {
     const result = parseClaudeUsageResponse({
       five_hour: { utilization: 42, resets_at: "2026-04-22T10:00:00Z" },
       seven_day: { utilization: 13, resets_at: "2026-04-29T10:00:00Z" },
@@ -33,11 +33,16 @@ describe("parseClaudeUsageResponse", () => {
         utilization: 67,
         resets_at: "2026-04-30T10:00:00Z",
       },
-      seven_day_opus: null,
+      seven_day_opus: {
+        utilization: 89,
+        resets_at: "2026-05-01T10:00:00Z",
+      },
     });
 
-    assert.equal(result.sonnetWeeklyPercent, 67);
-    assert.equal(result.sonnetWeeklyResetsAt, "2026-04-30T10:00:00Z");
+    assert.equal(result.weeklyPercent, 13);
+    assert.equal(result.weeklyResetsAt, "2026-04-29T10:00:00Z");
+    assert.equal(result.sonnetWeeklyPercent, undefined);
+    assert.equal(result.sonnetWeeklyResetsAt, undefined);
     assert.equal(result.opusWeeklyPercent, undefined);
     assert.equal(result.opusWeeklyResetsAt, undefined);
   });


### PR DESCRIPTION
## 무엇

HUD의 Claude(c) 행에서 Sonnet/Opus 모델별 주간 분리 표시(`Sn:`/`Op:` 배지)를 제거하고
통합 `5h:` / `1w:` 2-게이지 구조로 되돌린다 (Codex 행과 동일 형태).

## 왜

v10.29.0(`792399eb`)이 Claude 주간 게이지를 Sonnet/Opus로 쪼개 표시하기 시작했는데,
이는 독립 한도가 아니라 all-models 한도의 nested 가드레일이라 사용자에게 혼란을 준다.
운영 요청에 따라 통합 5h/1w 구조로 환원한다.

## 보존한 것 (792399eb의 정당한 수정은 그대로 유지)

- Keychain configDir 스코프 토큰 읽기 (Claude 토큰 게이지 빔 버그 수정)
- 주간(seven_day) 버킷 파싱, fetch User-Agent 헤더, stale 배지

## 제거한 것

- `hud/providers/claude.mjs`: `seven_day_sonnet`/`seven_day_opus` 파싱 + `sonnetWeekly*`/`opusWeekly*` 필드
- `hud/renderers.mjs`: `modelWeeklyPart`/`modelWeeklyParts` 헬퍼 + minimal/compact/full tier의 modelSuffix

## 검증

- HUD 전체 테스트: 52 tests / 52 pass / 0 fail
- biome lint clean, `git diff --check` pass
- 3-layer mirror byte-identical (root = packages/core = packages/triflux)
- 모든 tier(nano/micro/minimal/compact/full)에서 Claude가 통합 5h/1w로만 렌더

Codex 작성 → Claude 교차검증 통과.
