### PR TITLE
feat(hooks): auto-register interactive Antigravity (agy) sessions to hub

### DIFF
--- a/hooks/agy-session-hook.mjs
+++ b/hooks/agy-session-hook.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { argv, exit, stdin, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
+import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
+import {
+  heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
+  registerInteractiveSession as defaultRegisterInteractiveSession,
+} from "./session-start-fast.mjs";
+
+// hub-ensure is loaded lazily so the byte-identical packages/core mirror of this
+// file loads cleanly. packages/core mirrors scripts/lib only (not scripts/*), so a
+// static `../scripts/hub-ensure.mjs` import would make the core copy throw
+// ERR_MODULE_NOT_FOUND at load time. Mirrors codex-session-hook.mjs's pattern.
+async function defaultHubEnsureRun(stdinData) {
+  const { run } = await import(
+    new URL("../scripts/hub-ensure.mjs", import.meta.url).href
+  );
+  return run(stdinData);
+}
+
+function parsePayload(stdinData) {
+  try {
+    const raw = typeof stdinData === "string" ? stdinData : "";
+    return raw.trim()
+      ? { ok: true, payload: JSON.parse(raw) }
+      : { ok: false, payload: {} };
+  } catch {
+    return { ok: false, payload: {} };
+  }
+}
+
+// Antigravity hook payloads use camelCase system metadata (conversationId,
+// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
+// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
+// payload into that shape before delegating. conversationId is the stable
+// per-conversation UUID (== session identity); the first mounted workspace path
+// is the effective cwd.
+export function toSessionPayload(payload) {
+  const sessionId = String(payload?.conversationId || "").trim();
+  const workspacePaths = Array.isArray(payload?.workspacePaths)
+    ? payload.workspacePaths
+    : [];
+  const cwd =
+    typeof workspacePaths[0] === "string" && workspacePaths[0]
+      ? workspacePaths[0]
+      : process.cwd();
+  return JSON.stringify({ session_id: sessionId, cwd });
+}
+
+// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
+// fires before every model call, so the per-conversation invocationNum gates
+// register (first call == session start) vs heartbeat (subsequent calls).
+// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+export function normalizeMode(argvMode, payload) {
+  const direct = String(argvMode || "")
+    .trim()
+    .toLowerCase();
+  if (direct === "register" || direct === "heartbeat") return direct;
+
+  const invocationNum = Number(payload?.invocationNum);
+  if (Number.isFinite(invocationNum)) {
+    return invocationNum <= 1 ? "register" : "heartbeat";
+  }
+  // Unknown invocation index: register is idempotent and also ensures the hub,
+  // so it is the safe default for a first-contact payload.
+  return "register";
+}
+
+export async function runAgySessionHook(stdinData, opts = {}) {
+  const output = "{}\n";
+  const parsed = parsePayload(stdinData);
+  if (!parsed.ok) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const sessionPayload = toSessionPayload(parsed.payload);
+  const sessionId = JSON.parse(sessionPayload).session_id;
+  // No conversation id means nothing to register; stay a silent no-op.
+  if (!sessionId) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const mode = normalizeMode(opts.argvMode ?? argv[2], parsed.payload);
+  const hubEnsureRun = opts.hubEnsureRun || defaultHubEnsureRun;
+  const registerInteractiveSession =
+    opts.registerInteractiveSession || defaultRegisterInteractiveSession;
+  const heartbeatInteractiveSession =
+    opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
+  const drainPendingSynapse =
+    opts.drainPendingSynapse || defaultDrainPendingSynapse;
+
+  try {
+    if (mode === "register") {
+      try {
+        await hubEnsureRun(sessionPayload);
+      } catch {}
+      try {
+        registerInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(1000);
+      } catch {}
+    } else if (mode === "heartbeat") {
+      try {
+        heartbeatInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(500);
+      } catch {}
+    }
+  } catch {
+    // agy session hooks are observational and must never block the session.
+  }
+
+  if (opts.writeStdout !== false) {
+    stdout.write(output);
+  }
+  return output;
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    stdin.setEncoding("utf8");
+    stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    stdin.on("end", () => resolve(data));
+    stdin.on("error", () => resolve(data));
+  });
+}
+
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  const stdinData = await readStdin();
+  await runAgySessionHook(stdinData);
+  exit(0);
+}

--- a/packages/core/hooks/agy-session-hook.mjs
+++ b/packages/core/hooks/agy-session-hook.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { argv, exit, stdin, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
+import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
+import {
+  heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
+  registerInteractiveSession as defaultRegisterInteractiveSession,
+} from "./session-start-fast.mjs";
+
+// hub-ensure is loaded lazily so the byte-identical packages/core mirror of this
+// file loads cleanly. packages/core mirrors scripts/lib only (not scripts/*), so a
+// static `../scripts/hub-ensure.mjs` import would make the core copy throw
+// ERR_MODULE_NOT_FOUND at load time. Mirrors codex-session-hook.mjs's pattern.
+async function defaultHubEnsureRun(stdinData) {
+  const { run } = await import(
+    new URL("../scripts/hub-ensure.mjs", import.meta.url).href
+  );
+  return run(stdinData);
+}
+
+function parsePayload(stdinData) {
+  try {
+    const raw = typeof stdinData === "string" ? stdinData : "";
+    return raw.trim()
+      ? { ok: true, payload: JSON.parse(raw) }
+      : { ok: false, payload: {} };
+  } catch {
+    return { ok: false, payload: {} };
+  }
+}
+
+// Antigravity hook payloads use camelCase system metadata (conversationId,
+// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
+// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
+// payload into that shape before delegating. conversationId is the stable
+// per-conversation UUID (== session identity); the first mounted workspace path
+// is the effective cwd.
+export function toSessionPayload(payload) {
+  const sessionId = String(payload?.conversationId || "").trim();
+  const workspacePaths = Array.isArray(payload?.workspacePaths)
+    ? payload.workspacePaths
+    : [];
+  const cwd =
+    typeof workspacePaths[0] === "string" && workspacePaths[0]
+      ? workspacePaths[0]
+      : process.cwd();
+  return JSON.stringify({ session_id: sessionId, cwd });
+}
+
+// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
+// fires before every model call, so the per-conversation invocationNum gates
+// register (first call == session start) vs heartbeat (subsequent calls).
+// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+export function normalizeMode(argvMode, payload) {
+  const direct = String(argvMode || "")
+    .trim()
+    .toLowerCase();
+  if (direct === "register" || direct === "heartbeat") return direct;
+
+  const invocationNum = Number(payload?.invocationNum);
+  if (Number.isFinite(invocationNum)) {
+    return invocationNum <= 1 ? "register" : "heartbeat";
+  }
+  // Unknown invocation index: register is idempotent and also ensures the hub,
+  // so it is the safe default for a first-contact payload.
+  return "register";
+}
+
+export async function runAgySessionHook(stdinData, opts = {}) {
+  const output = "{}\n";
+  const parsed = parsePayload(stdinData);
+  if (!parsed.ok) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const sessionPayload = toSessionPayload(parsed.payload);
+  const sessionId = JSON.parse(sessionPayload).session_id;
+  // No conversation id means nothing to register; stay a silent no-op.
+  if (!sessionId) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const mode = normalizeMode(opts.argvMode ?? argv[2], parsed.payload);
+  const hubEnsureRun = opts.hubEnsureRun || defaultHubEnsureRun;
+  const registerInteractiveSession =
+    opts.registerInteractiveSession || defaultRegisterInteractiveSession;
+  const heartbeatInteractiveSession =
+    opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
+  const drainPendingSynapse =
+    opts.drainPendingSynapse || defaultDrainPendingSynapse;
+
+  try {
+    if (mode === "register") {
+      try {
+        await hubEnsureRun(sessionPayload);
+      } catch {}
+      try {
+        registerInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(1000);
+      } catch {}
+    } else if (mode === "heartbeat") {
+      try {
+        heartbeatInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(500);
+      } catch {}
+    }
+  } catch {
+    // agy session hooks are observational and must never block the session.
+  }
+
+  if (opts.writeStdout !== false) {
+    stdout.write(output);
+  }
+  return output;
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    stdin.setEncoding("utf8");
+    stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    stdin.on("end", () => resolve(data));
+    stdin.on("error", () => resolve(data));
+  });
+}
+
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  const stdinData = await readStdin();
+  await runAgySessionHook(stdinData);
+  exit(0);
+}

--- a/packages/triflux/hooks/agy-session-hook.mjs
+++ b/packages/triflux/hooks/agy-session-hook.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { argv, exit, stdin, stdout } from "node:process";
+import { pathToFileURL } from "node:url";
+import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
+import {
+  heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
+  registerInteractiveSession as defaultRegisterInteractiveSession,
+} from "./session-start-fast.mjs";
+
+// hub-ensure is loaded lazily so the byte-identical packages/core mirror of this
+// file loads cleanly. packages/core mirrors scripts/lib only (not scripts/*), so a
+// static `../scripts/hub-ensure.mjs` import would make the core copy throw
+// ERR_MODULE_NOT_FOUND at load time. Mirrors codex-session-hook.mjs's pattern.
+async function defaultHubEnsureRun(stdinData) {
+  const { run } = await import(
+    new URL("../scripts/hub-ensure.mjs", import.meta.url).href
+  );
+  return run(stdinData);
+}
+
+function parsePayload(stdinData) {
+  try {
+    const raw = typeof stdinData === "string" ? stdinData : "";
+    return raw.trim()
+      ? { ok: true, payload: JSON.parse(raw) }
+      : { ok: false, payload: {} };
+  } catch {
+    return { ok: false, payload: {} };
+  }
+}
+
+// Antigravity hook payloads use camelCase system metadata (conversationId,
+// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
+// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
+// payload into that shape before delegating. conversationId is the stable
+// per-conversation UUID (== session identity); the first mounted workspace path
+// is the effective cwd.
+export function toSessionPayload(payload) {
+  const sessionId = String(payload?.conversationId || "").trim();
+  const workspacePaths = Array.isArray(payload?.workspacePaths)
+    ? payload.workspacePaths
+    : [];
+  const cwd =
+    typeof workspacePaths[0] === "string" && workspacePaths[0]
+      ? workspacePaths[0]
+      : process.cwd();
+  return JSON.stringify({ session_id: sessionId, cwd });
+}
+
+// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
+// fires before every model call, so the per-conversation invocationNum gates
+// register (first call == session start) vs heartbeat (subsequent calls).
+// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+export function normalizeMode(argvMode, payload) {
+  const direct = String(argvMode || "")
+    .trim()
+    .toLowerCase();
+  if (direct === "register" || direct === "heartbeat") return direct;
+
+  const invocationNum = Number(payload?.invocationNum);
+  if (Number.isFinite(invocationNum)) {
+    return invocationNum <= 1 ? "register" : "heartbeat";
+  }
+  // Unknown invocation index: register is idempotent and also ensures the hub,
+  // so it is the safe default for a first-contact payload.
+  return "register";
+}
+
+export async function runAgySessionHook(stdinData, opts = {}) {
+  const output = "{}\n";
+  const parsed = parsePayload(stdinData);
+  if (!parsed.ok) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const sessionPayload = toSessionPayload(parsed.payload);
+  const sessionId = JSON.parse(sessionPayload).session_id;
+  // No conversation id means nothing to register; stay a silent no-op.
+  if (!sessionId) {
+    if (opts.writeStdout !== false) stdout.write(output);
+    return output;
+  }
+
+  const mode = normalizeMode(opts.argvMode ?? argv[2], parsed.payload);
+  const hubEnsureRun = opts.hubEnsureRun || defaultHubEnsureRun;
+  const registerInteractiveSession =
+    opts.registerInteractiveSession || defaultRegisterInteractiveSession;
+  const heartbeatInteractiveSession =
+    opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
+  const drainPendingSynapse =
+    opts.drainPendingSynapse || defaultDrainPendingSynapse;
+
+  try {
+    if (mode === "register") {
+      try {
+        await hubEnsureRun(sessionPayload);
+      } catch {}
+      try {
+        registerInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(1000);
+      } catch {}
+    } else if (mode === "heartbeat") {
+      try {
+        heartbeatInteractiveSession(sessionPayload);
+      } catch {}
+      try {
+        await drainPendingSynapse(500);
+      } catch {}
+    }
+  } catch {
+    // agy session hooks are observational and must never block the session.
+  }
+
+  if (opts.writeStdout !== false) {
+    stdout.write(output);
+  }
+  return output;
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    stdin.setEncoding("utf8");
+    stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    stdin.on("end", () => resolve(data));
+    stdin.on("error", () => resolve(data));
+  });
+}
+
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  const stdinData = await readStdin();
+  await runAgySessionHook(stdinData);
+  exit(0);
+}

--- a/packages/triflux/scripts/ensure-agy-hooks.mjs
+++ b/packages/triflux/scripts/ensure-agy-hooks.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = dirname(__dirname);
+const TRIFLUX_HOOK_BASENAME = "agy-session-hook.mjs";
+// Named hook group key in agy's hooks.json. agy maps top-level names to event
+// configs, unlike Codex which nests everything under a single `hooks` object.
+const HOOK_GROUP_NAME = "triflux-session";
+
+function atomicWriteFile(path, content) {
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, path);
+}
+
+function quoteCommandPath(value) {
+  return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function buildCommand(nodeBin, hookScriptPath) {
+  // No mode argument: the agy hook derives register vs heartbeat from the
+  // payload's invocationNum (first invocation registers, later ones heartbeat).
+  // Format mirrors codex-session-hook's proven hook command (bare node bin +
+  // quoted script path). agy's hook executor is the same jetski family; quoting
+  // the node bin too is unverified against agy's exec model, so we keep the
+  // known-working shape rather than risk breaking hook execution. Install paths
+  // are controlled (node bin + npm package dir), so the residual $()-in-path
+  // expansion risk is not a realistic threat.
+  return `${nodeBin} ${quoteCommandPath(hookScriptPath)}`;
+}
+
+function normalizeHooksJson(raw) {
+  try {
+    const parsed = raw.trim() ? JSON.parse(raw) : {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed;
+  } catch {
+    // Unreadable hooks.json: start from an empty map rather than clobbering with
+    // a parse error. A backup of the original is taken before any write.
+    return {};
+  }
+}
+
+// agy fires a single PreInvocation handler before every model call. One entry
+// covers both register and heartbeat because the hook self-selects on
+// invocationNum. (agy has no SessionStart / UserPromptSubmit split like Codex.)
+function buildDesiredGroup({ nodeBin, hookScriptPath }) {
+  return {
+    PreInvocation: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildCommand(nodeBin, hookScriptPath),
+            timeout: 15,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function formatHooksJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function timestamp() {
+  return new Date()
+    .toISOString()
+    .replace(/[-:.TZ]/g, "")
+    .slice(0, 14);
+}
+
+export function ensureAgyHooks(opts = {}) {
+  // agy's customization directory. Skip cleanly when the user has no agy
+  // install (no ~/.gemini/config), mirroring ensureCodexHooks' ~/.codex gate.
+  const geminiConfigHome =
+    opts.geminiConfigHome || join(homedir(), ".gemini", "config");
+  // Never install into the real user HOME while the test runner is active.
+  // scripts/test-lock.mjs sets TEST_LOCK_PID for every test process, and it is
+  // inherited by in-process callers (runCritical/runDeferred -> ensureCriticalSetup)
+  // and any spawned setup.mjs. Installer unit tests pass an explicit
+  // geminiConfigHome seam, which bypasses this guard.
+  if (!opts.geminiConfigHome && process.env.TEST_LOCK_PID) {
+    return { skipped: true, changed: false };
+  }
+  if (!existsSync(geminiConfigHome)) {
+    return { skipped: true, changed: false };
+  }
+
+  const hooksPath = resolve(geminiConfigHome, "hooks.json");
+  const hookScriptPath = resolve(
+    opts.hookScriptPath || join(PROJECT_ROOT, "hooks", TRIFLUX_HOOK_BASENAME),
+  );
+  const nodeBin = opts.nodeBin || process.execPath;
+  const desired = buildDesiredGroup({ nodeBin, hookScriptPath });
+
+  const original = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : "";
+  const hooksJson = normalizeHooksJson(original);
+  // Upsert only our named group; every other user-authored group is preserved.
+  hooksJson[HOOK_GROUP_NAME] = desired;
+  const next = formatHooksJson(hooksJson);
+
+  const changed = original !== next;
+  if (changed) {
+    mkdirSync(dirname(hooksPath), { recursive: true });
+    if (original) {
+      const backupPath = `${hooksPath}.bak-tfx-agy-hooks-${opts.backupTimestamp || timestamp()}`;
+      if (!existsSync(backupPath)) {
+        writeFileSync(backupPath, original, "utf8");
+      }
+    }
+    atomicWriteFile(hooksPath, next);
+  }
+
+  return { skipped: false, changed, hooksPath };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = ensureAgyHooks();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/packages/triflux/scripts/ensure-codex-hooks.mjs
+++ b/packages/triflux/scripts/ensure-codex-hooks.mjs
@@ -196,6 +196,14 @@ function timestamp() {
 
 export function ensureCodexHooks(opts = {}) {
   const codexHome = opts.codexHome || join(homedir(), ".codex");
+  // Never install into the real user HOME while the test runner is active.
+  // scripts/test-lock.mjs sets TEST_LOCK_PID for every test process, inherited by
+  // in-process callers (runCritical/runDeferred -> ensureCriticalSetup) and any
+  // spawned setup.mjs. Installer unit tests pass an explicit codexHome seam, which
+  // bypasses this guard.
+  if (!opts.codexHome && process.env.TEST_LOCK_PID) {
+    return { skipped: true, changedHooks: false, changedConfig: false };
+  }
   if (!existsSync(codexHome)) {
     return { skipped: true, changedHooks: false, changedConfig: false };
   }

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -26,6 +26,7 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "./claudemd-sync.mjs";
+import { ensureAgyHooks } from "./ensure-agy-hooks.mjs";
 import { ensureCodexHooks } from "./ensure-codex-hooks.mjs";
 import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
@@ -1377,6 +1378,9 @@ function ensureCriticalSetup() {
   try {
     ensureCodexHooks();
   } catch {}
+  try {
+    ensureAgyHooks();
+  } catch {}
 }
 
 export {
@@ -1387,6 +1391,7 @@ export {
   cleanupStaleSkills,
   DEPRECATED_SKILLS,
   detectDevMode,
+  ensureAgyHooks,
   ensureCodexHooks,
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
@@ -2164,6 +2169,20 @@ export async function runDeferred(stdinData) {
   } catch (error) {
     io.log(
       `  \x1b[33m⚠\x1b[0m Codex hooks 등록 실패: ${error.message || error}`,
+    );
+  }
+
+  try {
+    const agyHooksResult = ensureAgyHooks();
+    if (!agyHooksResult?.skipped && agyHooksResult?.changed) {
+      io.log(
+        "  \x1b[32m✓\x1b[0m Antigravity hooks: registered session sync hook",
+      );
+      synced++;
+    }
+  } catch (error) {
+    io.log(
+      `  \x1b[33m⚠\x1b[0m Antigravity hooks 등록 실패: ${error.message || error}`,
     );
   }
 

--- a/scripts/ensure-agy-hooks.mjs
+++ b/scripts/ensure-agy-hooks.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = dirname(__dirname);
+const TRIFLUX_HOOK_BASENAME = "agy-session-hook.mjs";
+// Named hook group key in agy's hooks.json. agy maps top-level names to event
+// configs, unlike Codex which nests everything under a single `hooks` object.
+const HOOK_GROUP_NAME = "triflux-session";
+
+function atomicWriteFile(path, content) {
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, path);
+}
+
+function quoteCommandPath(value) {
+  return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function buildCommand(nodeBin, hookScriptPath) {
+  // No mode argument: the agy hook derives register vs heartbeat from the
+  // payload's invocationNum (first invocation registers, later ones heartbeat).
+  // Format mirrors codex-session-hook's proven hook command (bare node bin +
+  // quoted script path). agy's hook executor is the same jetski family; quoting
+  // the node bin too is unverified against agy's exec model, so we keep the
+  // known-working shape rather than risk breaking hook execution. Install paths
+  // are controlled (node bin + npm package dir), so the residual $()-in-path
+  // expansion risk is not a realistic threat.
+  return `${nodeBin} ${quoteCommandPath(hookScriptPath)}`;
+}
+
+function normalizeHooksJson(raw) {
+  try {
+    const parsed = raw.trim() ? JSON.parse(raw) : {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed;
+  } catch {
+    // Unreadable hooks.json: start from an empty map rather than clobbering with
+    // a parse error. A backup of the original is taken before any write.
+    return {};
+  }
+}
+
+// agy fires a single PreInvocation handler before every model call. One entry
+// covers both register and heartbeat because the hook self-selects on
+// invocationNum. (agy has no SessionStart / UserPromptSubmit split like Codex.)
+function buildDesiredGroup({ nodeBin, hookScriptPath }) {
+  return {
+    PreInvocation: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildCommand(nodeBin, hookScriptPath),
+            timeout: 15,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function formatHooksJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function timestamp() {
+  return new Date()
+    .toISOString()
+    .replace(/[-:.TZ]/g, "")
+    .slice(0, 14);
+}
+
+export function ensureAgyHooks(opts = {}) {
+  // agy's customization directory. Skip cleanly when the user has no agy
+  // install (no ~/.gemini/config), mirroring ensureCodexHooks' ~/.codex gate.
+  const geminiConfigHome =
+    opts.geminiConfigHome || join(homedir(), ".gemini", "config");
+  // Never install into the real user HOME while the test runner is active.
+  // scripts/test-lock.mjs sets TEST_LOCK_PID for every test process, and it is
+  // inherited by in-process callers (runCritical/runDeferred -> ensureCriticalSetup)
+  // and any spawned setup.mjs. Installer unit tests pass an explicit
+  // geminiConfigHome seam, which bypasses this guard.
+  if (!opts.geminiConfigHome && process.env.TEST_LOCK_PID) {
+    return { skipped: true, changed: false };
+  }
+  if (!existsSync(geminiConfigHome)) {
+    return { skipped: true, changed: false };
+  }
+
+  const hooksPath = resolve(geminiConfigHome, "hooks.json");
+  const hookScriptPath = resolve(
+    opts.hookScriptPath || join(PROJECT_ROOT, "hooks", TRIFLUX_HOOK_BASENAME),
+  );
+  const nodeBin = opts.nodeBin || process.execPath;
+  const desired = buildDesiredGroup({ nodeBin, hookScriptPath });
+
+  const original = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : "";
+  const hooksJson = normalizeHooksJson(original);
+  // Upsert only our named group; every other user-authored group is preserved.
+  hooksJson[HOOK_GROUP_NAME] = desired;
+  const next = formatHooksJson(hooksJson);
+
+  const changed = original !== next;
+  if (changed) {
+    mkdirSync(dirname(hooksPath), { recursive: true });
+    if (original) {
+      const backupPath = `${hooksPath}.bak-tfx-agy-hooks-${opts.backupTimestamp || timestamp()}`;
+      if (!existsSync(backupPath)) {
+        writeFileSync(backupPath, original, "utf8");
+      }
+    }
+    atomicWriteFile(hooksPath, next);
+  }
+
+  return { skipped: false, changed, hooksPath };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = ensureAgyHooks();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/scripts/ensure-codex-hooks.mjs
+++ b/scripts/ensure-codex-hooks.mjs
@@ -196,6 +196,14 @@ function timestamp() {
 
 export function ensureCodexHooks(opts = {}) {
   const codexHome = opts.codexHome || join(homedir(), ".codex");
+  // Never install into the real user HOME while the test runner is active.
+  // scripts/test-lock.mjs sets TEST_LOCK_PID for every test process, inherited by
+  // in-process callers (runCritical/runDeferred -> ensureCriticalSetup) and any
+  // spawned setup.mjs. Installer unit tests pass an explicit codexHome seam, which
+  // bypasses this guard.
+  if (!opts.codexHome && process.env.TEST_LOCK_PID) {
+    return { skipped: true, changedHooks: false, changedConfig: false };
+  }
   if (!existsSync(codexHome)) {
     return { skipped: true, changedHooks: false, changedConfig: false };
   }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -26,6 +26,7 @@ import {
   ensureTfxSection,
   getLatestRoutingTable,
 } from "./claudemd-sync.mjs";
+import { ensureAgyHooks } from "./ensure-agy-hooks.mjs";
 import { ensureCodexHooks } from "./ensure-codex-hooks.mjs";
 import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
@@ -1377,6 +1378,9 @@ function ensureCriticalSetup() {
   try {
     ensureCodexHooks();
   } catch {}
+  try {
+    ensureAgyHooks();
+  } catch {}
 }
 
 export {
@@ -1387,6 +1391,7 @@ export {
   cleanupStaleSkills,
   DEPRECATED_SKILLS,
   detectDevMode,
+  ensureAgyHooks,
   ensureCodexHooks,
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
@@ -2164,6 +2169,20 @@ export async function runDeferred(stdinData) {
   } catch (error) {
     io.log(
       `  \x1b[33m⚠\x1b[0m Codex hooks 등록 실패: ${error.message || error}`,
+    );
+  }
+
+  try {
+    const agyHooksResult = ensureAgyHooks();
+    if (!agyHooksResult?.skipped && agyHooksResult?.changed) {
+      io.log(
+        "  \x1b[32m✓\x1b[0m Antigravity hooks: registered session sync hook",
+      );
+      synced++;
+    }
+  } catch (error) {
+    io.log(
+      `  \x1b[33m⚠\x1b[0m Antigravity hooks 등록 실패: ${error.message || error}`,
     );
   }
 

--- a/tests/unit/agy-session-hook.test.mjs
+++ b/tests/unit/agy-session-hook.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  normalizeMode,
+  runAgySessionHook,
+  toSessionPayload,
+} from "../../hooks/agy-session-hook.mjs";
+
+function agyPayload(overrides = {}) {
+  return JSON.stringify({
+    conversationId: "ec33ebf9-0cba-4100-8142-c61503f6c587",
+    workspacePaths: ["/work/triflux"],
+    transcriptPath: "/work/triflux/.gemini/antigravity/transcript.jsonl",
+    artifactDirectoryPath: "/work/triflux/.gemini/antigravity/artifacts",
+    invocationNum: 1,
+    ...overrides,
+  });
+}
+
+// What the adapter forwards to the session seams: the Codex-shaped payload.
+function sessionPayload(overrides = {}) {
+  return toSessionPayload(JSON.parse(agyPayload(overrides)));
+}
+
+describe("agy-session-hook adapter", () => {
+  it("toSessionPayload maps conversationId -> session_id and workspacePaths[0] -> cwd", () => {
+    const out = JSON.parse(
+      toSessionPayload({
+        conversationId: "conv-1",
+        workspacePaths: ["/a", "/b"],
+      }),
+    );
+    assert.deepEqual(out, { session_id: "conv-1", cwd: "/a" });
+  });
+
+  it("toSessionPayload falls back to process.cwd() when no workspace path is present", () => {
+    const out = JSON.parse(toSessionPayload({ conversationId: "conv-2" }));
+    assert.equal(out.session_id, "conv-2");
+    assert.equal(out.cwd, process.cwd());
+  });
+
+  it("normalizeMode gates on invocationNum: first call registers, later calls heartbeat", () => {
+    assert.equal(normalizeMode("", { invocationNum: 1 }), "register");
+    assert.equal(normalizeMode("", { invocationNum: 3 }), "heartbeat");
+    // explicit argv mode always wins
+    assert.equal(normalizeMode("heartbeat", { invocationNum: 1 }), "heartbeat");
+    assert.equal(normalizeMode("register", { invocationNum: 9 }), "register");
+    // unknown invocation index defaults to register (idempotent + ensures hub)
+    assert.equal(normalizeMode("", {}), "register");
+  });
+
+  it("register mode ensures the hub, registers the mapped payload, drains, returns {}", async () => {
+    const calls = [];
+    const result = await runAgySessionHook(agyPayload({ invocationNum: 1 }), {
+      writeStdout: false,
+      hubEnsureRun: async (stdinData) => calls.push(["ensure", stdinData]),
+      registerInteractiveSession: (stdinData) =>
+        calls.push(["register", stdinData]),
+      heartbeatInteractiveSession: () => calls.push(["heartbeat"]),
+      drainPendingSynapse: async (timeoutMs) =>
+        calls.push(["drain", timeoutMs]),
+    });
+
+    assert.equal(result, "{}\n");
+    assert.deepEqual(calls, [
+      ["ensure", sessionPayload({ invocationNum: 1 })],
+      ["register", sessionPayload({ invocationNum: 1 })],
+      ["drain", 1000],
+    ]);
+  });
+
+  it("heartbeat mode heartbeats the mapped payload and drains without hub ensure", async () => {
+    const calls = [];
+    const result = await runAgySessionHook(agyPayload({ invocationNum: 4 }), {
+      writeStdout: false,
+      hubEnsureRun: async () => calls.push(["ensure"]),
+      registerInteractiveSession: () => calls.push(["register"]),
+      heartbeatInteractiveSession: (stdinData) =>
+        calls.push(["heartbeat", stdinData]),
+      drainPendingSynapse: async (timeoutMs) =>
+        calls.push(["drain", timeoutMs]),
+    });
+
+    assert.equal(result, "{}\n");
+    assert.deepEqual(calls, [
+      ["heartbeat", sessionPayload({ invocationNum: 4 })],
+      ["drain", 500],
+    ]);
+  });
+
+  it("explicit argv register mode overrides a later invocationNum", async () => {
+    const calls = [];
+    await runAgySessionHook(agyPayload({ invocationNum: 7 }), {
+      argvMode: "register",
+      writeStdout: false,
+      hubEnsureRun: async () => calls.push("ensure"),
+      registerInteractiveSession: () => calls.push("register"),
+      drainPendingSynapse: async () => calls.push("drain"),
+    });
+    assert.deepEqual(calls, ["ensure", "register", "drain"]);
+  });
+
+  it("stays a silent no-op when conversationId is missing", async () => {
+    const calls = [];
+    const result = await runAgySessionHook(
+      JSON.stringify({ workspacePaths: ["/work"] }),
+      {
+        writeStdout: false,
+        hubEnsureRun: async () => calls.push("ensure"),
+        registerInteractiveSession: () => calls.push("register"),
+        heartbeatInteractiveSession: () => calls.push("heartbeat"),
+        drainPendingSynapse: async () => calls.push("drain"),
+      },
+    );
+    assert.equal(result, "{}\n");
+    assert.deepEqual(calls, []);
+  });
+
+  it("absorbs parse failures and seam errors while still returning {}", async () => {
+    const calls = [];
+    const result = await runAgySessionHook("{not-json", {
+      argvMode: "register",
+      writeStdout: false,
+      hubEnsureRun: async () => {
+        calls.push("ensure");
+        throw new Error("hub failed");
+      },
+      registerInteractiveSession: () => {
+        calls.push("register");
+        throw new Error("register failed");
+      },
+      drainPendingSynapse: async () => {
+        calls.push("drain");
+        throw new Error("drain failed");
+      },
+    });
+
+    assert.equal(result, "{}\n");
+    assert.deepEqual(calls, []);
+  });
+});

--- a/tests/unit/ensure-agy-hooks.test.mjs
+++ b/tests/unit/ensure-agy-hooks.test.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { ensureAgyHooks } from "../../scripts/ensure-agy-hooks.mjs";
+
+const tmpRoots = [];
+
+function makeGeminiConfigHome() {
+  const root = mkdtempSync(join(tmpdir(), "tfx-agy-hooks-test-"));
+  const configHome = join(root, ".gemini", "config");
+  mkdirSync(configHome, { recursive: true });
+  tmpRoots.push(root);
+  return configHome;
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("ensureAgyHooks", () => {
+  it("skips cleanly when the gemini config home is absent", () => {
+    const geminiConfigHome = join(
+      mkdtempSync(join(tmpdir(), "tfx-agy-hooks-missing-")),
+      ".gemini",
+      "config",
+    );
+    const result = ensureAgyHooks({ geminiConfigHome });
+
+    assert.equal(result.skipped, true);
+    assert.equal(result.changed, false);
+    assert.equal(existsSync(geminiConfigHome), false);
+  });
+
+  it("writes a PreInvocation group, preserves other groups, backs up, and is idempotent", () => {
+    const geminiConfigHome = makeGeminiConfigHome();
+    const hooksPath = join(geminiConfigHome, "hooks.json");
+    // Pre-existing user hook group that must survive the upsert.
+    writeFileSync(
+      hooksPath,
+      JSON.stringify(
+        {
+          "my-linter": {
+            PostToolUse: [
+              {
+                matcher: "run_command",
+                hooks: [{ type: "command", command: "./lint.sh", timeout: 10 }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+
+    const opts = {
+      geminiConfigHome,
+      hookScriptPath: "/repo/hooks/agy-session-hook.mjs",
+      nodeBin: "/opt/node",
+      backupTimestamp: "20260608T010203",
+    };
+    const first = ensureAgyHooks(opts);
+    const afterFirst = readFileSync(hooksPath, "utf8");
+    const second = ensureAgyHooks(opts);
+
+    assert.equal(first.skipped, false);
+    assert.equal(first.changed, true);
+    assert.equal(second.changed, false);
+    assert.equal(readFileSync(hooksPath, "utf8"), afterFirst);
+    assert.equal(
+      existsSync(`${hooksPath}.bak-tfx-agy-hooks-20260608T010203`),
+      true,
+    );
+
+    const parsed = JSON.parse(afterFirst);
+    // user group preserved
+    assert.equal(
+      parsed["my-linter"].PostToolUse[0].hooks[0].command,
+      "./lint.sh",
+    );
+    // triflux group present with the expected single PreInvocation command
+    assert.deepEqual(parsed["triflux-session"], {
+      PreInvocation: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: '/opt/node "/repo/hooks/agy-session-hook.mjs"',
+              timeout: 15,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("creates hooks.json from scratch when none exists (no backup written)", () => {
+    const geminiConfigHome = makeGeminiConfigHome();
+    const hooksPath = join(geminiConfigHome, "hooks.json");
+
+    const result = ensureAgyHooks({
+      geminiConfigHome,
+      hookScriptPath: "/repo/hooks/agy-session-hook.mjs",
+      nodeBin: "/opt/node",
+      backupTimestamp: "20260608T010203",
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(existsSync(hooksPath), true);
+    assert.equal(
+      existsSync(`${hooksPath}.bak-tfx-agy-hooks-20260608T010203`),
+      false,
+    );
+    const parsed = JSON.parse(readFileSync(hooksPath, "utf8"));
+    assert.ok(parsed["triflux-session"].PreInvocation);
+  });
+
+  it("re-seeds the triflux group when a corrupt hooks.json is present", () => {
+    const geminiConfigHome = makeGeminiConfigHome();
+    const hooksPath = join(geminiConfigHome, "hooks.json");
+    writeFileSync(hooksPath, "{ not valid json", "utf8");
+
+    const result = ensureAgyHooks({
+      geminiConfigHome,
+      hookScriptPath: "/repo/hooks/agy-session-hook.mjs",
+      nodeBin: "/opt/node",
+      backupTimestamp: "20260608T010203",
+    });
+
+    assert.equal(result.changed, true);
+    // corrupt original is backed up before overwrite
+    assert.equal(
+      existsSync(`${hooksPath}.bak-tfx-agy-hooks-20260608T010203`),
+      true,
+    );
+    const parsed = JSON.parse(readFileSync(hooksPath, "utf8"));
+    assert.ok(parsed["triflux-session"].PreInvocation);
+  });
+
+  it("skips the real-HOME install while the test runner is active (TEST_LOCK_PID)", () => {
+    const prevPid = process.env.TEST_LOCK_PID;
+    process.env.TEST_LOCK_PID = "test-guard";
+    try {
+      // No geminiConfigHome seam -> defaults to the real ~/.gemini/config. The
+      // guard must short-circuit before touching it. (The other tests pass an
+      // explicit seam and still write, proving the seam bypasses this guard.)
+      const result = ensureAgyHooks();
+      assert.equal(result.skipped, true);
+      assert.equal(result.changed, false);
+    } finally {
+      if (prevPid === undefined) delete process.env.TEST_LOCK_PID;
+      else process.env.TEST_LOCK_PID = prevPid;
+    }
+  });
+});

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -307,6 +307,12 @@ describe("setup-sync: user-state file exclusions", () => {
 });
 
 describe("setup-sync: dry-run 실행", () => {
+  // 훅 설치기(ensureCodexHooks/ensureAgyHooks)는 TEST_LOCK_PID 가 설정된 테스트
+  // 실행 중에는 explicit seam 없이 실제 HOME 에 쓰지 않도록 자체 가드되어 있다
+  // (scripts/ensure-*-hooks.mjs 참조). spawn 된 setup.mjs 도 TEST_LOCK_PID 를
+  // 상속하므로 이 dry-run 은 실제 CLI config 를 오염시키지 않는다. setup.mjs 가
+  // 백그라운드 hub 데몬을 띄우기 때문에 HOME 자체를 tmp 로 격리하면 정리 race
+  // (ENOTEMPTY) 가 발생하므로 가드 방식을 쓴다.
   it("setup.mjs를 --help 없이 실행해도 에러 없이 종료된다", () => {
     // setup.mjs는 main()이 process.argv[1] 매칭 시에만 실행되므로
     // 직접 node로 실행하여 exit code 0 확인


### PR DESCRIPTION
## 무엇
agy(Antigravity) **1.0.6**이 PreInvocation 등 이벤트 기반 훅(`~/.gemini/config/hooks.json`)을 얻었다. v10.32.0의 codex-session-hook 패턴을 agy로 미러해서, 인터랙티브 agy 세션이 인터랙티브 Codex 세션처럼 hub에 자동등록 → 멀티세션 CTO collect에 기여하도록 한다.

## 구현 (codex 대비 차이)
- **`hooks/agy-session-hook.mjs`** — 어댑터. agy payload(`conversationId`→`session_id`, `workspacePaths[0]`→`cwd`)를 codex-shape로 변환해 `registerInteractiveSession`/`heartbeatInteractiveSession`(session-start-fast.mjs)에 전달. agy엔 SessionStart/UserPromptSubmit가 없어 **PreInvocation 단일 이벤트**를 쓰고, `invocationNum<=1`→register(+hub-ensure)/그외→heartbeat로 게이트.
- **`scripts/ensure-agy-hooks.mjs`** — `~/.gemini/config/hooks.json`에 `triflux-session` PreInvocation 그룹 idempotent upsert. 다른 사용자 그룹 보존 + 백업 + atomic write. codex 0.137의 `trusted_hash` 게이트는 agy에 없어서 불필요.
- **`scripts/setup.mjs`** — `ensureAgyHooks`를 `ensureCodexHooks` 옆에 배선.
- 미러: hook→`packages/{triflux,core}`, installer→`packages/triflux` (codex와 동일 배치, tests 제외).

## 테스트 hermeticity (Codex 교차리뷰 High 지적 수정)
`ensureAgyHooks`/`ensureCodexHooks`가 **explicit `*Home` seam 없이 실제 HOME에 쓰려는데 `TEST_LOCK_PID`(scripts/test-lock.mjs가 모든 테스트 프로세스에 주입)가 set이면 skip**. 이전엔 in-process 호출(`runCritical`/`runDeferred`→`ensureCriticalSetup`) + spawn된 `setup.mjs`가 `npm test`마다 개발자의 실제 `~/.gemini/config`·`~/.codex`를 worktree 경로로 덮어썼다(실측 확인). codex 설치기도 같은 pre-existing 클래스라 함께 해결. 설치기 유닛테스트는 explicit seam으로 가드 바이패스.

## 검증
- 전체 스위트 **4129 pass / 0 fail / 18 skipped**, `lint:skills` PASS, biome clean.
- 전체 `npm test` 후 실제 `~/.gemini/config`·`~/.codex` md5 **무변경**(가드 작동 객관 확인).
- agy 유닛 13개(어댑터 8 + 설치기 5).

## 검증 경계 (수동)
훅 **실발화**는 PTY 의존이라 headless/CI에서 자가검증 불가(codex 훅 E2E gap과 동일). `--print`는 invocation 완료해도 훅을 스킵함을 실측. capability 존재는 공식문서(antigravity.google/docs/hooks)+바이너리 protobuf 훅으로 확실. **실발화는 실제 interactive `agy` 세션에서 1회 수동 확인 필요.**
