### PR TITLE
fix(native-bridge): dispatch에 daemon control-key 제시 + 거부 사유 보존

### DIFF
--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -113,6 +113,29 @@ export function sendClaudeControlRequest(
   });
 }
 
+// claude daemon 은 control.sock 의 mutating op(dispatch 등)에 control-key
+// 인증을 강제한다 (미제시 시 EAUTH "didn't present the daemon control key").
+// key 는 <configDir>/daemon/control.key (configDir 스코프별). 파일이 없으면
+// 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
+export async function readDaemonControlKey(
+  configDir = resolveClaudeConfigDir(),
+) {
+  try {
+    const key = await fs.readFile(
+      path.join(configDir, "daemon", "control.key"),
+      "utf8",
+    );
+    return key.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildDaemonControlAuth(configDir) {
+  const auth = await readDaemonControlKey(configDir);
+  return auth ? { auth } : {};
+}
+
 export function buildDaemonAttachRequest({
   short,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
@@ -1146,11 +1169,12 @@ export async function resolveDaemonBridgeSessionId({
   }
 }
 
-export async function killDaemonJob(controlSock, short) {
+export async function killDaemonJob(controlSock, short, { auth } = {}) {
   return await sendClaudeControlRequest(controlSock, {
     proto: 1,
     op: "kill",
     short,
+    ...(auth ? { auth } : {}),
   });
 }
 
@@ -1237,6 +1261,7 @@ export async function dispatchClaudeDaemonJob({
   const writeProjection =
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const readProcStart = _deps.getProcStart || getProcStart;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
 
   const short = payload.short;
   const sessionsDir =
@@ -1246,6 +1271,7 @@ export async function dispatchClaudeDaemonJob({
   // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
   if (accessControlSock) await accessControlSock(resolvedControlSock);
 
+  const controlAuth = await buildAuth(paths?.configDir);
   const dispatch = await sendControl(
     resolvedControlSock,
     {
@@ -1253,11 +1279,17 @@ export async function dispatchClaudeDaemonJob({
       op: "dispatch",
       d: payload,
       timeoutMs: dispatchTimeoutMs,
+      ...controlAuth,
     },
     { timeoutMs: dispatchTimeoutMs },
   );
   if (dispatch?.ok !== true) {
-    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+    // daemon 거부 사유를 보존한다 — generic 메시지만 던지면 EAUTH 같은
+    // 실원인이 묻혀 진단이 어려워진다.
+    const reason = dispatch?.error ? `: ${dispatch.error}` : "";
+    throw new Error(
+      `Claude daemon dispatch failed for ${name || short}${reason}`,
+    );
   }
 
   const pidOpts =

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -113,6 +113,29 @@ export function sendClaudeControlRequest(
   });
 }
 
+// claude daemon 은 control.sock 의 mutating op(dispatch 등)에 control-key
+// 인증을 강제한다 (미제시 시 EAUTH "didn't present the daemon control key").
+// key 는 <configDir>/daemon/control.key (configDir 스코프별). 파일이 없으면
+// 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
+export async function readDaemonControlKey(
+  configDir = resolveClaudeConfigDir(),
+) {
+  try {
+    const key = await fs.readFile(
+      path.join(configDir, "daemon", "control.key"),
+      "utf8",
+    );
+    return key.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildDaemonControlAuth(configDir) {
+  const auth = await readDaemonControlKey(configDir);
+  return auth ? { auth } : {};
+}
+
 export function buildDaemonAttachRequest({
   short,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
@@ -1146,11 +1169,12 @@ export async function resolveDaemonBridgeSessionId({
   }
 }
 
-export async function killDaemonJob(controlSock, short) {
+export async function killDaemonJob(controlSock, short, { auth } = {}) {
   return await sendClaudeControlRequest(controlSock, {
     proto: 1,
     op: "kill",
     short,
+    ...(auth ? { auth } : {}),
   });
 }
 
@@ -1237,6 +1261,7 @@ export async function dispatchClaudeDaemonJob({
   const writeProjection =
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const readProcStart = _deps.getProcStart || getProcStart;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
 
   const short = payload.short;
   const sessionsDir =
@@ -1246,6 +1271,7 @@ export async function dispatchClaudeDaemonJob({
   // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
   if (accessControlSock) await accessControlSock(resolvedControlSock);
 
+  const controlAuth = await buildAuth(paths?.configDir);
   const dispatch = await sendControl(
     resolvedControlSock,
     {
@@ -1253,11 +1279,17 @@ export async function dispatchClaudeDaemonJob({
       op: "dispatch",
       d: payload,
       timeoutMs: dispatchTimeoutMs,
+      ...controlAuth,
     },
     { timeoutMs: dispatchTimeoutMs },
   );
   if (dispatch?.ok !== true) {
-    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+    // daemon 거부 사유를 보존한다 — generic 메시지만 던지면 EAUTH 같은
+    // 실원인이 묻혀 진단이 어려워진다.
+    const reason = dispatch?.error ? `: ${dispatch.error}` : "";
+    throw new Error(
+      `Claude daemon dispatch failed for ${name || short}${reason}`,
+    );
   }
 
   const pidOpts =

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -113,6 +113,29 @@ export function sendClaudeControlRequest(
   });
 }
 
+// claude daemon 은 control.sock 의 mutating op(dispatch 등)에 control-key
+// 인증을 강제한다 (미제시 시 EAUTH "didn't present the daemon control key").
+// key 는 <configDir>/daemon/control.key (configDir 스코프별). 파일이 없으면
+// 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
+export async function readDaemonControlKey(
+  configDir = resolveClaudeConfigDir(),
+) {
+  try {
+    const key = await fs.readFile(
+      path.join(configDir, "daemon", "control.key"),
+      "utf8",
+    );
+    return key.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildDaemonControlAuth(configDir) {
+  const auth = await readDaemonControlKey(configDir);
+  return auth ? { auth } : {};
+}
+
 export function buildDaemonAttachRequest({
   short,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
@@ -1146,11 +1169,12 @@ export async function resolveDaemonBridgeSessionId({
   }
 }
 
-export async function killDaemonJob(controlSock, short) {
+export async function killDaemonJob(controlSock, short, { auth } = {}) {
   return await sendClaudeControlRequest(controlSock, {
     proto: 1,
     op: "kill",
     short,
+    ...(auth ? { auth } : {}),
   });
 }
 
@@ -1237,6 +1261,7 @@ export async function dispatchClaudeDaemonJob({
   const writeProjection =
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const readProcStart = _deps.getProcStart || getProcStart;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
 
   const short = payload.short;
   const sessionsDir =
@@ -1246,6 +1271,7 @@ export async function dispatchClaudeDaemonJob({
   // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
   if (accessControlSock) await accessControlSock(resolvedControlSock);
 
+  const controlAuth = await buildAuth(paths?.configDir);
   const dispatch = await sendControl(
     resolvedControlSock,
     {
@@ -1253,11 +1279,17 @@ export async function dispatchClaudeDaemonJob({
       op: "dispatch",
       d: payload,
       timeoutMs: dispatchTimeoutMs,
+      ...controlAuth,
     },
     { timeoutMs: dispatchTimeoutMs },
   );
   if (dispatch?.ok !== true) {
-    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+    // daemon 거부 사유를 보존한다 — generic 메시지만 던지면 EAUTH 같은
+    // 실원인이 묻혀 진단이 어려워진다.
+    const reason = dispatch?.error ? `: ${dispatch.error}` : "";
+    throw new Error(
+      `Claude daemon dispatch failed for ${name || short}${reason}`,
+    );
   }
 
   const pidOpts =

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -113,6 +113,29 @@ export function sendClaudeControlRequest(
   });
 }
 
+// claude daemon 은 control.sock 의 mutating op(dispatch 등)에 control-key
+// 인증을 강제한다 (미제시 시 EAUTH "didn't present the daemon control key").
+// key 는 <configDir>/daemon/control.key (configDir 스코프별). 파일이 없으면
+// 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
+export async function readDaemonControlKey(
+  configDir = resolveClaudeConfigDir(),
+) {
+  try {
+    const key = await fs.readFile(
+      path.join(configDir, "daemon", "control.key"),
+      "utf8",
+    );
+    return key.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildDaemonControlAuth(configDir) {
+  const auth = await readDaemonControlKey(configDir);
+  return auth ? { auth } : {};
+}
+
 export function buildDaemonAttachRequest({
   short,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
@@ -1146,11 +1169,12 @@ export async function resolveDaemonBridgeSessionId({
   }
 }
 
-export async function killDaemonJob(controlSock, short) {
+export async function killDaemonJob(controlSock, short, { auth } = {}) {
   return await sendClaudeControlRequest(controlSock, {
     proto: 1,
     op: "kill",
     short,
+    ...(auth ? { auth } : {}),
   });
 }
 
@@ -1237,6 +1261,7 @@ export async function dispatchClaudeDaemonJob({
   const writeProjection =
     _deps.writeClaudeSessionProjection || writeClaudeSessionProjection;
   const readProcStart = _deps.getProcStart || getProcStart;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
 
   const short = payload.short;
   const sessionsDir =
@@ -1246,6 +1271,7 @@ export async function dispatchClaudeDaemonJob({
   // native-bridge 는 control.sock 존재를 미리 점검한다 (없으면 fast-fail).
   if (accessControlSock) await accessControlSock(resolvedControlSock);
 
+  const controlAuth = await buildAuth(paths?.configDir);
   const dispatch = await sendControl(
     resolvedControlSock,
     {
@@ -1253,11 +1279,17 @@ export async function dispatchClaudeDaemonJob({
       op: "dispatch",
       d: payload,
       timeoutMs: dispatchTimeoutMs,
+      ...controlAuth,
     },
     { timeoutMs: dispatchTimeoutMs },
   );
   if (dispatch?.ok !== true) {
-    throw new Error(`Claude daemon dispatch failed for ${name || short}`);
+    // daemon 거부 사유를 보존한다 — generic 메시지만 던지면 EAUTH 같은
+    // 실원인이 묻혀 진단이 어려워진다.
+    const reason = dispatch?.error ? `: ${dispatch.error}` : "";
+    throw new Error(
+      `Claude daemon dispatch failed for ${name || short}${reason}`,
+    );
   }
 
   const pidOpts =

--- a/tests/unit/claude-daemon-dispatch-job.test.mjs
+++ b/tests/unit/claude-daemon-dispatch-job.test.mjs
@@ -208,3 +208,119 @@ test("teardownClaudeDaemonJob attempts every step even when killDaemonJob throws
     "removeProjection",
   ]);
 });
+
+test("dispatchClaudeDaemonJob presents daemon control.key as auth when present", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-auth-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  await fs.mkdir(path.join(configDir, "daemon"), { recursive: true });
+  await fs.writeFile(
+    path.join(configDir, "daemon", "control.key"),
+    "feedface00112233\n",
+    "utf8",
+  );
+  const short = "auth1234";
+  const { server, requests } = await listenDaemon(paths.controlSock, {
+    short,
+    pid: process.pid,
+  });
+
+  try {
+    await dispatchClaudeDaemonJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload: { proto: 1, short, sessionId: "auth1234-sess", cwd: "/tmp/p" },
+      agent: "codex",
+      name: "auth worker",
+      cwd: "/tmp/p",
+      _deps: {
+        getProcStart: () => "Mon Jan 1 00:00:00 2026",
+        resolveDaemonBridgeSessionId: async () => "cse_01Auth",
+      },
+    });
+    const dispatch = requests.find((r) => r.op === "dispatch");
+    assert.equal(
+      dispatch.auth,
+      "feedface00112233",
+      "control.key must be presented as auth (daemon enforces EAUTH otherwise)",
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dispatchClaudeDaemonJob omits auth when control.key is absent (legacy daemon)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-noauth-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const short = "noau5678";
+  const { server, requests } = await listenDaemon(paths.controlSock, {
+    short,
+    pid: process.pid,
+  });
+
+  try {
+    await dispatchClaudeDaemonJob({
+      paths,
+      controlSock: paths.controlSock,
+      payload: { proto: 1, short, sessionId: "noau5678-sess", cwd: "/tmp/p" },
+      agent: "codex",
+      name: "noauth worker",
+      cwd: "/tmp/p",
+      _deps: {
+        getProcStart: () => "Mon Jan 1 00:00:00 2026",
+        resolveDaemonBridgeSessionId: async () => "cse_01NoAuth",
+      },
+    });
+    const dispatch = requests.find((r) => r.op === "dispatch");
+    assert.equal(dispatch.auth, undefined, "no key file → no auth field");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dispatchClaudeDaemonJob preserves daemon rejection reason in error message", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-reject-"));
+  const configDir = path.join(tmp, "claude");
+  const paths = deriveClaudeDaemonPaths({ configDir });
+  await fs.mkdir(paths.daemonDir, { recursive: true });
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.on("data", () => {
+      socket.end(
+        `${JSON.stringify({
+          ok: false,
+          error:
+            "dispatch rejected: this client didn't present the daemon control key",
+          code: "EAUTH",
+        })}\n`,
+      );
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(paths.controlSock, resolve);
+  });
+
+  try {
+    await assert.rejects(
+      dispatchClaudeDaemonJob({
+        paths,
+        controlSock: paths.controlSock,
+        payload: { proto: 1, short: "rej90abc", sessionId: "rej-sess" },
+        agent: "codex",
+        name: "reject worker",
+        cwd: "/tmp/p",
+      }),
+      /didn't present the daemon control key/,
+      "daemon error reason must surface in the thrown message",
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 배경 (2026-06-10 진단)

오늘 swarm run 3회 전부에서 native-bridge 등록(`claude agents` 패널 row)이 `native_bridge_registration_failed`로 실패. 라이브 daemon probe로 원인 확정:

- claude daemon이 control.sock의 dispatch에 **control-key 인증을 강제** — 미제시 시 `EAUTH: "this client didn't present the daemon control key"`
- `684f59d3`는 key 제시(`buildDaemonControlAuth`)를 **experiments attach 하니스에만** 적용 — production 경로(`registerSwarmShard` → `dispatchClaudeDaemonJob`)는 미적용
- swarm-logs 전수 조사: 5월 run들엔 native-bridge 이벤트 자체가 없음(기능 머지 전) → 전형적 회귀가 아니라 **production 경로에서 한 번도 실효된 적 없던 인증 갭**

## Fix

- `readDaemonControlKey`/`buildDaemonControlAuth`: `<configDir>/daemon/control.key` 읽어 `auth` 필드로 제시. 키 파일 없으면 생략(구버전 daemon fail-open)
- `dispatchClaudeDaemonJob` dispatch 요청에 auth 포함 — **라이브 daemon 실증: ok:true + pid 회수 + kill 정리까지 전 경로 통과**
- `killDaemonJob`에 optional auth
- dispatch 거부 시 daemon error 사유를 예외 메시지에 보존 (generic 메시지가 오늘 진단을 지연시킨 관측성 결함)

## Tests

- 신규 3케이스: key 존재 시 auth 제시 / 부재 시 생략 / 거부 사유 surface — fake daemon 서버 기반, mkdtemp 격리
- dispatch-job 7/7, 인접 daemon-control/native-bridge 스위트 39/39, mirror gate OK (core/remote/triflux 3-layer 동기)