### PR TITLE
fix(codex-hooks): hooks.state canonical table 직렬화 + 멱등 수렴 — duplicate key 재발 차단

### DIFF
--- a/packages/triflux/scripts/__tests__/ensure-codex-hooks.test.mjs
+++ b/packages/triflux/scripts/__tests__/ensure-codex-hooks.test.mjs
@@ -1,0 +1,183 @@
+// ensure-codex-hooks 직렬화/멱등 회귀 테스트 (issue #394 배경)
+//
+// 핵심 계약:
+// 1. 기록은 codex CLI 0.137+ canonical 인 table-header 형식만 사용한다.
+// 2. strip/수렴 판정은 inline dotted-key / table-header 양 형식을 모두 인식한다.
+// 3. 이미 수렴 상태면 config 를 재기록하지 않는다 (SessionStart 마다 호출되므로).
+// 4. 어떤 입력 조합에서도 같은 키가 2회 직렬화되지 않는다 (TOML duplicate key
+//    = codex 전 호출 즉사).
+//
+// 전부 mkdtemp 격리 — 실 ~/.codex 무접촉.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { ensureCodexHooks } from "../ensure-codex-hooks.mjs";
+
+const TEMP_DIRS = [];
+
+function makeCodexHome() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-ensure-codex-hooks-"));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+function countOccurrences(content, needle) {
+  return content.split(needle).length - 1;
+}
+
+function managedKeyCounts(content, hooksPath) {
+  const counts = {};
+  for (const label of ["session_start", "user_prompt_submit"]) {
+    const key = `${hooksPath}:${label}:0:0`;
+    const inline = countOccurrences(content, `"${key}" = {`);
+    const table = countOccurrences(content, `[hooks.state."${key}"]`);
+    counts[label] = { inline, table, total: inline + table };
+  }
+  return counts;
+}
+
+describe("ensureCodexHooks — table-header 직렬화 + 멱등", () => {
+  it("fresh install: table-header 형식으로 각 키 1회 기록", () => {
+    const codexHome = makeCodexHome();
+    const result = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+
+    assert.equal(result.skipped, false);
+    assert.equal(result.changedHooks, true);
+    assert.equal(result.changedConfig, true);
+
+    const config = readFileSync(result.configPath, "utf8");
+    const counts = managedKeyCounts(config, result.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].table, 1, `${label} table 형식 1회`);
+      assert.equal(counts[label].inline, 0, `${label} inline 형식 0회`);
+    }
+  });
+
+  it("멱등: 2회 실행 시 changedConfig=false, 내용 불변", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const before = readFileSync(first.configPath, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, false, "2회차 config 무변경");
+    assert.equal(second.changedHooks, false, "2회차 hooks 무변경");
+    assert.equal(readFileSync(first.configPath, "utf8"), before);
+  });
+
+  it("재발 시나리오: inline+table 이중화 config 를 단일 table 로 dedupe", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+
+    // 과거 설치기(inline)와 codex 재직렬화(table)가 공존하는 오염 상태 재현:
+    // 현재 table 기록 위에, 같은 키/해시의 inline 라인을 [hooks.state] 헤더와
+    // 함께 prepend 한다 — 2026-06-10 실측 config.toml:151-156 구조.
+    const counts0 = managedKeyCounts(config, first.hooksPath);
+    assert.equal(counts0.session_start.table, 1);
+    const tableBlocks = config
+      .split("\n")
+      .filter((l) => l.includes("trusted_hash"));
+    assert.ok(tableBlocks.length >= 2);
+    const hashOf = (label) => {
+      const idx = config.indexOf(
+        `[hooks.state."${first.hooksPath}:${label}:0:0"]`,
+      );
+      const m = config.slice(idx).match(/trusted_hash = "([^"]+)"/);
+      return m[1];
+    };
+    const polluted = [
+      "[hooks.state]",
+      `"${first.hooksPath}:session_start:0:0" = { trusted_hash = "${hashOf("session_start")}" }`,
+      `"${first.hooksPath}:user_prompt_submit:0:0" = { trusted_hash = "${hashOf("user_prompt_submit")}" }`,
+      config,
+    ].join("\n");
+    writeFileSync(first.configPath, polluted, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, true, "오염 감지 시 재기록");
+    const cleaned = readFileSync(first.configPath, "utf8");
+    const counts = managedKeyCounts(cleaned, first.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].total, 1, `${label} 총 1회 (duplicate 해소)`);
+      assert.equal(counts[label].table, 1, `${label} table 형식으로 수렴`);
+    }
+  });
+
+  it("codex 가 table 로만 재직렬화한 config 는 수렴 상태로 보고 무변경", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+
+    // codex 재직렬화 시뮬레이션: 동일 키/해시가 table 형식으로만 존재
+    // (이미 우리 기록이 table 이므로 그대로가 그 상태다). 위에 무관 설정만 추가.
+    writeFileSync(first.configPath, `model = "gpt-5.5"\n\n${config}`, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, false, "수렴 상태 무변경");
+    const after = readFileSync(first.configPath, "utf8");
+    assert.ok(after.startsWith('model = "gpt-5.5"'), "비관리 설정 보존");
+  });
+
+  it("비관리 hooks.state 키(oh-my-codex 등)는 보존", () => {
+    const codexHome = makeCodexHome();
+    const configPath = join(codexHome, "config.toml");
+    const foreign =
+      '[hooks.state."oh-my-codex@local:hooks/hooks.json:stop:0:0"]\ntrusted_hash = "sha256:aaaa"\n';
+    writeFileSync(configPath, foreign, "utf8");
+
+    const result = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(result.configPath, "utf8");
+    assert.ok(
+      config.includes("oh-my-codex@local:hooks/hooks.json:stop:0:0"),
+      "외부 키 보존",
+    );
+    assert.equal(
+      countOccurrences(config, "oh-my-codex@local"),
+      1,
+      "외부 키 중복 없음",
+    );
+    const counts = managedKeyCounts(config, result.hooksPath);
+    assert.equal(counts.session_start.total, 1);
+  });
+
+  it("hash 불일치(stale trust) 시 양 형식 strip 후 table 1회 재기록", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+    // 해시를 임의 값으로 바꿔 stale trust 상태 재현
+    writeFileSync(
+      first.configPath,
+      config.replace(
+        /trusted_hash = "sha256:[0-9a-f]+"/g,
+        'trusted_hash = "sha256:stale"',
+      ),
+      "utf8",
+    );
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, true);
+    const after = readFileSync(first.configPath, "utf8");
+    const counts = managedKeyCounts(after, first.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].total, 1);
+      assert.equal(counts[label].table, 1);
+    }
+    // 관리 키 영역은 stale 해시가 아닌 유효한 sha256 으로 갱신됐다
+    assert.equal(
+      countOccurrences(after, "sha256:stale"),
+      0,
+      "stale 해시 잔존 없음",
+    );
+    const m = after.match(/trusted_hash = "(sha256:[0-9a-f]{64})"/);
+    assert.ok(m, "유효한 sha256 해시로 재기록");
+  });
+});

--- a/packages/triflux/scripts/ensure-codex-hooks.mjs
+++ b/packages/triflux/scripts/ensure-codex-hooks.mjs
@@ -133,16 +133,22 @@ function escapeTomlKey(key) {
   return `"${String(key).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function stateLine(key, hash) {
-  return `${escapeTomlKey(key)} = { trusted_hash = "${hash}" }`;
+// codex CLI 0.137+ 는 hooks.state 를 table-header 형식
+// ([hooks.state."<key>"] + trusted_hash = "...") 으로 직렬화한다. 과거
+// 이 설치기는 inline dotted-key 형식("<key>" = { trusted_hash = ... }) 으로
+// 기록했는데, codex 가 같은 키를 table 형식으로 재기록한 config 에 inline 을
+// 다시 append 하면 TOML duplicate key 가 되어 codex 전 호출이 즉사한다
+// (2026-06-10 실측, issue #394 배경). 기록은 codex canonical 인 table-header
+// 형식만 사용하고, strip 은 양 형식 모두 인식한다.
+function stateBlock(key, hash) {
+  return `[hooks.state.${escapeTomlKey(key)}]\ntrusted_hash = "${hash}"`;
 }
 
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function stripManagedStateLines(content, managedKeys, hooksPath) {
-  if (!content) return "";
+function managedKeyPatterns(managedKeys, hooksPath) {
   const escapedKeys = [...managedKeys].map((key) =>
     escapeRegExp(escapeTomlKey(key)),
   );
@@ -154,37 +160,75 @@ function stripManagedStateLines(content, managedKeys, hooksPath) {
       ),
     );
   }
-  const re = new RegExp(
+  return escapedKeys;
+}
+
+function stripManagedStateLines(content, managedKeys, hooksPath) {
+  if (!content) return "";
+  const escapedKeys = managedKeyPatterns(managedKeys, hooksPath);
+  const inlineRe = new RegExp(
     `^\\s*(?:${escapedKeys.join("|")})\\s*=\\s*\\{\\s*trusted_hash\\s*=.*\\}\\s*$`,
     "gm",
   );
-  return content.replace(re, "").replace(/\n{3,}/g, "\n\n");
+  const tableRe = new RegExp(
+    `^\\[hooks\\.state\\.(?:${escapedKeys.join("|")})\\]\\s*\\n(?:[ \\t]*trusted_hash[^\\n]*\\n?)*`,
+    "gm",
+  );
+  return content
+    .replace(inlineRe, "")
+    .replace(tableRe, "")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+// 관리 키의 현재 상태를 양 형식 모두에서 수집한다. 멱등 판정용:
+// 모든 entry 가 정확히 1회 존재하고 hash 가 일치하면 재기록하지 않는다.
+function collectManagedState(content, managedKeys, hooksPath) {
+  if (!content) return [];
+  const escapedKeys = managedKeyPatterns(managedKeys, hooksPath);
+  const found = [];
+  const inlineRe = new RegExp(
+    `^\\s*(${escapedKeys.join("|")})\\s*=\\s*\\{\\s*trusted_hash\\s*=\\s*"([^"]+)"`,
+    "gm",
+  );
+  const tableRe = new RegExp(
+    `^\\[hooks\\.state\\.(${escapedKeys.join("|")})\\]\\s*\\n[ \\t]*trusted_hash\\s*=\\s*"([^"]+)"`,
+    "gm",
+  );
+  for (const re of [inlineRe, tableRe]) {
+    let m = re.exec(content);
+    while (m) {
+      found.push({ key: m[1].replace(/^"|"$/g, ""), hash: m[2] });
+      m = re.exec(content);
+    }
+  }
+  return found;
+}
+
+function hooksStateConverged(content, entries, hooksPath) {
+  const managedKeys = new Set(entries.map((entry) => entry.key));
+  const found = collectManagedState(content, managedKeys, hooksPath);
+  return entries.every((entry) => {
+    const matches = found.filter((f) => f.key === entry.key);
+    return matches.length === 1 && matches[0].hash === entry.hash;
+  });
 }
 
 function mergeHooksState(content, entries, hooksPath) {
   const managedKeys = new Set(entries.map((entry) => entry.key));
-  let updated = stripManagedStateLines(content, managedKeys, hooksPath);
-  const lines = entries.map((entry) => stateLine(entry.key, entry.hash));
-  const sectionRe = /^\[hooks\.state\]\s*$/m;
-  const match = sectionRe.exec(updated);
-
-  if (!match) {
-    if (updated.length > 0 && !updated.endsWith("\n")) updated += "\n";
-    if (updated.length > 0 && !updated.endsWith("\n\n")) updated += "\n";
-    return `${updated}[hooks.state]\n${lines.join("\n")}\n`;
+  // 이미 수렴 상태(각 키 정확히 1회 + hash 일치, 형식 무관)면 무변경.
+  // SessionStart 마다 호출되므로 이 조기 종료가 없으면 config 를 매 세션
+  // 재기록하게 된다.
+  if (hooksStateConverged(content, entries, hooksPath)) {
+    return content;
   }
-
-  const sectionStart = match.index;
-  const afterHeader = match.index + match[0].length;
-  const nextSectionMatch = /^\[[^\]]+\]\s*$/m.exec(updated.slice(afterHeader));
-  const sectionEnd = nextSectionMatch
-    ? afterHeader + nextSectionMatch.index
-    : updated.length;
-  let sectionBody = updated.slice(sectionStart, sectionEnd).trimEnd();
-  sectionBody += `\n${lines.join("\n")}\n`;
-  return (
-    updated.slice(0, sectionStart) + sectionBody + updated.slice(sectionEnd)
-  );
+  let updated = stripManagedStateLines(content, managedKeys, hooksPath);
+  const blocks = entries.map((entry) => stateBlock(entry.key, entry.hash));
+  // table-header 서브테이블은 TOML 상 부모 [hooks.state] 재선언이 아니므로
+  // 파일 끝 append 가 항상 유효하다. 빈 [hooks.state] 헤더가 남아 있어도
+  // (서브테이블 선언과 공존 가능) 무해해서 건드리지 않는다.
+  if (updated.length > 0 && !updated.endsWith("\n")) updated += "\n";
+  if (updated.length > 0 && !updated.endsWith("\n\n")) updated += "\n";
+  return `${updated}${blocks.join("\n\n")}\n`;
 }
 
 function timestamp() {

--- a/scripts/__tests__/ensure-codex-hooks.test.mjs
+++ b/scripts/__tests__/ensure-codex-hooks.test.mjs
@@ -1,0 +1,183 @@
+// ensure-codex-hooks 직렬화/멱등 회귀 테스트 (issue #394 배경)
+//
+// 핵심 계약:
+// 1. 기록은 codex CLI 0.137+ canonical 인 table-header 형식만 사용한다.
+// 2. strip/수렴 판정은 inline dotted-key / table-header 양 형식을 모두 인식한다.
+// 3. 이미 수렴 상태면 config 를 재기록하지 않는다 (SessionStart 마다 호출되므로).
+// 4. 어떤 입력 조합에서도 같은 키가 2회 직렬화되지 않는다 (TOML duplicate key
+//    = codex 전 호출 즉사).
+//
+// 전부 mkdtemp 격리 — 실 ~/.codex 무접촉.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { ensureCodexHooks } from "../ensure-codex-hooks.mjs";
+
+const TEMP_DIRS = [];
+
+function makeCodexHome() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-ensure-codex-hooks-"));
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+function countOccurrences(content, needle) {
+  return content.split(needle).length - 1;
+}
+
+function managedKeyCounts(content, hooksPath) {
+  const counts = {};
+  for (const label of ["session_start", "user_prompt_submit"]) {
+    const key = `${hooksPath}:${label}:0:0`;
+    const inline = countOccurrences(content, `"${key}" = {`);
+    const table = countOccurrences(content, `[hooks.state."${key}"]`);
+    counts[label] = { inline, table, total: inline + table };
+  }
+  return counts;
+}
+
+describe("ensureCodexHooks — table-header 직렬화 + 멱등", () => {
+  it("fresh install: table-header 형식으로 각 키 1회 기록", () => {
+    const codexHome = makeCodexHome();
+    const result = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+
+    assert.equal(result.skipped, false);
+    assert.equal(result.changedHooks, true);
+    assert.equal(result.changedConfig, true);
+
+    const config = readFileSync(result.configPath, "utf8");
+    const counts = managedKeyCounts(config, result.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].table, 1, `${label} table 형식 1회`);
+      assert.equal(counts[label].inline, 0, `${label} inline 형식 0회`);
+    }
+  });
+
+  it("멱등: 2회 실행 시 changedConfig=false, 내용 불변", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const before = readFileSync(first.configPath, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, false, "2회차 config 무변경");
+    assert.equal(second.changedHooks, false, "2회차 hooks 무변경");
+    assert.equal(readFileSync(first.configPath, "utf8"), before);
+  });
+
+  it("재발 시나리오: inline+table 이중화 config 를 단일 table 로 dedupe", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+
+    // 과거 설치기(inline)와 codex 재직렬화(table)가 공존하는 오염 상태 재현:
+    // 현재 table 기록 위에, 같은 키/해시의 inline 라인을 [hooks.state] 헤더와
+    // 함께 prepend 한다 — 2026-06-10 실측 config.toml:151-156 구조.
+    const counts0 = managedKeyCounts(config, first.hooksPath);
+    assert.equal(counts0.session_start.table, 1);
+    const tableBlocks = config
+      .split("\n")
+      .filter((l) => l.includes("trusted_hash"));
+    assert.ok(tableBlocks.length >= 2);
+    const hashOf = (label) => {
+      const idx = config.indexOf(
+        `[hooks.state."${first.hooksPath}:${label}:0:0"]`,
+      );
+      const m = config.slice(idx).match(/trusted_hash = "([^"]+)"/);
+      return m[1];
+    };
+    const polluted = [
+      "[hooks.state]",
+      `"${first.hooksPath}:session_start:0:0" = { trusted_hash = "${hashOf("session_start")}" }`,
+      `"${first.hooksPath}:user_prompt_submit:0:0" = { trusted_hash = "${hashOf("user_prompt_submit")}" }`,
+      config,
+    ].join("\n");
+    writeFileSync(first.configPath, polluted, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, true, "오염 감지 시 재기록");
+    const cleaned = readFileSync(first.configPath, "utf8");
+    const counts = managedKeyCounts(cleaned, first.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].total, 1, `${label} 총 1회 (duplicate 해소)`);
+      assert.equal(counts[label].table, 1, `${label} table 형식으로 수렴`);
+    }
+  });
+
+  it("codex 가 table 로만 재직렬화한 config 는 수렴 상태로 보고 무변경", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+
+    // codex 재직렬화 시뮬레이션: 동일 키/해시가 table 형식으로만 존재
+    // (이미 우리 기록이 table 이므로 그대로가 그 상태다). 위에 무관 설정만 추가.
+    writeFileSync(first.configPath, `model = "gpt-5.5"\n\n${config}`, "utf8");
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, false, "수렴 상태 무변경");
+    const after = readFileSync(first.configPath, "utf8");
+    assert.ok(after.startsWith('model = "gpt-5.5"'), "비관리 설정 보존");
+  });
+
+  it("비관리 hooks.state 키(oh-my-codex 등)는 보존", () => {
+    const codexHome = makeCodexHome();
+    const configPath = join(codexHome, "config.toml");
+    const foreign =
+      '[hooks.state."oh-my-codex@local:hooks/hooks.json:stop:0:0"]\ntrusted_hash = "sha256:aaaa"\n';
+    writeFileSync(configPath, foreign, "utf8");
+
+    const result = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(result.configPath, "utf8");
+    assert.ok(
+      config.includes("oh-my-codex@local:hooks/hooks.json:stop:0:0"),
+      "외부 키 보존",
+    );
+    assert.equal(
+      countOccurrences(config, "oh-my-codex@local"),
+      1,
+      "외부 키 중복 없음",
+    );
+    const counts = managedKeyCounts(config, result.hooksPath);
+    assert.equal(counts.session_start.total, 1);
+  });
+
+  it("hash 불일치(stale trust) 시 양 형식 strip 후 table 1회 재기록", () => {
+    const codexHome = makeCodexHome();
+    const first = ensureCodexHooks({ codexHome, backupTimestamp: "t0" });
+    const config = readFileSync(first.configPath, "utf8");
+    // 해시를 임의 값으로 바꿔 stale trust 상태 재현
+    writeFileSync(
+      first.configPath,
+      config.replace(
+        /trusted_hash = "sha256:[0-9a-f]+"/g,
+        'trusted_hash = "sha256:stale"',
+      ),
+      "utf8",
+    );
+
+    const second = ensureCodexHooks({ codexHome, backupTimestamp: "t1" });
+    assert.equal(second.changedConfig, true);
+    const after = readFileSync(first.configPath, "utf8");
+    const counts = managedKeyCounts(after, first.hooksPath);
+    for (const label of ["session_start", "user_prompt_submit"]) {
+      assert.equal(counts[label].total, 1);
+      assert.equal(counts[label].table, 1);
+    }
+    // 관리 키 영역은 stale 해시가 아닌 유효한 sha256 으로 갱신됐다
+    assert.equal(
+      countOccurrences(after, "sha256:stale"),
+      0,
+      "stale 해시 잔존 없음",
+    );
+    const m = after.match(/trusted_hash = "(sha256:[0-9a-f]{64})"/);
+    assert.ok(m, "유효한 sha256 해시로 재기록");
+  });
+});

--- a/scripts/ensure-codex-hooks.mjs
+++ b/scripts/ensure-codex-hooks.mjs
@@ -133,16 +133,22 @@ function escapeTomlKey(key) {
   return `"${String(key).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
-function stateLine(key, hash) {
-  return `${escapeTomlKey(key)} = { trusted_hash = "${hash}" }`;
+// codex CLI 0.137+ 는 hooks.state 를 table-header 형식
+// ([hooks.state."<key>"] + trusted_hash = "...") 으로 직렬화한다. 과거
+// 이 설치기는 inline dotted-key 형식("<key>" = { trusted_hash = ... }) 으로
+// 기록했는데, codex 가 같은 키를 table 형식으로 재기록한 config 에 inline 을
+// 다시 append 하면 TOML duplicate key 가 되어 codex 전 호출이 즉사한다
+// (2026-06-10 실측, issue #394 배경). 기록은 codex canonical 인 table-header
+// 형식만 사용하고, strip 은 양 형식 모두 인식한다.
+function stateBlock(key, hash) {
+  return `[hooks.state.${escapeTomlKey(key)}]\ntrusted_hash = "${hash}"`;
 }
 
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function stripManagedStateLines(content, managedKeys, hooksPath) {
-  if (!content) return "";
+function managedKeyPatterns(managedKeys, hooksPath) {
   const escapedKeys = [...managedKeys].map((key) =>
     escapeRegExp(escapeTomlKey(key)),
   );
@@ -154,37 +160,75 @@ function stripManagedStateLines(content, managedKeys, hooksPath) {
       ),
     );
   }
-  const re = new RegExp(
+  return escapedKeys;
+}
+
+function stripManagedStateLines(content, managedKeys, hooksPath) {
+  if (!content) return "";
+  const escapedKeys = managedKeyPatterns(managedKeys, hooksPath);
+  const inlineRe = new RegExp(
     `^\\s*(?:${escapedKeys.join("|")})\\s*=\\s*\\{\\s*trusted_hash\\s*=.*\\}\\s*$`,
     "gm",
   );
-  return content.replace(re, "").replace(/\n{3,}/g, "\n\n");
+  const tableRe = new RegExp(
+    `^\\[hooks\\.state\\.(?:${escapedKeys.join("|")})\\]\\s*\\n(?:[ \\t]*trusted_hash[^\\n]*\\n?)*`,
+    "gm",
+  );
+  return content
+    .replace(inlineRe, "")
+    .replace(tableRe, "")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+// 관리 키의 현재 상태를 양 형식 모두에서 수집한다. 멱등 판정용:
+// 모든 entry 가 정확히 1회 존재하고 hash 가 일치하면 재기록하지 않는다.
+function collectManagedState(content, managedKeys, hooksPath) {
+  if (!content) return [];
+  const escapedKeys = managedKeyPatterns(managedKeys, hooksPath);
+  const found = [];
+  const inlineRe = new RegExp(
+    `^\\s*(${escapedKeys.join("|")})\\s*=\\s*\\{\\s*trusted_hash\\s*=\\s*"([^"]+)"`,
+    "gm",
+  );
+  const tableRe = new RegExp(
+    `^\\[hooks\\.state\\.(${escapedKeys.join("|")})\\]\\s*\\n[ \\t]*trusted_hash\\s*=\\s*"([^"]+)"`,
+    "gm",
+  );
+  for (const re of [inlineRe, tableRe]) {
+    let m = re.exec(content);
+    while (m) {
+      found.push({ key: m[1].replace(/^"|"$/g, ""), hash: m[2] });
+      m = re.exec(content);
+    }
+  }
+  return found;
+}
+
+function hooksStateConverged(content, entries, hooksPath) {
+  const managedKeys = new Set(entries.map((entry) => entry.key));
+  const found = collectManagedState(content, managedKeys, hooksPath);
+  return entries.every((entry) => {
+    const matches = found.filter((f) => f.key === entry.key);
+    return matches.length === 1 && matches[0].hash === entry.hash;
+  });
 }
 
 function mergeHooksState(content, entries, hooksPath) {
   const managedKeys = new Set(entries.map((entry) => entry.key));
-  let updated = stripManagedStateLines(content, managedKeys, hooksPath);
-  const lines = entries.map((entry) => stateLine(entry.key, entry.hash));
-  const sectionRe = /^\[hooks\.state\]\s*$/m;
-  const match = sectionRe.exec(updated);
-
-  if (!match) {
-    if (updated.length > 0 && !updated.endsWith("\n")) updated += "\n";
-    if (updated.length > 0 && !updated.endsWith("\n\n")) updated += "\n";
-    return `${updated}[hooks.state]\n${lines.join("\n")}\n`;
+  // 이미 수렴 상태(각 키 정확히 1회 + hash 일치, 형식 무관)면 무변경.
+  // SessionStart 마다 호출되므로 이 조기 종료가 없으면 config 를 매 세션
+  // 재기록하게 된다.
+  if (hooksStateConverged(content, entries, hooksPath)) {
+    return content;
   }
-
-  const sectionStart = match.index;
-  const afterHeader = match.index + match[0].length;
-  const nextSectionMatch = /^\[[^\]]+\]\s*$/m.exec(updated.slice(afterHeader));
-  const sectionEnd = nextSectionMatch
-    ? afterHeader + nextSectionMatch.index
-    : updated.length;
-  let sectionBody = updated.slice(sectionStart, sectionEnd).trimEnd();
-  sectionBody += `\n${lines.join("\n")}\n`;
-  return (
-    updated.slice(0, sectionStart) + sectionBody + updated.slice(sectionEnd)
-  );
+  let updated = stripManagedStateLines(content, managedKeys, hooksPath);
+  const blocks = entries.map((entry) => stateBlock(entry.key, entry.hash));
+  // table-header 서브테이블은 TOML 상 부모 [hooks.state] 재선언이 아니므로
+  // 파일 끝 append 가 항상 유효하다. 빈 [hooks.state] 헤더가 남아 있어도
+  // (서브테이블 선언과 공존 가능) 무해해서 건드리지 않는다.
+  if (updated.length > 0 && !updated.endsWith("\n")) updated += "\n";
+  if (updated.length > 0 && !updated.endsWith("\n\n")) updated += "\n";
+  return `${updated}${blocks.join("\n\n")}\n`;
 }
 
 function timestamp() {

--- a/tests/unit/ensure-codex-hooks.test.mjs
+++ b/tests/unit/ensure-codex-hooks.test.mjs
@@ -164,13 +164,15 @@ describe("ensureCodexHooks", () => {
       /"\/tmp\/elsewhere\/hooks\.json:session_start:0:0" = \{ trusted_hash = "sha256:other" \}/,
     );
     assert.doesNotMatch(configAfterFirst, /sha256:stale/);
+    // 관리 키는 codex CLI 0.137+ canonical 인 table-header 형식으로 기록된다
+    // (inline dotted-key 는 codex 자체 재직렬화와 duplicate key 충돌 — #394).
     assert.match(
       configAfterFirst,
-      /"\S+hooks\.json:session_start:1:0" = \{ trusted_hash = "sha256:[0-9a-f]{64}" \}/,
+      /\[hooks\.state\."\S+hooks\.json:session_start:1:0"\]\ntrusted_hash = "sha256:[0-9a-f]{64}"/,
     );
     assert.match(
       configAfterFirst,
-      /"\S+hooks\.json:user_prompt_submit:1:0" = \{ trusted_hash = "sha256:[0-9a-f]{64}" \}/,
+      /\[hooks\.state\."\S+hooks\.json:user_prompt_submit:1:0"\]\ntrusted_hash = "sha256:[0-9a-f]{64}"/,
     );
   });
 


### PR DESCRIPTION
## P1 핫픽스 (#394 연관)

### 증상
`~/.codex/config.toml` hooks.state 에 같은 키가 inline + table-header 양 형식으로 이중 직렬화 → TOML duplicate key → **codex 전 호출 exit 1**. 수동으로 inline 을 지워도 **다음 Claude 세션 시작에 재발** (2026-06-10 라이브에서 2회 실측 — 두 번째 재발이 swarm v2 run 워커 4기 전멸의 원인).

### Root cause
- 재발 트리거: SessionStart 훅 → `runCritical`(scripts/setup.mjs:1427) → `ensureCriticalSetup`(:1445) → `ensureCodexHooks`(:1378) — **모든 claude 세션 시작마다 실행**.
- `stripManagedStateLines` 가 inline 형식만 인식 → codex CLI 0.137+ 가 trust 를 table-header 로 재직렬화해둔 config 에서 strip 실패 → inline 재append → duplicate.

### Fix
- strip 이 관리 키의 inline/table-header 양 형식을 모두 제거
- **수렴 조기 종료**: 각 관리 키가 정확히 1회 존재하고 hash 일치(형식 무관)면 무기록 — 세션마다 config 재기록하던 동작 자체를 차단
- 기록은 codex canonical 인 table-header 형식, EOF append (서브테이블은 [hooks.state] 재선언 아님)
- 이중화된 기존 config 는 다음 실행에서 자동 dedupe

### Tests (mkdtemp 격리, 실 ~/.codex 무접촉)
fresh install / 멱등 2회 / inline+table dedupe / codex 재직렬화 수렴 / 비관리(oh-my-codex) 키 보존 / stale-hash 재기록 — 신규 6케이스. scripts/__tests__ 전체 238/238 pass. packages/triflux 미러 byte-identical (mirror gate OK).