### PR TITLE
fix(mcp): drop serena from CORE_SERVERS forced-enable set

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,3 +41,29 @@ triflux 워크스페이스에서 Antigravity CLI의 역할과 운영 규칙. 1M 
 ## 검증
 - 변경 후 lint/typecheck/test 실행
 - 새 차단 규칙은 항상 대안 API와 함께 추가 (차단만 추가하면 데드락)
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /gstack:office-hours
+- Strategy/scope → invoke /gstack:plan-ceo-review
+- Architecture → invoke /gstack:plan-eng-review
+- Design system/plan review → invoke /gstack:design-consultation or /gstack:plan-design-review
+- Full review pipeline → invoke /gstack:autoplan
+- Bugs/errors → invoke /gstack:investigate
+- QA/testing site behavior → invoke /gstack:qa or /gstack:qa-only
+- Code review/diff check → invoke /gstack:review
+- Visual polish → invoke /gstack:design-review
+- Ship/deploy/PR → invoke /gstack:ship or /gstack:land-and-deploy
+- Save progress → invoke /gstack:context-save
+- Resume context → invoke /gstack:context-restore
+- Author a backlog-ready spec/issue → invoke /gstack:spec
+
+## Health Stack
+
+- lint: biome check .
+- test: node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 "tests/**/*.test.mjs" "scripts/__tests__/**/*.test.mjs" && npm run lint:skills
+- deadcode: npx knip
+- gbrain: gbrain doctor --json

--- a/packages/core/scripts/lib/mcp-manifest.mjs
+++ b/packages/core/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/remote/scripts/lib/mcp-manifest.mjs
+++ b/packages/remote/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/triflux/scripts/lib/mcp-manifest.mjs
+++ b/packages/triflux/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/triflux/scripts/mcp-gateway-start.ps1
+++ b/packages/triflux/scripts/mcp-gateway-start.ps1
@@ -15,7 +15,6 @@ $Servers = @(
   @{ Name = 'exa';          Port = 8102; Cmd = 'npx -y exa-mcp-server';                        EnvVars = @('EXA_API_KEY') }
   @{ Name = 'tavily';       Port = 8103; Cmd = 'npx -y tavily-mcp@latest';                     EnvVars = @('TAVILY_API_KEY') }
   @{ Name = 'jira';         Port = 8104; Cmd = 'npx -y mcp-jira-cloud@latest';                 EnvVars = @('JIRA_API_TOKEN', 'JIRA_EMAIL', 'JIRA_INSTANCE_URL') }
-  @{ Name = 'serena';       Port = 8105; Cmd = 'uvx --from git+https://github.com/oraios/serena serena start-mcp-server'; EnvVars = @() }
   @{ Name = 'notion';       Port = 8106; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
   @{ Name = 'notion-guest'; Port = 8107; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
 )

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -339,11 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7, serena)는 API 키 불필요, 자동 활성화됨을 표시:
+Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
 ```
 ✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
-✅ serena   — 시맨틱 코드 분석 (API 키 불필요)
 ```
+
+> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -407,7 +408,7 @@ node -e "
 {
   "version": 1,
   "updatedAt": "2026-03-31T...",
-  "enabled": ["context7", "serena", "brave-search", "exa"]
+  "enabled": ["context7", "brave-search", "exa"]
 }
 ```
 
@@ -419,7 +420,6 @@ node -e "
 | 서버 | 상태 | 비고 |
 |------|------|------|
 | context7 | ✅ 활성 | Core (항상 활성) |
-| serena | ✅ 활성 | Core (항상 활성) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -339,12 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
+강제 활성(Core) 서버는 현재 없다 (mcp-manifest.mjs `CORE_SERVERS = []`). 모든 서버는 매니페스트 enabled 목록 기반으로만 활성화된다. API 키가 필요 없는 context7는 기본 권장으로 표시:
 ```
-✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
+✅ context7 — 라이브러리 문서 조회 (API 키 불필요, 매니페스트 기반)
 ```
 
-> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
+> serena는 2026-06-10 core에서 제거됨. core 강제 활성을 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -419,7 +419,7 @@ node -e "
 
 | 서버 | 상태 | 비고 |
 |------|------|------|
-| context7 | ✅ 활성 | Core (항상 활성) |
+| context7 | ✅ 활성 | API 키 불필요 (매니페스트 기반) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/scripts/lib/mcp-manifest.mjs
+++ b/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/scripts/mcp-gateway-start.ps1
+++ b/scripts/mcp-gateway-start.ps1
@@ -15,7 +15,6 @@ $Servers = @(
   @{ Name = 'exa';          Port = 8102; Cmd = 'npx -y exa-mcp-server';                        EnvVars = @('EXA_API_KEY') }
   @{ Name = 'tavily';       Port = 8103; Cmd = 'npx -y tavily-mcp@latest';                     EnvVars = @('TAVILY_API_KEY') }
   @{ Name = 'jira';         Port = 8104; Cmd = 'npx -y mcp-jira-cloud@latest';                 EnvVars = @('JIRA_API_TOKEN', 'JIRA_EMAIL', 'JIRA_INSTANCE_URL') }
-  @{ Name = 'serena';       Port = 8105; Cmd = 'uvx --from git+https://github.com/oraios/serena serena start-mcp-server'; EnvVars = @() }
   @{ Name = 'notion';       Port = 8106; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
   @{ Name = 'notion-guest'; Port = 8107; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
 )

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -339,11 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7, serena)는 API 키 불필요, 자동 활성화됨을 표시:
+Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
 ```
 ✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
-✅ serena   — 시맨틱 코드 분석 (API 키 불필요)
 ```
+
+> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -407,7 +408,7 @@ node -e "
 {
   "version": 1,
   "updatedAt": "2026-03-31T...",
-  "enabled": ["context7", "serena", "brave-search", "exa"]
+  "enabled": ["context7", "brave-search", "exa"]
 }
 ```
 
@@ -419,7 +420,6 @@ node -e "
 | 서버 | 상태 | 비고 |
 |------|------|------|
 | context7 | ✅ 활성 | Core (항상 활성) |
-| serena | ✅ 활성 | Core (항상 활성) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -339,12 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
+강제 활성(Core) 서버는 현재 없다 (mcp-manifest.mjs `CORE_SERVERS = []`). 모든 서버는 매니페스트 enabled 목록 기반으로만 활성화된다. API 키가 필요 없는 context7는 기본 권장으로 표시:
 ```
-✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
+✅ context7 — 라이브러리 문서 조회 (API 키 불필요, 매니페스트 기반)
 ```
 
-> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
+> serena는 2026-06-10 core에서 제거됨. core 강제 활성을 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -419,7 +419,7 @@ node -e "
 
 | 서버 | 상태 | 비고 |
 |------|------|------|
-| context7 | ✅ 활성 | Core (항상 활성) |
+| context7 | ✅ 활성 | API 키 불필요 (매니페스트 기반) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |


### PR DESCRIPTION
## 문제

serena MCP를 registry/manifest에서 지워도 매 세션 부활했다 ("자꾸 생기네").

## 원인

부활 벡터는 registry가 아니라 코드 레벨 강제 2곳 + stale 클라이언트 엔트리:

1. `scripts/lib/mcp-manifest.mjs`의 `CORE_SERVERS = ["serena"]` 하드코딩
   - `isServerEnabled()`가 매니페스트 무시하고 항상 true → `mcp-gateway-start.mjs:140`이 매 게이트웨이 기동마다 serena를 :8105에 spawn
   - `writeManifest()` / `filterByManifest()`도 CORE를 강제 합류 → 매니페스트에서 지워도 재기록
2. 홈 `~/.mcp.json`의 stale serena 엔트리 (모든 프로젝트의 조상 경로라 어느 세션이든 합류, sync는 prune 안 함) — 이건 user-state라 PR 밖에서 정리 완료

## 변경

| 파일 | 내용 |
|------|------|
| `scripts/lib/mcp-manifest.mjs` | `CORE_SERVERS = []` (serena 제거) |
| `packages/{core,remote,triflux}/scripts/lib/mcp-manifest.mjs` | byte-identical mirror (diff -q 확인) |
| `skills/tfx-setup/SKILL.md` | 5-2 Core 서버 안내에서 serena 제거 + 제거 사유 주석, 예시 manifest/결과표 갱신 |
| `packages/triflux/skills/tfx-setup/SKILL.md` | byte-identical mirror |

`mcp-gateway-servers.mjs`의 serena 정의는 dormant opt-in으로 유지 — 매니페스트 enablement 없이는 절대 spawn되지 않음. Windows 전용 `mcp-gateway-start.ps1`의 하드코딩 목록은 별도 정리 대상으로 남김.

## 검증

- `isServerEnabled("serena")` → false (repo + `~/.claude/scripts` 배포본 실측)
- `node --test scripts/__tests__/mcp-gateway-health-check.test.mjs scripts/__tests__/mcp-guard-engine-policy-sync.test.mjs` → 12/12 pass
- `npm run lint:skills` → PASS (43 files)
- `npx biome check` 변경 파일 → clean
- `claude mcp list` → serena 소멸, 잔여 서버 정상 Connected
- gateway verify → context7/brave-search만 healthy 체크 (manifest 필터 정상)