### PR TITLE
fix(cto): close efficacy gaps — agy north-star wiring + interactive live tracking

### DIFF
--- a/cto/collect.mjs
+++ b/cto/collect.mjs
@@ -346,7 +346,7 @@ function collectUltragoal(dirPath, rootDir, collectedAt) {
   }
 }
 
-function collectSwarm(rootDir, collectedAt) {
+export function collectSwarm(rootDir, collectedAt) {
   const locksPath = join(rootDir, ".triflux", "swarm-locks.json");
   const logsDir = join(rootDir, ".triflux", "swarm-logs");
   if (!existsSync(locksPath) && !existsSync(logsDir)) {
@@ -364,6 +364,30 @@ function collectSwarm(rootDir, collectedAt) {
       detail.locks = safeSummary(locks);
       if (Array.isArray(locks?.shards)) detail.shards = locks.shards;
       else if (Array.isArray(locks)) detail.shards = locks;
+      else if (locks && typeof locks === "object") {
+        // 실제 producer(hub/team/swarm-locks.mjs persist)는
+        // { "<file>": { workerId, leaseType, sessionMeta } } 형태의 lock map 을 쓴다.
+        // workerId 가 곧 shard.name 이다 — swarm-hypervisor 가
+        // acquire(shard.name, shard.files) 로 잠그기 때문(swarm-hypervisor.mjs:753).
+        // workerId 별로 묶어 active shard row 로 환원한다. (expired lock 정밀 필터는
+        // hub snapshot() 의 책임이라, 여기서는 persist 된 보유 lock 전부를 active 로 본다.)
+        const byWorker = new Map();
+        for (const entry of Object.values(locks)) {
+          const workerId =
+            entry && typeof entry.workerId === "string" ? entry.workerId : null;
+          if (!workerId) continue;
+          let row = byWorker.get(workerId);
+          if (!row) {
+            row = { shard_name: workerId, phase: "active", members: [] };
+            byWorker.set(workerId, row);
+          }
+          const host = entry?.sessionMeta?.host;
+          if (typeof host === "string" && host && !row.members.includes(host)) {
+            row.members.push(host);
+          }
+        }
+        detail.shards = [...byWorker.values()];
+      }
     }
     if (existsSync(logsDir)) {
       detail.log_runs = readdirSync(logsDir, { withFileTypes: true })

--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -146,6 +146,24 @@ async function readSynapseOverlay(opts) {
   }
 }
 
+// active_shards 의 source 는 live_sessions 와 다르다: live_sessions 는 synapse
+// overlay(실시간 세션)에서, active_shards 는 collect 가 .triflux/swarm-locks.json 을
+// snapshot 한 current.json(sources.tfx_swarm.detail.shards)에서 온다. synapse
+// overlay 가 shard 를 채우는 경로가 생기면 그쪽을 우선하고, 없으면 snapshot 으로
+// fallback 한다(현재 overlay 의 active_shards 는 항상 비어 snapshot 을 쓴다).
+function deriveActiveShards(current, overlay) {
+  // overlay(synapse)가 채운 shard 중 식별 가능한 것만 authoritative 로 본다.
+  // normalizeSynapseOverlay 가 shard_name 을 null 로 정규화한 무효 행이 snapshot
+  // fallback 을 가로채지 않도록 먼저 거른다.
+  const overlayShards = Array.isArray(overlay?.active_shards)
+    ? overlay.active_shards.filter((shard) => shard?.shard_name)
+    : [];
+  if (overlayShards.length > 0) return overlayShards;
+  const shards = current?.sources?.tfx_swarm?.detail?.shards;
+  if (!Array.isArray(shards)) return [];
+  return shards.map(normalizeActiveShard).filter((shard) => shard.shard_name);
+}
+
 function projectStatus(current, overlay) {
   return {
     schema_version: current?.schema_version || SCHEMA_VERSION,
@@ -155,7 +173,7 @@ function projectStatus(current, overlay) {
     summary: current?.summary || {},
     ledger_tail: Array.isArray(current?.ledger_tail) ? current.ledger_tail : [],
     live_sessions: overlay.live_sessions,
-    active_shards: overlay.active_shards,
+    active_shards: deriveActiveShards(current, overlay),
   };
 }
 

--- a/hooks/hook-orchestrator.mjs
+++ b/hooks/hook-orchestrator.mjs
@@ -441,6 +441,30 @@ async function main() {
     }
   }
 
+  // ── UserPromptSubmit: interactive 세션 liveness heartbeat ──
+  // SessionStart 가 register, 매 프롬프트가 갱신한다(사용자 활동 = liveness). 이
+  // 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜 `cto status`
+  // 의 live_sessions 가 항상 비어 보인다. fire-and-forget POST 는 process.exit 가
+  // 버리므로(cf. [[project_process_exit_drops_fire_and_forget]]) 발사 직후 바로
+  // drain 한다 — 아래 registry hook 이 없어 early-exit 하는 경로에서도 flush 를
+  // 보장하기 위해서다. drain 은 localhost POST 라 보통 즉시 반환되고, hub stall
+  // 시에만 짧은 상한(500ms)으로 프롬프트 지연을 막는다. keyword-detector /
+  // north-star 등 registry hook 은 그 뒤로 평소대로 실행된다.
+  if (eventName === "UserPromptSubmit") {
+    try {
+      const { heartbeatInteractiveSession } = await import(
+        "./session-start-fast.mjs"
+      );
+      heartbeatInteractiveSession(stdinRaw);
+      const { drainPendingSynapse } = await import(
+        "../hub/team/synapse-http.mjs"
+      );
+      await drainPendingSynapse(500);
+    } catch {
+      /* best-effort — heartbeat 실패가 프롬프트 턴을 막지 않는다 */
+    }
+  }
+
   // 이벤트에 해당하는 훅 목록
   const hooks = registry.events[eventName];
   if (!hooks || hooks.length === 0) process.exit(0);

--- a/hooks/session-start-fast.mjs
+++ b/hooks/session-start-fast.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  buildSynapseTaskSummary,
   drainPendingSynapse,
   heartbeatSynapseSession,
   registerSynapseSession,
@@ -128,6 +129,40 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       .catch(() => {});
   } catch {
     /* best-effort — never affects session start */
+  }
+}
+
+/**
+ * UserPromptSubmit 마다 interactive 세션의 liveness 를 갱신한다.
+ * SessionStart 가 register, 이후 매 프롬프트가 heartbeat — 사용자 활동이 곧
+ * liveness 다. 이 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜
+ * `cto status` 의 live_sessions 가 항상 비어 보인다.
+ *
+ * heartbeat 는 fire-and-forget POST 이므로 호출측(hook-orchestrator)이
+ * process.exit 전에 drainPendingSynapse 로 flush 해야 drop 되지 않는다
+ * (cf. SessionStart 의 execute() 자체 drain).
+ *
+ * pid 는 register 와 동일하게 보내지 않는다(91-92 주석): liveness 는 TTL +
+ * heartbeat 가 담당한다.
+ *
+ * @param {string} stdinData UserPromptSubmit stdin JSON
+ * @param {object} [seams] 테스트용 injectable seam
+ * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
+ * @returns {void}
+ */
+export function heartbeatInteractiveSession(stdinData, seams = {}) {
+  const heartbeat = seams.heartbeat || heartbeatSynapseSession;
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const partial = { worktreePath: cwd, host: "local" };
+    const prompt = typeof payload?.prompt === "string" ? payload.prompt : "";
+    if (prompt) partial.taskSummary = buildSynapseTaskSummary(prompt);
+    heartbeat(sessionId, partial);
+  } catch {
+    /* best-effort — never affects the prompt turn */
   }
 }
 

--- a/packages/core/hooks/hook-orchestrator.mjs
+++ b/packages/core/hooks/hook-orchestrator.mjs
@@ -441,6 +441,30 @@ async function main() {
     }
   }
 
+  // ── UserPromptSubmit: interactive 세션 liveness heartbeat ──
+  // SessionStart 가 register, 매 프롬프트가 갱신한다(사용자 활동 = liveness). 이
+  // 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜 `cto status`
+  // 의 live_sessions 가 항상 비어 보인다. fire-and-forget POST 는 process.exit 가
+  // 버리므로(cf. [[project_process_exit_drops_fire_and_forget]]) 발사 직후 바로
+  // drain 한다 — 아래 registry hook 이 없어 early-exit 하는 경로에서도 flush 를
+  // 보장하기 위해서다. drain 은 localhost POST 라 보통 즉시 반환되고, hub stall
+  // 시에만 짧은 상한(500ms)으로 프롬프트 지연을 막는다. keyword-detector /
+  // north-star 등 registry hook 은 그 뒤로 평소대로 실행된다.
+  if (eventName === "UserPromptSubmit") {
+    try {
+      const { heartbeatInteractiveSession } = await import(
+        "./session-start-fast.mjs"
+      );
+      heartbeatInteractiveSession(stdinRaw);
+      const { drainPendingSynapse } = await import(
+        "../hub/team/synapse-http.mjs"
+      );
+      await drainPendingSynapse(500);
+    } catch {
+      /* best-effort — heartbeat 실패가 프롬프트 턴을 막지 않는다 */
+    }
+  }
+
   // 이벤트에 해당하는 훅 목록
   const hooks = registry.events[eventName];
   if (!hooks || hooks.length === 0) process.exit(0);

--- a/packages/core/hooks/session-start-fast.mjs
+++ b/packages/core/hooks/session-start-fast.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  buildSynapseTaskSummary,
   drainPendingSynapse,
   heartbeatSynapseSession,
   registerSynapseSession,
@@ -128,6 +129,40 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       .catch(() => {});
   } catch {
     /* best-effort — never affects session start */
+  }
+}
+
+/**
+ * UserPromptSubmit 마다 interactive 세션의 liveness 를 갱신한다.
+ * SessionStart 가 register, 이후 매 프롬프트가 heartbeat — 사용자 활동이 곧
+ * liveness 다. 이 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜
+ * `cto status` 의 live_sessions 가 항상 비어 보인다.
+ *
+ * heartbeat 는 fire-and-forget POST 이므로 호출측(hook-orchestrator)이
+ * process.exit 전에 drainPendingSynapse 로 flush 해야 drop 되지 않는다
+ * (cf. SessionStart 의 execute() 자체 drain).
+ *
+ * pid 는 register 와 동일하게 보내지 않는다(91-92 주석): liveness 는 TTL +
+ * heartbeat 가 담당한다.
+ *
+ * @param {string} stdinData UserPromptSubmit stdin JSON
+ * @param {object} [seams] 테스트용 injectable seam
+ * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
+ * @returns {void}
+ */
+export function heartbeatInteractiveSession(stdinData, seams = {}) {
+  const heartbeat = seams.heartbeat || heartbeatSynapseSession;
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const partial = { worktreePath: cwd, host: "local" };
+    const prompt = typeof payload?.prompt === "string" ? payload.prompt : "";
+    if (prompt) partial.taskSummary = buildSynapseTaskSummary(prompt);
+    heartbeat(sessionId, partial);
+  } catch {
+    /* best-effort — never affects the prompt turn */
   }
 }
 

--- a/packages/triflux/cto/collect.mjs
+++ b/packages/triflux/cto/collect.mjs
@@ -346,7 +346,7 @@ function collectUltragoal(dirPath, rootDir, collectedAt) {
   }
 }
 
-function collectSwarm(rootDir, collectedAt) {
+export function collectSwarm(rootDir, collectedAt) {
   const locksPath = join(rootDir, ".triflux", "swarm-locks.json");
   const logsDir = join(rootDir, ".triflux", "swarm-logs");
   if (!existsSync(locksPath) && !existsSync(logsDir)) {
@@ -364,6 +364,30 @@ function collectSwarm(rootDir, collectedAt) {
       detail.locks = safeSummary(locks);
       if (Array.isArray(locks?.shards)) detail.shards = locks.shards;
       else if (Array.isArray(locks)) detail.shards = locks;
+      else if (locks && typeof locks === "object") {
+        // 실제 producer(hub/team/swarm-locks.mjs persist)는
+        // { "<file>": { workerId, leaseType, sessionMeta } } 형태의 lock map 을 쓴다.
+        // workerId 가 곧 shard.name 이다 — swarm-hypervisor 가
+        // acquire(shard.name, shard.files) 로 잠그기 때문(swarm-hypervisor.mjs:753).
+        // workerId 별로 묶어 active shard row 로 환원한다. (expired lock 정밀 필터는
+        // hub snapshot() 의 책임이라, 여기서는 persist 된 보유 lock 전부를 active 로 본다.)
+        const byWorker = new Map();
+        for (const entry of Object.values(locks)) {
+          const workerId =
+            entry && typeof entry.workerId === "string" ? entry.workerId : null;
+          if (!workerId) continue;
+          let row = byWorker.get(workerId);
+          if (!row) {
+            row = { shard_name: workerId, phase: "active", members: [] };
+            byWorker.set(workerId, row);
+          }
+          const host = entry?.sessionMeta?.host;
+          if (typeof host === "string" && host && !row.members.includes(host)) {
+            row.members.push(host);
+          }
+        }
+        detail.shards = [...byWorker.values()];
+      }
     }
     if (existsSync(logsDir)) {
       detail.log_runs = readdirSync(logsDir, { withFileTypes: true })

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -146,6 +146,24 @@ async function readSynapseOverlay(opts) {
   }
 }
 
+// active_shards 의 source 는 live_sessions 와 다르다: live_sessions 는 synapse
+// overlay(실시간 세션)에서, active_shards 는 collect 가 .triflux/swarm-locks.json 을
+// snapshot 한 current.json(sources.tfx_swarm.detail.shards)에서 온다. synapse
+// overlay 가 shard 를 채우는 경로가 생기면 그쪽을 우선하고, 없으면 snapshot 으로
+// fallback 한다(현재 overlay 의 active_shards 는 항상 비어 snapshot 을 쓴다).
+function deriveActiveShards(current, overlay) {
+  // overlay(synapse)가 채운 shard 중 식별 가능한 것만 authoritative 로 본다.
+  // normalizeSynapseOverlay 가 shard_name 을 null 로 정규화한 무효 행이 snapshot
+  // fallback 을 가로채지 않도록 먼저 거른다.
+  const overlayShards = Array.isArray(overlay?.active_shards)
+    ? overlay.active_shards.filter((shard) => shard?.shard_name)
+    : [];
+  if (overlayShards.length > 0) return overlayShards;
+  const shards = current?.sources?.tfx_swarm?.detail?.shards;
+  if (!Array.isArray(shards)) return [];
+  return shards.map(normalizeActiveShard).filter((shard) => shard.shard_name);
+}
+
 function projectStatus(current, overlay) {
   return {
     schema_version: current?.schema_version || SCHEMA_VERSION,
@@ -155,7 +173,7 @@ function projectStatus(current, overlay) {
     summary: current?.summary || {},
     ledger_tail: Array.isArray(current?.ledger_tail) ? current.ledger_tail : [],
     live_sessions: overlay.live_sessions,
-    active_shards: overlay.active_shards,
+    active_shards: deriveActiveShards(current, overlay),
   };
 }
 

--- a/packages/triflux/hooks/hook-orchestrator.mjs
+++ b/packages/triflux/hooks/hook-orchestrator.mjs
@@ -441,6 +441,30 @@ async function main() {
     }
   }
 
+  // ── UserPromptSubmit: interactive 세션 liveness heartbeat ──
+  // SessionStart 가 register, 매 프롬프트가 갱신한다(사용자 활동 = liveness). 이
+  // 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜 `cto status`
+  // 의 live_sessions 가 항상 비어 보인다. fire-and-forget POST 는 process.exit 가
+  // 버리므로(cf. [[project_process_exit_drops_fire_and_forget]]) 발사 직후 바로
+  // drain 한다 — 아래 registry hook 이 없어 early-exit 하는 경로에서도 flush 를
+  // 보장하기 위해서다. drain 은 localhost POST 라 보통 즉시 반환되고, hub stall
+  // 시에만 짧은 상한(500ms)으로 프롬프트 지연을 막는다. keyword-detector /
+  // north-star 등 registry hook 은 그 뒤로 평소대로 실행된다.
+  if (eventName === "UserPromptSubmit") {
+    try {
+      const { heartbeatInteractiveSession } = await import(
+        "./session-start-fast.mjs"
+      );
+      heartbeatInteractiveSession(stdinRaw);
+      const { drainPendingSynapse } = await import(
+        "../hub/team/synapse-http.mjs"
+      );
+      await drainPendingSynapse(500);
+    } catch {
+      /* best-effort — heartbeat 실패가 프롬프트 턴을 막지 않는다 */
+    }
+  }
+
   // 이벤트에 해당하는 훅 목록
   const hooks = registry.events[eventName];
   if (!hooks || hooks.length === 0) process.exit(0);

--- a/packages/triflux/hooks/session-start-fast.mjs
+++ b/packages/triflux/hooks/session-start-fast.mjs
@@ -14,6 +14,7 @@ import { execFile } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  buildSynapseTaskSummary,
   drainPendingSynapse,
   heartbeatSynapseSession,
   registerSynapseSession,
@@ -128,6 +129,40 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       .catch(() => {});
   } catch {
     /* best-effort — never affects session start */
+  }
+}
+
+/**
+ * UserPromptSubmit 마다 interactive 세션의 liveness 를 갱신한다.
+ * SessionStart 가 register, 이후 매 프롬프트가 heartbeat — 사용자 활동이 곧
+ * liveness 다. 이 갱신이 없으면 hub monitor 가 5분 TTL 후 세션을 stale 로 전이시켜
+ * `cto status` 의 live_sessions 가 항상 비어 보인다.
+ *
+ * heartbeat 는 fire-and-forget POST 이므로 호출측(hook-orchestrator)이
+ * process.exit 전에 drainPendingSynapse 로 flush 해야 drop 되지 않는다
+ * (cf. SessionStart 의 execute() 자체 drain).
+ *
+ * pid 는 register 와 동일하게 보내지 않는다(91-92 주석): liveness 는 TTL +
+ * heartbeat 가 담당한다.
+ *
+ * @param {string} stdinData UserPromptSubmit stdin JSON
+ * @param {object} [seams] 테스트용 injectable seam
+ * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
+ * @returns {void}
+ */
+export function heartbeatInteractiveSession(stdinData, seams = {}) {
+  const heartbeat = seams.heartbeat || heartbeatSynapseSession;
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const partial = { worktreePath: cwd, host: "local" };
+    const prompt = typeof payload?.prompt === "string" ? payload.prompt : "";
+    if (prompt) partial.taskSummary = buildSynapseTaskSummary(prompt);
+    heartbeat(sessionId, partial);
+  } catch {
+    /* best-effort — never affects the prompt turn */
   }
 }
 

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -2767,6 +2767,17 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "antigravity" ]]; then
+    # CTO north-star: codex lane(line ~2670)과 동일하게 brief 를 prompt 앞에 주입.
+    # prepend_codex_north_star 는 CLI-agnostic (TFX_CTO_NORTH_STAR opt-out +
+    # .triflux/lake/current.md 만 참조) 하므로 agy 워커에서도 그대로 재사용한다.
+    # sentinel 은 command-substitution 이 trailing newline 을 삼키는 것을 막는다.
+    local _agy_north_star_file="${WORKDIR:-$PWD}/.triflux/lake/current.md"
+    if [[ -r "$_agy_north_star_file" ]]; then
+      local _agy_prompt_sentinel="__TFX_AGY_PROMPT_END_${$}_${RANDOM}__"
+      local _agy_full_prompt_with_sentinel
+      _agy_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_agy_prompt_sentinel")"
+      FULL_PROMPT="${_agy_full_prompt_with_sentinel%"$_agy_prompt_sentinel"}"
+    fi
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then
       local agy_stderr_bytes=0

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -2767,6 +2767,17 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "antigravity" ]]; then
+    # CTO north-star: codex lane(line ~2670)과 동일하게 brief 를 prompt 앞에 주입.
+    # prepend_codex_north_star 는 CLI-agnostic (TFX_CTO_NORTH_STAR opt-out +
+    # .triflux/lake/current.md 만 참조) 하므로 agy 워커에서도 그대로 재사용한다.
+    # sentinel 은 command-substitution 이 trailing newline 을 삼키는 것을 막는다.
+    local _agy_north_star_file="${WORKDIR:-$PWD}/.triflux/lake/current.md"
+    if [[ -r "$_agy_north_star_file" ]]; then
+      local _agy_prompt_sentinel="__TFX_AGY_PROMPT_END_${$}_${RANDOM}__"
+      local _agy_full_prompt_with_sentinel
+      _agy_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_agy_prompt_sentinel")"
+      FULL_PROMPT="${_agy_full_prompt_with_sentinel%"$_agy_prompt_sentinel"}"
+    fi
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then
       local agy_stderr_bytes=0

--- a/tests/unit/cto-collect-swarm.test.mjs
+++ b/tests/unit/cto-collect-swarm.test.mjs
@@ -1,0 +1,70 @@
+// tests/unit/cto-collect-swarm.test.mjs — collectSwarm shard derivation
+//
+// The real .triflux/swarm-locks.json producer (hub/team/swarm-locks.mjs persist)
+// writes a lock OBJECT MAP { "<file>": { workerId, leaseType, sessionMeta } },
+// not { shards: [...] }. workerId IS the shard name (swarm-hypervisor calls
+// acquire(shard.name, shard.files)). This test reproduces the exact
+// createSwarmLocks -> persist -> collectSwarm path so cto status active_shards
+// can never silently regress to [] when real locks exist.
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { collectSwarm } from "../../cto/collect.mjs";
+import { createSwarmLocks } from "../../hub/team/swarm-locks.mjs";
+
+describe("collectSwarm derives active shards from the real lock map", () => {
+  let sandboxDir;
+
+  beforeEach(() => {
+    sandboxDir = mkdtempSync(join(tmpdir(), "triflux-collect-swarm-"));
+  });
+
+  afterEach(() => {
+    rmSync(sandboxDir, { recursive: true, force: true });
+  });
+
+  it("reduces the persisted lock object map (workerId=shard.name) into shard rows", () => {
+    const persistPath = join(sandboxDir, ".triflux", "swarm-locks.json");
+    const locks = createSwarmLocks({ repoRoot: sandboxDir, persistPath });
+    locks.acquire("shard-auth", ["src/a.js", "src/b.js"], {
+      sessionMeta: { sessionId: "s1", host: "ryzen", taskSummary: "auth" },
+    });
+    locks.acquire("shard-ui", ["src/c.js"]);
+
+    const result = collectSwarm(sandboxDir, "2026-06-02T00:00:00.000Z");
+
+    assert.equal(result.available, true);
+    const shards = result.detail.shards;
+    assert.equal(shards.length, 2);
+    const byName = Object.fromEntries(shards.map((s) => [s.shard_name, s]));
+    assert.ok(byName["shard-auth"], "shard-auth row missing");
+    assert.equal(byName["shard-auth"].phase, "active");
+    assert.deepEqual(byName["shard-auth"].members, ["ryzen"]);
+    assert.ok(byName["shard-ui"], "shard-ui row missing");
+    assert.deepEqual(byName["shard-ui"].members, []);
+  });
+
+  it("still honors a future { shards: [...] } array shape (forward-compat)", () => {
+    const dir = join(sandboxDir, ".triflux");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "swarm-locks.json"),
+      JSON.stringify({ shards: [{ shard_name: "explicit" }] }),
+      "utf8",
+    );
+
+    const result = collectSwarm(sandboxDir, "2026-06-02T00:00:00.000Z");
+
+    assert.equal(result.detail.shards.length, 1);
+    assert.equal(result.detail.shards[0].shard_name, "explicit");
+  });
+
+  it("reports an unavailable source when there are no locks or logs", () => {
+    const result = collectSwarm(sandboxDir, "2026-06-02T00:00:00.000Z");
+    assert.equal(result.available, false);
+  });
+});

--- a/tests/unit/cto-status.test.mjs
+++ b/tests/unit/cto-status.test.mjs
@@ -1,0 +1,165 @@
+// tests/unit/cto-status.test.mjs — cto status overlay projection
+//
+// active_shards 와 live_sessions 의 source 가 다르다는 계약을 고정한다:
+// live_sessions 는 synapse overlay(실시간 세션), active_shards 는 collect 가
+// .triflux/swarm-locks.json 을 snapshot 한 current.json(sources.tfx_swarm.detail.
+// shards)에서 온다. 이전에는 active_shards 가 무조건 [] 로 하드코딩돼 있었다.
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { runStatus } from "../../cto/status.mjs";
+
+function collectingStdout() {
+  let buf = "";
+  return {
+    write(chunk) {
+      buf += chunk;
+    },
+    text() {
+      return buf;
+    },
+  };
+}
+
+function writeCurrent(lakeRoot, current) {
+  mkdirSync(lakeRoot, { recursive: true });
+  writeFileSync(
+    join(lakeRoot, "current.json"),
+    JSON.stringify(current),
+    "utf8",
+  );
+}
+
+const emptyOverlay = async () => ({ sessions: [], active_shards: [] });
+
+describe("cto status active_shards / live_sessions projection", () => {
+  let sandboxDir;
+  let lakeRoot;
+
+  beforeEach(() => {
+    sandboxDir = mkdtempSync(join(tmpdir(), "triflux-cto-status-"));
+    lakeRoot = join(sandboxDir, ".triflux", "lake");
+  });
+
+  afterEach(() => {
+    rmSync(sandboxDir, { recursive: true, force: true });
+  });
+
+  it("fills active_shards from the collected swarm snapshot when overlay is empty", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: {
+        tfx_swarm: {
+          available: true,
+          detail: {
+            shards: [
+              { shard_name: "auth", phase: "active", members: ["codex"] },
+              { name: "ui" },
+              { nope: "no identifier" },
+            ],
+          },
+        },
+      },
+    });
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      synapseReader: emptyOverlay,
+    });
+
+    // shard_name 식별자가 없는 엔트리는 제외된다.
+    assert.equal(status.active_shards.length, 2);
+    assert.equal(status.active_shards[0].shard_name, "auth");
+    assert.equal(status.active_shards[0].phase, "active");
+    assert.deepEqual(status.active_shards[0].members, ["codex"]);
+    assert.equal(status.active_shards[1].shard_name, "ui");
+  });
+
+  it("returns empty active_shards when the snapshot has no swarm shards", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: { tfx_swarm: { available: false } },
+    });
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      synapseReader: emptyOverlay,
+    });
+
+    assert.deepEqual(status.active_shards, []);
+  });
+
+  it("prefers synapse overlay active_shards over the snapshot when present", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: {
+        tfx_swarm: { detail: { shards: [{ shard_name: "snapshot-shard" }] } },
+      },
+    });
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      synapseReader: async () => ({
+        sessions: [],
+        active_shards: [{ shard_name: "live-shard", phase: "active" }],
+      }),
+    });
+
+    assert.equal(status.active_shards.length, 1);
+    assert.equal(status.active_shards[0].shard_name, "live-shard");
+  });
+
+  it("still sources live_sessions from the synapse overlay, independent of shards", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: { tfx_swarm: { detail: { shards: [{ shard_name: "s1" }] } } },
+    });
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      synapseReader: async () => ({
+        sessions: [{ sessionId: "live-1", phase: "active" }],
+        active_shards: [],
+      }),
+    });
+
+    assert.equal(status.live_sessions.length, 1);
+    assert.equal(status.live_sessions[0].sessionId, "live-1");
+    // active_shards 는 overlay 와 무관하게 snapshot 에서 채워진다.
+    assert.equal(status.active_shards[0].shard_name, "s1");
+  });
+
+  it("ignores overlay shards with no identifier and falls back to the snapshot", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: { tfx_swarm: { detail: { shards: [{ shard_name: "snap" }] } } },
+    });
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      // normalizeSynapseOverlay turns this into [{ shard_name: null, ... }];
+      // it must NOT suppress the valid snapshot shard.
+      synapseReader: async () => ({
+        sessions: [],
+        active_shards: [{ nope: "bad" }],
+      }),
+    });
+
+    assert.equal(status.active_shards.length, 1);
+    assert.equal(status.active_shards[0].shard_name, "snap");
+  });
+});

--- a/tests/unit/hook-orchestrator.test.mjs
+++ b/tests/unit/hook-orchestrator.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -8,6 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -88,6 +89,42 @@ function runOrchestrator({
       TRIFLUX_HOOK_CACHE_DIR: cacheDir,
       TRIFLUX_HOOK_CACHE_TTL_MS: "10000",
     },
+  });
+}
+
+// Async variant: spawnSync blocks the parent event loop, so an in-process mock
+// hub can't accept the child's loopback POST until the child has already exited
+// (deadlock). spawn keeps the parent loop live so the synapse POST round-trips.
+function runOrchestratorAsync({
+  cwd,
+  registryPath,
+  cacheDir,
+  env = {},
+  payload,
+}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [ORCHESTRATOR_PATH], {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+        TRIFLUX_HOOK_REGISTRY: registryPath,
+        TRIFLUX_HOOK_CACHE_DIR: cacheDir,
+        TRIFLUX_HOOK_CACHE_TTL_MS: "10000",
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
   });
 }
 
@@ -422,5 +459,157 @@ describe("hook-orchestrator PreToolUse:Bash dedupe", () => {
     const output = JSON.parse(result.stdout);
     assert.equal(output.decision, "block");
     assert.match(output.reason, /Block 1\/2/);
+  });
+});
+
+describe("hook-orchestrator UserPromptSubmit synapse heartbeat", () => {
+  let sandboxDir;
+  let hookScriptPath;
+  let registryPath;
+  let cacheDir;
+
+  beforeEach(() => {
+    sandboxDir = mkdtempSync(join(tmpdir(), "triflux-hook-orch-hb-"));
+    hookScriptPath = writeHookScript(sandboxDir);
+    registryPath = join(sandboxDir, "hook-registry.json");
+    cacheDir = join(sandboxDir, "cache");
+  });
+
+  afterEach(() => {
+    rmSync(sandboxDir, { recursive: true, force: true });
+  });
+
+  // A real loopback hub: the heartbeat POST is fire-and-forget, so this proves
+  // the orchestrator drains it before process.exit (cf. the
+  // process-exit-drops-fire-and-forget regression class) — a mock fetchImpl
+  // could not, since the hook runs in a spawned process.
+  function startMockHub() {
+    const received = [];
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        received.push({ url: req.url, body });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{}");
+      });
+    });
+    return { server, received };
+  }
+
+  function upsRegistry() {
+    return JSON.stringify(
+      createRegistry(
+        [
+          {
+            id: "noop-ups",
+            matcher: "*",
+            command: hookCommand(
+              hookScriptPath,
+              join(sandboxDir, "ups.txt"),
+              "noop",
+              "",
+              "noop",
+            ),
+            priority: 0,
+            enabled: true,
+          },
+        ],
+        "UserPromptSubmit",
+      ),
+      null,
+      2,
+    );
+  }
+
+  it("fires a synapse heartbeat POST and drains it before process.exit", async () => {
+    const { server, received } = startMockHub();
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    writeFileSync(registryPath, upsRegistry(), "utf8");
+
+    const result = await runOrchestratorAsync({
+      cwd: sandboxDir,
+      registryPath,
+      cacheDir,
+      env: {
+        TFX_HUB_URL: `http://127.0.0.1:${port}`,
+        TFX_HUB_TOKEN: "test-token",
+      },
+      payload: {
+        hook_event_name: "UserPromptSubmit",
+        session_id: "sess-ups",
+        cwd: sandboxDir,
+        prompt: "implement the heartbeat wiring",
+      },
+    });
+
+    await new Promise((resolve) => server.close(resolve));
+
+    assert.equal(result.status, 0, result.stderr);
+    const hb = received.find((r) => r.url === "/synapse/heartbeat");
+    assert.ok(hb, "expected a /synapse/heartbeat POST to reach the hub");
+    const parsed = JSON.parse(hb.body);
+    assert.equal(parsed.sessionId, "sess-ups");
+    assert.equal(parsed.partial.taskSummary, "implement the heartbeat wiring");
+    assert.equal(parsed.partial.worktreePath, sandboxDir);
+    // pid is never sent — liveness is the TTL + heartbeat's job.
+    assert.equal("pid" in parsed.partial, false);
+  });
+
+  it("does not fire a heartbeat for non-UserPromptSubmit events", async () => {
+    const { server, received } = startMockHub();
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    writeFileSync(
+      registryPath,
+      JSON.stringify(
+        createRegistry(
+          [
+            {
+              id: "noop-read",
+              matcher: "*",
+              command: hookCommand(
+                hookScriptPath,
+                join(sandboxDir, "read.txt"),
+                "noop",
+                "",
+                "noop",
+              ),
+              priority: 0,
+              enabled: true,
+            },
+          ],
+          "PreToolUse",
+        ),
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = await runOrchestratorAsync({
+      cwd: sandboxDir,
+      registryPath,
+      cacheDir,
+      env: { TFX_HUB_URL: `http://127.0.0.1:${port}` },
+      payload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Read",
+        tool_input: {},
+      },
+    });
+
+    await new Promise((resolve) => server.close(resolve));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      received.find((r) => r.url === "/synapse/heartbeat"),
+      undefined,
+    );
   });
 });

--- a/tests/unit/session-start-synapse.test.mjs
+++ b/tests/unit/session-start-synapse.test.mjs
@@ -9,7 +9,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { registerInteractiveSession } from "../../hooks/session-start-fast.mjs";
+import {
+  heartbeatInteractiveSession,
+  registerInteractiveSession,
+} from "../../hooks/session-start-fast.mjs";
 
 function payloadJson(obj) {
   return JSON.stringify(obj);
@@ -133,6 +136,92 @@ describe("registerInteractiveSession (SessionStart self-register)", () => {
 
     assert.equal(registered.length, 1);
     // worktreePath defaults back to cwd and branch is empty → no new info → no heartbeat.
+    assert.equal(heartbeats.length, 0);
+  });
+});
+
+describe("heartbeatInteractiveSession (UserPromptSubmit liveness)", () => {
+  it("fires a heartbeat with cwd-derived worktree, host, and prompt task summary", () => {
+    const heartbeats = [];
+
+    heartbeatInteractiveSession(
+      payloadJson({
+        session_id: "sess-hb",
+        cwd: "/home/dev/proj",
+        prompt: "implement the live-session heartbeat",
+      }),
+      {
+        heartbeat: (sessionId, partial) =>
+          heartbeats.push({ sessionId, partial }),
+      },
+    );
+
+    assert.equal(heartbeats.length, 1);
+    assert.equal(heartbeats[0].sessionId, "sess-hb");
+    assert.equal(heartbeats[0].partial.worktreePath, "/home/dev/proj");
+    assert.equal(heartbeats[0].partial.host, "local");
+    assert.equal(
+      heartbeats[0].partial.taskSummary,
+      "implement the live-session heartbeat",
+    );
+    // pid must NOT be sent — liveness is the TTL + heartbeat's job (cf. register).
+    assert.equal("pid" in heartbeats[0].partial, false);
+  });
+
+  it("caps the task summary at 100 chars (buildSynapseTaskSummary contract)", () => {
+    const heartbeats = [];
+
+    heartbeatInteractiveSession(
+      payloadJson({
+        session_id: "sess-long",
+        cwd: "/p",
+        prompt: "x".repeat(250),
+      }),
+      {
+        heartbeat: (sessionId, partial) =>
+          heartbeats.push({ sessionId, partial }),
+      },
+    );
+
+    assert.equal(heartbeats[0].partial.taskSummary.length, 100);
+  });
+
+  it("omits taskSummary when the payload carries no prompt", () => {
+    const heartbeats = [];
+
+    heartbeatInteractiveSession(
+      payloadJson({ session_id: "sess-noprompt", cwd: "/p" }),
+      {
+        heartbeat: (sessionId, partial) =>
+          heartbeats.push({ sessionId, partial }),
+      },
+    );
+
+    assert.equal(heartbeats.length, 1);
+    assert.equal("taskSummary" in heartbeats[0].partial, false);
+  });
+
+  it("is a no-op when the payload has no session_id", () => {
+    const heartbeats = [];
+
+    heartbeatInteractiveSession(payloadJson({ cwd: "/p", prompt: "hi" }), {
+      heartbeat: (sessionId, partial) =>
+        heartbeats.push({ sessionId, partial }),
+    });
+
+    assert.equal(heartbeats.length, 0);
+  });
+
+  it("is a no-op (no throw) on unparseable payload", () => {
+    const heartbeats = [];
+
+    assert.doesNotThrow(() =>
+      heartbeatInteractiveSession("{not json", {
+        heartbeat: (sessionId, partial) =>
+          heartbeats.push({ sessionId, partial }),
+      }),
+    );
+
     assert.equal(heartbeats.length, 0);
   });
 });

--- a/tests/unit/tfx-route-codex-north-star.test.mjs
+++ b/tests/unit/tfx-route-codex-north-star.test.mjs
@@ -119,4 +119,41 @@ describe("tfx-route Codex north-star prepend", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, prompt);
   });
+
+  it("wires the antigravity lane to prepend the same north-star brief", () => {
+    // codex lane(line ~2670)과 동일하게 antigravity dispatch 직전에 north-star 를
+    // prepend 해야 한다. prepend_codex_north_star 는 CLI-agnostic 이라 재사용한다.
+    const laneStart = routeSource.indexOf(
+      'elif [[ "$CLI_TYPE" == "antigravity" ]]; then',
+    );
+    assert.ok(laneStart >= 0, "antigravity dispatch lane not found");
+    const dispatchIdx = routeSource.indexOf("run_antigravity_exec", laneStart);
+    assert.ok(dispatchIdx > laneStart, "run_antigravity_exec call not found");
+    const lane = routeSource.slice(laneStart, dispatchIdx);
+
+    assert.match(
+      lane,
+      /current\.md/,
+      "antigravity lane must read .triflux/lake/current.md",
+    );
+    assert.match(
+      lane,
+      /prepend_codex_north_star "\$FULL_PROMPT"/,
+      "antigravity lane must call prepend_codex_north_star before dispatch",
+    );
+    assert.match(
+      lane,
+      /FULL_PROMPT=/,
+      "antigravity lane must reassign FULL_PROMPT with the prepended brief",
+    );
+  });
+
+  it("keeps the codex lane north-star prepend wiring (regression guard)", () => {
+    const codexIdx = routeSource.indexOf("_codex_north_star_file=");
+    assert.ok(codexIdx >= 0, "codex lane north-star wiring missing");
+    assert.match(
+      routeSource.slice(codexIdx, codexIdx + 400),
+      /prepend_codex_north_star "\$FULL_PROMPT"/,
+    );
+  });
 });


### PR DESCRIPTION
## 무엇

CTO lake console(PR #380) 머지 후 efficacy 검증(sentinel probe)에서 드러난 2개 갭을 막는다.
plan의 의도적 non-goal이 아니라 단순 미배선/미구현이었다.

## 작업 A — agy/antigravity north-star 배선

- 문제: codex 워커만 north-star brief를 받고 agy 워커는 못 받음.
- 수정: `scripts/tfx-route.sh` antigravity lane에 `prepend_codex_north_star` 동등 로직 추가.
  `TFX_CTO_NORTH_STAR=0` opt-out 동일 적용. boundary는 adapter가 아닌 tfx-route.sh 유지.

## 작업 B — interactive 세션 live 추적

- 문제: interactive 세션이 SessionStart 1회 heartbeat(pid:null)만 → TTL 초과 → `cto status`
  live_sessions 항상 `[]`. 또한 `cto/status.mjs` active_shards가 하드코딩 `[]`.
- 수정:
  - SessionStart/주기 hook heartbeat로 interactive 세션을 synapse registry에 갱신 유지
  - `cto/status.mjs` active_shards를 실제 swarm shard에서 derive
  - `cto/collect.mjs`가 swarm lock object map(`{file:{workerId}}`)을 workerId별 shard row로 환원
    (Codex 교차리뷰가 발견한 근본 갭)

## 검증

- 7 suites / 31 tests pass: cto-collect-swarm, cto-status, hook-orchestrator,
  session-start-synapse, tfx-route-codex-north-star
- biome lint clean (745 files)
- agy sentinel probe 통과 (agy 워커가 north-star 토큰 출력 확인)
- 3-layer mirror (root / packages/core / packages/triflux) 동기

Claude 작성 → Codex 교차검증 통과.
