### PR TITLE
fix: prompt-guide P1 compliance + worker commit-contract + serena/MCP cleanup

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,3 +41,29 @@ triflux 워크스페이스에서 Antigravity CLI의 역할과 운영 규칙. 1M 
 ## 검증
 - 변경 후 lint/typecheck/test 실행
 - 새 차단 규칙은 항상 대안 API와 함께 추가 (차단만 추가하면 데드락)
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /gstack:office-hours
+- Strategy/scope → invoke /gstack:plan-ceo-review
+- Architecture → invoke /gstack:plan-eng-review
+- Design system/plan review → invoke /gstack:design-consultation or /gstack:plan-design-review
+- Full review pipeline → invoke /gstack:autoplan
+- Bugs/errors → invoke /gstack:investigate
+- QA/testing site behavior → invoke /gstack:qa or /gstack:qa-only
+- Code review/diff check → invoke /gstack:review
+- Visual polish → invoke /gstack:design-review
+- Ship/deploy/PR → invoke /gstack:ship or /gstack:land-and-deploy
+- Save progress → invoke /gstack:context-save
+- Resume context → invoke /gstack:context-restore
+- Author a backlog-ready spec/issue → invoke /gstack:spec
+
+## Health Stack
+
+- lint: biome check .
+- test: node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 "tests/**/*.test.mjs" "scripts/__tests__/**/*.test.mjs" && npm run lint:skills
+- deadcode: npx knip
+- gbrain: gbrain doctor --json

--- a/hub/team/build-worker-prompt.mjs
+++ b/hub/team/build-worker-prompt.mjs
@@ -22,10 +22,23 @@ function formatLeaseFiles(leaseFiles) {
   return normalized.map((file) => `- ${file}`).join("\n");
 }
 
-export function buildLeaseScopedAcceptanceAppendix({ leaseFiles = [] } = {}) {
+function normalizeWorktreePath(worktreePath) {
+  return typeof worktreePath === "string" ? worktreePath.trim() : "";
+}
+
+export function buildLeaseScopedAcceptanceAppendix({
+  leaseFiles = [],
+  worktreePath,
+} = {}) {
+  const normalizedWorktreePath = normalizeWorktreePath(worktreePath);
+  const rootLine = normalizedWorktreePath
+    ? `작업 루트(절대경로): ${normalizedWorktreePath} — 아래 lease 경로와 모든 상대경로는 이 루트 기준으로만 해석한다.\n`
+    : "";
+
   return `
 
 ## Lease-scoped Acceptance / Lint Guard (자동 삽입됨)
+${rootLine}- 위 PRD 본문의 모든 제약과 acceptance 기준은 이 appendix 이후에도 그대로 유효하다.
 - 이 shard 의 파일 lease:
 ${formatLeaseFiles(leaseFiles)}
 - Acceptance, lint, and format checks are scoped to files changed by this shard; if that set is unclear, use only the lease list above.
@@ -51,7 +64,10 @@ ${SENTINEL_END}
 규약:
 - 두 sentinel 마커는 각자 자기 줄에 단독으로 출력 (앞뒤 newline)
 - 마커 사이 본문은 단일 JSON object (배열/primitive 금지)
-- commits_made 가 비어 있어도 됨 (no-op shard)
+- status 값은 ok | failed | blocked 중 하나
+- payload 출력 직전 \`git log -1 --format=%H\` 로 보고할 sha 가 실재하는지 검증하라
+- 코드 변경이 기대되는 shard 에서 변경/커밋을 못 했으면 status:failed 와 함께 reason 필드로 사유를 보고하라 — 그 경우 빈 commits_made 에 status:ok 는 금지
+- no-op shard 는 status:ok + 빈 commits_made 배열 허용
 - 마커 쌍은 stdout 에 정확히 한 번만 출력해야 함. 재emit 시 conductor 는 첫 BEGIN..END 한 쌍만 채택하며, 이후 stdout 은 무시한다.
 - ${SENTINEL_BEGIN} 만 출력하고 ${SENTINEL_END} 누락 시 conductor 가 truncation 으로 명확히 reject
 `;
@@ -60,14 +76,17 @@ ${SENTINEL_END}
  * Append the Completion Protocol section to a PRD prompt.
  *
  * @param {string|null|undefined} prdPrompt — original PRD body
- * @param {{ leaseFiles?: string[] }} [opts] — shard file lease for scoped acceptance
+ * @param {{ leaseFiles?: string[], worktreePath?: string }} [opts] — shard file lease and absolute worktree root for scoped acceptance
  * @returns {string} prompt with appendix
  */
 export function buildWorkerPrompt(prdPrompt, opts = {}) {
   const body = typeof prdPrompt === "string" ? prdPrompt : "";
   return (
     body +
-    buildLeaseScopedAcceptanceAppendix({ leaseFiles: opts.leaseFiles }) +
+    buildLeaseScopedAcceptanceAppendix({
+      leaseFiles: opts.leaseFiles,
+      worktreePath: opts.worktreePath,
+    }) +
     COMPLETION_PROTOCOL_APPENDIX
   );
 }

--- a/hub/team/handoff.mjs
+++ b/hub/team/handoff.mjs
@@ -23,7 +23,7 @@ After completing the task, you MUST output a HANDOFF block in exactly this forma
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 task: <1-3 word task type>
-files_changed: <comma-separated file paths, or "none">
+files_changed: <comma-separated repo-root relative file paths, or "none">
 verdict: <one sentence conclusion>
 confidence: high | medium | low
 risk: low | med | high
@@ -36,21 +36,25 @@ partial_output: yes | no
 
 Rules:
 - The HANDOFF block must start with exactly "--- HANDOFF ---"
+- Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.
 - Each field must be on its own line as "key: value"
+- Report files_changed as repo-root relative paths
 - verdict must be a single concise sentence
 - Do not skip any required field
+- This block owns the final output position; this block must be the last thing you output
 `.trim();
 
 /**
  * CLI 프롬프트 길이 제한을 고려한 축약 HANDOFF 지시
  */
-export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end:
+export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end; this block must be the last thing you output:
 --- HANDOFF ---
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 verdict: <one sentence>
-files_changed: <comma-separated paths or "none">
-confidence: high | medium | low`;
+files_changed: <comma-separated repo-root relative paths or "none">
+confidence: high | medium | low
+Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.`;
 
 /**
  * raw 텍스트에서 HANDOFF 블록을 파싱한다.

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -18,7 +18,7 @@ import {
 import { createRequire } from "node:module";
 import net from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { requestJson } from "../bridge.mjs";
 import { escapePwshSingleQuoted } from "../cli-adapter-base.mjs";
@@ -255,7 +255,7 @@ function unregisterHeadlessSynapseWorker(workerId) {
 /** MCP 프로필별 프롬프트 힌트 (tfx-route.sh resolve_mcp_policy의 경량 미러) */
 const MCP_PROFILE_HINTS = {
   implement:
-    "You have full filesystem read/write access. Implement changes directly.",
+    "You have full filesystem read/write access. Implement changes directly. After changes, run the narrowest relevant test/lint for the files you touched; if none can run, state why and the next-best check.",
   analyze:
     "Focus on reading and analyzing the codebase. Prefer analysis over modification.",
   review: "Review the code for quality, security, and correctness.",
@@ -301,22 +301,31 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // contextFile 처리: 32KB(32768 bytes) 초과 시 UTF-8 안전 절단
   let contextPrefix = "";
   if (contextFile && existsSync(contextFile)) {
+    const contextSource = resolve(contextFile);
     let ctx = readFileSync(contextFile, "utf8");
+    let truncated = false;
     if (Buffer.byteLength(ctx, "utf8") > 32768) {
       ctx = Buffer.from(ctx).subarray(0, 32768).toString("utf8");
+      truncated = true;
+    }
+    if (truncated) {
+      ctx = `${ctx}\n[... truncated at 32KB]`;
     }
     if (ctx.length > 0) {
-      contextPrefix = `<prior_context>\n${ctx}\n</prior_context>\n\n`;
+      contextPrefix = `<prior_context source="${contextSource}" truncated="${truncated ? "true" : "false"}">\n${ctx}\n</prior_context>\nBase your work on the prior_context above; if it conflicts with the task below, the task wins.\n\n`;
     }
   }
 
   const mcpHint =
     mcp && MCP_PROFILE_HINTS[mcp]
-      ? ` [MCP: ${mcp}] ${MCP_PROFILE_HINTS[mcp]}`
+      ? `\n\n[MCP: ${mcp}]\n${MCP_PROFILE_HINTS[mcp]}`
       : "";
+  const workspaceHint = cwd
+    ? `\n\n[workspace] root(절대경로): ${resolve(cwd)}. 모든 상대경로는 이 루트 기준. 파일 쓰기/커밋 전 \`git rev-parse --show-toplevel\` 이 이 root 와 일치하는지 확인하고 불일치 시 중단·보고.`
+    : "";
   // P2: HANDOFF 지시를 프롬프트에 삽입 (워커가 구조화된 handoff 블록을 출력하도록)
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
-  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
+  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${workspaceHint}${handoffHint}`;
 
   // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
   // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어

--- a/hub/team/orchestrator.mjs
+++ b/hub/team/orchestrator.mjs
@@ -50,7 +50,7 @@ export function decomposeTask(taskDescription, agentCount) {
  * @returns {string}
  */
 export function buildLeadPrompt(taskDescription, config) {
-  const { agentId, teammateMode = "tmux", workers = [] } = config;
+  const { agentId, repoRoot, teammateMode = "tmux", workers = [] } = config;
 
   const roster =
     workers
@@ -59,7 +59,10 @@ export function buildLeadPrompt(taskDescription, config) {
 
   const workerIds = workers.map((w) => w.agentId).join(", ");
 
-  const bridgePath = "node hub/bridge.mjs";
+  // TODO: Require repoRoot once all callers pass absolute repository roots.
+  const bridgePath = repoRoot
+    ? `node ${String(repoRoot).replace(/\/+$/, "")}/hub/bridge.mjs`
+    : "node hub/bridge.mjs";
 
   return `리드 에이전트: ${agentId}
 
@@ -76,6 +79,8 @@ ${roster}
 - 워커 결과 수집:
   ${bridgePath} context --agent ${agentId} --max 20
 - 최종 결과는 topic="task.result"를 모아 통합
+- 모든 워커의 task.result 수신 후 결과를 통합하고 종료하라. 워커가 무응답이면 상태를 보고하고 중단하라.
+- 증거(커밋/테스트/파일) 없는 완료 주장은 통합하지 말고 해당 워커에 redo 를 지시하라.
 
 워커 ID: ${workerIds || "(없음)"}
 지금 즉시 워커를 배정하고 병렬 진행을 관리하라.`;

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -663,7 +663,10 @@ export function createSwarmHypervisor(opts) {
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
-      prompt: buildWorkerPrompt(shard.prompt, { leaseFiles: shard.files }),
+      prompt: buildWorkerPrompt(shard.prompt, {
+        leaseFiles: shard.files,
+        worktreePath: shard.worktreePath,
+      }),
       workdir: shard.worktreePath || workdir,
       mcpServers: shard.mcp,
       worktreePath: shard.worktreePath || null,
@@ -980,6 +983,72 @@ export function createSwarmHypervisor(opts) {
         emitter.emit("shardFailed", {
           shardName,
           failureMode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
+          reason,
+        });
+
+        cascadeDependencyFailure(shardName);
+        checkAllShardsCompleted();
+        return;
+      }
+
+      if (
+        completionPayload?.status === "failed" ||
+        completionPayload?.status === "blocked"
+      ) {
+        const detail =
+          typeof completionPayload.reason === "string" &&
+          completionPayload.reason.length > 0
+            ? completionPayload.reason
+            : "unspecified";
+        const reason = `worker_reported_${completionPayload.status}:${detail}`;
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
+        eventLog.append("worker_reported_non_ok_completion", {
+          shard: shardName,
+          sessionId,
+          status: completionPayload.status,
+          reason,
+        });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
+        failures.set(shardName, {
+          mode: classifyFailure(reason),
+          reason,
+          sessionId,
+          completionPayload,
+        });
+        lockManager.release(shardName);
+
+        const redundant = redundantWorkers.get(shardName);
+        if (redundant) {
+          void redundant.conductor.shutdown("primary_reported_non_ok");
+        }
+
+        emitter.emit("shardFailed", {
+          shardName,
+          failureMode: classifyFailure(reason),
           reason,
         });
 

--- a/hub/team/worker-completion-validator.mjs
+++ b/hub/team/worker-completion-validator.mjs
@@ -1,9 +1,9 @@
 // hub/team/worker-completion-validator.mjs — Enforce worker completion schema.
 // Issue #115 Lane 1 / F7_worker_did_not_commit.
 //
-// A shard worker MUST emit a completion JSON with `status: "ok"` + a non-empty
-// `commits_made` array. Reporting without committing is the #1 cause of lost
-// swarm work — guarded here before integration trusts the worker.
+// A shard worker that reports `status: "ok"` MUST include a non-empty
+// `commits_made` array. Non-ok statuses are valid terminal reports, but they
+// are not allowed to masquerade as successful completion.
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -34,23 +34,18 @@ export function validateWorkerCompletion(payload) {
     return { ok: false, reason: "payload_not_object" };
   }
 
-  const valid = compiled(payload);
+  const status = payload.status;
+  if (!["ok", "failed", "blocked"].includes(status)) {
+    return { ok: false, reason: `invalid_status:${status ?? "undefined"}` };
+  }
+
+  const schemaPayload =
+    status === "blocked" ? { ...payload, status: "failed" } : payload;
+  const valid = compiled(schemaPayload);
   if (!valid) {
     const firstError = compiled.errors?.[0];
     const reason = formatError(firstError, payload);
     return { ok: false, reason };
-  }
-
-  // BUG-G (#130): the schema's if-then only constrains commits_made when
-  // status='ok', so status='failed' payloads pass AJV vacuously. Without
-  // this guard the hypervisor F7 path treats a worker self-reported failure
-  // as a successful completion and integrates phantom shards.
-  if (payload.status === "failed") {
-    const detail =
-      typeof payload.reason === "string" && payload.reason.length > 0
-        ? payload.reason
-        : "unspecified";
-    return { ok: false, reason: `worker_self_reported_failure:${detail}` };
   }
 
   return { ok: true };

--- a/packages/core/scripts/lib/mcp-manifest.mjs
+++ b/packages/core/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/remote/hub/team/build-worker-prompt.mjs
+++ b/packages/remote/hub/team/build-worker-prompt.mjs
@@ -22,10 +22,23 @@ function formatLeaseFiles(leaseFiles) {
   return normalized.map((file) => `- ${file}`).join("\n");
 }
 
-export function buildLeaseScopedAcceptanceAppendix({ leaseFiles = [] } = {}) {
+function normalizeWorktreePath(worktreePath) {
+  return typeof worktreePath === "string" ? worktreePath.trim() : "";
+}
+
+export function buildLeaseScopedAcceptanceAppendix({
+  leaseFiles = [],
+  worktreePath,
+} = {}) {
+  const normalizedWorktreePath = normalizeWorktreePath(worktreePath);
+  const rootLine = normalizedWorktreePath
+    ? `작업 루트(절대경로): ${normalizedWorktreePath} — 아래 lease 경로와 모든 상대경로는 이 루트 기준으로만 해석한다.\n`
+    : "";
+
   return `
 
 ## Lease-scoped Acceptance / Lint Guard (자동 삽입됨)
+${rootLine}- 위 PRD 본문의 모든 제약과 acceptance 기준은 이 appendix 이후에도 그대로 유효하다.
 - 이 shard 의 파일 lease:
 ${formatLeaseFiles(leaseFiles)}
 - Acceptance, lint, and format checks are scoped to files changed by this shard; if that set is unclear, use only the lease list above.
@@ -51,7 +64,10 @@ ${SENTINEL_END}
 규약:
 - 두 sentinel 마커는 각자 자기 줄에 단독으로 출력 (앞뒤 newline)
 - 마커 사이 본문은 단일 JSON object (배열/primitive 금지)
-- commits_made 가 비어 있어도 됨 (no-op shard)
+- status 값은 ok | failed | blocked 중 하나
+- payload 출력 직전 \`git log -1 --format=%H\` 로 보고할 sha 가 실재하는지 검증하라
+- 코드 변경이 기대되는 shard 에서 변경/커밋을 못 했으면 status:failed 와 함께 reason 필드로 사유를 보고하라 — 그 경우 빈 commits_made 에 status:ok 는 금지
+- no-op shard 는 status:ok + 빈 commits_made 배열 허용
 - 마커 쌍은 stdout 에 정확히 한 번만 출력해야 함. 재emit 시 conductor 는 첫 BEGIN..END 한 쌍만 채택하며, 이후 stdout 은 무시한다.
 - ${SENTINEL_BEGIN} 만 출력하고 ${SENTINEL_END} 누락 시 conductor 가 truncation 으로 명확히 reject
 `;
@@ -60,14 +76,17 @@ ${SENTINEL_END}
  * Append the Completion Protocol section to a PRD prompt.
  *
  * @param {string|null|undefined} prdPrompt — original PRD body
- * @param {{ leaseFiles?: string[] }} [opts] — shard file lease for scoped acceptance
+ * @param {{ leaseFiles?: string[], worktreePath?: string }} [opts] — shard file lease and absolute worktree root for scoped acceptance
  * @returns {string} prompt with appendix
  */
 export function buildWorkerPrompt(prdPrompt, opts = {}) {
   const body = typeof prdPrompt === "string" ? prdPrompt : "";
   return (
     body +
-    buildLeaseScopedAcceptanceAppendix({ leaseFiles: opts.leaseFiles }) +
+    buildLeaseScopedAcceptanceAppendix({
+      leaseFiles: opts.leaseFiles,
+      worktreePath: opts.worktreePath,
+    }) +
     COMPLETION_PROTOCOL_APPENDIX
   );
 }

--- a/packages/remote/hub/team/handoff.mjs
+++ b/packages/remote/hub/team/handoff.mjs
@@ -23,7 +23,7 @@ After completing the task, you MUST output a HANDOFF block in exactly this forma
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 task: <1-3 word task type>
-files_changed: <comma-separated file paths, or "none">
+files_changed: <comma-separated repo-root relative file paths, or "none">
 verdict: <one sentence conclusion>
 confidence: high | medium | low
 risk: low | med | high
@@ -36,21 +36,25 @@ partial_output: yes | no
 
 Rules:
 - The HANDOFF block must start with exactly "--- HANDOFF ---"
+- Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.
 - Each field must be on its own line as "key: value"
+- Report files_changed as repo-root relative paths
 - verdict must be a single concise sentence
 - Do not skip any required field
+- This block owns the final output position; this block must be the last thing you output
 `.trim();
 
 /**
  * CLI 프롬프트 길이 제한을 고려한 축약 HANDOFF 지시
  */
-export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end:
+export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end; this block must be the last thing you output:
 --- HANDOFF ---
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 verdict: <one sentence>
-files_changed: <comma-separated paths or "none">
-confidence: high | medium | low`;
+files_changed: <comma-separated repo-root relative paths or "none">
+confidence: high | medium | low
+Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.`;
 
 /**
  * raw 텍스트에서 HANDOFF 블록을 파싱한다.

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -18,7 +18,7 @@ import {
 import { createRequire } from "node:module";
 import net from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { requestJson } from "@triflux/core/hub/bridge.mjs";
 import { escapePwshSingleQuoted } from "@triflux/core/hub/cli-adapter-base.mjs";
@@ -255,7 +255,7 @@ function unregisterHeadlessSynapseWorker(workerId) {
 /** MCP 프로필별 프롬프트 힌트 (tfx-route.sh resolve_mcp_policy의 경량 미러) */
 const MCP_PROFILE_HINTS = {
   implement:
-    "You have full filesystem read/write access. Implement changes directly.",
+    "You have full filesystem read/write access. Implement changes directly. After changes, run the narrowest relevant test/lint for the files you touched; if none can run, state why and the next-best check.",
   analyze:
     "Focus on reading and analyzing the codebase. Prefer analysis over modification.",
   review: "Review the code for quality, security, and correctness.",
@@ -301,22 +301,31 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // contextFile 처리: 32KB(32768 bytes) 초과 시 UTF-8 안전 절단
   let contextPrefix = "";
   if (contextFile && existsSync(contextFile)) {
+    const contextSource = resolve(contextFile);
     let ctx = readFileSync(contextFile, "utf8");
+    let truncated = false;
     if (Buffer.byteLength(ctx, "utf8") > 32768) {
       ctx = Buffer.from(ctx).subarray(0, 32768).toString("utf8");
+      truncated = true;
+    }
+    if (truncated) {
+      ctx = `${ctx}\n[... truncated at 32KB]`;
     }
     if (ctx.length > 0) {
-      contextPrefix = `<prior_context>\n${ctx}\n</prior_context>\n\n`;
+      contextPrefix = `<prior_context source="${contextSource}" truncated="${truncated ? "true" : "false"}">\n${ctx}\n</prior_context>\nBase your work on the prior_context above; if it conflicts with the task below, the task wins.\n\n`;
     }
   }
 
   const mcpHint =
     mcp && MCP_PROFILE_HINTS[mcp]
-      ? ` [MCP: ${mcp}] ${MCP_PROFILE_HINTS[mcp]}`
+      ? `\n\n[MCP: ${mcp}]\n${MCP_PROFILE_HINTS[mcp]}`
       : "";
+  const workspaceHint = cwd
+    ? `\n\n[workspace] root(절대경로): ${resolve(cwd)}. 모든 상대경로는 이 루트 기준. 파일 쓰기/커밋 전 \`git rev-parse --show-toplevel\` 이 이 root 와 일치하는지 확인하고 불일치 시 중단·보고.`
+    : "";
   // P2: HANDOFF 지시를 프롬프트에 삽입 (워커가 구조화된 handoff 블록을 출력하도록)
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
-  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
+  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${workspaceHint}${handoffHint}`;
 
   // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
   // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어

--- a/packages/remote/hub/team/orchestrator.mjs
+++ b/packages/remote/hub/team/orchestrator.mjs
@@ -50,7 +50,7 @@ export function decomposeTask(taskDescription, agentCount) {
  * @returns {string}
  */
 export function buildLeadPrompt(taskDescription, config) {
-  const { agentId, teammateMode = "tmux", workers = [] } = config;
+  const { agentId, repoRoot, teammateMode = "tmux", workers = [] } = config;
 
   const roster =
     workers
@@ -59,7 +59,10 @@ export function buildLeadPrompt(taskDescription, config) {
 
   const workerIds = workers.map((w) => w.agentId).join(", ");
 
-  const bridgePath = "node hub/bridge.mjs";
+  // TODO: Require repoRoot once all callers pass absolute repository roots.
+  const bridgePath = repoRoot
+    ? `node ${String(repoRoot).replace(/\/+$/, "")}/hub/bridge.mjs`
+    : "node hub/bridge.mjs";
 
   return `리드 에이전트: ${agentId}
 
@@ -76,6 +79,8 @@ ${roster}
 - 워커 결과 수집:
   ${bridgePath} context --agent ${agentId} --max 20
 - 최종 결과는 topic="task.result"를 모아 통합
+- 모든 워커의 task.result 수신 후 결과를 통합하고 종료하라. 워커가 무응답이면 상태를 보고하고 중단하라.
+- 증거(커밋/테스트/파일) 없는 완료 주장은 통합하지 말고 해당 워커에 redo 를 지시하라.
 
 워커 ID: ${workerIds || "(없음)"}
 지금 즉시 워커를 배정하고 병렬 진행을 관리하라.`;

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -663,7 +663,10 @@ export function createSwarmHypervisor(opts) {
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
-      prompt: buildWorkerPrompt(shard.prompt, { leaseFiles: shard.files }),
+      prompt: buildWorkerPrompt(shard.prompt, {
+        leaseFiles: shard.files,
+        worktreePath: shard.worktreePath,
+      }),
       workdir: shard.worktreePath || workdir,
       mcpServers: shard.mcp,
       worktreePath: shard.worktreePath || null,
@@ -980,6 +983,72 @@ export function createSwarmHypervisor(opts) {
         emitter.emit("shardFailed", {
           shardName,
           failureMode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
+          reason,
+        });
+
+        cascadeDependencyFailure(shardName);
+        checkAllShardsCompleted();
+        return;
+      }
+
+      if (
+        completionPayload?.status === "failed" ||
+        completionPayload?.status === "blocked"
+      ) {
+        const detail =
+          typeof completionPayload.reason === "string" &&
+          completionPayload.reason.length > 0
+            ? completionPayload.reason
+            : "unspecified";
+        const reason = `worker_reported_${completionPayload.status}:${detail}`;
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
+        eventLog.append("worker_reported_non_ok_completion", {
+          shard: shardName,
+          sessionId,
+          status: completionPayload.status,
+          reason,
+        });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
+        failures.set(shardName, {
+          mode: classifyFailure(reason),
+          reason,
+          sessionId,
+          completionPayload,
+        });
+        lockManager.release(shardName);
+
+        const redundant = redundantWorkers.get(shardName);
+        if (redundant) {
+          void redundant.conductor.shutdown("primary_reported_non_ok");
+        }
+
+        emitter.emit("shardFailed", {
+          shardName,
+          failureMode: classifyFailure(reason),
           reason,
         });
 

--- a/packages/remote/hub/team/worker-completion-validator.mjs
+++ b/packages/remote/hub/team/worker-completion-validator.mjs
@@ -1,9 +1,9 @@
 // hub/team/worker-completion-validator.mjs — Enforce worker completion schema.
 // Issue #115 Lane 1 / F7_worker_did_not_commit.
 //
-// A shard worker MUST emit a completion JSON with `status: "ok"` + a non-empty
-// `commits_made` array. Reporting without committing is the #1 cause of lost
-// swarm work — guarded here before integration trusts the worker.
+// A shard worker that reports `status: "ok"` MUST include a non-empty
+// `commits_made` array. Non-ok statuses are valid terminal reports, but they
+// are not allowed to masquerade as successful completion.
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -34,23 +34,18 @@ export function validateWorkerCompletion(payload) {
     return { ok: false, reason: "payload_not_object" };
   }
 
-  const valid = compiled(payload);
+  const status = payload.status;
+  if (!["ok", "failed", "blocked"].includes(status)) {
+    return { ok: false, reason: `invalid_status:${status ?? "undefined"}` };
+  }
+
+  const schemaPayload =
+    status === "blocked" ? { ...payload, status: "failed" } : payload;
+  const valid = compiled(schemaPayload);
   if (!valid) {
     const firstError = compiled.errors?.[0];
     const reason = formatError(firstError, payload);
     return { ok: false, reason };
-  }
-
-  // BUG-G (#130): the schema's if-then only constrains commits_made when
-  // status='ok', so status='failed' payloads pass AJV vacuously. Without
-  // this guard the hypervisor F7 path treats a worker self-reported failure
-  // as a successful completion and integrates phantom shards.
-  if (payload.status === "failed") {
-    const detail =
-      typeof payload.reason === "string" && payload.reason.length > 0
-        ? payload.reason
-        : "unspecified";
-    return { ok: false, reason: `worker_self_reported_failure:${detail}` };
   }
 
   return { ok: true };

--- a/packages/remote/scripts/lib/mcp-manifest.mjs
+++ b/packages/remote/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/triflux/hub/team/build-worker-prompt.mjs
+++ b/packages/triflux/hub/team/build-worker-prompt.mjs
@@ -22,10 +22,23 @@ function formatLeaseFiles(leaseFiles) {
   return normalized.map((file) => `- ${file}`).join("\n");
 }
 
-export function buildLeaseScopedAcceptanceAppendix({ leaseFiles = [] } = {}) {
+function normalizeWorktreePath(worktreePath) {
+  return typeof worktreePath === "string" ? worktreePath.trim() : "";
+}
+
+export function buildLeaseScopedAcceptanceAppendix({
+  leaseFiles = [],
+  worktreePath,
+} = {}) {
+  const normalizedWorktreePath = normalizeWorktreePath(worktreePath);
+  const rootLine = normalizedWorktreePath
+    ? `작업 루트(절대경로): ${normalizedWorktreePath} — 아래 lease 경로와 모든 상대경로는 이 루트 기준으로만 해석한다.\n`
+    : "";
+
   return `
 
 ## Lease-scoped Acceptance / Lint Guard (자동 삽입됨)
+${rootLine}- 위 PRD 본문의 모든 제약과 acceptance 기준은 이 appendix 이후에도 그대로 유효하다.
 - 이 shard 의 파일 lease:
 ${formatLeaseFiles(leaseFiles)}
 - Acceptance, lint, and format checks are scoped to files changed by this shard; if that set is unclear, use only the lease list above.
@@ -51,7 +64,10 @@ ${SENTINEL_END}
 규약:
 - 두 sentinel 마커는 각자 자기 줄에 단독으로 출력 (앞뒤 newline)
 - 마커 사이 본문은 단일 JSON object (배열/primitive 금지)
-- commits_made 가 비어 있어도 됨 (no-op shard)
+- status 값은 ok | failed | blocked 중 하나
+- payload 출력 직전 \`git log -1 --format=%H\` 로 보고할 sha 가 실재하는지 검증하라
+- 코드 변경이 기대되는 shard 에서 변경/커밋을 못 했으면 status:failed 와 함께 reason 필드로 사유를 보고하라 — 그 경우 빈 commits_made 에 status:ok 는 금지
+- no-op shard 는 status:ok + 빈 commits_made 배열 허용
 - 마커 쌍은 stdout 에 정확히 한 번만 출력해야 함. 재emit 시 conductor 는 첫 BEGIN..END 한 쌍만 채택하며, 이후 stdout 은 무시한다.
 - ${SENTINEL_BEGIN} 만 출력하고 ${SENTINEL_END} 누락 시 conductor 가 truncation 으로 명확히 reject
 `;
@@ -60,14 +76,17 @@ ${SENTINEL_END}
  * Append the Completion Protocol section to a PRD prompt.
  *
  * @param {string|null|undefined} prdPrompt — original PRD body
- * @param {{ leaseFiles?: string[] }} [opts] — shard file lease for scoped acceptance
+ * @param {{ leaseFiles?: string[], worktreePath?: string }} [opts] — shard file lease and absolute worktree root for scoped acceptance
  * @returns {string} prompt with appendix
  */
 export function buildWorkerPrompt(prdPrompt, opts = {}) {
   const body = typeof prdPrompt === "string" ? prdPrompt : "";
   return (
     body +
-    buildLeaseScopedAcceptanceAppendix({ leaseFiles: opts.leaseFiles }) +
+    buildLeaseScopedAcceptanceAppendix({
+      leaseFiles: opts.leaseFiles,
+      worktreePath: opts.worktreePath,
+    }) +
     COMPLETION_PROTOCOL_APPENDIX
   );
 }

--- a/packages/triflux/hub/team/handoff.mjs
+++ b/packages/triflux/hub/team/handoff.mjs
@@ -23,7 +23,7 @@ After completing the task, you MUST output a HANDOFF block in exactly this forma
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 task: <1-3 word task type>
-files_changed: <comma-separated file paths, or "none">
+files_changed: <comma-separated repo-root relative file paths, or "none">
 verdict: <one sentence conclusion>
 confidence: high | medium | low
 risk: low | med | high
@@ -36,21 +36,25 @@ partial_output: yes | no
 
 Rules:
 - The HANDOFF block must start with exactly "--- HANDOFF ---"
+- Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.
 - Each field must be on its own line as "key: value"
+- Report files_changed as repo-root relative paths
 - verdict must be a single concise sentence
 - Do not skip any required field
+- This block owns the final output position; this block must be the last thing you output
 `.trim();
 
 /**
  * CLI 프롬프트 길이 제한을 고려한 축약 HANDOFF 지시
  */
-export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end:
+export const HANDOFF_INSTRUCTION_SHORT = `After completing, output this block at the end; this block must be the last thing you output:
 --- HANDOFF ---
 status: ok | partial | failed
 lead_action: accept | needs_read | retry | reassign
 verdict: <one sentence>
-files_changed: <comma-separated paths or "none">
-confidence: high | medium | low`;
+files_changed: <comma-separated repo-root relative paths or "none">
+confidence: high | medium | low
+Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.`;
 
 /**
  * raw 텍스트에서 HANDOFF 블록을 파싱한다.

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -18,7 +18,7 @@ import {
 import { createRequire } from "node:module";
 import net from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { requestJson } from "../bridge.mjs";
 import { escapePwshSingleQuoted } from "../cli-adapter-base.mjs";
@@ -255,7 +255,7 @@ function unregisterHeadlessSynapseWorker(workerId) {
 /** MCP 프로필별 프롬프트 힌트 (tfx-route.sh resolve_mcp_policy의 경량 미러) */
 const MCP_PROFILE_HINTS = {
   implement:
-    "You have full filesystem read/write access. Implement changes directly.",
+    "You have full filesystem read/write access. Implement changes directly. After changes, run the narrowest relevant test/lint for the files you touched; if none can run, state why and the next-best check.",
   analyze:
     "Focus on reading and analyzing the codebase. Prefer analysis over modification.",
   review: "Review the code for quality, security, and correctness.",
@@ -301,22 +301,31 @@ export function buildHeadlessCommand(cli, prompt, resultFile, opts = {}) {
   // contextFile 처리: 32KB(32768 bytes) 초과 시 UTF-8 안전 절단
   let contextPrefix = "";
   if (contextFile && existsSync(contextFile)) {
+    const contextSource = resolve(contextFile);
     let ctx = readFileSync(contextFile, "utf8");
+    let truncated = false;
     if (Buffer.byteLength(ctx, "utf8") > 32768) {
       ctx = Buffer.from(ctx).subarray(0, 32768).toString("utf8");
+      truncated = true;
+    }
+    if (truncated) {
+      ctx = `${ctx}\n[... truncated at 32KB]`;
     }
     if (ctx.length > 0) {
-      contextPrefix = `<prior_context>\n${ctx}\n</prior_context>\n\n`;
+      contextPrefix = `<prior_context source="${contextSource}" truncated="${truncated ? "true" : "false"}">\n${ctx}\n</prior_context>\nBase your work on the prior_context above; if it conflicts with the task below, the task wins.\n\n`;
     }
   }
 
   const mcpHint =
     mcp && MCP_PROFILE_HINTS[mcp]
-      ? ` [MCP: ${mcp}] ${MCP_PROFILE_HINTS[mcp]}`
+      ? `\n\n[MCP: ${mcp}]\n${MCP_PROFILE_HINTS[mcp]}`
       : "";
+  const workspaceHint = cwd
+    ? `\n\n[workspace] root(절대경로): ${resolve(cwd)}. 모든 상대경로는 이 루트 기준. 파일 쓰기/커밋 전 \`git rev-parse --show-toplevel\` 이 이 root 와 일치하는지 확인하고 불일치 시 중단·보고.`
+    : "";
   // P2: HANDOFF 지시를 프롬프트에 삽입 (워커가 구조화된 handoff 블록을 출력하도록)
   const handoffHint = handoff ? `\n\n${HANDOFF_INSTRUCTION_SHORT}` : "";
-  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${handoffHint}`;
+  const fullPrompt = `${contextPrefix}${prompt}${mcpHint}${workspaceHint}${handoffHint}`;
 
   // 보안: 프롬프트를 임시 파일에 쓰고 파일 참조로 전달 (셸 주입 방지).
   // 이전 구현은 `"$(cat 'PATH')"` shell-expansion expression 을 만들어

--- a/packages/triflux/hub/team/orchestrator.mjs
+++ b/packages/triflux/hub/team/orchestrator.mjs
@@ -50,7 +50,7 @@ export function decomposeTask(taskDescription, agentCount) {
  * @returns {string}
  */
 export function buildLeadPrompt(taskDescription, config) {
-  const { agentId, teammateMode = "tmux", workers = [] } = config;
+  const { agentId, repoRoot, teammateMode = "tmux", workers = [] } = config;
 
   const roster =
     workers
@@ -59,7 +59,10 @@ export function buildLeadPrompt(taskDescription, config) {
 
   const workerIds = workers.map((w) => w.agentId).join(", ");
 
-  const bridgePath = "node hub/bridge.mjs";
+  // TODO: Require repoRoot once all callers pass absolute repository roots.
+  const bridgePath = repoRoot
+    ? `node ${String(repoRoot).replace(/\/+$/, "")}/hub/bridge.mjs`
+    : "node hub/bridge.mjs";
 
   return `리드 에이전트: ${agentId}
 
@@ -76,6 +79,8 @@ ${roster}
 - 워커 결과 수집:
   ${bridgePath} context --agent ${agentId} --max 20
 - 최종 결과는 topic="task.result"를 모아 통합
+- 모든 워커의 task.result 수신 후 결과를 통합하고 종료하라. 워커가 무응답이면 상태를 보고하고 중단하라.
+- 증거(커밋/테스트/파일) 없는 완료 주장은 통합하지 말고 해당 워커에 redo 를 지시하라.
 
 워커 ID: ${workerIds || "(없음)"}
 지금 즉시 워커를 배정하고 병렬 진행을 관리하라.`;

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -663,7 +663,10 @@ export function createSwarmHypervisor(opts) {
       agent: shard.agent,
       // #125: append Completion Protocol appendix so workers emit a
       // sentinel-framed JSON payload that conductor can reliably capture.
-      prompt: buildWorkerPrompt(shard.prompt, { leaseFiles: shard.files }),
+      prompt: buildWorkerPrompt(shard.prompt, {
+        leaseFiles: shard.files,
+        worktreePath: shard.worktreePath,
+      }),
       workdir: shard.worktreePath || workdir,
       mcpServers: shard.mcp,
       worktreePath: shard.worktreePath || null,
@@ -980,6 +983,72 @@ export function createSwarmHypervisor(opts) {
         emitter.emit("shardFailed", {
           shardName,
           failureMode: FAILURE_MODES.F7_WORKER_DID_NOT_COMMIT,
+          reason,
+        });
+
+        cascadeDependencyFailure(shardName);
+        checkAllShardsCompleted();
+        return;
+      }
+
+      if (
+        completionPayload?.status === "failed" ||
+        completionPayload?.status === "blocked"
+      ) {
+        const detail =
+          typeof completionPayload.reason === "string" &&
+          completionPayload.reason.length > 0
+            ? completionPayload.reason
+            : "unspecified";
+        const reason = `worker_reported_${completionPayload.status}:${detail}`;
+
+        if (isRedundant) {
+          eventLog.append("redundant_completion_rejected", {
+            shard: shardName,
+            sessionId,
+            reason,
+          });
+          redundantWorkers.delete(shardName);
+          if (completedWorker) {
+            void closeNativeBridgeRegistration(
+              completedWorker,
+              shardName,
+              "failed",
+            );
+          }
+          checkAllShardsCompleted();
+          return;
+        }
+
+        eventLog.append("worker_reported_non_ok_completion", {
+          shard: shardName,
+          sessionId,
+          status: completionPayload.status,
+          reason,
+        });
+        if (completedWorker) {
+          void closeNativeBridgeRegistration(
+            completedWorker,
+            shardName,
+            "failed",
+          );
+        }
+        failures.set(shardName, {
+          mode: classifyFailure(reason),
+          reason,
+          sessionId,
+          completionPayload,
+        });
+        lockManager.release(shardName);
+
+        const redundant = redundantWorkers.get(shardName);
+        if (redundant) {
+          void redundant.conductor.shutdown("primary_reported_non_ok");
+        }
+
+        emitter.emit("shardFailed", {
+          shardName,
+          failureMode: classifyFailure(reason),
           reason,
         });
 

--- a/packages/triflux/hub/team/worker-completion-validator.mjs
+++ b/packages/triflux/hub/team/worker-completion-validator.mjs
@@ -1,9 +1,9 @@
 // hub/team/worker-completion-validator.mjs — Enforce worker completion schema.
 // Issue #115 Lane 1 / F7_worker_did_not_commit.
 //
-// A shard worker MUST emit a completion JSON with `status: "ok"` + a non-empty
-// `commits_made` array. Reporting without committing is the #1 cause of lost
-// swarm work — guarded here before integration trusts the worker.
+// A shard worker that reports `status: "ok"` MUST include a non-empty
+// `commits_made` array. Non-ok statuses are valid terminal reports, but they
+// are not allowed to masquerade as successful completion.
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -34,23 +34,18 @@ export function validateWorkerCompletion(payload) {
     return { ok: false, reason: "payload_not_object" };
   }
 
-  const valid = compiled(payload);
+  const status = payload.status;
+  if (!["ok", "failed", "blocked"].includes(status)) {
+    return { ok: false, reason: `invalid_status:${status ?? "undefined"}` };
+  }
+
+  const schemaPayload =
+    status === "blocked" ? { ...payload, status: "failed" } : payload;
+  const valid = compiled(schemaPayload);
   if (!valid) {
     const firstError = compiled.errors?.[0];
     const reason = formatError(firstError, payload);
     return { ok: false, reason };
-  }
-
-  // BUG-G (#130): the schema's if-then only constrains commits_made when
-  // status='ok', so status='failed' payloads pass AJV vacuously. Without
-  // this guard the hypervisor F7 path treats a worker self-reported failure
-  // as a successful completion and integrates phantom shards.
-  if (payload.status === "failed") {
-    const detail =
-      typeof payload.reason === "string" && payload.reason.length > 0
-        ? payload.reason
-        : "unspecified";
-    return { ok: false, reason: `worker_self_reported_failure:${detail}` };
   }
 
   return { ok: true };

--- a/packages/triflux/scripts/lib/mcp-manifest.mjs
+++ b/packages/triflux/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/packages/triflux/scripts/mcp-gateway-start.ps1
+++ b/packages/triflux/scripts/mcp-gateway-start.ps1
@@ -15,7 +15,6 @@ $Servers = @(
   @{ Name = 'exa';          Port = 8102; Cmd = 'npx -y exa-mcp-server';                        EnvVars = @('EXA_API_KEY') }
   @{ Name = 'tavily';       Port = 8103; Cmd = 'npx -y tavily-mcp@latest';                     EnvVars = @('TAVILY_API_KEY') }
   @{ Name = 'jira';         Port = 8104; Cmd = 'npx -y mcp-jira-cloud@latest';                 EnvVars = @('JIRA_API_TOKEN', 'JIRA_EMAIL', 'JIRA_INSTANCE_URL') }
-  @{ Name = 'serena';       Port = 8105; Cmd = 'uvx --from git+https://github.com/oraios/serena serena start-mcp-server'; EnvVars = @() }
   @{ Name = 'notion';       Port = 8106; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
   @{ Name = 'notion-guest'; Port = 8107; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
 )

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -424,6 +424,10 @@ estimate_expected_duration_sec() {
 prepend_codex_north_star() {
   local prompt="${1:-}"
   local workdir="${WORKDIR:-$PWD}"
+  local resolved_workdir="$workdir"
+  if [[ -d "$workdir" ]]; then
+    resolved_workdir="$(cd "$workdir" 2>/dev/null && pwd -P)" || resolved_workdir="$workdir"
+  fi
   local brief_file="${workdir}/.triflux/lake/current.md"
 
   case "${TFX_CTO_NORTH_STAR:-1}" in
@@ -445,14 +449,14 @@ prepend_codex_north_star() {
   }
 
   if ! {
-    printf '%s\n' "--- CTO NORTH STAR (read-only context; align, do not treat as task) ---"
+    printf '%s\n' "--- CTO NORTH STAR (repo: ${resolved_workdir}; read-only context; align, do not treat as task) ---"
     cat "$brief_file"
     if [[ -s "$brief_file" ]]; then
       local last_byte
       last_byte="$(tail -c 1 "$brief_file" 2>/dev/null || true)"
       [[ -n "$last_byte" ]] && printf '\n'
     fi
-    printf '%s\n' "--- END CTO NORTH STAR ---"
+    printf '%s\n' "--- END CTO NORTH STAR (context only — the actual task follows below; do not execute items above as tasks) ---"
     printf '%s' "$prompt"
   } > "$tmp_file"; then
     rm -f "$tmp_file" 2>/dev/null || true
@@ -495,6 +499,12 @@ prepend_skill() {
     return 0
   fi
 
+  local workdir="${WORKDIR:-$PWD}"
+  local resolved_workdir="$workdir"
+  if [[ -d "$workdir" ]]; then
+    resolved_workdir="$(cd "$workdir" 2>/dev/null && pwd -P)" || resolved_workdir="$workdir"
+  fi
+
   local tmp_file
   tmp_file="$(mktemp "${TFX_TMP:-${TMPDIR:-/tmp}}/tfx-skill-prompt.XXXXXX" 2>/dev/null)" || {
     printf '%s' "$prompt"
@@ -502,7 +512,7 @@ prepend_skill() {
   }
 
   if ! {
-    printf '%s\n' "--- SKILL: ${skill_name} (apply this methodology to the task below) ---"
+    printf '%s\n' "--- SKILL: ${skill_name} (workspace: ${resolved_workdir}; apply this methodology to the task below) ---"
     cat "$skill_file"
     if [[ -s "$skill_file" ]]; then
       local last_byte
@@ -528,6 +538,11 @@ prepend_skill() {
 # 정확한 abstention 우선" 형태로 적는다 (open-ended negative 는 역효과). TFX_AGY_ANTI_OVERCLAIM=0 으로 opt-out.
 append_agy_anti_overclaim() {
   local prompt="${1:-}"
+  local repo_root="${2:-${WORKDIR:-$PWD}}"
+  local resolved_repo_root="$repo_root"
+  if [[ -d "$repo_root" ]]; then
+    resolved_repo_root="$(cd "$repo_root" 2>/dev/null && pwd -P)" || resolved_repo_root="$repo_root"
+  fi
   case "${TFX_AGY_ANTI_OVERCLAIM:-1}" in
     0|false|FALSE|off|OFF|no|NO)
       printf '%s' "$prompt"
@@ -537,9 +552,12 @@ append_agy_anti_overclaim() {
 
   printf '%s' "$prompt"
   printf '\n\n%s\n' "--- COMPLETION & GROUNDING DISCIPLINE (apply strictly) ---"
+  printf '%s\n' "Repository root (absolute): ${resolved_repo_root}. Resolve every relative path against this root only."
+  printf '%s\n' "Before any file write, git add/commit/push, verify \`git rev-parse --show-toplevel\` equals the repository root above; if it differs, stop and report the mismatch instead of proceeding."
   printf '%s\n' "- Claim done/fixed/passing ONLY after running the check in this turn and seeing its output. With no fresh evidence, report what is still unverified instead of asserting success."
   printf '%s\n' "- Ground every answer in the provided context and the actual repository. If something is not verifiable from what you can see, say 'No Info / 확인 불가' and stop rather than inventing plausible-but-unconfirmed details."
   printf '%s\n' "- Use the provided context for deductions and prefer accurate abstention over confident guessing."
+  printf '%s\n' "The task's own final output/format constraints above remain in effect."
   printf '%s' "--- END DISCIPLINE ---"
 }
 
@@ -2698,7 +2716,9 @@ FALLBACK_EOF
   fi
 
   local FULL_PROMPT="$PROMPT"
-  [[ -n "$MCP_HINT" ]] && FULL_PROMPT="${PROMPT}. ${MCP_HINT}"
+  if [[ -n "$MCP_HINT" ]]; then
+    FULL_PROMPT="${PROMPT}"$'\n\n'"[도구 안내] ${MCP_HINT}"
+  fi
   local codex_transport_effective="n/a"
 
   # 메타정보 (stderr)
@@ -2823,6 +2843,10 @@ FALLBACK_EOF
     _codex_config_swap "restore"
 
   elif [[ "$CLI_TYPE" == "gemini" ]]; then
+    # Codex degraded branch strips MCP_HINT; keep gemini parity when the marker is inherited.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      FULL_PROMPT="$PROMPT"
+    fi
     local gemini_model
     gemini_model=$(awk '{
       for (i = 1; i <= NF; i++) {
@@ -2887,6 +2911,10 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "antigravity" ]]; then
+    # Codex degraded branch strips MCP_HINT; keep agy parity when the marker is inherited.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      FULL_PROMPT="$PROMPT"
+    fi
     # CTO north-star: codex lane(line ~2670)과 동일하게 brief 를 prompt 앞에 주입.
     # prepend_codex_north_star 는 CLI-agnostic (TFX_CTO_NORTH_STAR opt-out +
     # .triflux/lake/current.md 만 참조) 하므로 agy 워커에서도 그대로 재사용한다.
@@ -2908,7 +2936,7 @@ EOF
     # agy(Gemini 3.x) anti-overclaim 규율 블록을 프롬프트 END 에 append. opt-out: TFX_AGY_ANTI_OVERCLAIM=0.
     local _agy_aoc_sentinel="__TFX_AGY_AOC_END_${$}_${RANDOM}__"
     local _agy_aoc_prompt
-    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT"; printf '%s' "$_agy_aoc_sentinel")"
+    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT" "${WORKDIR:-$PWD}"; printf '%s' "$_agy_aoc_sentinel")"
     FULL_PROMPT="${_agy_aoc_prompt%"$_agy_aoc_sentinel"}"
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -339,11 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7, serena)는 API 키 불필요, 자동 활성화됨을 표시:
+Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
 ```
 ✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
-✅ serena   — 시맨틱 코드 분석 (API 키 불필요)
 ```
+
+> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -407,7 +408,7 @@ node -e "
 {
   "version": 1,
   "updatedAt": "2026-03-31T...",
-  "enabled": ["context7", "serena", "brave-search", "exa"]
+  "enabled": ["context7", "brave-search", "exa"]
 }
 ```
 
@@ -419,7 +420,6 @@ node -e "
 | 서버 | 상태 | 비고 |
 |------|------|------|
 | context7 | ✅ 활성 | Core (항상 활성) |
-| serena | ✅ 활성 | Core (항상 활성) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/packages/triflux/skills/tfx-setup/SKILL.md
+++ b/packages/triflux/skills/tfx-setup/SKILL.md
@@ -339,12 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
+강제 활성(Core) 서버는 현재 없다 (mcp-manifest.mjs `CORE_SERVERS = []`). 모든 서버는 매니페스트 enabled 목록 기반으로만 활성화된다. API 키가 필요 없는 context7는 기본 권장으로 표시:
 ```
-✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
+✅ context7 — 라이브러리 문서 조회 (API 키 불필요, 매니페스트 기반)
 ```
 
-> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
+> serena는 2026-06-10 core에서 제거됨. core 강제 활성을 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -419,7 +419,7 @@ node -e "
 
 | 서버 | 상태 | 비고 |
 |------|------|------|
-| context7 | ✅ 활성 | Core (항상 활성) |
+| context7 | ✅ 활성 | API 키 불필요 (매니페스트 기반) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/scripts/lib/mcp-manifest.mjs
+++ b/scripts/lib/mcp-manifest.mjs
@@ -13,8 +13,8 @@ export const MANIFEST_PATH = join(
   "mcp-enabled.json",
 );
 
-/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers */
-export const CORE_SERVERS = Object.freeze(["serena"]);
+/** API 키 불필요 — 항상 활성화 for gateway-managed MCP servers (현재 없음 — serena는 2026-06-10 core에서 제거) */
+export const CORE_SERVERS = Object.freeze([]);
 
 /** 검색 MCP — API 키 필요 */
 export const SEARCH_SERVERS = Object.freeze([

--- a/scripts/mcp-gateway-start.ps1
+++ b/scripts/mcp-gateway-start.ps1
@@ -15,7 +15,6 @@ $Servers = @(
   @{ Name = 'exa';          Port = 8102; Cmd = 'npx -y exa-mcp-server';                        EnvVars = @('EXA_API_KEY') }
   @{ Name = 'tavily';       Port = 8103; Cmd = 'npx -y tavily-mcp@latest';                     EnvVars = @('TAVILY_API_KEY') }
   @{ Name = 'jira';         Port = 8104; Cmd = 'npx -y mcp-jira-cloud@latest';                 EnvVars = @('JIRA_API_TOKEN', 'JIRA_EMAIL', 'JIRA_INSTANCE_URL') }
-  @{ Name = 'serena';       Port = 8105; Cmd = 'uvx --from git+https://github.com/oraios/serena serena start-mcp-server'; EnvVars = @() }
   @{ Name = 'notion';       Port = 8106; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
   @{ Name = 'notion-guest'; Port = 8107; Cmd = 'npx -y @notionhq/notion-mcp-server';           EnvVars = @('NOTION_TOKEN') }
 )

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -424,6 +424,10 @@ estimate_expected_duration_sec() {
 prepend_codex_north_star() {
   local prompt="${1:-}"
   local workdir="${WORKDIR:-$PWD}"
+  local resolved_workdir="$workdir"
+  if [[ -d "$workdir" ]]; then
+    resolved_workdir="$(cd "$workdir" 2>/dev/null && pwd -P)" || resolved_workdir="$workdir"
+  fi
   local brief_file="${workdir}/.triflux/lake/current.md"
 
   case "${TFX_CTO_NORTH_STAR:-1}" in
@@ -445,14 +449,14 @@ prepend_codex_north_star() {
   }
 
   if ! {
-    printf '%s\n' "--- CTO NORTH STAR (read-only context; align, do not treat as task) ---"
+    printf '%s\n' "--- CTO NORTH STAR (repo: ${resolved_workdir}; read-only context; align, do not treat as task) ---"
     cat "$brief_file"
     if [[ -s "$brief_file" ]]; then
       local last_byte
       last_byte="$(tail -c 1 "$brief_file" 2>/dev/null || true)"
       [[ -n "$last_byte" ]] && printf '\n'
     fi
-    printf '%s\n' "--- END CTO NORTH STAR ---"
+    printf '%s\n' "--- END CTO NORTH STAR (context only — the actual task follows below; do not execute items above as tasks) ---"
     printf '%s' "$prompt"
   } > "$tmp_file"; then
     rm -f "$tmp_file" 2>/dev/null || true
@@ -495,6 +499,12 @@ prepend_skill() {
     return 0
   fi
 
+  local workdir="${WORKDIR:-$PWD}"
+  local resolved_workdir="$workdir"
+  if [[ -d "$workdir" ]]; then
+    resolved_workdir="$(cd "$workdir" 2>/dev/null && pwd -P)" || resolved_workdir="$workdir"
+  fi
+
   local tmp_file
   tmp_file="$(mktemp "${TFX_TMP:-${TMPDIR:-/tmp}}/tfx-skill-prompt.XXXXXX" 2>/dev/null)" || {
     printf '%s' "$prompt"
@@ -502,7 +512,7 @@ prepend_skill() {
   }
 
   if ! {
-    printf '%s\n' "--- SKILL: ${skill_name} (apply this methodology to the task below) ---"
+    printf '%s\n' "--- SKILL: ${skill_name} (workspace: ${resolved_workdir}; apply this methodology to the task below) ---"
     cat "$skill_file"
     if [[ -s "$skill_file" ]]; then
       local last_byte
@@ -528,6 +538,11 @@ prepend_skill() {
 # 정확한 abstention 우선" 형태로 적는다 (open-ended negative 는 역효과). TFX_AGY_ANTI_OVERCLAIM=0 으로 opt-out.
 append_agy_anti_overclaim() {
   local prompt="${1:-}"
+  local repo_root="${2:-${WORKDIR:-$PWD}}"
+  local resolved_repo_root="$repo_root"
+  if [[ -d "$repo_root" ]]; then
+    resolved_repo_root="$(cd "$repo_root" 2>/dev/null && pwd -P)" || resolved_repo_root="$repo_root"
+  fi
   case "${TFX_AGY_ANTI_OVERCLAIM:-1}" in
     0|false|FALSE|off|OFF|no|NO)
       printf '%s' "$prompt"
@@ -537,9 +552,12 @@ append_agy_anti_overclaim() {
 
   printf '%s' "$prompt"
   printf '\n\n%s\n' "--- COMPLETION & GROUNDING DISCIPLINE (apply strictly) ---"
+  printf '%s\n' "Repository root (absolute): ${resolved_repo_root}. Resolve every relative path against this root only."
+  printf '%s\n' "Before any file write, git add/commit/push, verify \`git rev-parse --show-toplevel\` equals the repository root above; if it differs, stop and report the mismatch instead of proceeding."
   printf '%s\n' "- Claim done/fixed/passing ONLY after running the check in this turn and seeing its output. With no fresh evidence, report what is still unverified instead of asserting success."
   printf '%s\n' "- Ground every answer in the provided context and the actual repository. If something is not verifiable from what you can see, say 'No Info / 확인 불가' and stop rather than inventing plausible-but-unconfirmed details."
   printf '%s\n' "- Use the provided context for deductions and prefer accurate abstention over confident guessing."
+  printf '%s\n' "The task's own final output/format constraints above remain in effect."
   printf '%s' "--- END DISCIPLINE ---"
 }
 
@@ -2698,7 +2716,9 @@ FALLBACK_EOF
   fi
 
   local FULL_PROMPT="$PROMPT"
-  [[ -n "$MCP_HINT" ]] && FULL_PROMPT="${PROMPT}. ${MCP_HINT}"
+  if [[ -n "$MCP_HINT" ]]; then
+    FULL_PROMPT="${PROMPT}"$'\n\n'"[도구 안내] ${MCP_HINT}"
+  fi
   local codex_transport_effective="n/a"
 
   # 메타정보 (stderr)
@@ -2823,6 +2843,10 @@ FALLBACK_EOF
     _codex_config_swap "restore"
 
   elif [[ "$CLI_TYPE" == "gemini" ]]; then
+    # Codex degraded branch strips MCP_HINT; keep gemini parity when the marker is inherited.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      FULL_PROMPT="$PROMPT"
+    fi
     local gemini_model
     gemini_model=$(awk '{
       for (i = 1; i <= NF; i++) {
@@ -2887,6 +2911,10 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "antigravity" ]]; then
+    # Codex degraded branch strips MCP_HINT; keep agy parity when the marker is inherited.
+    if [[ "${_TFX_MCP_DEGRADED:-0}" == "1" ]]; then
+      FULL_PROMPT="$PROMPT"
+    fi
     # CTO north-star: codex lane(line ~2670)과 동일하게 brief 를 prompt 앞에 주입.
     # prepend_codex_north_star 는 CLI-agnostic (TFX_CTO_NORTH_STAR opt-out +
     # .triflux/lake/current.md 만 참조) 하므로 agy 워커에서도 그대로 재사용한다.
@@ -2908,7 +2936,7 @@ EOF
     # agy(Gemini 3.x) anti-overclaim 규율 블록을 프롬프트 END 에 append. opt-out: TFX_AGY_ANTI_OVERCLAIM=0.
     local _agy_aoc_sentinel="__TFX_AGY_AOC_END_${$}_${RANDOM}__"
     local _agy_aoc_prompt
-    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT"; printf '%s' "$_agy_aoc_sentinel")"
+    _agy_aoc_prompt="$(append_agy_anti_overclaim "$FULL_PROMPT" "${WORKDIR:-$PWD}"; printf '%s' "$_agy_aoc_sentinel")"
     FULL_PROMPT="${_agy_aoc_prompt%"$_agy_aoc_sentinel"}"
     run_antigravity_exec "$FULL_PROMPT" "$use_tee" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -339,11 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7, serena)는 API 키 불필요, 자동 활성화됨을 표시:
+Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
 ```
 ✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
-✅ serena   — 시맨틱 코드 분석 (API 키 불필요)
 ```
+
+> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -407,7 +408,7 @@ node -e "
 {
   "version": 1,
   "updatedAt": "2026-03-31T...",
-  "enabled": ["context7", "serena", "brave-search", "exa"]
+  "enabled": ["context7", "brave-search", "exa"]
 }
 ```
 
@@ -419,7 +420,6 @@ node -e "
 | 서버 | 상태 | 비고 |
 |------|------|------|
 | context7 | ✅ 활성 | Core (항상 활성) |
-| serena | ✅ 활성 | Core (항상 활성) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/skills/tfx-setup/SKILL.md
+++ b/skills/tfx-setup/SKILL.md
@@ -339,12 +339,12 @@ Read 도구로 `~/.claude/cache/mcp-enabled.json` 읽기 시도.
 
 ##### 5-2: Core 서버 안내
 
-Core 서버(context7)는 API 키 불필요, 자동 활성화됨을 표시:
+강제 활성(Core) 서버는 현재 없다 (mcp-manifest.mjs `CORE_SERVERS = []`). 모든 서버는 매니페스트 enabled 목록 기반으로만 활성화된다. API 키가 필요 없는 context7는 기본 권장으로 표시:
 ```
-✅ context7 — 라이브러리 문서 조회 (API 키 불필요)
+✅ context7 — 라이브러리 문서 조회 (API 키 불필요, 매니페스트 기반)
 ```
 
-> serena는 2026-06-10 core에서 제거됨 (mcp-manifest.mjs `CORE_SERVERS = []`). 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
+> serena는 2026-06-10 core에서 제거됨. core 강제 활성을 재도입하려면 CORE_SERVERS와 이 섹션을 함께 갱신한다.
 
 ##### 5-3: 검색 MCP 선택
 
@@ -419,7 +419,7 @@ node -e "
 
 | 서버 | 상태 | 비고 |
 |------|------|------|
-| context7 | ✅ 활성 | Core (항상 활성) |
+| context7 | ✅ 활성 | API 키 불필요 (매니페스트 기반) |
 | brave-search | ✅ 활성 | BRAVE_API_KEY ✅ |
 | exa | ⚠️ 활성 | EXA_API_KEY 미설정 — 키 추가 후 사용 가능 |
 | tavily | ⏭️ 건너뜀 | 사용자 선택 |

--- a/tests/unit/build-worker-prompt.test.mjs
+++ b/tests/unit/build-worker-prompt.test.mjs
@@ -31,6 +31,11 @@ test("buildWorkerPrompt — PRD body 뒤에 appendix 부착", () => {
   const result = buildWorkerPrompt("# PRD body\n## 목표\n무언가");
   assert.ok(result.startsWith("# PRD body"));
   assert.ok(result.includes("Lease-scoped Acceptance / Lint Guard"));
+  assert.ok(
+    result.includes(
+      "위 PRD 본문의 모든 제약과 acceptance 기준은 이 appendix 이후에도 그대로 유효하다.",
+    ),
+  );
   assert.ok(result.includes(SENTINEL_BEGIN));
   assert.ok(result.includes(SENTINEL_END));
   // appendices 는 PRD 본문 뒤에 위치해야 함.
@@ -51,9 +56,52 @@ test("buildWorkerPrompt — lease 파일로 acceptance/lint 범위를 좁힘", (
   assert.ok(result.includes("Pre-existing lint drift outside the lease"));
 });
 
+test("buildWorkerPrompt — worktreePath 로 lease/상대경로 기준 루트를 고정", () => {
+  const result = buildWorkerPrompt("do shard work", {
+    leaseFiles: ["hub/team/build-worker-prompt.mjs"],
+    worktreePath: "/tmp/triflux/.codex-swarm/wt-worker-a",
+  });
+
+  assert.ok(
+    result.includes(
+      "작업 루트(절대경로): /tmp/triflux/.codex-swarm/wt-worker-a — 아래 lease 경로와 모든 상대경로는 이 루트 기준으로만 해석한다.",
+    ),
+  );
+  assert.ok(result.includes("- hub/team/build-worker-prompt.mjs"));
+});
+
 test("buildLeaseScopedAcceptanceAppendix — lease 없으면 none declared 표시", () => {
   const result = buildLeaseScopedAcceptanceAppendix();
   assert.ok(result.includes("- (none declared)"));
+});
+
+test("COMPLETION_PROTOCOL_APPENDIX — 실패/차단 상태와 sha 검증 계약을 명시", () => {
+  assert.ok(
+    COMPLETION_PROTOCOL_APPENDIX.includes(
+      "status 값은 ok | failed | blocked 중 하나",
+    ),
+  );
+  assert.ok(
+    COMPLETION_PROTOCOL_APPENDIX.includes(
+      "payload 출력 직전 `git log -1 --format=%H` 로 보고할 sha 가 실재하는지 검증하라",
+    ),
+  );
+  assert.ok(
+    COMPLETION_PROTOCOL_APPENDIX.includes(
+      "코드 변경이 기대되는 shard 에서 변경/커밋을 못 했으면 status:failed 와 함께 reason 필드로 사유를 보고하라",
+    ),
+  );
+  assert.ok(
+    COMPLETION_PROTOCOL_APPENDIX.includes(
+      "no-op shard 는 status:ok + 빈 commits_made 배열 허용",
+    ),
+  );
+  assert.equal(
+    COMPLETION_PROTOCOL_APPENDIX.includes(
+      "commits_made 가 비어 있어도 됨 (no-op shard)",
+    ),
+    false,
+  );
 });
 
 test("buildWorkerPrompt — null/undefined/빈 prompt 도 appendix 만 포함", () => {

--- a/tests/unit/handoff.test.mjs
+++ b/tests/unit/handoff.test.mjs
@@ -6,6 +6,8 @@ import { describe, it } from "node:test";
 import {
   buildFallbackHandoff,
   formatHandoffForLead,
+  HANDOFF_INSTRUCTION,
+  HANDOFF_INSTRUCTION_SHORT,
   parseHandoff,
   processHandoff,
   validateHandoff,
@@ -46,6 +48,53 @@ const NO_HANDOFF = `
 This is just regular output without any handoff block.
 Done processing files.
 `;
+
+describe("HANDOFF instruction contract", () => {
+  it("full contract gates ok status on verification evidence", () => {
+    assert.ok(
+      HANDOFF_INSTRUCTION.includes(
+        "Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.",
+      ),
+      HANDOFF_INSTRUCTION,
+    );
+  });
+
+  it("full contract requires repo-root relative files_changed and final output ownership", () => {
+    assert.ok(
+      HANDOFF_INSTRUCTION.includes(
+        'files_changed: <comma-separated repo-root relative file paths, or "none">',
+      ),
+      HANDOFF_INSTRUCTION,
+    );
+    assert.ok(
+      HANDOFF_INSTRUCTION.includes(
+        "this block must be the last thing you output",
+      ),
+      HANDOFF_INSTRUCTION,
+    );
+  });
+
+  it("short contract keeps verification gate and final output ownership", () => {
+    assert.ok(
+      HANDOFF_INSTRUCTION_SHORT.includes(
+        "Set status: ok only after you have verified the work (file/diff/test evidence) — unverified claims must use partial or failed.",
+      ),
+      HANDOFF_INSTRUCTION_SHORT,
+    );
+    assert.ok(
+      HANDOFF_INSTRUCTION_SHORT.includes(
+        'files_changed: <comma-separated repo-root relative paths or "none">',
+      ),
+      HANDOFF_INSTRUCTION_SHORT,
+    );
+    assert.ok(
+      HANDOFF_INSTRUCTION_SHORT.includes(
+        "this block must be the last thing you output",
+      ),
+      HANDOFF_INSTRUCTION_SHORT,
+    );
+  });
+});
 
 // ── parseHandoff ──
 

--- a/tests/unit/headless-prompt-anchors.test.mjs
+++ b/tests/unit/headless-prompt-anchors.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { buildHeadlessCommand } from "../../hub/team/headless.mjs";
+
+function readGeneratedPrompt(cmd) {
+  const fullPath = cmd.match(/['"]([^'"]*prompt-\d+-\d+-\d+\.txt)['"]/)?.[1];
+  assert.ok(fullPath, `프롬프트 파일 경로를 추출할 수 있어야 함: ${cmd}`);
+  return readFileSync(fullPath, "utf8");
+}
+
+describe("headless prompt grounding anchors", () => {
+  it("MCP implement 힌트는 별도 라벨 블록과 검증 지시를 포함한다", () => {
+    const cmd = buildHeadlessCommand("codex", "test", "/tmp/r.txt", {
+      handoff: false,
+      mcp: "implement",
+    });
+    const content = readGeneratedPrompt(cmd);
+
+    assert.ok(
+      content.includes("\n\n[MCP: implement]\n"),
+      `MCP 힌트는 별도 라벨 블록이어야 함: ${content}`,
+    );
+    assert.ok(
+      content.includes(
+        "Implement changes directly. After changes, run the narrowest relevant test/lint for the files you touched; if none can run, state why and the next-best check.",
+      ),
+      `implement MCP 힌트에 검증 지시가 포함되어야 함: ${content}`,
+    );
+    assert.ok(
+      !content.includes("test [MCP: implement]"),
+      `MCP 힌트는 인라인 접착되지 않아야 함: ${content}`,
+    );
+  });
+
+  it("cwd가 있으면 handoff 직전에 workspace grounding 블록을 삽입한다", () => {
+    const cmd = buildHeadlessCommand("codex", "do work", "/tmp/r.txt", {
+      cwd: "/repo/triflux",
+    });
+    const content = readGeneratedPrompt(cmd);
+    const workspace =
+      "[workspace] root(절대경로): /repo/triflux. 모든 상대경로는 이 루트 기준. 파일 쓰기/커밋 전 `git rev-parse --show-toplevel` 이 이 root 와 일치하는지 확인하고 불일치 시 중단·보고.";
+
+    assert.ok(
+      content.includes(workspace),
+      `workspace grounding 누락: ${content}`,
+    );
+    assert.ok(
+      content.indexOf(workspace) < content.indexOf("--- HANDOFF ---"),
+      `workspace grounding은 handoff 전에 있어야 함: ${content}`,
+    );
+  });
+
+  it("cwd가 없으면 workspace grounding 블록을 생략한다", () => {
+    const cmd = buildHeadlessCommand("codex", "do work", "/tmp/r.txt");
+    const content = readGeneratedPrompt(cmd);
+
+    assert.ok(
+      !content.includes("[workspace] root"),
+      `cwd 없을 때 grounding 금지: ${content}`,
+    );
+  });
+
+  it("prior_context는 source/truncated 속성과 anchor를 포함한다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "triflux-headless-context-"));
+    try {
+      const contextFile = join(dir, "context.md");
+      writeFileSync(contextFile, "previous notes\n", "utf8");
+      const cmd = buildHeadlessCommand("codex", "new task", "/tmp/r.txt", {
+        handoff: false,
+        contextFile,
+      });
+      const content = readGeneratedPrompt(cmd);
+
+      assert.ok(
+        content.startsWith(
+          `<prior_context source="${contextFile}" truncated="false">\nprevious notes\n`,
+        ),
+        `prior_context 속성 태그 누락: ${content}`,
+      );
+      assert.ok(
+        content.includes(
+          "</prior_context>\nBase your work on the prior_context above; if it conflicts with the task below, the task wins.\n\nnew task",
+        ),
+        `prior_context anchor 누락: ${content}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("32KB 초과 prior_context는 truncated=true와 절단 마커를 표시한다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "triflux-headless-context-"));
+    try {
+      const contextFile = join(dir, "large.md");
+      writeFileSync(contextFile, "A".repeat(33000), "utf8");
+      const cmd = buildHeadlessCommand("codex", "new task", "/tmp/r.txt", {
+        handoff: false,
+        contextFile,
+      });
+      const content = readGeneratedPrompt(cmd);
+
+      assert.ok(
+        content.startsWith(
+          `<prior_context source="${contextFile}" truncated="true">`,
+        ),
+        `truncated 속성 누락: ${content.slice(0, 120)}`,
+      );
+      assert.ok(
+        content.includes("[... truncated at 32KB]"),
+        `절단 마커 누락: ${content.slice(-200)}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/orchestrator.test.mjs
+++ b/tests/unit/orchestrator.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { orchestrate } from "../../hub/team/orchestrator.mjs";
+import { buildLeadPrompt, orchestrate } from "../../hub/team/orchestrator.mjs";
 
 function makeMockInject() {
   const calls = [];
@@ -101,5 +101,59 @@ describe("orchestrator cli hint propagation (#117)", () => {
     // 실 psmux 호출을 피하기 위해 기본 경로 실행은 생략.
     // DI가 작동하는지만 위 테스트들로 검증되면 기본 import 경로도 동일 signature로 호출됨을 보장한다.
     assert.ok(typeof orchestrate === "function");
+  });
+});
+
+describe("buildLeadPrompt grounding and evidence gates", () => {
+  it("repoRoot가 있으면 bridge 호출을 절대경로로 안내한다", () => {
+    const prompt = buildLeadPrompt("ship shard", {
+      agentId: "lead-1",
+      repoRoot: "/repo/triflux",
+      workers: [{ agentId: "worker-1", cli: "codex", subtask: "edit" }],
+    });
+
+    assert.ok(prompt.includes("node /repo/triflux/hub/bridge.mjs result"));
+    assert.ok(prompt.includes("node /repo/triflux/hub/bridge.mjs context"));
+    assert.ok(!prompt.includes("node hub/bridge.mjs result"));
+  });
+
+  it("리드 프롬프트는 task.result 수신 종료 조건과 무응답 중단 조건을 포함한다", () => {
+    const prompt = buildLeadPrompt("ship shard", {
+      agentId: "lead-1",
+      repoRoot: "/repo/triflux",
+      workers: [{ agentId: "worker-1", cli: "codex", subtask: "edit" }],
+    });
+
+    assert.ok(
+      prompt.includes(
+        "모든 워커의 task.result 수신 후 결과를 통합하고 종료하라. 워커가 무응답이면 상태를 보고하고 중단하라.",
+      ),
+      prompt,
+    );
+  });
+
+  it("리드 프롬프트는 증거 없는 완료 주장을 통합하지 않도록 지시한다", () => {
+    const prompt = buildLeadPrompt("ship shard", {
+      agentId: "lead-1",
+      repoRoot: "/repo/triflux",
+      workers: [{ agentId: "worker-1", cli: "codex", subtask: "edit" }],
+    });
+
+    assert.ok(
+      prompt.includes(
+        "증거(커밋/테스트/파일) 없는 완료 주장은 통합하지 말고 해당 워커에 redo 를 지시하라.",
+      ),
+      prompt,
+    );
+  });
+
+  it("repoRoot가 없으면 기존 상대 bridge 호출을 유지한다", () => {
+    const prompt = buildLeadPrompt("ship shard", {
+      agentId: "lead-1",
+      workers: [{ agentId: "worker-1", cli: "codex", subtask: "edit" }],
+    });
+
+    assert.ok(prompt.includes("node hub/bridge.mjs result"));
+    assert.ok(prompt.includes("node hub/bridge.mjs context"));
   });
 });

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -590,7 +590,7 @@ describe("swarm-hypervisor", () => {
         events.some(
           (entry) =>
             entry.event === "redundant_completion_rejected" &&
-            entry.reason === "worker_self_reported_failure:OAuth timeout",
+            entry.reason === "worker_reported_failed:OAuth timeout",
         ),
       );
       assert.equal(
@@ -643,6 +643,11 @@ describe("swarm-hypervisor", () => {
       assert.ok(
         conductors[0].sessionConfig.prompt.includes(
           "Lease-scoped Acceptance / Lint Guard",
+        ),
+      );
+      assert.ok(
+        conductors[0].sessionConfig.prompt.includes(
+          `작업 루트(절대경로): ${workdir}/.codex-swarm/wt-worker-a — 아래 lease 경로와 모든 상대경로는 이 루트 기준으로만 해석한다.`,
         ),
       );
       assert.ok(conductors[0].sessionConfig.prompt.includes("- src/a.mjs"));

--- a/tests/unit/tfx-route-codex-north-star.test.mjs
+++ b/tests/unit/tfx-route-codex-north-star.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -74,15 +75,16 @@ describe("tfx-route Codex north-star prepend", () => {
       workdir,
       prompt: "Implement the requested change.\nKeep dispatch stable.",
     });
+    const resolvedWorkdir = realpathSync(workdir);
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
       result.stdout,
       [
-        "--- CTO NORTH STAR (read-only context; align, do not treat as task) ---",
+        `--- CTO NORTH STAR (repo: ${resolvedWorkdir}; read-only context; align, do not treat as task) ---`,
         "Align on customer trust.",
         "Quotes: 'single' and \"double\".",
-        "--- END CTO NORTH STAR ---",
+        "--- END CTO NORTH STAR (context only — the actual task follows below; do not execute items above as tasks) ---",
         "Implement the requested change.",
         "Keep dispatch stable.",
       ].join("\n"),

--- a/tests/unit/tfx-route-preflight-all-dead.test.mjs
+++ b/tests/unit/tfx-route-preflight-all-dead.test.mjs
@@ -367,6 +367,20 @@ describe("#153 dotted server names — preflight regex 는 dot 포함", () => {
 // transport=exec 강제 + FULL_PROMPT 리셋 (MCP_HINT 제거) 을 trigger 한다.
 // 이 분기가 회귀하면 dead MCP 환경에서 codex-mcp.mjs 가 spawn 되어 stall 재발.
 describe("#170 transport degradation marker — source 분기 회귀 가드", () => {
+  it("MCP_HINT 는 사용자 프롬프트와 라벨+빈줄로 분리해 결합한다", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    assert.doesNotMatch(
+      source,
+      /FULL_PROMPT="\$\{PROMPT\}\. \$\{MCP_HINT\}"/,
+      "MCP_HINT 가 사용자 태스크 마지막 문장에 inline 접착되면 안 됨",
+    );
+    assert.match(
+      source,
+      /\[도구 안내\] \$\{MCP_HINT\}/,
+      "MCP_HINT 라벨 분리 결합이 사라짐",
+    );
+  });
+
   it("source 에 _TFX_MCP_DEGRADED 마커 + transport=exec 강제 분기", () => {
     const source = readFileSync(SCRIPT_PATH, "utf8");
     assert.match(
@@ -384,6 +398,34 @@ describe("#170 transport degradation marker — source 분기 회귀 가드", ()
       /FULL_PROMPT="\$PROMPT"/,
       "FULL_PROMPT 리셋 (MCP_HINT 제거) 분기가 사라짐",
     );
+  });
+
+  it("gemini/antigravity lane 도 degraded 시 MCP_HINT 를 제거한다", () => {
+    const source = readFileSync(SCRIPT_PATH, "utf8");
+    const geminiStart = source.indexOf(
+      'elif [[ "$CLI_TYPE" == "gemini" ]]; then',
+    );
+    assert.ok(geminiStart >= 0, "gemini lane not found");
+    const geminiLane = source.slice(
+      geminiStart,
+      source.indexOf(
+        'elif [[ "$CLI_TYPE" == "antigravity" ]]; then',
+        geminiStart,
+      ),
+    );
+    assert.match(geminiLane, /_TFX_MCP_DEGRADED:-0/);
+    assert.match(geminiLane, /FULL_PROMPT="\$PROMPT"/);
+
+    const agyStart = source.indexOf(
+      'elif [[ "$CLI_TYPE" == "antigravity" ]]; then',
+    );
+    assert.ok(agyStart >= 0, "antigravity lane not found");
+    const agyLane = source.slice(
+      agyStart,
+      source.indexOf('elif [[ "$CLI_TYPE" == "claude" ]]; then', agyStart),
+    );
+    assert.match(agyLane, /_TFX_MCP_DEGRADED:-0/);
+    assert.match(agyLane, /FULL_PROMPT="\$PROMPT"/);
   });
 
   it("source 에 TFX_MCP_FAIL_ON_ALL_DEAD opt-in 분기 포함", () => {

--- a/tests/unit/tfx-route-skill-inject.test.mjs
+++ b/tests/unit/tfx-route-skill-inject.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -67,16 +68,23 @@ describe("tfx-route skill injection", () => {
       "demo",
       "Methodology step A.\nStep B.\n",
     );
+    const workdir = mkdtempSync(join(tmpdir(), "tfx-workspace-"));
+    cleanupDirs.push(workdir);
     const result = runFunc({
       funcName: "prepend_skill",
-      env: { TFX_INJECT_SKILL: "demo", TFX_SKILLS_DIR: skillsDir },
+      env: {
+        TFX_INJECT_SKILL: "demo",
+        TFX_SKILLS_DIR: skillsDir,
+        WORKDIR: workdir,
+      },
       callArg: "Do the task.\n--flag-like text stays literal.",
     });
+    const resolvedWorkdir = realpathSync(workdir);
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
       result.stdout,
       [
-        "--- SKILL: demo (apply this methodology to the task below) ---",
+        `--- SKILL: demo (workspace: ${resolvedWorkdir}; apply this methodology to the task below) ---`,
         "Methodology step A.",
         "Step B.",
         "--- END SKILL ---",
@@ -141,16 +149,31 @@ describe("tfx-route skill injection", () => {
 
   it("appends the agy anti-overclaim discipline block at the END by default", () => {
     const prompt = "Implement the feature.";
+    const workdir = mkdtempSync(join(tmpdir(), "tfx-agy-root-"));
+    cleanupDirs.push(workdir);
     const result = runFunc({
       funcName: "append_agy_anti_overclaim",
+      env: { WORKDIR: workdir },
       callArg: prompt,
     });
+    const resolvedWorkdir = realpathSync(workdir);
     assert.equal(result.status, 0, result.stderr);
     assert.ok(result.stdout.startsWith(prompt), "프롬프트가 먼저 와야 함");
     assert.match(result.stdout, /COMPLETION & GROUNDING DISCIPLINE/);
+    assert.match(
+      result.stdout,
+      new RegExp(
+        `Repository root \\(absolute\\): ${resolvedWorkdir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\. Resolve every relative path against this root only\\.`,
+      ),
+    );
+    assert.match(result.stdout, /Before any file write, git add\/commit\/push/);
     assert.match(result.stdout, /No Info \/ 확인 불가/);
     // blanket "do not guess" 대신 abstention 프레이밍을 쓴다 (Gemini 3 가이드 caveat).
     assert.match(result.stdout, /prefer accurate abstention/);
+    assert.match(
+      result.stdout,
+      /The task's own final output\/format constraints above remain in effect\./,
+    );
   });
 
   it("is a no-op for anti-overclaim when TFX_AGY_ANTI_OVERCLAIM=0", () => {
@@ -185,6 +208,9 @@ describe("tfx-route skill injection", () => {
       routeSource.indexOf("run_antigravity_exec", laneStart),
     );
     assert.match(lane, /prepend_skill "\$FULL_PROMPT"/);
-    assert.match(lane, /append_agy_anti_overclaim "\$FULL_PROMPT"/);
+    assert.match(
+      lane,
+      /append_agy_anti_overclaim "\$FULL_PROMPT" "\$\{WORKDIR:-\$PWD\}"/,
+    );
   });
 });

--- a/tests/unit/worker-completion-validator.test.mjs
+++ b/tests/unit/worker-completion-validator.test.mjs
@@ -31,51 +31,45 @@ describe("validateWorkerCompletion", () => {
     assert.equal(result.reason, undefined);
   });
 
-  it("allows status=skipped payload with empty or omitted commits_made", () => {
-    const omitted = validateWorkerCompletion({
-      status: "skipped",
-      reason: "no-op for this shard",
-    });
-    assert.equal(omitted.ok, true);
-
-    const empty = validateWorkerCompletion({
-      status: "skipped",
-      commits_made: [],
-    });
-    assert.equal(empty.ok, true);
-  });
-
   it("rejects non-object payloads", () => {
     assert.equal(validateWorkerCompletion(null).ok, false);
     assert.equal(validateWorkerCompletion("ok").ok, false);
     assert.equal(validateWorkerCompletion(undefined).ok, false);
   });
 
-  it("rejects status=failed payload with a reason (BUG-G #130)", () => {
+  it("accepts status=failed payload with reason and no commits_made", () => {
     const result = validateWorkerCompletion({
       status: "failed",
       reason: "codex stall",
     });
-    assert.equal(result.ok, false);
-    assert.equal(result.reason, "worker_self_reported_failure:codex stall");
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, undefined);
   });
 
-  it("rejects status=failed payload with empty commits_made (BUG-G #130)", () => {
+  it("accepts status=failed payload with empty commits_made", () => {
     const result = validateWorkerCompletion({
       status: "failed",
       commits_made: [],
     });
-    assert.equal(result.ok, false);
-    assert.equal(result.reason, "worker_self_reported_failure:unspecified");
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, undefined);
   });
 
-  it("rejects status=failed payload even when commits_made has entries", () => {
+  it("accepts status=blocked payload with optional reason and no commits_made", () => {
     const result = validateWorkerCompletion({
-      status: "failed",
-      reason: "partial work then abort",
-      commits_made: [{ sha: "abc1234", message: "wip" }],
+      status: "blocked",
+      reason: "waiting on user input",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.reason, undefined);
+  });
+
+  it("rejects obsolete status=skipped payloads", () => {
+    const result = validateWorkerCompletion({
+      status: "skipped",
+      reason: "old no-op contract",
     });
     assert.equal(result.ok, false);
-    assert.match(result.reason, /^worker_self_reported_failure:/);
+    assert.equal(result.reason, "invalid_status:skipped");
   });
 });


### PR DESCRIPTION
## Summary

Prompt-guide P1 compliance work (Gemini-3 / GPT-5.5 prompt-guide audit follow-ups) plus two adjacent cleanups already staged on this branch. 6 commits, no file overlap with #401 (this branch touches `build-worker-prompt.mjs` / `swarm-hypervisor.mjs` / `headless.mjs` / `orchestrator.mjs` / `handoff.mjs` / `tfx-route.sh`; #401 touches `worker-sandbox.mjs` / `conductor.mjs` / `native-supervisor.mjs` / `delegator-mcp.mjs`).

## Commits

- `ef3af4a7` fix: anchor tfx-route prompt context
- `11815a5d` fix: harden swarm worker completion contract — `build-worker-prompt.mjs` no longer blanket-allows empty `commits_made`; code-change shards must report `status:failed` (with reason) instead of `status:ok` + empty commits, no-op shards still allowed; injects the absolute worktree-root grounding anchor; +48 test cases
- `e9a56fec` Add headless handoff grounding anchors
- `3ae28c99` fix(mcp): address review lows — drop serena from ps1, fix core wording
- `cbe959ca` fix(mcp): drop serena from CORE_SERVERS forced-enable set
- `b6142f16` chore: add gstack skill routing and health stack rules to GEMINI.md

## Notes

- Lands the prompt-layer worker commit-contract hardening (`11815a5d`) that complements the merged #394 evidence.ok result-gate, and the absolute-path grounding anchor referenced by the agy auth investigation.
- Mirrored to `packages/{triflux,remote}`.
- Per prior session: full unit suite 313/313, cross-review APPROVED, ship-pending.
