### PR TITLE
feat(tfx-route): opt-in skill injection + agy anti-overclaim discipline

### DIFF
--- a/.triflux/plans/decision-tfx-skill-passing.md
+++ b/.triflux/plans/decision-tfx-skill-passing.md
@@ -1,0 +1,44 @@
+# DECISION — tfx-auto의 codex/agy 스킬 전달 방식
+
+> 출처: 세션 d8696d4e research 워크플로우(omc gh + codex/agy 네이티브 스킬 + gemini 환각, 4 agents) + tfx-route.sh 정적 감사. 2026-06-08.
+
+## 1. 결정 (DECIDE)
+
+**채택: 즉석 prose 주입 (skill 내용을 프롬프트 앞에 prepend) — 2.3.1 "네이티브 CLI 스킬 호출"은 기각, 2.3.2 너프는 사용자 기각.**
+
+근거 4가지:
+1. **네이티브 headless 스킬 호출이 미지원** — codex 0.137 / agy 1.0.6 둘 다 SKILL.md 시스템은 있으나 `/name` 슬래시는 **인터랙티브 TUI 전용**이고, `codex exec` / `agy --print` 같은 headless one-shot엔 named-skill 호출 플래그가 없다. codex `$skill-name`은 프롬프트 본문 텍스트(exec에서 honor 미문서), 그 외엔 모델 description auto-load(비결정적). triflux는 100% headless이므로 네이티브 경로는 신뢰 불가. (출처: developers.openai.com/codex/cli/slash-commands·reference; dev.to antigravity guide; 로컬 SKILL.md 실측)
+2. **레퍼런스(omc)가 정확히 prose 주입을 쓴다** — omc는 codex/gemini에 항상 plain-text 프롬프트를 넘기고 네이티브 스킬을 의도적으로 회피. 유일한 스킬화는 자기 role .md를 raw text로 prepend(`--agent-prompt`). 검증된 패턴. (출처: omc src/cli/ask.ts:231-234, scripts/run-provider-advisor.js)
+3. **triflux 전달이 이미 parse-safe** — codex argv `--` 뒤 전달(셸 재확장 없음), agy stdin `printf '%s'`(백슬래시/₩ 미해석). omc의 shell:false + stdin fallback과 동일. prose 주입은 파싱 위험 0 추가.
+4. **DRY + explicit-over-clever** — `prepend_codex_north_star()`(tfx-route.sh)가 이미 CLI-agnostic prose-prepend로 존재. 같은 패턴으로 `prepend_skill()` 추가만 하면 됨. 네이티브 스킬 브릿지는 clever·fragile·CLI 버전 결합이라 회피.
+
+**하이브리드 단서**: codex `~/.codex/skills/`에 description 매칭 스킬이 등록돼 있으면 exec에서도 auto-load될 *수도* 있으나 비결정적·미문서 → **의존하지 않는다**.
+
+## 2. 파싱 안전 규칙 (구현 불변식)
+
+주입은 반드시 `printf`/`cat` → temp file → prompt 앞에 붙이는 방식만 사용. `eval`/unquoted 확장 금지. codex는 argv `--` 뒤, agy는 stdin pipe 유지. `$`·`₩`·`\`는 리터럴 보존.
+
+## 3. 구현 (IMPLEMENT) — ✅ 완료 (commit 31594494, branch worktree-tfx-skill-inject)
+
+- `prepend_skill(prompt)`: `TFX_INJECT_SKILL` 설정 시 `skills/<name>/SKILL.md` 본문을 delimited block으로 prepend. 미설정 no-op. path-traversal 가드(`/`·`..` 거부). codex·agy 레인 공통.
+- `append_agy_anti_overclaim(prompt)`: agy 레인 전용, 완료/grounding 규율 블록을 프롬프트 END에 append (ITEM3).
+- codex 레인(north-star 직후) + agy 레인 wiring.
+- `packages/triflux/scripts/tfx-route.sh` byte-identical 미러.
+- `tfx-auto` SKILL.md: `--skill <name>` 플래그 + 커맨드→스킬 convention + agy anti-overclaim 문서화.
+- 테스트: `tests/unit/tfx-route-skill-inject.test.mjs` 9개(주입/no-op/parse-safety $·₩·\\·--flag/traversal 거부/anti-overclaim/레인 wiring). north-star 회귀 5/5 무손상. lint:skills 42 PASS.
+
+## 4. ITEM3 — gemini/agy 환각·거짓완료 완화
+
+Gemini 3.x 과신은 실증됨(AA-Omniscience: 정확도 53-56% 대비 환각률 88-91%, 추상화 최저; 3.1 Pro는 88→50% 개선). 완화책을 prose 주입으로 agy 레인에 통합:
+
+- **agy anti-overclaim 블록**(append_agy_anti_overclaim, 기본 on): fresh 증거 없이 완료 주장 금지(superpowers verification-before-completion Iron Law), grounded abstention("No Info" 후 중단), "주어진 context로 추론 + accurate abstention 우선". 부정 제약은 Gemini 3 공식 가이드대로 END 배치, blanket "do not guess" 회피.
+- agy 자기보고 완료 불신: 기존 commit-evidence 게이트 + codex↔claude 교차리뷰로 이미 방어(메모리 feedback_agy_swarm_no_commit). 강화.
+- Context7 MCP(이미 가용): codex/agy 코드답변 grounding 권장.
+- API-level(Search grounding, Vertex check-grounding 0-1 score+citation_threshold)은 CLI 레인 밖 → 후속.
+- ⚠️ Antigravity Artifacts/Walkthrough는 human-review aid지 hard gate 아님(같은 과신 모델이 생성) → 단독 의존 금지.
+
+## 5. 미해결 / 리스크
+
+- live EMPIRICAL: codex/agy에 `$`/`₩` 포함 스킬 프롬프트 실제 전달은 `prepend_skill` 함수 경유 smoke + 단위테스트로 리터럴 보존 증명(headless-guard로 codex/agy 실프로세스 transcript는 미실행, 정적+함수레벨 증명으로 갈음).
+- 커맨드→스킬 auto-map은 convention(tfx-auto가 `--skill` set)으로만 제공, 코드 자동 매핑은 의도적으로 default-off(부적절 스킬 누출 방지).
+- 커뮤니티 환각 완화 efficacy 수치는 control group 없는 blog claim.

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -460,6 +460,85 @@ prepend_codex_north_star() {
   rm -f "$tmp_file" 2>/dev/null || true
 }
 
+# prepend_skill: opt-in 으로 등록된 스킬의 SKILL.md 본문을 프롬프트 앞에 주입한다.
+# 활성 조건은 TFX_INJECT_SKILL env (tfx-auto 가 --skill <name> 으로 set). 미설정이면
+# 현행 동작 그대로 (no-op). CLI-agnostic — codex/agy 레인에서 동일하게 재사용한다.
+# 전달은 prepend_codex_north_star 와 동일하게 printf/cat → temp file 만 사용하므로
+# $ / 백슬래시(₩) 같은 특수문자를 셸 재확장 없이 리터럴로 보존한다 (parse-safe).
+# 스킬 경로: ${TFX_SKILLS_DIR:-<repo>/skills}/<name>/SKILL.md.
+prepend_skill() {
+  local prompt="${1:-}"
+  local skill_name="${TFX_INJECT_SKILL:-}"
+  if [[ -z "$skill_name" ]]; then
+    printf '%s' "$prompt"
+    return 0
+  fi
+  # 경로 탈출 방지: skill_name 은 skills/ 하위 단일 디렉토리 이름만 허용한다.
+  if [[ "$skill_name" == *"/"* || "$skill_name" == *".."* ]]; then
+    echo "[tfx-route] WARNING: TFX_INJECT_SKILL='${skill_name}' 에 경로 구분자/.. 포함 — 주입 거부" >&2
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  local skills_dir="${TFX_SKILLS_DIR:-}"
+  if [[ -z "$skills_dir" ]]; then
+    skills_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)/skills"
+  fi
+  local skill_file="${skills_dir}/${skill_name}/SKILL.md"
+  if [[ ! -r "$skill_file" ]]; then
+    echo "[tfx-route] WARNING: TFX_INJECT_SKILL='${skill_name}' 스킬을 찾지 못함 ($skill_file) — 주입 생략" >&2
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  local tmp_file
+  tmp_file="$(mktemp "${TFX_TMP:-${TMPDIR:-/tmp}}/tfx-skill-prompt.XXXXXX" 2>/dev/null)" || {
+    printf '%s' "$prompt"
+    return 0
+  }
+
+  if ! {
+    printf '%s\n' "--- SKILL: ${skill_name} (apply this methodology to the task below) ---"
+    cat "$skill_file"
+    if [[ -s "$skill_file" ]]; then
+      local last_byte
+      last_byte="$(tail -c 1 "$skill_file" 2>/dev/null || true)"
+      [[ -n "$last_byte" ]] && printf '\n'
+    fi
+    printf '%s\n' "--- END SKILL ---"
+    printf '%s' "$prompt"
+  } > "$tmp_file"; then
+    rm -f "$tmp_file" 2>/dev/null || true
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  cat "$tmp_file" 2>/dev/null || printf '%s' "$prompt"
+  rm -f "$tmp_file" 2>/dev/null || true
+}
+
+# append_agy_anti_overclaim: agy(Gemini 3.x) 레인 전용 완료/grounding 규율 블록을
+# 프롬프트 *뒤*에 붙인다. Gemini 3.x 는 과신(overconfidence) outlier 라 거짓 완료
+# 주장·환각이 잦다 (AA-Omniscience 실증). 부정 제약은 Gemini 3 공식 가이드 권고대로
+# 프롬프트 END 에 배치하고, blanket "do not guess" 대신 "주어진 context 로 추론 +
+# 정확한 abstention 우선" 형태로 적는다 (open-ended negative 는 역효과). TFX_AGY_ANTI_OVERCLAIM=0 으로 opt-out.
+append_agy_anti_overclaim() {
+  local prompt="${1:-}"
+  case "${TFX_AGY_ANTI_OVERCLAIM:-1}" in
+    0|false|FALSE|off|OFF|no|NO)
+      printf '%s' "$prompt"
+      return 0
+      ;;
+  esac
+
+  printf '%s' "$prompt"
+  printf '\n\n%s\n' "--- COMPLETION & GROUNDING DISCIPLINE (apply strictly) ---"
+  printf '%s\n' "- Claim done/fixed/passing ONLY after running the check in this turn and seeing its output. With no fresh evidence, report what is still unverified instead of asserting success."
+  printf '%s\n' "- Ground every answer in the provided context and the actual repository. If something is not verifiable from what you can see, say 'No Info / 확인 불가' and stop rather than inventing plausible-but-unconfirmed details."
+  printf '%s\n' "- Use the provided context for deductions and prefer accurate abstention over confident guessing."
+  printf '%s' "--- END DISCIPLINE ---"
+}
+
 read_probe_state() {
   local pid="$1"
   local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
@@ -2674,6 +2753,14 @@ FALLBACK_EOF
       _codex_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_codex_prompt_sentinel")"
       FULL_PROMPT="${_codex_full_prompt_with_sentinel%"$_codex_prompt_sentinel"}"
     fi
+    # Opt-in 스킬 주입 (TFX_INJECT_SKILL). north-star 와 동일한 sentinel 패턴으로
+    # trailing newline 을 보존한다. 미설정이면 prepend_skill 이 no-op.
+    if [[ -n "${TFX_INJECT_SKILL:-}" ]]; then
+      local _codex_skill_sentinel="__TFX_CODEX_SKILL_END_${$}_${RANDOM}__"
+      local _codex_skill_prompt
+      _codex_skill_prompt="$(prepend_skill "$FULL_PROMPT"; printf '%s' "$_codex_skill_sentinel")"
+      FULL_PROMPT="${_codex_skill_prompt%"$_codex_skill_sentinel"}"
+    fi
     codex_transport_effective="exec"
     if [[ "$TFX_CODEX_TRANSPORT" != "exec" ]]; then
       run_codex_mcp "$FULL_PROMPT" "$use_tee" || exit_code=$?
@@ -2778,6 +2865,18 @@ EOF
       _agy_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_agy_prompt_sentinel")"
       FULL_PROMPT="${_agy_full_prompt_with_sentinel%"$_agy_prompt_sentinel"}"
     fi
+    # Opt-in 스킬 주입 (TFX_INJECT_SKILL) — codex 레인과 동일.
+    if [[ -n "${TFX_INJECT_SKILL:-}" ]]; then
+      local _agy_skill_sentinel="__TFX_AGY_SKILL_END_${$}_${RANDOM}__"
+      local _agy_skill_prompt
+      _agy_skill_prompt="$(prepend_skill "$FULL_PROMPT"; printf '%s' "$_agy_skill_sentinel")"
+      FULL_PROMPT="${_agy_skill_prompt%"$_agy_skill_sentinel"}"
+    fi
+    # agy(Gemini 3.x) anti-overclaim 규율 블록을 프롬프트 END 에 append. opt-out: TFX_AGY_ANTI_OVERCLAIM=0.
+    local _agy_aoc_sentinel="__TFX_AGY_AOC_END_${$}_${RANDOM}__"
+    local _agy_aoc_prompt
+    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT"; printf '%s' "$_agy_aoc_sentinel")"
+    FULL_PROMPT="${_agy_aoc_prompt%"$_agy_aoc_sentinel"}"
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then
       local agy_stderr_bytes=0

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -28,7 +28,7 @@ triggers:
   - spec-panel
   - business-panel
   - index-repo
-argument-hint: "<command|task> [args...] [--cli auto|codex|antigravity|claude] [--mode quick|deep|consensus] [--risk-tier auto|low|medium|high] [--shape consensus|debate|panel] [--cli-set triad|no-antigravity|custom] [--parallel 1|N|swarm] [--retry 0|1|ralph] [--isolation none|worktree] [--remote <host>|none]"
+argument-hint: "<command|task> [args...] [--cli auto|codex|antigravity|claude] [--mode quick|deep|consensus] [--risk-tier auto|low|medium|high] [--shape consensus|debate|panel] [--cli-set triad|no-antigravity|custom] [--parallel 1|N|swarm] [--retry 0|1|ralph] [--isolation none|worktree] [--remote <host>|none] [--skill <name>]"
 ---
 
 # tfx-auto — 통합 CLI 오케스트레이터
@@ -169,6 +169,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--no-claude-native` | false (기본) | Claude native sub-agent 경로 유지 | — |
 | `--no-claude-native` | true | Claude native 경로 disable, CLI 기반 worker 강제 | tfx-route.sh |
 | `--max-iterations` | `0` (기본, unlimited) | `--retry ralph`/`auto-escalate` 상한 | retry-state-machine.mjs |
+| `--skill` | `<name>` | `skills/<name>/SKILL.md` 본문을 codex/agy 프롬프트 앞에 주입 (`TFX_INJECT_SKILL`). 미지정 시 no-op | tfx-route.sh |
 
 ### `--risk-tier` 계약
 
@@ -204,6 +205,37 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 - `--retry ralph` → true ralph state machine (Phase 3, retry-state-machine.mjs)
 - `--retry auto-escalate` → CLI 승격 체인 (Phase 3)
 - `--max-iterations N` (N>0) → ralph/auto-escalate 에 상한 부여
+- `--skill <name>` → `TFX_INJECT_SKILL=<name>` 로 tfx-route.sh 에 전달. 스킬 파일 부재 시 warning 후 주입 생략 (fail-open, 작업은 계속)
+
+### 스킬 주입 (`--skill <name>`)
+
+codex/agy 워커 프롬프트 앞에 등록된 스킬의 방법론을 주입하는 **opt-in** 프레임워크. 설계 근거는 `decision-skill-passing` (omc 레퍼런스 + codex/agy 네이티브 스킬 조사):
+
+- **메커니즘**: `--skill <name>` → tfx-route.sh `TFX_INJECT_SKILL=<name>`. `skills/<name>/SKILL.md` 본문을 `--- SKILL: <name> (apply this methodology...) ---` delimited block 으로 프롬프트 앞에 prepend. codex·agy 레인 공통 (CLI-agnostic, `prepend_skill`).
+- **기본 off**: 미지정이면 no-op → 현행 동작 그대로. 회귀 위험 없음.
+- **파싱 안전**: prepend 는 `printf`/`cat` → temp file 만 사용. codex 는 argv `--` 뒤, agy 는 stdin `printf %s` 로 전달되므로 `$`(codex)·`₩`/백슬래시(agy) 같은 특수문자를 셸 재확장 없이 **리터럴 보존**. 스킬 본문을 그대로 넘겨도 깨지지 않음.
+- **네이티브 스킬을 안 쓰는 이유**: codex `$skill-name`/`/name` 슬래시와 agy `/name` 은 둘 다 **인터랙티브 TUI 전용** → headless one-shot 에서 named-skill 강제 호출 불가 (미문서). 그래서 prose 주입을 채택 (레퍼런스 omc 도 role .md 를 raw prepend, 네이티브 회피).
+
+#### 커맨드→스킬 매핑 (tfx-auto convention, opt-in)
+
+tfx-auto 가 커맨드/agent 별로 주입할 스킬을 고를 때 쓰는 **권고 테이블**. 기본은 매핑 없음 (명시 `--skill` 만 작동) — 부적절한 스킬이 모든 프롬프트에 새는 것을 막는다. 프로젝트가 명시적으로 활성화할 때만 아래를 적용해 `--skill` 을 자동 부여한다.
+
+| 커맨드/agent | 권고 스킬 | 비고 |
+|--------------|-----------|------|
+| (기본) | 없음 | explicit `--skill` 우선 |
+| 프로젝트 정의 | 프로젝트가 지정 | 활성화 시 tfx-auto 가 해당 `--skill` set |
+
+> 매핑된 스킬 파일이 없으면 `prepend_skill` 이 warning 후 주입을 생략한다 (fail-open). 존재하지 않는 매핑을 "주입됨"으로 가정하지 않는다.
+
+#### agy anti-overclaim (자동, agy 레인 전용)
+
+agy(Gemini 3.x) 레인은 `TFX_AGY_ANTI_OVERCLAIM`(기본 on) 으로 완료/grounding 규율 블록을 프롬프트 **END** 에 자동 append (`append_agy_anti_overclaim`). Gemini 3.x 과신(AA-Omniscience 실측: 정확도 53-56% 대비 환각률 88-91%) 대응:
+
+- fresh 증거 없이 done/fixed/passing 주장 금지.
+- 검증 불가 시 `No Info / 확인 불가` 후 중단 (날조 금지).
+- 추론은 주어진 context 로, confident guessing 보다 accurate abstention 우선.
+
+부정 제약은 Gemini 3 공식 가이드대로 **END 배치**하고 blanket "do not guess" 는 역효과라 피한다. opt-out: `TFX_AGY_ANTI_OVERCLAIM=0`.
 
 ### Retry state machine 계약 (legacy autoroute / persist 이관)
 

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -460,6 +460,85 @@ prepend_codex_north_star() {
   rm -f "$tmp_file" 2>/dev/null || true
 }
 
+# prepend_skill: opt-in 으로 등록된 스킬의 SKILL.md 본문을 프롬프트 앞에 주입한다.
+# 활성 조건은 TFX_INJECT_SKILL env (tfx-auto 가 --skill <name> 으로 set). 미설정이면
+# 현행 동작 그대로 (no-op). CLI-agnostic — codex/agy 레인에서 동일하게 재사용한다.
+# 전달은 prepend_codex_north_star 와 동일하게 printf/cat → temp file 만 사용하므로
+# $ / 백슬래시(₩) 같은 특수문자를 셸 재확장 없이 리터럴로 보존한다 (parse-safe).
+# 스킬 경로: ${TFX_SKILLS_DIR:-<repo>/skills}/<name>/SKILL.md.
+prepend_skill() {
+  local prompt="${1:-}"
+  local skill_name="${TFX_INJECT_SKILL:-}"
+  if [[ -z "$skill_name" ]]; then
+    printf '%s' "$prompt"
+    return 0
+  fi
+  # 경로 탈출 방지: skill_name 은 skills/ 하위 단일 디렉토리 이름만 허용한다.
+  if [[ "$skill_name" == *"/"* || "$skill_name" == *".."* ]]; then
+    echo "[tfx-route] WARNING: TFX_INJECT_SKILL='${skill_name}' 에 경로 구분자/.. 포함 — 주입 거부" >&2
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  local skills_dir="${TFX_SKILLS_DIR:-}"
+  if [[ -z "$skills_dir" ]]; then
+    skills_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)/skills"
+  fi
+  local skill_file="${skills_dir}/${skill_name}/SKILL.md"
+  if [[ ! -r "$skill_file" ]]; then
+    echo "[tfx-route] WARNING: TFX_INJECT_SKILL='${skill_name}' 스킬을 찾지 못함 ($skill_file) — 주입 생략" >&2
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  local tmp_file
+  tmp_file="$(mktemp "${TFX_TMP:-${TMPDIR:-/tmp}}/tfx-skill-prompt.XXXXXX" 2>/dev/null)" || {
+    printf '%s' "$prompt"
+    return 0
+  }
+
+  if ! {
+    printf '%s\n' "--- SKILL: ${skill_name} (apply this methodology to the task below) ---"
+    cat "$skill_file"
+    if [[ -s "$skill_file" ]]; then
+      local last_byte
+      last_byte="$(tail -c 1 "$skill_file" 2>/dev/null || true)"
+      [[ -n "$last_byte" ]] && printf '\n'
+    fi
+    printf '%s\n' "--- END SKILL ---"
+    printf '%s' "$prompt"
+  } > "$tmp_file"; then
+    rm -f "$tmp_file" 2>/dev/null || true
+    printf '%s' "$prompt"
+    return 0
+  fi
+
+  cat "$tmp_file" 2>/dev/null || printf '%s' "$prompt"
+  rm -f "$tmp_file" 2>/dev/null || true
+}
+
+# append_agy_anti_overclaim: agy(Gemini 3.x) 레인 전용 완료/grounding 규율 블록을
+# 프롬프트 *뒤*에 붙인다. Gemini 3.x 는 과신(overconfidence) outlier 라 거짓 완료
+# 주장·환각이 잦다 (AA-Omniscience 실증). 부정 제약은 Gemini 3 공식 가이드 권고대로
+# 프롬프트 END 에 배치하고, blanket "do not guess" 대신 "주어진 context 로 추론 +
+# 정확한 abstention 우선" 형태로 적는다 (open-ended negative 는 역효과). TFX_AGY_ANTI_OVERCLAIM=0 으로 opt-out.
+append_agy_anti_overclaim() {
+  local prompt="${1:-}"
+  case "${TFX_AGY_ANTI_OVERCLAIM:-1}" in
+    0|false|FALSE|off|OFF|no|NO)
+      printf '%s' "$prompt"
+      return 0
+      ;;
+  esac
+
+  printf '%s' "$prompt"
+  printf '\n\n%s\n' "--- COMPLETION & GROUNDING DISCIPLINE (apply strictly) ---"
+  printf '%s\n' "- Claim done/fixed/passing ONLY after running the check in this turn and seeing its output. With no fresh evidence, report what is still unverified instead of asserting success."
+  printf '%s\n' "- Ground every answer in the provided context and the actual repository. If something is not verifiable from what you can see, say 'No Info / 확인 불가' and stop rather than inventing plausible-but-unconfirmed details."
+  printf '%s\n' "- Use the provided context for deductions and prefer accurate abstention over confident guessing."
+  printf '%s' "--- END DISCIPLINE ---"
+}
+
 read_probe_state() {
   local pid="$1"
   local state_file="${TFX_PROBE_STATE_FILE:-${TFX_PROBE_DIR}/${pid}.json}"
@@ -2674,6 +2753,14 @@ FALLBACK_EOF
       _codex_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_codex_prompt_sentinel")"
       FULL_PROMPT="${_codex_full_prompt_with_sentinel%"$_codex_prompt_sentinel"}"
     fi
+    # Opt-in 스킬 주입 (TFX_INJECT_SKILL). north-star 와 동일한 sentinel 패턴으로
+    # trailing newline 을 보존한다. 미설정이면 prepend_skill 이 no-op.
+    if [[ -n "${TFX_INJECT_SKILL:-}" ]]; then
+      local _codex_skill_sentinel="__TFX_CODEX_SKILL_END_${$}_${RANDOM}__"
+      local _codex_skill_prompt
+      _codex_skill_prompt="$(prepend_skill "$FULL_PROMPT"; printf '%s' "$_codex_skill_sentinel")"
+      FULL_PROMPT="${_codex_skill_prompt%"$_codex_skill_sentinel"}"
+    fi
     codex_transport_effective="exec"
     if [[ "$TFX_CODEX_TRANSPORT" != "exec" ]]; then
       run_codex_mcp "$FULL_PROMPT" "$use_tee" || exit_code=$?
@@ -2778,6 +2865,18 @@ EOF
       _agy_full_prompt_with_sentinel="$(prepend_codex_north_star "$FULL_PROMPT"; printf '%s' "$_agy_prompt_sentinel")"
       FULL_PROMPT="${_agy_full_prompt_with_sentinel%"$_agy_prompt_sentinel"}"
     fi
+    # Opt-in 스킬 주입 (TFX_INJECT_SKILL) — codex 레인과 동일.
+    if [[ -n "${TFX_INJECT_SKILL:-}" ]]; then
+      local _agy_skill_sentinel="__TFX_AGY_SKILL_END_${$}_${RANDOM}__"
+      local _agy_skill_prompt
+      _agy_skill_prompt="$(prepend_skill "$FULL_PROMPT"; printf '%s' "$_agy_skill_sentinel")"
+      FULL_PROMPT="${_agy_skill_prompt%"$_agy_skill_sentinel"}"
+    fi
+    # agy(Gemini 3.x) anti-overclaim 규율 블록을 프롬프트 END 에 append. opt-out: TFX_AGY_ANTI_OVERCLAIM=0.
+    local _agy_aoc_sentinel="__TFX_AGY_AOC_END_${$}_${RANDOM}__"
+    local _agy_aoc_prompt
+    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT"; printf '%s' "$_agy_aoc_sentinel")"
+    FULL_PROMPT="${_agy_aoc_prompt%"$_agy_aoc_sentinel"}"
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then
       local agy_stderr_bytes=0

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -28,7 +28,7 @@ triggers:
   - spec-panel
   - business-panel
   - index-repo
-argument-hint: "<command|task> [args...] [--cli auto|codex|antigravity|claude] [--mode quick|deep|consensus] [--risk-tier auto|low|medium|high] [--shape consensus|debate|panel] [--cli-set triad|no-antigravity|custom] [--parallel 1|N|swarm] [--retry 0|1|ralph] [--isolation none|worktree] [--remote <host>|none]"
+argument-hint: "<command|task> [args...] [--cli auto|codex|antigravity|claude] [--mode quick|deep|consensus] [--risk-tier auto|low|medium|high] [--shape consensus|debate|panel] [--cli-set triad|no-antigravity|custom] [--parallel 1|N|swarm] [--retry 0|1|ralph] [--isolation none|worktree] [--remote <host>|none] [--skill <name>]"
 ---
 
 # tfx-auto — 통합 CLI 오케스트레이터
@@ -169,6 +169,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--no-claude-native` | false (기본) | Claude native sub-agent 경로 유지 | — |
 | `--no-claude-native` | true | Claude native 경로 disable, CLI 기반 worker 강제 | tfx-route.sh |
 | `--max-iterations` | `0` (기본, unlimited) | `--retry ralph`/`auto-escalate` 상한 | retry-state-machine.mjs |
+| `--skill` | `<name>` | `skills/<name>/SKILL.md` 본문을 codex/agy 프롬프트 앞에 주입 (`TFX_INJECT_SKILL`). 미지정 시 no-op | tfx-route.sh |
 
 ### `--risk-tier` 계약
 
@@ -204,6 +205,37 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 - `--retry ralph` → true ralph state machine (Phase 3, retry-state-machine.mjs)
 - `--retry auto-escalate` → CLI 승격 체인 (Phase 3)
 - `--max-iterations N` (N>0) → ralph/auto-escalate 에 상한 부여
+- `--skill <name>` → `TFX_INJECT_SKILL=<name>` 로 tfx-route.sh 에 전달. 스킬 파일 부재 시 warning 후 주입 생략 (fail-open, 작업은 계속)
+
+### 스킬 주입 (`--skill <name>`)
+
+codex/agy 워커 프롬프트 앞에 등록된 스킬의 방법론을 주입하는 **opt-in** 프레임워크. 설계 근거는 `decision-skill-passing` (omc 레퍼런스 + codex/agy 네이티브 스킬 조사):
+
+- **메커니즘**: `--skill <name>` → tfx-route.sh `TFX_INJECT_SKILL=<name>`. `skills/<name>/SKILL.md` 본문을 `--- SKILL: <name> (apply this methodology...) ---` delimited block 으로 프롬프트 앞에 prepend. codex·agy 레인 공통 (CLI-agnostic, `prepend_skill`).
+- **기본 off**: 미지정이면 no-op → 현행 동작 그대로. 회귀 위험 없음.
+- **파싱 안전**: prepend 는 `printf`/`cat` → temp file 만 사용. codex 는 argv `--` 뒤, agy 는 stdin `printf %s` 로 전달되므로 `$`(codex)·`₩`/백슬래시(agy) 같은 특수문자를 셸 재확장 없이 **리터럴 보존**. 스킬 본문을 그대로 넘겨도 깨지지 않음.
+- **네이티브 스킬을 안 쓰는 이유**: codex `$skill-name`/`/name` 슬래시와 agy `/name` 은 둘 다 **인터랙티브 TUI 전용** → headless one-shot 에서 named-skill 강제 호출 불가 (미문서). 그래서 prose 주입을 채택 (레퍼런스 omc 도 role .md 를 raw prepend, 네이티브 회피).
+
+#### 커맨드→스킬 매핑 (tfx-auto convention, opt-in)
+
+tfx-auto 가 커맨드/agent 별로 주입할 스킬을 고를 때 쓰는 **권고 테이블**. 기본은 매핑 없음 (명시 `--skill` 만 작동) — 부적절한 스킬이 모든 프롬프트에 새는 것을 막는다. 프로젝트가 명시적으로 활성화할 때만 아래를 적용해 `--skill` 을 자동 부여한다.
+
+| 커맨드/agent | 권고 스킬 | 비고 |
+|--------------|-----------|------|
+| (기본) | 없음 | explicit `--skill` 우선 |
+| 프로젝트 정의 | 프로젝트가 지정 | 활성화 시 tfx-auto 가 해당 `--skill` set |
+
+> 매핑된 스킬 파일이 없으면 `prepend_skill` 이 warning 후 주입을 생략한다 (fail-open). 존재하지 않는 매핑을 "주입됨"으로 가정하지 않는다.
+
+#### agy anti-overclaim (자동, agy 레인 전용)
+
+agy(Gemini 3.x) 레인은 `TFX_AGY_ANTI_OVERCLAIM`(기본 on) 으로 완료/grounding 규율 블록을 프롬프트 **END** 에 자동 append (`append_agy_anti_overclaim`). Gemini 3.x 과신(AA-Omniscience 실측: 정확도 53-56% 대비 환각률 88-91%) 대응:
+
+- fresh 증거 없이 done/fixed/passing 주장 금지.
+- 검증 불가 시 `No Info / 확인 불가` 후 중단 (날조 금지).
+- 추론은 주어진 context 로, confident guessing 보다 accurate abstention 우선.
+
+부정 제약은 Gemini 3 공식 가이드대로 **END 배치**하고 blanket "do not guess" 는 역효과라 피한다. opt-out: `TFX_AGY_ANTI_OVERCLAIM=0`.
 
 ### Retry state machine 계약 (legacy autoroute / persist 이관)
 

--- a/tests/unit/tfx-route-skill-inject.test.mjs
+++ b/tests/unit/tfx-route-skill-inject.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { BASH_EXE } from "../helpers/bash-path.mjs";
+
+const routeSource = readFileSync(
+  join(process.cwd(), "scripts", "tfx-route.sh"),
+  "utf8",
+);
+
+// north-star 테스트와 동일한 brace-matching 함수 추출기.
+function extractFunction(funcName) {
+  const start = routeSource.indexOf(`${funcName}() {`);
+  assert.ok(start >= 0, `${funcName} 정의를 찾을 수 없음`);
+  let depth = 0;
+  for (let i = start; i < routeSource.length; i += 1) {
+    if (routeSource[i] === "{") depth += 1;
+    if (routeSource[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return routeSource.slice(start, i + 1);
+    }
+  }
+  throw new Error(`${funcName} 끝을 찾을 수 없음`);
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function runFunc({ funcName, env = {}, callArg }) {
+  const funcDef = extractFunction(funcName);
+  const script = [
+    "set -euo pipefail",
+    ...Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`),
+    funcDef,
+    `${funcName} ${shellQuote(callArg)}`,
+  ].join("\n");
+  return spawnSync(BASH_EXE, ["-c", script], { encoding: "utf8" });
+}
+
+describe("tfx-route skill injection", () => {
+  const cleanupDirs = [];
+  after(() => {
+    for (const dir of cleanupDirs)
+      rmSync(dir, { recursive: true, force: true });
+  });
+
+  function fixtureSkillsDir(name, body) {
+    const dir = mkdtempSync(join(tmpdir(), "tfx-skills-"));
+    cleanupDirs.push(dir);
+    mkdirSync(join(dir, name), { recursive: true });
+    writeFileSync(join(dir, name, "SKILL.md"), body);
+    return dir;
+  }
+
+  it("prepends the delimited skill block when TFX_INJECT_SKILL is set", () => {
+    const skillsDir = fixtureSkillsDir(
+      "demo",
+      "Methodology step A.\nStep B.\n",
+    );
+    const result = runFunc({
+      funcName: "prepend_skill",
+      env: { TFX_INJECT_SKILL: "demo", TFX_SKILLS_DIR: skillsDir },
+      callArg: "Do the task.\n--flag-like text stays literal.",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      result.stdout,
+      [
+        "--- SKILL: demo (apply this methodology to the task below) ---",
+        "Methodology step A.",
+        "Step B.",
+        "--- END SKILL ---",
+        "Do the task.",
+        "--flag-like text stays literal.",
+      ].join("\n"),
+    );
+  });
+
+  it("is a no-op when TFX_INJECT_SKILL is unset", () => {
+    const prompt = "Original prompt stays first.\n--flag literal.";
+    const result = runFunc({ funcName: "prepend_skill", callArg: prompt });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, prompt);
+  });
+
+  it("is a no-op (prompt unchanged on stdout) when the skill file is absent", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "tfx-skills-empty-"));
+    cleanupDirs.push(emptyDir);
+    const prompt = "Prompt with no skill.";
+    const result = runFunc({
+      funcName: "prepend_skill",
+      env: { TFX_INJECT_SKILL: "missing", TFX_SKILLS_DIR: emptyDir },
+      callArg: prompt,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, prompt);
+    assert.match(result.stderr, /스킬을 찾지 못함/);
+  });
+
+  it("rejects a skill name with path separators (no traversal)", () => {
+    const skillsDir = fixtureSkillsDir("demo", "Guidance.\n");
+    const prompt = "Prompt body.";
+    const result = runFunc({
+      funcName: "prepend_skill",
+      env: { TFX_INJECT_SKILL: "../../etc/demo", TFX_SKILLS_DIR: skillsDir },
+      callArg: prompt,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, prompt);
+    assert.match(result.stderr, /경로 구분자/);
+  });
+
+  it("preserves $ / ₩ / backslash / --flag literally (parse-safe)", () => {
+    const skillsDir = fixtureSkillsDir("demo", "Guidance.\n");
+    const prompt = "Cost is $FOO and ₩100, path C:\\temp\\x, and --dry-run.";
+    const result = runFunc({
+      funcName: "prepend_skill",
+      env: { TFX_INJECT_SKILL: "demo", TFX_SKILLS_DIR: skillsDir },
+      callArg: prompt,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    // 프롬프트는 블록 뒤에 그대로 붙으므로 stdout 이 원본 프롬프트로 끝나야 한다.
+    assert.ok(
+      result.stdout.endsWith(prompt),
+      `프롬프트가 리터럴로 보존되지 않음:\n${result.stdout}`,
+    );
+    assert.ok(result.stdout.includes("$FOO"));
+    assert.ok(result.stdout.includes("₩100"));
+    assert.ok(result.stdout.includes("C:\\temp\\x"));
+  });
+
+  it("appends the agy anti-overclaim discipline block at the END by default", () => {
+    const prompt = "Implement the feature.";
+    const result = runFunc({
+      funcName: "append_agy_anti_overclaim",
+      callArg: prompt,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.startsWith(prompt), "프롬프트가 먼저 와야 함");
+    assert.match(result.stdout, /COMPLETION & GROUNDING DISCIPLINE/);
+    assert.match(result.stdout, /No Info \/ 확인 불가/);
+    // blanket "do not guess" 대신 abstention 프레이밍을 쓴다 (Gemini 3 가이드 caveat).
+    assert.match(result.stdout, /prefer accurate abstention/);
+  });
+
+  it("is a no-op for anti-overclaim when TFX_AGY_ANTI_OVERCLAIM=0", () => {
+    const prompt = "Implement the feature.";
+    const result = runFunc({
+      funcName: "append_agy_anti_overclaim",
+      env: { TFX_AGY_ANTI_OVERCLAIM: "0" },
+      callArg: prompt,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, prompt);
+  });
+
+  it("wires the codex lane to call prepend_skill before dispatch", () => {
+    const codexIdx = routeSource.indexOf("_codex_north_star_file=");
+    assert.ok(codexIdx >= 0, "codex lane not found");
+    const lane = routeSource.slice(
+      codexIdx,
+      routeSource.indexOf('codex_transport_effective="exec"', codexIdx),
+    );
+    assert.match(lane, /TFX_INJECT_SKILL/);
+    assert.match(lane, /prepend_skill "\$FULL_PROMPT"/);
+  });
+
+  it("wires the antigravity lane to call prepend_skill + append_agy_anti_overclaim", () => {
+    const laneStart = routeSource.indexOf(
+      'elif [[ "$CLI_TYPE" == "antigravity" ]]; then',
+    );
+    assert.ok(laneStart >= 0, "antigravity lane not found");
+    const lane = routeSource.slice(
+      laneStart,
+      routeSource.indexOf("run_antigravity_exec", laneStart),
+    );
+    assert.match(lane, /prepend_skill "\$FULL_PROMPT"/);
+    assert.match(lane, /append_agy_anti_overclaim "\$FULL_PROMPT"/);
+  });
+});


### PR DESCRIPTION
## What
codex/agy 워커 프롬프트에 등록 스킬의 방법론을 주입하는 **opt-in** 프레임워크 + agy(Gemini 3.x) anti-overclaim 규율 블록.

- `prepend_skill()` — `TFX_INJECT_SKILL` 설정 시 `skills/<name>/SKILL.md`를 codex/agy 프롬프트 앞에 prepend (tfx-auto `--skill <name>`). 미설정 no-op(현행 동작 무변경). path-traversal 가드.
- `append_agy_anti_overclaim()` — agy 레인이 완료/grounding 규율 블록을 프롬프트 END에 append (`TFX_AGY_ANTI_OVERCLAIM`, 기본 on): fresh 증거 없이 완료 주장 금지, grounded abstention("No Info").
- tfx-auto SKILL.md: `--skill` 플래그 + 커맨드→스킬 convention + agy anti-overclaim 문서.

## Why (결정 근거)
`.triflux/plans/decision-tfx-skill-passing.md` 참조. codex 0.137 / agy 1.0.6 네이티브 스킬(`/name` 슬래시, codex `$skill-name`)은 **인터랙티브 TUI 전용** → headless named-invocation 불가. triflux는 headless 전용이라 네이티브 경로 신뢰 불가. 레퍼런스 omc도 plain-text prompt + role .md raw prepend. → **prose 주입 채택, 네이티브 기각.**

**파싱 안전**: codex argv `--` 뒤(셸 재확장 없음), agy stdin `printf %s`(백슬래시/₩ 미해석). 주입은 printf/cat→temp file만 → `$`/`₩`/`\` 리터럴 보존.

**ITEM3 (gemini 환각)**: Gemini 3.x 과신 outlier(AA-Omniscience: 정확도 53-56% 대비 환각률 88-91%). anti-overclaim 블록이 Gemini 3 공식 가이드 적용(split-step verify, grounded abstention, 부정제약 END 배치, blanket "do not guess" 회피).

## Verification
- `npm test`: **4091 pass / 0 fail**
- `npm run lint:skills`: 42 PASS
- 신규 9 단위테스트 (parse-safety `$`/`₩`/`\`/`--flag`, traversal guard, lane wiring)
- north-star 회귀: 5/5 (무변경)
- packages/triflux 미러: byte-identical
- 교차리뷰(Codex): PASS, no actionable defects (적대적 `$`/backslash/sentinel/agy-stdin probe)

## Test plan
`TFX_INJECT_SKILL=<name> bash scripts/tfx-route.sh executor '<\$VAR 포함 프롬프트>' implement` → 스킬 블록 prepend, `\$VAR` 리터럴.