### PR TITLE
fix: keep host HOME for antigravity-family swarm/team workers

### DIFF
--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -1140,6 +1140,7 @@ export function createConductor(opts = {}) {
       const sandbox = buildWorkerSandboxEnv({
         cwd: resolvedConfig.workdir || process.cwd(),
         sessionId: resolvedConfig.id,
+        agent: resolvedConfig.agent,
         env: { ...process.env, ...(resolvedConfig.env || {}) },
       });
       resolvedConfig = {

--- a/hub/team/native-supervisor.mjs
+++ b/hub/team/native-supervisor.mjs
@@ -173,11 +173,15 @@ function spawnMember(member) {
         ? process.env.TERM
         : "xterm-256color",
   };
+  // Worker members get HOME-isolated sandboxes, but antigravity-family agents
+  // (agy/gemini) are carved out inside buildWorkerSandboxEnv so their keyring/
+  // OAuth auth resolves — pass member.cli so the carve-out applies in-process too.
   const sandbox =
     member.role === "worker"
       ? buildWorkerSandboxEnv({
           cwd: config.workdir || process.cwd(),
           sessionId: `${sessionName}-${member.name}`,
+          agent: member.cli,
           env: baseEnv,
         })
       : { env: {}, root: null };

--- a/hub/team/worker-sandbox.mjs
+++ b/hub/team/worker-sandbox.mjs
@@ -19,6 +19,23 @@ function isDisabled(env = {}) {
   return /^(0|false|no|off)$/i.test(String(env.TFX_WORKER_SANDBOX ?? ""));
 }
 
+// Antigravity-family CLIs (agy/gemini) authenticate only via interactive OAuth and
+// store credentials in the OS keyring plus HOME-relative ~/.gemini state bound to the
+// logged-in user. They expose no headless-auth flag and no config-home env
+// (antigravity-cli issues #223/#155/#316), so overriding HOME forces a re-auth that
+// never completes in a headless swarm/team worker — the worker times out at the OAuth
+// wait and does no work (the agy "no_commit" symptom). Keep the host HOME for these
+// agents so the keyring and ~/.gemini resolve. Codex stays isolated via CODEX_HOME.
+const AUTH_HOME_BOUND_AGENTS = new Set(["antigravity", "agy", "gemini"]);
+
+function isAuthHomeBoundAgent(agent) {
+  return AUTH_HOME_BOUND_AGENTS.has(
+    String(agent ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
 function windowsHomeParts(home) {
   const normalized = String(home || "").replace(/\//g, "\\");
   const match = normalized.match(/^([a-zA-Z]:)(\\.*)$/);
@@ -36,14 +53,25 @@ function mkdirAll(paths) {
  * @param {object} opts
  * @param {string} [opts.cwd] Worktree/current working directory for the worker.
  * @param {string} [opts.sessionId] Stable session/member id.
+ * @param {string} [opts.agent] Worker CLI/agent; antigravity-family agents skip the
+ *   HOME override so their keyring/OAuth credentials resolve (see note above).
  * @param {object} [opts.env] Existing env used for opt-out and explicit root.
  * @param {boolean} [opts.create=true] Create directories eagerly.
- * @returns {{env: object, root: string|null, home: string|null, disabled: boolean}}
+ * @returns {{env: object, root: string|null, home: string|null, disabled: boolean, reason?: string}}
  */
 export function buildWorkerSandboxEnv(opts = {}) {
   const env = opts.env && typeof opts.env === "object" ? opts.env : {};
   if (isDisabled(env)) {
     return { env: {}, root: null, home: null, disabled: true };
+  }
+  if (isAuthHomeBoundAgent(opts.agent)) {
+    return {
+      env: {},
+      root: null,
+      home: null,
+      disabled: true,
+      reason: "auth-home-bound-agent",
+    };
   }
 
   const cwd = resolve(opts.cwd || process.cwd());

--- a/hub/workers/delegator-mcp.mjs
+++ b/hub/workers/delegator-mcp.mjs
@@ -971,6 +971,7 @@ export class DelegatorMcpWorker {
         args.workerIndex ||
         args.agentType ||
         "route",
+      agent: args.provider,
       env: baseEnv,
     });
     const env = { ...baseEnv, ...sandbox.env };

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -1140,6 +1140,7 @@ export function createConductor(opts = {}) {
       const sandbox = buildWorkerSandboxEnv({
         cwd: resolvedConfig.workdir || process.cwd(),
         sessionId: resolvedConfig.id,
+        agent: resolvedConfig.agent,
         env: { ...process.env, ...(resolvedConfig.env || {}) },
       });
       resolvedConfig = {

--- a/packages/remote/hub/team/native-supervisor.mjs
+++ b/packages/remote/hub/team/native-supervisor.mjs
@@ -173,11 +173,15 @@ function spawnMember(member) {
         ? process.env.TERM
         : "xterm-256color",
   };
+  // Worker members get HOME-isolated sandboxes, but antigravity-family agents
+  // (agy/gemini) are carved out inside buildWorkerSandboxEnv so their keyring/
+  // OAuth auth resolves — pass member.cli so the carve-out applies in-process too.
   const sandbox =
     member.role === "worker"
       ? buildWorkerSandboxEnv({
           cwd: config.workdir || process.cwd(),
           sessionId: `${sessionName}-${member.name}`,
+          agent: member.cli,
           env: baseEnv,
         })
       : { env: {}, root: null };

--- a/packages/remote/hub/team/worker-sandbox.mjs
+++ b/packages/remote/hub/team/worker-sandbox.mjs
@@ -19,6 +19,23 @@ function isDisabled(env = {}) {
   return /^(0|false|no|off)$/i.test(String(env.TFX_WORKER_SANDBOX ?? ""));
 }
 
+// Antigravity-family CLIs (agy/gemini) authenticate only via interactive OAuth and
+// store credentials in the OS keyring plus HOME-relative ~/.gemini state bound to the
+// logged-in user. They expose no headless-auth flag and no config-home env
+// (antigravity-cli issues #223/#155/#316), so overriding HOME forces a re-auth that
+// never completes in a headless swarm/team worker — the worker times out at the OAuth
+// wait and does no work (the agy "no_commit" symptom). Keep the host HOME for these
+// agents so the keyring and ~/.gemini resolve. Codex stays isolated via CODEX_HOME.
+const AUTH_HOME_BOUND_AGENTS = new Set(["antigravity", "agy", "gemini"]);
+
+function isAuthHomeBoundAgent(agent) {
+  return AUTH_HOME_BOUND_AGENTS.has(
+    String(agent ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
 function windowsHomeParts(home) {
   const normalized = String(home || "").replace(/\//g, "\\");
   const match = normalized.match(/^([a-zA-Z]:)(\\.*)$/);
@@ -36,14 +53,25 @@ function mkdirAll(paths) {
  * @param {object} opts
  * @param {string} [opts.cwd] Worktree/current working directory for the worker.
  * @param {string} [opts.sessionId] Stable session/member id.
+ * @param {string} [opts.agent] Worker CLI/agent; antigravity-family agents skip the
+ *   HOME override so their keyring/OAuth credentials resolve (see note above).
  * @param {object} [opts.env] Existing env used for opt-out and explicit root.
  * @param {boolean} [opts.create=true] Create directories eagerly.
- * @returns {{env: object, root: string|null, home: string|null, disabled: boolean}}
+ * @returns {{env: object, root: string|null, home: string|null, disabled: boolean, reason?: string}}
  */
 export function buildWorkerSandboxEnv(opts = {}) {
   const env = opts.env && typeof opts.env === "object" ? opts.env : {};
   if (isDisabled(env)) {
     return { env: {}, root: null, home: null, disabled: true };
+  }
+  if (isAuthHomeBoundAgent(opts.agent)) {
+    return {
+      env: {},
+      root: null,
+      home: null,
+      disabled: true,
+      reason: "auth-home-bound-agent",
+    };
   }
 
   const cwd = resolve(opts.cwd || process.cwd());

--- a/packages/remote/hub/workers/delegator-mcp.mjs
+++ b/packages/remote/hub/workers/delegator-mcp.mjs
@@ -971,6 +971,7 @@ export class DelegatorMcpWorker {
         args.workerIndex ||
         args.agentType ||
         "route",
+      agent: args.provider,
       env: baseEnv,
     });
     const env = { ...baseEnv, ...sandbox.env };

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -1140,6 +1140,7 @@ export function createConductor(opts = {}) {
       const sandbox = buildWorkerSandboxEnv({
         cwd: resolvedConfig.workdir || process.cwd(),
         sessionId: resolvedConfig.id,
+        agent: resolvedConfig.agent,
         env: { ...process.env, ...(resolvedConfig.env || {}) },
       });
       resolvedConfig = {

--- a/packages/triflux/hub/team/native-supervisor.mjs
+++ b/packages/triflux/hub/team/native-supervisor.mjs
@@ -173,11 +173,15 @@ function spawnMember(member) {
         ? process.env.TERM
         : "xterm-256color",
   };
+  // Worker members get HOME-isolated sandboxes, but antigravity-family agents
+  // (agy/gemini) are carved out inside buildWorkerSandboxEnv so their keyring/
+  // OAuth auth resolves — pass member.cli so the carve-out applies in-process too.
   const sandbox =
     member.role === "worker"
       ? buildWorkerSandboxEnv({
           cwd: config.workdir || process.cwd(),
           sessionId: `${sessionName}-${member.name}`,
+          agent: member.cli,
           env: baseEnv,
         })
       : { env: {}, root: null };

--- a/packages/triflux/hub/team/worker-sandbox.mjs
+++ b/packages/triflux/hub/team/worker-sandbox.mjs
@@ -19,6 +19,23 @@ function isDisabled(env = {}) {
   return /^(0|false|no|off)$/i.test(String(env.TFX_WORKER_SANDBOX ?? ""));
 }
 
+// Antigravity-family CLIs (agy/gemini) authenticate only via interactive OAuth and
+// store credentials in the OS keyring plus HOME-relative ~/.gemini state bound to the
+// logged-in user. They expose no headless-auth flag and no config-home env
+// (antigravity-cli issues #223/#155/#316), so overriding HOME forces a re-auth that
+// never completes in a headless swarm/team worker — the worker times out at the OAuth
+// wait and does no work (the agy "no_commit" symptom). Keep the host HOME for these
+// agents so the keyring and ~/.gemini resolve. Codex stays isolated via CODEX_HOME.
+const AUTH_HOME_BOUND_AGENTS = new Set(["antigravity", "agy", "gemini"]);
+
+function isAuthHomeBoundAgent(agent) {
+  return AUTH_HOME_BOUND_AGENTS.has(
+    String(agent ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
 function windowsHomeParts(home) {
   const normalized = String(home || "").replace(/\//g, "\\");
   const match = normalized.match(/^([a-zA-Z]:)(\\.*)$/);
@@ -36,14 +53,25 @@ function mkdirAll(paths) {
  * @param {object} opts
  * @param {string} [opts.cwd] Worktree/current working directory for the worker.
  * @param {string} [opts.sessionId] Stable session/member id.
+ * @param {string} [opts.agent] Worker CLI/agent; antigravity-family agents skip the
+ *   HOME override so their keyring/OAuth credentials resolve (see note above).
  * @param {object} [opts.env] Existing env used for opt-out and explicit root.
  * @param {boolean} [opts.create=true] Create directories eagerly.
- * @returns {{env: object, root: string|null, home: string|null, disabled: boolean}}
+ * @returns {{env: object, root: string|null, home: string|null, disabled: boolean, reason?: string}}
  */
 export function buildWorkerSandboxEnv(opts = {}) {
   const env = opts.env && typeof opts.env === "object" ? opts.env : {};
   if (isDisabled(env)) {
     return { env: {}, root: null, home: null, disabled: true };
+  }
+  if (isAuthHomeBoundAgent(opts.agent)) {
+    return {
+      env: {},
+      root: null,
+      home: null,
+      disabled: true,
+      reason: "auth-home-bound-agent",
+    };
   }
 
   const cwd = resolve(opts.cwd || process.cwd());

--- a/packages/triflux/hub/workers/delegator-mcp.mjs
+++ b/packages/triflux/hub/workers/delegator-mcp.mjs
@@ -971,6 +971,7 @@ export class DelegatorMcpWorker {
         args.workerIndex ||
         args.agentType ||
         "route",
+      agent: args.provider,
       env: baseEnv,
     });
     const env = { ...baseEnv, ...sandbox.env };

--- a/tests/unit/worker-sandbox.test.mjs
+++ b/tests/unit/worker-sandbox.test.mjs
@@ -164,4 +164,95 @@ describe("worker sandbox env", () => {
     assert.equal(env.CODEX_HOME, join(hostHome, ".codex"));
     assert.equal(env.TFX_WORKER_SANDBOX_SCOPE, "delegator-route");
   });
+
+  it("keeps the host HOME for antigravity-family agents (no headless auth)", () => {
+    const cwd = tmpRoot("worker-sandbox-agy");
+    for (const agent of ["antigravity", "agy", "gemini", "AGY"]) {
+      const result = buildWorkerSandboxEnv({
+        cwd,
+        sessionId: "agy-worker",
+        agent,
+        env: { HOME: "/host/home" },
+      });
+      assert.equal(result.disabled, true, `${agent} should skip the sandbox`);
+      assert.equal(result.reason, "auth-home-bound-agent");
+      assert.deepEqual(result.env, {});
+    }
+  });
+
+  it("still sandboxes codex (it is isolated via CODEX_HOME)", () => {
+    const cwd = tmpRoot("worker-sandbox-codex-agent");
+    const result = buildWorkerSandboxEnv({
+      cwd,
+      sessionId: "codex-worker",
+      agent: "codex",
+      env: { HOME: "/host/home" },
+    });
+    const expectedHome = join(cwd, ".triflux", "worker-home", "codex-worker");
+    assert.equal(result.disabled, false);
+    assert.equal(result.env.HOME, expectedHome);
+    assert.equal(result.env.CODEX_HOME, join("/host/home", ".codex"));
+  });
+
+  it("conductor antigravity worker spawns with the host HOME (auth carve-out)", async () => {
+    const logsDir = tmpRoot("worker-sandbox-agy-logs");
+    const workdir = tmpRoot("worker-sandbox-agy-workdir");
+    const calls = [];
+    const fakeBroker = new EventEmitter();
+    fakeBroker.lease = () => undefined;
+    const conductor = createConductor({
+      logsDir,
+      maxRestarts: 0,
+      probeOpts: {
+        intervalMs: 999_999,
+        l1ThresholdMs: 999_999,
+        l3ThresholdMs: 999_999,
+      },
+      broker: fakeBroker,
+      deps: { spawn: mockSpawnRecorder(calls) },
+    });
+
+    try {
+      conductor.spawnSession({
+        id: "sandbox-agy",
+        agent: "antigravity",
+        prompt: "test",
+        workdir,
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(calls.length, 1);
+      const env = calls[0].env;
+      const sandboxHome = join(
+        workdir,
+        ".triflux",
+        "worker-home",
+        "sandbox-agy",
+      );
+      assert.notEqual(env.HOME, sandboxHome);
+      assert.equal(env.HOME, process.env.HOME);
+    } finally {
+      await conductor.shutdown("worker_sandbox_agy_test_cleanup");
+    }
+  });
+
+  it("delegator route keeps the host HOME for the antigravity provider", () => {
+    const cwd = tmpRoot("worker-sandbox-agy-delegator");
+    const hostHome = tmpRoot("worker-sandbox-agy-host-home");
+    const worker = new DelegatorMcpWorker({
+      cwd,
+      env: {
+        HOME: hostHome,
+        PATH: process.env.PATH || "",
+      },
+    });
+
+    const env = worker._buildRouteEnv({
+      provider: "antigravity",
+      teamTaskId: "task/agy",
+    });
+
+    assert.equal(env.HOME, hostHome);
+    assert.equal(env.TFX_WORKER_SANDBOX_SCOPE, undefined);
+  });
 });


### PR DESCRIPTION
## Problem

Headless swarm / team **agy (antigravity) workers** hit an interactive OAuth re-auth barrier and do no work — the agy `no_commit` symptom. Evidence: `run-1779871641572` shards `native-guard` and `swarm-lease-scope` (both antigravity) timed out in their `*.out.log`:

```
Authentication required. Please visit the URL to log in: https://accounts.google.com/o/oauth2/auth?...antigravity.google/oauth-callback...
Waiting for authentication (timeout 30s)...
Error: authentication timed out.
```

codex shards in the same run committed fine.

## Root cause

`hub/team/worker-sandbox.mjs` overrides `HOME` to a per-worker sandbox dir (default-on) and preserves `CODEX_HOME` for codex, but had **no equivalent for agy/gemini**. The Antigravity CLI has **no headless-auth method** (no API key / service account / config-home env — confirmed via the official README "authenticates via the system keyring, falling back to Google Sign-In" + antigravity-cli issues #223 / #155 / #316). Its OAuth credentials live in the OS keyring (`svce=gemini`, `acct=antigravity`) plus HOME-relative `~/.gemini` bound to the logged-in user, so the HOME override forces a re-auth that never completes.

Reproduced on agy 1.0.7: `HOME=$(mktemp -d) agy --print` hits the same barrier; symlinking `~/.gemini` alone does not fix it (the Keychain is also HOME-relative and the token is device/session-bound). The only working path is to run agy with the host's real HOME.

## Fix

Carve antigravity-family agents (`antigravity`/`agy`/`gemini`) out of the HOME override in `buildWorkerSandboxEnv` so the host keyring and `~/.gemini` resolve; **codex stays isolated via `CODEX_HOME`** (unchanged). Thread the worker agent through all three sandbox spawn sites:

- `conductor.mjs` (swarm) — `agent: resolvedConfig.agent`
- `delegator-mcp.mjs` (multi / `tfx multi`) — `agent: args.provider`
- `native-supervisor.mjs` (in-process / native team) — `agent: member.cli`

Tradeoff: agy-family workers now use the real host `~/.gemini` (symmetric with codex sharing the host `~/.codex` via `CODEX_HOME`).

## Verification

- `worker-sandbox.test.mjs` — **9/9** (+4 cases: agy-family carve-out, codex still isolated, conductor agy → host HOME, delegator agy → host HOME)
- `conductor.test.mjs` + `swarm-hypervisor.test.mjs` (+ dynamic-routing) — **115/115**
- `native-supervisor.mjs` syntax-checked (`node --check`); it is a top-level CLI script so the carve-out is covered by the central `worker-sandbox` tests and the passthrough mirrors the two tested call sites
- biome clean on changed files; `release:check-mirror` + `release:check-sync` pass
- Mirrored to `packages/{triflux,remote}` (triflux byte-identical, remote `@triflux/core` imports preserved)

## Cross-review

Codex reviewed: carve-out logic, conductor/delegator passthroughs, security tradeoff, and mirrors all approved. One High (the `native-supervisor` spawn site was initially missed) was fixed per Codex's recommendation using the same passthrough pattern.

## Scope

This fixes the **agy auth** root cause only. The separate worker-prompt commit-contract hardening (empty `commits_made` allowed for code shards) is already implemented in the prompt-guide branch (`11815a5d`) and is not duplicated here.
