### PR TITLE
fix(codex): codex 0.137 MCP profile field drop + hermetic config-swap tests

### DIFF
--- a/hub/workers/codex-mcp.mjs
+++ b/hub/workers/codex-mcp.mjs
@@ -1,4 +1,7 @@
 // hub/workers/codex-mcp.mjs — Codex MCP 서버 래퍼
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -94,13 +97,78 @@ function normalizeStructuredContent(structuredContent, fallbackText = "") {
   return { threadId, content };
 }
 
-function buildCodexArguments(prompt, opts = {}) {
+/**
+ * Read a top-level TOML scalar (`key = "value"` / `key = 'value'` /
+ * `key = value`), tolerating an inline `# comment` and surrounding whitespace.
+ * Returns the trimmed value, or null when the key is absent/empty. Intentionally
+ * tiny — the per-profile files only carry `model` + `model_reasoning_effort`.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @returns {string|null}
+ */
+function readTomlScalar(raw, key) {
+  const re = new RegExp(
+    `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+    "m",
+  );
+  const match = raw.match(re);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to its concrete
+ * `model` + reasoning effort. SSOT = the per-profile file written by
+ * `tfx setup` at `~/.codex/<profile>.config.toml`. Falls back to deriving the
+ * effort from the `<...>_<effort>` naming convention when the file is absent.
+ *
+ * codex 0.137 removed `profile` from the Codex MCP tool schema, so we translate
+ * the profile into the still-accepted `model` + `config` fields instead of
+ * forwarding `profile` (which now hard-fails with "unknown field `profile`").
+ *
+ * @param {string} profileName
+ * @returns {{ model: string|null, reasoningEffort: string|null }}
+ */
+export function resolveCodexProfileConfig(profileName) {
+  const result = { model: null, reasoningEffort: null };
+  if (typeof profileName !== "string" || !profileName) return result;
+
+  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    result.model = readTomlScalar(raw, "model");
+    result.reasoningEffort = readTomlScalar(raw, "model_reasoning_effort");
+  } catch {
+    // Profile file absent (non-file alias). Derive effort from the naming
+    // convention; leave model unset so codex uses its config.toml default.
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) {
+      const map = {
+        xhigh: "xhigh",
+        high: "high",
+        med: "medium",
+        medium: "medium",
+        low: "low",
+      };
+      result.reasoningEffort = map[suffix[1]] || null;
+    }
+  }
+  return result;
+}
+
+export function buildCodexArguments(prompt, opts = {}) {
   const args = { prompt };
 
   if (typeof opts.cwd === "string" && opts.cwd) args.cwd = opts.cwd;
   if (typeof opts.model === "string" && opts.model) args.model = opts.model;
-  if (typeof opts.profile === "string" && opts.profile)
-    args.profile = opts.profile;
+  // NOTE: `profile` is intentionally NOT forwarded as a Codex tool argument.
+  // codex 0.137 dropped it from the tool schema; it is resolved into
+  // `model` + `config.model_reasoning_effort` just before return (see below).
   if (typeof opts.approvalPolicy === "string" && opts.approvalPolicy) {
     args["approval-policy"] = opts.approvalPolicy;
   }
@@ -118,6 +186,22 @@ function buildCodexArguments(prompt, opts = {}) {
   }
   if (typeof opts.compactPrompt === "string" && opts.compactPrompt) {
     args["compact-prompt"] = opts.compactPrompt;
+  }
+
+  // Map the effort profile to model + reasoning effort instead of forwarding the
+  // (0.137-rejected) `profile` field. Explicit opts.model wins over the profile;
+  // profile effort merges on top of any opts.config.
+  if (typeof opts.profile === "string" && opts.profile) {
+    const resolved = resolveCodexProfileConfig(opts.profile);
+    if (resolved.model && typeof args.model !== "string") {
+      args.model = resolved.model;
+    }
+    if (resolved.reasoningEffort) {
+      args.config = {
+        ...(args.config || {}),
+        model_reasoning_effort: resolved.reasoningEffort,
+      };
+    }
   }
 
   return args;

--- a/packages/remote/hub/workers/codex-mcp.mjs
+++ b/packages/remote/hub/workers/codex-mcp.mjs
@@ -1,4 +1,7 @@
 // hub/workers/codex-mcp.mjs — Codex MCP 서버 래퍼
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -94,13 +97,78 @@ function normalizeStructuredContent(structuredContent, fallbackText = "") {
   return { threadId, content };
 }
 
-function buildCodexArguments(prompt, opts = {}) {
+/**
+ * Read a top-level TOML scalar (`key = "value"` / `key = 'value'` /
+ * `key = value`), tolerating an inline `# comment` and surrounding whitespace.
+ * Returns the trimmed value, or null when the key is absent/empty. Intentionally
+ * tiny — the per-profile files only carry `model` + `model_reasoning_effort`.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @returns {string|null}
+ */
+function readTomlScalar(raw, key) {
+  const re = new RegExp(
+    `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+    "m",
+  );
+  const match = raw.match(re);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to its concrete
+ * `model` + reasoning effort. SSOT = the per-profile file written by
+ * `tfx setup` at `~/.codex/<profile>.config.toml`. Falls back to deriving the
+ * effort from the `<...>_<effort>` naming convention when the file is absent.
+ *
+ * codex 0.137 removed `profile` from the Codex MCP tool schema, so we translate
+ * the profile into the still-accepted `model` + `config` fields instead of
+ * forwarding `profile` (which now hard-fails with "unknown field `profile`").
+ *
+ * @param {string} profileName
+ * @returns {{ model: string|null, reasoningEffort: string|null }}
+ */
+export function resolveCodexProfileConfig(profileName) {
+  const result = { model: null, reasoningEffort: null };
+  if (typeof profileName !== "string" || !profileName) return result;
+
+  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    result.model = readTomlScalar(raw, "model");
+    result.reasoningEffort = readTomlScalar(raw, "model_reasoning_effort");
+  } catch {
+    // Profile file absent (non-file alias). Derive effort from the naming
+    // convention; leave model unset so codex uses its config.toml default.
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) {
+      const map = {
+        xhigh: "xhigh",
+        high: "high",
+        med: "medium",
+        medium: "medium",
+        low: "low",
+      };
+      result.reasoningEffort = map[suffix[1]] || null;
+    }
+  }
+  return result;
+}
+
+export function buildCodexArguments(prompt, opts = {}) {
   const args = { prompt };
 
   if (typeof opts.cwd === "string" && opts.cwd) args.cwd = opts.cwd;
   if (typeof opts.model === "string" && opts.model) args.model = opts.model;
-  if (typeof opts.profile === "string" && opts.profile)
-    args.profile = opts.profile;
+  // NOTE: `profile` is intentionally NOT forwarded as a Codex tool argument.
+  // codex 0.137 dropped it from the tool schema; it is resolved into
+  // `model` + `config.model_reasoning_effort` just before return (see below).
   if (typeof opts.approvalPolicy === "string" && opts.approvalPolicy) {
     args["approval-policy"] = opts.approvalPolicy;
   }
@@ -118,6 +186,22 @@ function buildCodexArguments(prompt, opts = {}) {
   }
   if (typeof opts.compactPrompt === "string" && opts.compactPrompt) {
     args["compact-prompt"] = opts.compactPrompt;
+  }
+
+  // Map the effort profile to model + reasoning effort instead of forwarding the
+  // (0.137-rejected) `profile` field. Explicit opts.model wins over the profile;
+  // profile effort merges on top of any opts.config.
+  if (typeof opts.profile === "string" && opts.profile) {
+    const resolved = resolveCodexProfileConfig(opts.profile);
+    if (resolved.model && typeof args.model !== "string") {
+      args.model = resolved.model;
+    }
+    if (resolved.reasoningEffort) {
+      args.config = {
+        ...(args.config || {}),
+        model_reasoning_effort: resolved.reasoningEffort,
+      };
+    }
   }
 
   return args;

--- a/packages/triflux/hub/workers/codex-mcp.mjs
+++ b/packages/triflux/hub/workers/codex-mcp.mjs
@@ -1,4 +1,7 @@
 // hub/workers/codex-mcp.mjs — Codex MCP 서버 래퍼
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -94,13 +97,78 @@ function normalizeStructuredContent(structuredContent, fallbackText = "") {
   return { threadId, content };
 }
 
-function buildCodexArguments(prompt, opts = {}) {
+/**
+ * Read a top-level TOML scalar (`key = "value"` / `key = 'value'` /
+ * `key = value`), tolerating an inline `# comment` and surrounding whitespace.
+ * Returns the trimmed value, or null when the key is absent/empty. Intentionally
+ * tiny — the per-profile files only carry `model` + `model_reasoning_effort`.
+ *
+ * @param {string} raw
+ * @param {string} key
+ * @returns {string|null}
+ */
+function readTomlScalar(raw, key) {
+  const re = new RegExp(
+    `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+    "m",
+  );
+  const match = raw.match(re);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to its concrete
+ * `model` + reasoning effort. SSOT = the per-profile file written by
+ * `tfx setup` at `~/.codex/<profile>.config.toml`. Falls back to deriving the
+ * effort from the `<...>_<effort>` naming convention when the file is absent.
+ *
+ * codex 0.137 removed `profile` from the Codex MCP tool schema, so we translate
+ * the profile into the still-accepted `model` + `config` fields instead of
+ * forwarding `profile` (which now hard-fails with "unknown field `profile`").
+ *
+ * @param {string} profileName
+ * @returns {{ model: string|null, reasoningEffort: string|null }}
+ */
+export function resolveCodexProfileConfig(profileName) {
+  const result = { model: null, reasoningEffort: null };
+  if (typeof profileName !== "string" || !profileName) return result;
+
+  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    result.model = readTomlScalar(raw, "model");
+    result.reasoningEffort = readTomlScalar(raw, "model_reasoning_effort");
+  } catch {
+    // Profile file absent (non-file alias). Derive effort from the naming
+    // convention; leave model unset so codex uses its config.toml default.
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) {
+      const map = {
+        xhigh: "xhigh",
+        high: "high",
+        med: "medium",
+        medium: "medium",
+        low: "low",
+      };
+      result.reasoningEffort = map[suffix[1]] || null;
+    }
+  }
+  return result;
+}
+
+export function buildCodexArguments(prompt, opts = {}) {
   const args = { prompt };
 
   if (typeof opts.cwd === "string" && opts.cwd) args.cwd = opts.cwd;
   if (typeof opts.model === "string" && opts.model) args.model = opts.model;
-  if (typeof opts.profile === "string" && opts.profile)
-    args.profile = opts.profile;
+  // NOTE: `profile` is intentionally NOT forwarded as a Codex tool argument.
+  // codex 0.137 dropped it from the tool schema; it is resolved into
+  // `model` + `config.model_reasoning_effort` just before return (see below).
   if (typeof opts.approvalPolicy === "string" && opts.approvalPolicy) {
     args["approval-policy"] = opts.approvalPolicy;
   }
@@ -118,6 +186,22 @@ function buildCodexArguments(prompt, opts = {}) {
   }
   if (typeof opts.compactPrompt === "string" && opts.compactPrompt) {
     args["compact-prompt"] = opts.compactPrompt;
+  }
+
+  // Map the effort profile to model + reasoning effort instead of forwarding the
+  // (0.137-rejected) `profile` field. Explicit opts.model wins over the profile;
+  // profile effort merges on top of any opts.config.
+  if (typeof opts.profile === "string" && opts.profile) {
+    const resolved = resolveCodexProfileConfig(opts.profile);
+    if (resolved.model && typeof args.model !== "string") {
+      args.model = resolved.model;
+    }
+    if (resolved.reasoningEffort) {
+      args.config = {
+        ...(args.config || {}),
+        model_reasoning_effort: resolved.reasoningEffort,
+      };
+    }
   }
 
   return args;

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -123,7 +123,11 @@ _preflight_check_gh_auth
 # top-level sandbox/approval_mode와 의미가 다르다. 이 값이 "approve"이면
 # codex exec이 non-TTY subprocess에서 승인 대기로 stall하므로 감지 대상에서 제외.
 # (refs: tellang/triflux#66, Yeachan-Heo/oh-my-codex#1478)
-_CODEX_CONFIG="${HOME}/.codex/config.toml"
+# TFX_CODEX_CONFIG override: integration tests that run the full route script
+# point this at an isolated tmpdir config so the MCP config-swap never mutates
+# the real ~/.codex/config.toml (non-hermetic corruption guard). Defaults to the
+# real path for normal runs.
+_CODEX_CONFIG="${TFX_CODEX_CONFIG:-${HOME}/.codex/config.toml}"
 _CODEX_HAS_SANDBOX=""
 if [[ -f "$_CODEX_CONFIG" ]] && awk '
   /^\[{1,2}mcp_servers\..*\.tools\./ { in_mcp_tool=1; next }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -123,7 +123,11 @@ _preflight_check_gh_auth
 # top-level sandbox/approval_mode와 의미가 다르다. 이 값이 "approve"이면
 # codex exec이 non-TTY subprocess에서 승인 대기로 stall하므로 감지 대상에서 제외.
 # (refs: tellang/triflux#66, Yeachan-Heo/oh-my-codex#1478)
-_CODEX_CONFIG="${HOME}/.codex/config.toml"
+# TFX_CODEX_CONFIG override: integration tests that run the full route script
+# point this at an isolated tmpdir config so the MCP config-swap never mutates
+# the real ~/.codex/config.toml (non-hermetic corruption guard). Defaults to the
+# real path for normal runs.
+_CODEX_CONFIG="${TFX_CODEX_CONFIG:-${HOME}/.codex/config.toml}"
 _CODEX_HAS_SANDBOX=""
 if [[ -f "$_CODEX_CONFIG" ]] && awk '
   /^\[{1,2}mcp_servers\..*\.tools\./ { in_mcp_tool=1; next }

--- a/tests/helpers/codex-config-fixture.mjs
+++ b/tests/helpers/codex-config-fixture.mjs
@@ -1,0 +1,64 @@
+// tests/helpers/codex-config-fixture.mjs
+//
+// Integration tests that run the full scripts/tfx-route.sh with a codex agent +
+// a non-"none" mcp_profile (e.g. "minimal") trigger tfx-route's MCP config-swap,
+// which by default mutates the REAL ~/.codex/config.toml and backs it up to a
+// shared `${config}.pre-exec`. Under `--test-concurrency`, multiple such test
+// files swap the same real config + shared backup at once → read-modify-write
+// race → the user's real config can be left filtered/corrupted (node_repl,
+// gbrain, auth headers dropped) and the swap-restore fails (flaky exit 1).
+//
+// Give each test FILE its own throwaway config via the TFX_CODEX_CONFIG seam
+// (scripts/tfx-route.sh) so the swap operates on an isolated copy — never the
+// real ~/.codex, and never shared across concurrent files.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Must exceed tfx-route's 500-byte corruption guard so the swap path actually
+// runs (instead of bailing). Carries context7 + brave-search so the "minimal"
+// allowed-server filter has matches to keep.
+const FIXTURE_CONFIG = `model = "gpt-5.5"
+model_reasoning_effort = "high"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.brave-search]
+url = "http://127.0.0.1:8101/mcp"
+
+[mcp_servers.tfx-hub]
+url = "http://127.0.0.1:27888/mcp"
+
+[mcp_servers.exa]
+url = "https://mcp.exa.ai/mcp"
+
+[mcp_servers.serena]
+url = "http://127.0.0.1:8105/mcp"
+
+# Isolated throwaway codex config fixture for tfx-route integration tests.
+# This file is created under the OS tmpdir and is NEVER the real
+# ~/.codex/config.toml. The padding below keeps it above the 500-byte
+# config-swap corruption guard so the swap executes hermetically.
+[fixture]
+purpose = "tfx-route integration test isolation"
+note = "the config-swap mutates this copy, leaving the developer's real codex config untouched even when many test files run concurrently"
+`;
+
+/**
+ * Create a unique, isolated codex config.toml for one test file and return its
+ * path (point TFX_CODEX_CONFIG at it). Call once per test file at module scope.
+ *
+ * @returns {{ path: string, dir: string, cleanup: () => void }}
+ */
+export function makeIsolatedCodexConfig() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-codex-cfg-"));
+  const path = join(dir, "config.toml");
+  writeFileSync(path, FIXTURE_CONFIG);
+  return {
+    path,
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}

--- a/tests/integration/delegator-mcp.test.mjs
+++ b/tests/integration/delegator-mcp.test.mjs
@@ -300,8 +300,13 @@ describe("delegator-mcp stdio server", () => {
       });
 
       // 캐시의 부분 리스트가 availableServers로 주입되면 안 됨 — 교집합 필터로 MCP 서버 탈락 버그 유발
+      // model_reasoning_effort: designer→gpt55_xhigh 프로필이 config로 해석됨
+      // (codex 0.137이 profile 필드를 폐기 → effort는 config로 전달). mcp_servers는 여전히 {}.
       const config = JSON.parse(result.structuredContent.output);
-      assert.deepEqual(config, { mcp_servers: {} });
+      assert.deepEqual(config, {
+        mcp_servers: {},
+        model_reasoning_effort: "xhigh",
+      });
     } finally {
       restoreSearchEngineCacheBackup(originalCache);
       await closeClient(client, transport);
@@ -332,7 +337,11 @@ describe("delegator-mcp stdio server", () => {
         },
       });
       const codexConfig = JSON.parse(codexResult.structuredContent.output);
-      assert.deepEqual(codexConfig, { mcp_servers: {} });
+      // designer→gpt55_xhigh effort가 config로 해석됨 (profile 필드 폐기 대응)
+      assert.deepEqual(codexConfig, {
+        mcp_servers: {},
+        model_reasoning_effort: "xhigh",
+      });
 
       const aliasResult = await client.callTool({
         name: "triflux-delegate",

--- a/tests/integration/hub-restart.test.mjs
+++ b/tests/integration/hub-restart.test.mjs
@@ -19,9 +19,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { BASH_EXE, toBashPath } from "../helpers/bash-path.mjs";
+import { makeIsolatedCodexConfig } from "../helpers/codex-config-fixture.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -31,6 +32,11 @@ const ROUTE_SCRIPT = toBashPath(
 const FIXTURE_BIN = toBashPath(
   resolve(PROJECT_ROOT, "tests", "fixtures", "bin"),
 );
+
+// Isolate tfx-route's codex config-swap so the full-route invocations below
+// never mutate the real ~/.codex/config.toml under concurrency.
+const isolatedCodex = makeIsolatedCodexConfig();
+after(() => isolatedCodex.cleanup());
 
 function output(result) {
   return `${result.stdout || ""}\n${result.stderr || ""}`;
@@ -278,6 +284,7 @@ if (cmd === 'team-task-update' && process.argv.includes('--claim')) {
           env: {
             ...process.env,
             PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+            TFX_CODEX_CONFIG: isolatedCodex.path,
             FAKE_CODEX_MODE: "exec",
             TFX_CODEX_TRANSPORT: "exec",
             TFX_CTO_NORTH_STAR: "0",
@@ -371,6 +378,7 @@ if (cmd === 'team-task-update' && process.argv.includes('--claim')) {
           env: {
             ...process.env,
             PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+            TFX_CODEX_CONFIG: isolatedCodex.path,
             FAKE_CODEX_MODE: "exec",
             TFX_CODEX_TRANSPORT: "exec",
             TFX_CTO_NORTH_STAR: "0",
@@ -463,6 +471,7 @@ if (cmd === 'team-task-update') {
           env: {
             ...process.env,
             PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+            TFX_CODEX_CONFIG: isolatedCodex.path,
             FAKE_CODEX_MODE: "exec",
             TFX_CODEX_TRANSPORT: "exec",
             TFX_CTO_NORTH_STAR: "0",
@@ -565,6 +574,7 @@ if (cmd === 'team-task-update' && isClaim) {
           env: {
             ...process.env,
             PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+            TFX_CODEX_CONFIG: isolatedCodex.path,
             FAKE_CODEX_MODE: "exec",
             TFX_CODEX_TRANSPORT: "exec",
             TFX_CTO_NORTH_STAR: "0",

--- a/tests/integration/tfx-route-quota.test.mjs
+++ b/tests/integration/tfx-route-quota.test.mjs
@@ -8,6 +8,7 @@ import { dirname, resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { BASH_EXE, toBashPath } from "../helpers/bash-path.mjs";
+import { makeIsolatedCodexConfig } from "../helpers/codex-config-fixture.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -16,6 +17,11 @@ const ROUTE_SCRIPT = toBashPath(ROUTE_SCRIPT_WIN);
 const FIXTURE_BIN = toBashPath(
   resolve(PROJECT_ROOT, "tests", "fixtures", "bin"),
 );
+
+// Isolate tfx-route's codex config-swap so the full-route invocations below
+// never mutate the real ~/.codex/config.toml under concurrency.
+const isolatedCodex = makeIsolatedCodexConfig();
+after(() => isolatedCodex.cleanup());
 
 // 헬퍼: bash 스크립트에서 특정 함수 내용만 추출
 function extractFunction(scriptPath, funcName) {
@@ -341,6 +347,7 @@ auto_reroute codex
         encoding: "utf8",
         env: {
           ...process.env,
+          TFX_CODEX_CONFIG: isolatedCodex.path,
           TFX_CLI_MODE: "auto",
           TFX_QUOTA_REROUTE: "0",
           CODEX_BIN: fakeCodex,
@@ -372,6 +379,7 @@ auto_reroute codex
         encoding: "utf8",
         env: {
           ...process.env,
+          TFX_CODEX_CONFIG: isolatedCodex.path,
           TFX_CLI_MODE: "auto",
           TFX_REROUTED_FROM: "gemini", // 이전에 gemini에서 넘어왔음을 가정
           CODEX_BIN: fakeCodex,

--- a/tests/integration/tfx-route-team-bridge.test.mjs
+++ b/tests/integration/tfx-route-team-bridge.test.mjs
@@ -3,9 +3,10 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { BASH_EXE, toBashPath } from "../helpers/bash-path.mjs";
+import { makeIsolatedCodexConfig } from "../helpers/codex-config-fixture.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -19,6 +20,11 @@ const FAKE_BRIDGE = toBashPath(
   resolve(PROJECT_ROOT, "tests", "fixtures", "fake-bridge.mjs"),
 );
 
+// Isolate tfx-route's codex config-swap to a throwaway file so the full-route
+// invocations below never mutate the real ~/.codex/config.toml under concurrency.
+const isolatedCodex = makeIsolatedCodexConfig();
+after(() => isolatedCodex.cleanup());
+
 function runBash(command, extraEnv = {}) {
   return spawnSync(BASH_EXE, ["-c", command], {
     cwd: PROJECT_ROOT,
@@ -26,6 +32,7 @@ function runBash(command, extraEnv = {}) {
     env: {
       ...process.env,
       PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
+      TFX_CODEX_CONFIG: isolatedCodex.path,
       TFX_CODEX_TRANSPORT: "exec",
       TFX_CTO_NORTH_STAR: "0",
       // #148: 테스트 환경 MCP probe 결과는 모두 dead → preflight 가 early-fail.

--- a/tests/unit/codex-mcp-profile-resolve.test.mjs
+++ b/tests/unit/codex-mcp-profile-resolve.test.mjs
@@ -1,0 +1,158 @@
+// Regression guard: codex 0.137 dropped `profile` from the Codex MCP tool
+// schema (accepted: prompt/model/cwd/approval-policy/sandbox/config/
+// base-instructions/developer-instructions/compact-prompt). Sending `profile`
+// hard-fails with "unknown field `profile`". buildCodexArguments must translate
+// the effort profile into `model` + `config.model_reasoning_effort` and must
+// never emit a `profile` tool argument.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+  buildCodexArguments,
+  resolveCodexProfileConfig,
+} from "../../hub/workers/codex-mcp.mjs";
+
+const tempDirs = [];
+let savedCodexHome;
+
+beforeEach(() => {
+  savedCodexHome = process.env.CODEX_HOME;
+  const root = mkdtempSync(join(tmpdir(), "triflux-codex-profile-"));
+  tempDirs.push(root);
+  process.env.CODEX_HOME = root;
+  writeFileSync(
+    join(root, "gpt55_high.config.toml"),
+    'model = "gpt-5.5"\nmodel_reasoning_effort = "high"\n',
+  );
+  writeFileSync(
+    join(root, "gpt55_xhigh.config.toml"),
+    'model = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+  );
+});
+
+afterEach(() => {
+  if (savedCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = savedCodexHome;
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("resolveCodexProfileConfig", () => {
+  it("reads model + reasoning effort from the SSOT profile file", () => {
+    assert.deepEqual(resolveCodexProfileConfig("gpt55_high"), {
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+    });
+    assert.deepEqual(resolveCodexProfileConfig("gpt55_xhigh"), {
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+    });
+  });
+
+  it("tolerates inline comments and single quotes", () => {
+    const root = process.env.CODEX_HOME;
+    writeFileSync(
+      join(root, "gpt55_commented.config.toml"),
+      'model = "gpt-5.5"   # pinned\nmodel_reasoning_effort = "high"  # effort lane\n',
+    );
+    assert.deepEqual(resolveCodexProfileConfig("gpt55_commented"), {
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+    });
+    writeFileSync(
+      join(root, "gpt55_squote.config.toml"),
+      "model = 'gpt-5.5'\nmodel_reasoning_effort = 'low'\n",
+    );
+    assert.deepEqual(resolveCodexProfileConfig("gpt55_squote"), {
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+    });
+  });
+
+  it("derives effort from the naming convention when the file is absent", () => {
+    // No gpt55_med file written → fallback path.
+    assert.deepEqual(resolveCodexProfileConfig("gpt55_med"), {
+      model: null,
+      reasoningEffort: "medium",
+    });
+  });
+
+  it("returns nulls for an unknown non-file alias", () => {
+    assert.deepEqual(resolveCodexProfileConfig("none"), {
+      model: null,
+      reasoningEffort: null,
+    });
+    assert.deepEqual(resolveCodexProfileConfig(""), {
+      model: null,
+      reasoningEffort: null,
+    });
+  });
+});
+
+describe("buildCodexArguments — codex 0.137 profile regression guard", () => {
+  it("never emits a `profile` tool argument", () => {
+    const args = buildCodexArguments("hi", {
+      profile: "gpt55_high",
+      cwd: "/tmp",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    assert.equal(
+      Object.hasOwn(args, "profile"),
+      false,
+      "args must not carry the 0.137-rejected `profile` field",
+    );
+  });
+
+  it("maps the effort profile to model + config.model_reasoning_effort", () => {
+    const args = buildCodexArguments("hi", { profile: "gpt55_high" });
+    assert.equal(args.model, "gpt-5.5");
+    assert.equal(args.config?.model_reasoning_effort, "high");
+  });
+
+  it("lets an explicit model win over the profile model", () => {
+    const args = buildCodexArguments("hi", {
+      profile: "gpt55_high",
+      model: "gpt-5.5-codex",
+    });
+    assert.equal(args.model, "gpt-5.5-codex");
+    // effort still applied from the profile
+    assert.equal(args.config?.model_reasoning_effort, "high");
+  });
+
+  it("merges profile effort on top of an explicit config object", () => {
+    const args = buildCodexArguments("hi", {
+      profile: "gpt55_xhigh",
+      config: { foo: "bar" },
+    });
+    assert.equal(args.config.foo, "bar");
+    assert.equal(args.config.model_reasoning_effort, "xhigh");
+  });
+
+  it("only sets the accepted Codex tool fields", () => {
+    const args = buildCodexArguments("hi", {
+      profile: "gpt55_high",
+      cwd: "/tmp",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const accepted = new Set([
+      "prompt",
+      "model",
+      "cwd",
+      "approval-policy",
+      "sandbox",
+      "config",
+      "base-instructions",
+      "developer-instructions",
+      "compact-prompt",
+    ]);
+    for (const key of Object.keys(args)) {
+      assert.ok(accepted.has(key), `unexpected tool field forwarded: ${key}`);
+    }
+  });
+});


### PR DESCRIPTION
## 문제
codex가 0.136→**0.137**로 자동 업데이트된 뒤 default codex 레인이 0초 만에 실패:
`Failed to parse configuration for Codex tool: unknown field \`profile\``.

codex 0.137이 **Codex MCP tool 스키마에서 \`profile\` 필드를 폐기**했는데, triflux의 `codex-mcp.mjs`가 여전히 `args.profile`을 tool 인자로 전송 → 하드 실패 (0.136 success → 0.137 failed 회귀). **CLI `exec --profile` 플래그는 무관**(0.137에서 정상, 실측).

## 수정
### 1. codex 0.137 MCP profile fix (`abaa388c`)
- `buildCodexArguments`가 `args.profile` 전송을 멈추고 `resolveCodexProfileConfig`로 profile → `model` + `config.model_reasoning_effort` 해석 (SSOT `~/.codex/<p>.config.toml`, inline-comment tolerant TOML 파싱 + name-suffix fallback).
- 미러: `hub/workers/codex-mcp.mjs` → `packages/triflux`, `packages/remote`(import 보존).
- 회귀 테스트 + delegator-mcp 기대값 갱신(effort가 profile 필드 대신 config로).

### 2. hermetic config-swap 테스트 격리 (`65e0dc4d`)
- 통합 테스트(team-bridge/hub-restart/quota)가 full `tfx-route.sh`를 실행해 **실제 `~/.codex/config.toml`을 config-swap**하다 동시성 레이스로 손상시키던 non-hermetic 버그.
- `scripts/tfx-route.sh`에 `TFX_CODEX_CONFIG` override seam(backward-compat) + per-file throwaway fixture 헬퍼.

## 검증
- 실제 codex MCP 잡 exit 0 (0.137).
- 풀 `npm test` green (4091 pass / 0 fail), lint:skills PASS.
- 동시성 stress 후 실제 `~/.codex` 8서버 그대로(무결).
- Codex 교차리뷰: P0/P1 없음, P2(quota) 반영 완료.