### PR TITLE
fix(synapse): prune stale sessions + self-heal dropped registrations

### DIFF
--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -2054,6 +2054,16 @@ export async function startHub({
   }, 60000);
   sessionTimer.unref();
 
+  const synapsePruneTimer = setInterval(() => {
+    try {
+      const { count } = synapseRegistry.pruneExpired();
+      if (count > 0) hubLog.info({ count }, "synapse.prune");
+    } catch (err) {
+      hubLog.warn({ err }, "synapse.prune_failed");
+    }
+  }, 60000);
+  synapsePruneTimer.unref();
+
   // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
   // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
   const orphanCleanupTimer = setInterval(
@@ -2288,6 +2298,7 @@ export async function startHub({
               router.stopSweeper();
               clearInterval(hitlTimer);
               clearInterval(sessionTimer);
+              clearInterval(synapsePruneTimer);
               clearInterval(rateLimitTimer);
               clearInterval(orphanCleanupTimer);
               if (idleTimer) {

--- a/hub/team/synapse-registry.mjs
+++ b/hub/team/synapse-registry.mjs
@@ -5,6 +5,7 @@ const DEFAULT_LOCAL_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEFAULT_LOCAL_TIMEOUT_MS = 30_000;
 const DEFAULT_REMOTE_HEARTBEAT_INTERVAL_MS = 15_000;
 const DEFAULT_REMOTE_TIMEOUT_MS = 90_000;
+const DEFAULT_EXPIRE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // Interactive (Claude/Codex) sessions idle for long stretches; a 30s local
 // timeout produces stale false-positives. 5-minute TTL + an `idle` state
 // distinguishes "alive but inactive" from "presumed dead".
@@ -133,6 +134,7 @@ export function createSynapseRegistry(opts = {}) {
     remoteTimeoutMs = DEFAULT_REMOTE_TIMEOUT_MS,
     interactiveHeartbeatIntervalMs = DEFAULT_INTERACTIVE_HEARTBEAT_INTERVAL_MS,
     interactiveTimeoutMs = DEFAULT_INTERACTIVE_TIMEOUT_MS,
+    expireTimeoutMs = DEFAULT_EXPIRE_TIMEOUT_MS,
   } = opts;
 
   const sessions = new Map();
@@ -355,10 +357,89 @@ export function createSynapseRegistry(opts = {}) {
     return true;
   }
 
+  // stale/expired 세션이 expireTimeoutMs 넘게 누적되면 Map에서 제거.
+  // live(active/idle)는 lastHeartbeat가 오래돼도 보존 — git-preflight dirty-file 가드가 의존.
+  function pruneExpired(opts2 = {}) {
+    if (destroyed) return { removed: [], count: 0 };
+
+    const cutoff =
+      typeof opts2.olderThanMs === "number"
+        ? opts2.olderThanMs
+        : expireTimeoutMs;
+    const removed = [];
+    const currentTime = now();
+
+    for (const [sessionId, session] of sessions) {
+      if (
+        isLiveStatus(session.status) ||
+        currentTime - session.lastHeartbeat <= cutoff
+      ) {
+        continue;
+      }
+
+      stopMonitor(sessionId);
+      sessions.delete(sessionId);
+      removed.push(sessionId);
+      notifyRemoved(session);
+    }
+
+    if (removed.length > 0) persist();
+    return { removed, count: removed.length };
+  }
+
   function heartbeat(sessionId, partialMeta = null) {
     const normalized = normalizeSessionId(sessionId);
     const session = sessions.get(normalized);
-    if (!session) return false;
+    if (!session) {
+      // self-heal은 위치 정보(worktreePath 또는 cwd)가 있는 heartbeat에서만
+      // 발동한다. UserPromptSubmit heartbeat는 항상 worktreePath를 보내므로
+      // SessionStart register POST drop 복구 경로는 커버되고, taskSummary만 담은
+      // 빈약한 heartbeat로 위치 없는 가비지 세션이 register 되는 것은 막는다
+      // (그 경우는 기존대로 false → 400/heartbeat failed).
+      const hasLocator =
+        partialMeta &&
+        typeof partialMeta === "object" &&
+        !Array.isArray(partialMeta) &&
+        ((typeof partialMeta.worktreePath === "string" &&
+          partialMeta.worktreePath.length > 0) ||
+          (typeof partialMeta.cwd === "string" && partialMeta.cwd.length > 0));
+      const canSelfHeal = Boolean(normalized) && hasLocator;
+      if (!canSelfHeal) return false;
+
+      // 미등록 세션 heartbeat = SessionStart register POST가 drop된 경우.
+      // self-heal로 register 복구(영구 미등록 방지).
+      //
+      // sessionKind는 명시값이 없으면 "interactive"로 본다. 실제 복구 경로인
+      // heartbeatInteractiveSession은 worktreePath/host/taskSummary만 보내고
+      // sessionKind는 생략하는데, sanitizeSession 기본값("headless")으로 떨어지면
+      // 복구된 Claude 세션이 30초 local timeout을 받아 idle/5분 TTL을 잃고 곧장
+      // stale로 전이돼 getActive()/peer discovery에서 사라진다(이 PRD가 고치려던
+      // 원래 증상의 재현). heartbeat 기반 liveness로 살아나는 세션은 interactive다.
+      const sanitizedKind =
+        typeof partialMeta.sessionKind === "string"
+          ? partialMeta.sessionKind
+          : "interactive";
+      const healed = sanitizeSession(
+        {
+          ...partialMeta,
+          sessionId: normalized,
+          sessionKind: sanitizedKind,
+          status: "active",
+          lastHeartbeat: now(),
+        },
+        normalized,
+      );
+      if (!healed) return false;
+
+      sessions.set(normalized, healed);
+      startMonitor(normalized);
+      persist();
+      emitter?.emit("synapse.session.started", {
+        sessionId: normalized,
+        session: cloneSession(healed),
+      });
+      return true;
+    }
 
     const wasRemote = session.isRemote;
     const updated = { ...session, lastHeartbeat: now(), status: "active" };
@@ -492,6 +573,7 @@ export function createSynapseRegistry(opts = {}) {
   return Object.freeze({
     register,
     unregister,
+    pruneExpired,
     heartbeat,
     getActive,
     getAll,

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -2054,6 +2054,16 @@ export async function startHub({
   }, 60000);
   sessionTimer.unref();
 
+  const synapsePruneTimer = setInterval(() => {
+    try {
+      const { count } = synapseRegistry.pruneExpired();
+      if (count > 0) hubLog.info({ count }, "synapse.prune");
+    } catch (err) {
+      hubLog.warn({ err }, "synapse.prune_failed");
+    }
+  }, 60000);
+  synapsePruneTimer.unref();
+
   // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
   // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
   const orphanCleanupTimer = setInterval(
@@ -2288,6 +2298,7 @@ export async function startHub({
               router.stopSweeper();
               clearInterval(hitlTimer);
               clearInterval(sessionTimer);
+              clearInterval(synapsePruneTimer);
               clearInterval(rateLimitTimer);
               clearInterval(orphanCleanupTimer);
               if (idleTimer) {

--- a/packages/remote/hub/team/synapse-registry.mjs
+++ b/packages/remote/hub/team/synapse-registry.mjs
@@ -5,6 +5,7 @@ const DEFAULT_LOCAL_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEFAULT_LOCAL_TIMEOUT_MS = 30_000;
 const DEFAULT_REMOTE_HEARTBEAT_INTERVAL_MS = 15_000;
 const DEFAULT_REMOTE_TIMEOUT_MS = 90_000;
+const DEFAULT_EXPIRE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // Interactive (Claude/Codex) sessions idle for long stretches; a 30s local
 // timeout produces stale false-positives. 5-minute TTL + an `idle` state
 // distinguishes "alive but inactive" from "presumed dead".
@@ -133,6 +134,7 @@ export function createSynapseRegistry(opts = {}) {
     remoteTimeoutMs = DEFAULT_REMOTE_TIMEOUT_MS,
     interactiveHeartbeatIntervalMs = DEFAULT_INTERACTIVE_HEARTBEAT_INTERVAL_MS,
     interactiveTimeoutMs = DEFAULT_INTERACTIVE_TIMEOUT_MS,
+    expireTimeoutMs = DEFAULT_EXPIRE_TIMEOUT_MS,
   } = opts;
 
   const sessions = new Map();
@@ -355,10 +357,89 @@ export function createSynapseRegistry(opts = {}) {
     return true;
   }
 
+  // stale/expired 세션이 expireTimeoutMs 넘게 누적되면 Map에서 제거.
+  // live(active/idle)는 lastHeartbeat가 오래돼도 보존 — git-preflight dirty-file 가드가 의존.
+  function pruneExpired(opts2 = {}) {
+    if (destroyed) return { removed: [], count: 0 };
+
+    const cutoff =
+      typeof opts2.olderThanMs === "number"
+        ? opts2.olderThanMs
+        : expireTimeoutMs;
+    const removed = [];
+    const currentTime = now();
+
+    for (const [sessionId, session] of sessions) {
+      if (
+        isLiveStatus(session.status) ||
+        currentTime - session.lastHeartbeat <= cutoff
+      ) {
+        continue;
+      }
+
+      stopMonitor(sessionId);
+      sessions.delete(sessionId);
+      removed.push(sessionId);
+      notifyRemoved(session);
+    }
+
+    if (removed.length > 0) persist();
+    return { removed, count: removed.length };
+  }
+
   function heartbeat(sessionId, partialMeta = null) {
     const normalized = normalizeSessionId(sessionId);
     const session = sessions.get(normalized);
-    if (!session) return false;
+    if (!session) {
+      // self-heal은 위치 정보(worktreePath 또는 cwd)가 있는 heartbeat에서만
+      // 발동한다. UserPromptSubmit heartbeat는 항상 worktreePath를 보내므로
+      // SessionStart register POST drop 복구 경로는 커버되고, taskSummary만 담은
+      // 빈약한 heartbeat로 위치 없는 가비지 세션이 register 되는 것은 막는다
+      // (그 경우는 기존대로 false → 400/heartbeat failed).
+      const hasLocator =
+        partialMeta &&
+        typeof partialMeta === "object" &&
+        !Array.isArray(partialMeta) &&
+        ((typeof partialMeta.worktreePath === "string" &&
+          partialMeta.worktreePath.length > 0) ||
+          (typeof partialMeta.cwd === "string" && partialMeta.cwd.length > 0));
+      const canSelfHeal = Boolean(normalized) && hasLocator;
+      if (!canSelfHeal) return false;
+
+      // 미등록 세션 heartbeat = SessionStart register POST가 drop된 경우.
+      // self-heal로 register 복구(영구 미등록 방지).
+      //
+      // sessionKind는 명시값이 없으면 "interactive"로 본다. 실제 복구 경로인
+      // heartbeatInteractiveSession은 worktreePath/host/taskSummary만 보내고
+      // sessionKind는 생략하는데, sanitizeSession 기본값("headless")으로 떨어지면
+      // 복구된 Claude 세션이 30초 local timeout을 받아 idle/5분 TTL을 잃고 곧장
+      // stale로 전이돼 getActive()/peer discovery에서 사라진다(이 PRD가 고치려던
+      // 원래 증상의 재현). heartbeat 기반 liveness로 살아나는 세션은 interactive다.
+      const sanitizedKind =
+        typeof partialMeta.sessionKind === "string"
+          ? partialMeta.sessionKind
+          : "interactive";
+      const healed = sanitizeSession(
+        {
+          ...partialMeta,
+          sessionId: normalized,
+          sessionKind: sanitizedKind,
+          status: "active",
+          lastHeartbeat: now(),
+        },
+        normalized,
+      );
+      if (!healed) return false;
+
+      sessions.set(normalized, healed);
+      startMonitor(normalized);
+      persist();
+      emitter?.emit("synapse.session.started", {
+        sessionId: normalized,
+        session: cloneSession(healed),
+      });
+      return true;
+    }
 
     const wasRemote = session.isRemote;
     const updated = { ...session, lastHeartbeat: now(), status: "active" };
@@ -492,6 +573,7 @@ export function createSynapseRegistry(opts = {}) {
   return Object.freeze({
     register,
     unregister,
+    pruneExpired,
     heartbeat,
     getActive,
     getAll,

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -2054,6 +2054,16 @@ export async function startHub({
   }, 60000);
   sessionTimer.unref();
 
+  const synapsePruneTimer = setInterval(() => {
+    try {
+      const { count } = synapseRegistry.pruneExpired();
+      if (count > 0) hubLog.info({ count }, "synapse.prune");
+    } catch (err) {
+      hubLog.warn({ err }, "synapse.prune_failed");
+    }
+  }, 60000);
+  synapsePruneTimer.unref();
+
   // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
   // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
   const orphanCleanupTimer = setInterval(
@@ -2288,6 +2298,7 @@ export async function startHub({
               router.stopSweeper();
               clearInterval(hitlTimer);
               clearInterval(sessionTimer);
+              clearInterval(synapsePruneTimer);
               clearInterval(rateLimitTimer);
               clearInterval(orphanCleanupTimer);
               if (idleTimer) {

--- a/packages/triflux/hub/team/synapse-registry.mjs
+++ b/packages/triflux/hub/team/synapse-registry.mjs
@@ -5,6 +5,7 @@ const DEFAULT_LOCAL_HEARTBEAT_INTERVAL_MS = 5_000;
 const DEFAULT_LOCAL_TIMEOUT_MS = 30_000;
 const DEFAULT_REMOTE_HEARTBEAT_INTERVAL_MS = 15_000;
 const DEFAULT_REMOTE_TIMEOUT_MS = 90_000;
+const DEFAULT_EXPIRE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // Interactive (Claude/Codex) sessions idle for long stretches; a 30s local
 // timeout produces stale false-positives. 5-minute TTL + an `idle` state
 // distinguishes "alive but inactive" from "presumed dead".
@@ -133,6 +134,7 @@ export function createSynapseRegistry(opts = {}) {
     remoteTimeoutMs = DEFAULT_REMOTE_TIMEOUT_MS,
     interactiveHeartbeatIntervalMs = DEFAULT_INTERACTIVE_HEARTBEAT_INTERVAL_MS,
     interactiveTimeoutMs = DEFAULT_INTERACTIVE_TIMEOUT_MS,
+    expireTimeoutMs = DEFAULT_EXPIRE_TIMEOUT_MS,
   } = opts;
 
   const sessions = new Map();
@@ -355,10 +357,89 @@ export function createSynapseRegistry(opts = {}) {
     return true;
   }
 
+  // stale/expired 세션이 expireTimeoutMs 넘게 누적되면 Map에서 제거.
+  // live(active/idle)는 lastHeartbeat가 오래돼도 보존 — git-preflight dirty-file 가드가 의존.
+  function pruneExpired(opts2 = {}) {
+    if (destroyed) return { removed: [], count: 0 };
+
+    const cutoff =
+      typeof opts2.olderThanMs === "number"
+        ? opts2.olderThanMs
+        : expireTimeoutMs;
+    const removed = [];
+    const currentTime = now();
+
+    for (const [sessionId, session] of sessions) {
+      if (
+        isLiveStatus(session.status) ||
+        currentTime - session.lastHeartbeat <= cutoff
+      ) {
+        continue;
+      }
+
+      stopMonitor(sessionId);
+      sessions.delete(sessionId);
+      removed.push(sessionId);
+      notifyRemoved(session);
+    }
+
+    if (removed.length > 0) persist();
+    return { removed, count: removed.length };
+  }
+
   function heartbeat(sessionId, partialMeta = null) {
     const normalized = normalizeSessionId(sessionId);
     const session = sessions.get(normalized);
-    if (!session) return false;
+    if (!session) {
+      // self-heal은 위치 정보(worktreePath 또는 cwd)가 있는 heartbeat에서만
+      // 발동한다. UserPromptSubmit heartbeat는 항상 worktreePath를 보내므로
+      // SessionStart register POST drop 복구 경로는 커버되고, taskSummary만 담은
+      // 빈약한 heartbeat로 위치 없는 가비지 세션이 register 되는 것은 막는다
+      // (그 경우는 기존대로 false → 400/heartbeat failed).
+      const hasLocator =
+        partialMeta &&
+        typeof partialMeta === "object" &&
+        !Array.isArray(partialMeta) &&
+        ((typeof partialMeta.worktreePath === "string" &&
+          partialMeta.worktreePath.length > 0) ||
+          (typeof partialMeta.cwd === "string" && partialMeta.cwd.length > 0));
+      const canSelfHeal = Boolean(normalized) && hasLocator;
+      if (!canSelfHeal) return false;
+
+      // 미등록 세션 heartbeat = SessionStart register POST가 drop된 경우.
+      // self-heal로 register 복구(영구 미등록 방지).
+      //
+      // sessionKind는 명시값이 없으면 "interactive"로 본다. 실제 복구 경로인
+      // heartbeatInteractiveSession은 worktreePath/host/taskSummary만 보내고
+      // sessionKind는 생략하는데, sanitizeSession 기본값("headless")으로 떨어지면
+      // 복구된 Claude 세션이 30초 local timeout을 받아 idle/5분 TTL을 잃고 곧장
+      // stale로 전이돼 getActive()/peer discovery에서 사라진다(이 PRD가 고치려던
+      // 원래 증상의 재현). heartbeat 기반 liveness로 살아나는 세션은 interactive다.
+      const sanitizedKind =
+        typeof partialMeta.sessionKind === "string"
+          ? partialMeta.sessionKind
+          : "interactive";
+      const healed = sanitizeSession(
+        {
+          ...partialMeta,
+          sessionId: normalized,
+          sessionKind: sanitizedKind,
+          status: "active",
+          lastHeartbeat: now(),
+        },
+        normalized,
+      );
+      if (!healed) return false;
+
+      sessions.set(normalized, healed);
+      startMonitor(normalized);
+      persist();
+      emitter?.emit("synapse.session.started", {
+        sessionId: normalized,
+        session: cloneSession(healed),
+      });
+      return true;
+    }
 
     const wasRemote = session.isRemote;
     const updated = { ...session, lastHeartbeat: now(), status: "active" };
@@ -492,6 +573,7 @@ export function createSynapseRegistry(opts = {}) {
   return Object.freeze({
     register,
     unregister,
+    pruneExpired,
     heartbeat,
     getActive,
     getAll,

--- a/tests/unit/synapse-registry.test.mjs
+++ b/tests/unit/synapse-registry.test.mjs
@@ -135,6 +135,134 @@ describe("synapse-registry", () => {
     reg.destroy();
   });
 
+  it("pruneExpired removes long-stale sessions but keeps live ones", async () => {
+    const reg = createSynapseRegistry({
+      persistPath,
+      localHeartbeatIntervalMs: 5,
+      localTimeoutMs: 15,
+      expireTimeoutMs: 30,
+    });
+
+    const removedSessions = [];
+    reg.onRemoved((session) => {
+      removedSessions.push(session.sessionId);
+    });
+
+    reg.register(baseMeta({ sessionId: "headless-stale" }));
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(reg.getSession("headless-stale").status, "stale");
+
+    reg.register(
+      baseMeta({
+        sessionId: "interactive-live",
+        sessionKind: "interactive",
+      }),
+    );
+
+    const result = reg.pruneExpired();
+    assert.deepEqual(result.removed, ["headless-stale"]);
+    assert.equal(result.count, 1);
+    assert.equal(reg.getSession("headless-stale"), null);
+    assert.equal(
+      reg.getAll().some((s) => s.sessionId === "headless-stale"),
+      false,
+    );
+    assert.equal(reg.getSession("interactive-live").status, "active");
+    assert.deepEqual(removedSessions, ["headless-stale"]);
+
+    reg.destroy();
+  });
+
+  it("heartbeat self-heals an unregistered session", () => {
+    const reg = createSynapseRegistry({ persistPath });
+
+    const ok = reg.heartbeat("ghost-session", {
+      worktreePath: "/tmp/x",
+      sessionKind: "interactive",
+    });
+
+    assert.equal(ok, true);
+    const session = reg.getSession("ghost-session");
+    assert.ok(session);
+    assert.equal(session.sessionId, "ghost-session");
+    assert.equal(session.worktreePath, "/tmp/x");
+    assert.equal(session.sessionKind, "interactive");
+    assert.equal(session.status, "active");
+
+    reg.destroy();
+  });
+
+  it("self-heal defaults to interactive on the real UserPromptSubmit shape (no sessionKind)", async () => {
+    // heartbeatInteractiveSession은 worktreePath/host/taskSummary만 보내고
+    // sessionKind는 생략한다. self-heal이 이를 headless로 분류하면 복구된
+    // 세션이 짧은 local timeout으로 곧장 stale이 돼 사라진다(원래 증상 재현).
+    const reg = createSynapseRegistry({
+      persistPath,
+      // headless면 15ms 만에 stale; interactive면 5s TTL까지 살아있어야 한다.
+      localHeartbeatIntervalMs: 5,
+      localTimeoutMs: 15,
+      interactiveHeartbeatIntervalMs: 10,
+      interactiveTimeoutMs: 5_000,
+    });
+
+    const ok = reg.heartbeat("drop-recovered", {
+      worktreePath: "/tmp/recovered",
+      host: "local",
+      taskSummary: "resumed prompt",
+    });
+    assert.equal(ok, true);
+    assert.equal(reg.getSession("drop-recovered").sessionKind, "interactive");
+
+    // headless라면 이 시점에 stale이지만, interactive로 복구됐으므로 live여야 한다.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const after = reg.getSession("drop-recovered");
+    assert.notEqual(after.status, "stale");
+    assert.equal(
+      reg.getActive().some((s) => s.sessionId === "drop-recovered"),
+      true,
+    );
+
+    reg.destroy();
+  });
+
+  it("heartbeat does NOT self-heal without a locator (worktreePath/cwd)", () => {
+    const reg = createSynapseRegistry({ persistPath });
+
+    // taskSummary만 담긴 빈약한 heartbeat는 위치 정보가 없으므로 self-heal
+    // 대상이 아니다 — 위치 없는 가비지 세션 register 방지.
+    const ok = reg.heartbeat("no-locator", { taskSummary: "missing" });
+
+    assert.equal(ok, false);
+    assert.equal(reg.getSession("no-locator"), null);
+
+    // cwd locator만 있어도 self-heal 된다(worktreePath 외 경로 커버).
+    const okCwd = reg.heartbeat("cwd-only", { cwd: "/tmp/cwd-heal" });
+    assert.equal(okCwd, true);
+    assert.equal(reg.getSession("cwd-only")?.status, "active");
+
+    reg.destroy();
+  });
+
+  it("pruneExpired with explicit olderThanMs", async () => {
+    const reg = createSynapseRegistry({
+      persistPath,
+      localHeartbeatIntervalMs: 5,
+      localTimeoutMs: 15,
+      expireTimeoutMs: 60_000,
+    });
+
+    reg.register(baseMeta({ sessionId: "explicit-prune" }));
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(reg.getSession("explicit-prune").status, "stale");
+
+    const result = reg.pruneExpired({ olderThanMs: 1 });
+    assert.deepEqual(result.removed, ["explicit-prune"]);
+    assert.equal(result.count, 1);
+    assert.equal(reg.getSession("explicit-prune"), null);
+
+    reg.destroy();
+  });
+
   it("persists and restores session state", () => {
     const reg1 = createSynapseRegistry({ persistPath });
     reg1.register(


### PR DESCRIPTION
## What
bg/interactive 세션이 synapse registry 조율 평면에서 사라지고 dead 세션이 무한 누적되던 두 결함을 함께 고친다. (실측: `/synapse/sessions` 36개 중 35 stale, live 세션 부재.)

- **`pruneExpired()`**: stale/expired 세션을 `expireTimeoutMs`(기본 24h) 초과 시 Map에서 제거. **live(active/idle)는 lastHeartbeat가 오래돼도 보존** — git-preflight dirty-file 가드가 의존하는 라이브 세션 가시성 유지. 기존엔 status만 stale로 마킹하고 절대 제거 안 해 무한 누적.
- **heartbeat self-heal**: 미등록 세션이 locator(worktreePath/cwd) 있는 heartbeat를 보내면 register로 복구 → SessionStart register POST가 drop돼도 첫 UserPromptSubmit heartbeat가 세션을 살림. locator 없는 빈약한 heartbeat는 기존대로 false(가비지 방지). self-heal 세션은 `sessionKind` 명시 없으면 **interactive**로 본다(headless 기본값이면 30s timeout→즉시 stale로 원래 증상 재현).
- **hub/server.mjs**: 60초 주기 `synapsePruneTimer` sweep + shutdown `clearInterval`.
- packages/{triflux,remote} 3-layer 미러 (triflux byte-identical, remote @triflux/core import 변환).

## Why
세션 d8696d4e 라이브 진단: bg Claude daemon 세션이 hub MCP roster·synapse registry 어디에도 안 잡혀 조율 실패(DLQ 누적). 근본원인 = register 신뢰성 + stale prune 부재. (메모리 project_bg_session_coordination_plane_mismatch.)

## Verification
- `tests/unit/synapse-registry.test.mjs`: **28/28 pass** (pruneExpired live 보존/explicit olderThanMs, self-heal 발동/미발동/UserPromptSubmit interactive 보존)
- 교차리뷰(Claude, Codex 작성분 검토): PASS — pruneExpired live-preserve 정확, self-heal interactive-default 통찰 타당, 미러 정합(remote import 변환 확인).

## Note
projection-bridge는 의도적으로 만들지 않음 (메모리상 misdiagnosis로 플래그됨) — register 신뢰성 + stale prune이 1순위 근본 수정.