### PR TITLE
fix(daemon-control): present control key on attach/interrupt/kill verbs

### DIFF
--- a/hub/bridge.mjs
+++ b/hub/bridge.mjs
@@ -1270,8 +1270,11 @@ async function cmdDaemonAttach(args) {
     const payload = readBridgePayload(args);
     if (!payload.prompt) throw new Error("prompt is required");
 
-    const { attachClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      attachClaudeDaemonSession,
+      buildDaemonControlAuth,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1291,6 +1294,9 @@ async function cmdDaemonAttach(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
@@ -1298,6 +1304,7 @@ async function cmdDaemonAttach(args) {
         controlSock: probe.controlSock,
         short,
         input: payload.prompt,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 30_000),
@@ -1331,8 +1338,11 @@ async function cmdDaemonInterrupt(args) {
   try {
     const payload = readBridgePayload(args);
 
-    const { interruptClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      buildDaemonControlAuth,
+      interruptClaudeDaemonSession,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1352,12 +1362,16 @@ async function cmdDaemonInterrupt(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
       result = await interruptClaudeDaemonSession({
         controlSock: probe.controlSock,
         short,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 5000),

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -468,6 +468,7 @@ export function buildDaemonAttachRequest({
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps = { terminal: null, mux: null, ssh: false },
+  auth,
 } = {}) {
   if (!short) throw new Error("short is required");
   return {
@@ -477,6 +478,7 @@ export function buildDaemonAttachRequest({
     cols,
     rows,
     caps,
+    ...(auth ? { auth } : {}),
   };
 }
 
@@ -1010,6 +1012,7 @@ export function attachClaudeDaemonSession({
   controlSock,
   short,
   input,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1117,7 +1120,9 @@ export function attachClaudeDaemonSession({
     });
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1233,6 +1238,7 @@ export function attachClaudeDaemonSession({
 export function interruptClaudeDaemonSession({
   controlSock,
   short,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1283,7 +1289,9 @@ export function interruptClaudeDaemonSession({
     socket.on("error", fail);
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1509,6 +1517,7 @@ export async function sendKillBySessionId({
   daemonPaths,
   sessionId,
   timeoutMs = 6000,
+  auth,
 } = {}) {
   const controlSock = daemonPaths?.controlSock;
   if (!controlSock || !sessionId) {
@@ -1528,12 +1537,16 @@ export async function sendKillBySessionId({
     if (!job?.short) {
       return { ok: true, killed: false, reason: "not_found" };
     }
+    const controlAuth = auth
+      ? { auth }
+      : await buildDaemonControlAuth(daemonPaths?.configDir);
     return await sendClaudeControlRequest(
       controlSock,
       {
         proto: 1,
         op: "kill",
         short: job.short,
+        ...controlAuth,
       },
       { timeoutMs },
     );
@@ -1683,6 +1696,7 @@ export async function teardownClaudeDaemonJob({
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const removeJobStateImpl = _deps.removeClaudeJobState;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
   const resolvedControlSock = controlSock || paths?.controlSock;
   const resolvedJobsDir =
     jobsDir ||
@@ -1698,7 +1712,10 @@ export async function teardownClaudeDaemonJob({
     steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
   }
   if (resolvedControlSock && short) {
-    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+    const controlAuth = await buildAuth(paths?.configDir);
+    steps.push(
+      killJob(resolvedControlSock, short, controlAuth).catch(() => {}),
+    );
   }
   if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
     steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));

--- a/hub/team/headless.mjs
+++ b/hub/team/headless.mjs
@@ -26,6 +26,7 @@ import { getMaxSpawnPerSec } from "../lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 import { getBackend } from "./backend.mjs";
 import {
+  buildDaemonControlAuth,
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   dispatchClaudeDaemonJob,
@@ -1073,9 +1074,14 @@ export async function cleanupDaemonDispatches(dispatches) {
         }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
-        await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        const controlAuth = await buildDaemonControlAuth(
+          dispatch.daemonPaths?.configDir,
+        ).catch(() => ({}));
+        await killDaemonJob(
+          dispatch.controlSock,
+          dispatch.daemonShort,
+          controlAuth,
+        ).catch(() => {});
       }
     }),
   );
@@ -1253,9 +1259,16 @@ async function waitForDaemonCompletion(
         dispatch.daemonCompletionMatched = true;
         cleanupDaemonDispatches([dispatch]).catch(() => {});
       } else {
-        killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        buildDaemonControlAuth(dispatch.daemonPaths?.configDir)
+          .catch(() => ({}))
+          .then((controlAuth) =>
+            killDaemonJob(
+              dispatch.controlSock,
+              dispatch.daemonShort,
+              controlAuth,
+            ),
+          )
+          .catch(() => {});
       }
       resolve(finalCompletion);
     };

--- a/packages/core/hub/bridge.mjs
+++ b/packages/core/hub/bridge.mjs
@@ -1270,8 +1270,11 @@ async function cmdDaemonAttach(args) {
     const payload = readBridgePayload(args);
     if (!payload.prompt) throw new Error("prompt is required");
 
-    const { attachClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      attachClaudeDaemonSession,
+      buildDaemonControlAuth,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1291,6 +1294,9 @@ async function cmdDaemonAttach(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
@@ -1298,6 +1304,7 @@ async function cmdDaemonAttach(args) {
         controlSock: probe.controlSock,
         short,
         input: payload.prompt,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 30_000),
@@ -1331,8 +1338,11 @@ async function cmdDaemonInterrupt(args) {
   try {
     const payload = readBridgePayload(args);
 
-    const { interruptClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      buildDaemonControlAuth,
+      interruptClaudeDaemonSession,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1352,12 +1362,16 @@ async function cmdDaemonInterrupt(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
       result = await interruptClaudeDaemonSession({
         controlSock: probe.controlSock,
         short,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 5000),

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -468,6 +468,7 @@ export function buildDaemonAttachRequest({
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps = { terminal: null, mux: null, ssh: false },
+  auth,
 } = {}) {
   if (!short) throw new Error("short is required");
   return {
@@ -477,6 +478,7 @@ export function buildDaemonAttachRequest({
     cols,
     rows,
     caps,
+    ...(auth ? { auth } : {}),
   };
 }
 
@@ -1010,6 +1012,7 @@ export function attachClaudeDaemonSession({
   controlSock,
   short,
   input,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1117,7 +1120,9 @@ export function attachClaudeDaemonSession({
     });
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1233,6 +1238,7 @@ export function attachClaudeDaemonSession({
 export function interruptClaudeDaemonSession({
   controlSock,
   short,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1283,7 +1289,9 @@ export function interruptClaudeDaemonSession({
     socket.on("error", fail);
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1509,6 +1517,7 @@ export async function sendKillBySessionId({
   daemonPaths,
   sessionId,
   timeoutMs = 6000,
+  auth,
 } = {}) {
   const controlSock = daemonPaths?.controlSock;
   if (!controlSock || !sessionId) {
@@ -1528,12 +1537,16 @@ export async function sendKillBySessionId({
     if (!job?.short) {
       return { ok: true, killed: false, reason: "not_found" };
     }
+    const controlAuth = auth
+      ? { auth }
+      : await buildDaemonControlAuth(daemonPaths?.configDir);
     return await sendClaudeControlRequest(
       controlSock,
       {
         proto: 1,
         op: "kill",
         short: job.short,
+        ...controlAuth,
       },
       { timeoutMs },
     );
@@ -1683,6 +1696,7 @@ export async function teardownClaudeDaemonJob({
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const removeJobStateImpl = _deps.removeClaudeJobState;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
   const resolvedControlSock = controlSock || paths?.controlSock;
   const resolvedJobsDir =
     jobsDir ||
@@ -1698,7 +1712,10 @@ export async function teardownClaudeDaemonJob({
     steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
   }
   if (resolvedControlSock && short) {
-    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+    const controlAuth = await buildAuth(paths?.configDir);
+    steps.push(
+      killJob(resolvedControlSock, short, controlAuth).catch(() => {}),
+    );
   }
   if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
     steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -468,6 +468,7 @@ export function buildDaemonAttachRequest({
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps = { terminal: null, mux: null, ssh: false },
+  auth,
 } = {}) {
   if (!short) throw new Error("short is required");
   return {
@@ -477,6 +478,7 @@ export function buildDaemonAttachRequest({
     cols,
     rows,
     caps,
+    ...(auth ? { auth } : {}),
   };
 }
 
@@ -1010,6 +1012,7 @@ export function attachClaudeDaemonSession({
   controlSock,
   short,
   input,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1117,7 +1120,9 @@ export function attachClaudeDaemonSession({
     });
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1233,6 +1238,7 @@ export function attachClaudeDaemonSession({
 export function interruptClaudeDaemonSession({
   controlSock,
   short,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1283,7 +1289,9 @@ export function interruptClaudeDaemonSession({
     socket.on("error", fail);
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1509,6 +1517,7 @@ export async function sendKillBySessionId({
   daemonPaths,
   sessionId,
   timeoutMs = 6000,
+  auth,
 } = {}) {
   const controlSock = daemonPaths?.controlSock;
   if (!controlSock || !sessionId) {
@@ -1528,12 +1537,16 @@ export async function sendKillBySessionId({
     if (!job?.short) {
       return { ok: true, killed: false, reason: "not_found" };
     }
+    const controlAuth = auth
+      ? { auth }
+      : await buildDaemonControlAuth(daemonPaths?.configDir);
     return await sendClaudeControlRequest(
       controlSock,
       {
         proto: 1,
         op: "kill",
         short: job.short,
+        ...controlAuth,
       },
       { timeoutMs },
     );
@@ -1683,6 +1696,7 @@ export async function teardownClaudeDaemonJob({
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const removeJobStateImpl = _deps.removeClaudeJobState;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
   const resolvedControlSock = controlSock || paths?.controlSock;
   const resolvedJobsDir =
     jobsDir ||
@@ -1698,7 +1712,10 @@ export async function teardownClaudeDaemonJob({
     steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
   }
   if (resolvedControlSock && short) {
-    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+    const controlAuth = await buildAuth(paths?.configDir);
+    steps.push(
+      killJob(resolvedControlSock, short, controlAuth).catch(() => {}),
+    );
   }
   if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
     steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -26,6 +26,7 @@ import { getMaxSpawnPerSec } from "@triflux/core/hub/lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 import { getBackend } from "./backend.mjs";
 import {
+  buildDaemonControlAuth,
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   dispatchClaudeDaemonJob,
@@ -1073,9 +1074,14 @@ export async function cleanupDaemonDispatches(dispatches) {
         }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
-        await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        const controlAuth = await buildDaemonControlAuth(
+          dispatch.daemonPaths?.configDir,
+        ).catch(() => ({}));
+        await killDaemonJob(
+          dispatch.controlSock,
+          dispatch.daemonShort,
+          controlAuth,
+        ).catch(() => {});
       }
     }),
   );
@@ -1253,9 +1259,16 @@ async function waitForDaemonCompletion(
         dispatch.daemonCompletionMatched = true;
         cleanupDaemonDispatches([dispatch]).catch(() => {});
       } else {
-        killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        buildDaemonControlAuth(dispatch.daemonPaths?.configDir)
+          .catch(() => ({}))
+          .then((controlAuth) =>
+            killDaemonJob(
+              dispatch.controlSock,
+              dispatch.daemonShort,
+              controlAuth,
+            ),
+          )
+          .catch(() => {});
       }
       resolve(finalCompletion);
     };

--- a/packages/triflux/hub/bridge.mjs
+++ b/packages/triflux/hub/bridge.mjs
@@ -1270,8 +1270,11 @@ async function cmdDaemonAttach(args) {
     const payload = readBridgePayload(args);
     if (!payload.prompt) throw new Error("prompt is required");
 
-    const { attachClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      attachClaudeDaemonSession,
+      buildDaemonControlAuth,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1291,6 +1294,9 @@ async function cmdDaemonAttach(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
@@ -1298,6 +1304,7 @@ async function cmdDaemonAttach(args) {
         controlSock: probe.controlSock,
         short,
         input: payload.prompt,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 30_000),
@@ -1331,8 +1338,11 @@ async function cmdDaemonInterrupt(args) {
   try {
     const payload = readBridgePayload(args);
 
-    const { interruptClaudeDaemonSession, probeClaudeDaemonCandidates } =
-      await loadDaemonControl();
+    const {
+      buildDaemonControlAuth,
+      interruptClaudeDaemonSession,
+      probeClaudeDaemonCandidates,
+    } = await loadDaemonControl();
     const probe = await probeClaudeDaemonCandidates({
       configDir: payload.configDir,
       env: process.env,
@@ -1352,12 +1362,16 @@ async function cmdDaemonInterrupt(args) {
         }),
       );
     }
+    const controlAuth = await buildDaemonControlAuth(
+      probe.daemon?.configDir ?? payload.configDir,
+    );
 
     let result;
     try {
       result = await interruptClaudeDaemonSession({
         controlSock: probe.controlSock,
         short,
+        ...controlAuth,
         cols: numericOption(payload.cols, undefined),
         rows: numericOption(payload.rows, undefined),
         timeoutMs: numericOption(payload.timeoutMs, 5000),

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -468,6 +468,7 @@ export function buildDaemonAttachRequest({
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps = { terminal: null, mux: null, ssh: false },
+  auth,
 } = {}) {
   if (!short) throw new Error("short is required");
   return {
@@ -477,6 +478,7 @@ export function buildDaemonAttachRequest({
     cols,
     rows,
     caps,
+    ...(auth ? { auth } : {}),
   };
 }
 
@@ -1010,6 +1012,7 @@ export function attachClaudeDaemonSession({
   controlSock,
   short,
   input,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1117,7 +1120,9 @@ export function attachClaudeDaemonSession({
     });
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1233,6 +1238,7 @@ export function attachClaudeDaemonSession({
 export function interruptClaudeDaemonSession({
   controlSock,
   short,
+  auth,
   cols = DEFAULT_DAEMON_ATTACH_COLS,
   rows = 40,
   caps,
@@ -1283,7 +1289,9 @@ export function interruptClaudeDaemonSession({
     socket.on("error", fail);
     socket.on("connect", () => {
       socket.write(
-        `${JSON.stringify(buildDaemonAttachRequest({ short, cols, rows, caps }))}\n`,
+        `${JSON.stringify(
+          buildDaemonAttachRequest({ short, cols, rows, caps, auth }),
+        )}\n`,
       );
     });
     socket.on("data", (chunk) => {
@@ -1509,6 +1517,7 @@ export async function sendKillBySessionId({
   daemonPaths,
   sessionId,
   timeoutMs = 6000,
+  auth,
 } = {}) {
   const controlSock = daemonPaths?.controlSock;
   if (!controlSock || !sessionId) {
@@ -1528,12 +1537,16 @@ export async function sendKillBySessionId({
     if (!job?.short) {
       return { ok: true, killed: false, reason: "not_found" };
     }
+    const controlAuth = auth
+      ? { auth }
+      : await buildDaemonControlAuth(daemonPaths?.configDir);
     return await sendClaudeControlRequest(
       controlSock,
       {
         proto: 1,
         op: "kill",
         short: job.short,
+        ...controlAuth,
       },
       { timeoutMs },
     );
@@ -1683,6 +1696,7 @@ export async function teardownClaudeDaemonJob({
     _deps.removeClaudeSessionProjection || removeClaudeSessionProjection;
   const killJob = _deps.killDaemonJob || killDaemonJob;
   const removeJobStateImpl = _deps.removeClaudeJobState;
+  const buildAuth = _deps.buildDaemonControlAuth || buildDaemonControlAuth;
   const resolvedControlSock = controlSock || paths?.controlSock;
   const resolvedJobsDir =
     jobsDir ||
@@ -1698,7 +1712,10 @@ export async function teardownClaudeDaemonJob({
     steps.push(sendKillBySessionId({ daemonPaths, sessionId }).catch(() => {}));
   }
   if (resolvedControlSock && short) {
-    steps.push(killJob(resolvedControlSock, short).catch(() => {}));
+    const controlAuth = await buildAuth(paths?.configDir);
+    steps.push(
+      killJob(resolvedControlSock, short, controlAuth).catch(() => {}),
+    );
   }
   if (removeJobState && removeJobStateImpl && resolvedJobsDir && short) {
     steps.push(removeJobStateImpl(resolvedJobsDir, short).catch(() => {}));

--- a/packages/triflux/hub/team/headless.mjs
+++ b/packages/triflux/hub/team/headless.mjs
@@ -26,6 +26,7 @@ import { getMaxSpawnPerSec } from "../lib/spawn-trace.mjs";
 import { IS_WINDOWS } from "../platform.mjs";
 import { getBackend } from "./backend.mjs";
 import {
+  buildDaemonControlAuth,
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths as deriveClaudeControlPaths,
   dispatchClaudeDaemonJob,
@@ -1073,9 +1074,14 @@ export async function cleanupDaemonDispatches(dispatches) {
         }).catch(() => {});
       }
       if (dispatch.controlSock && dispatch.daemonShort) {
-        await killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        const controlAuth = await buildDaemonControlAuth(
+          dispatch.daemonPaths?.configDir,
+        ).catch(() => ({}));
+        await killDaemonJob(
+          dispatch.controlSock,
+          dispatch.daemonShort,
+          controlAuth,
+        ).catch(() => {});
       }
     }),
   );
@@ -1253,9 +1259,16 @@ async function waitForDaemonCompletion(
         dispatch.daemonCompletionMatched = true;
         cleanupDaemonDispatches([dispatch]).catch(() => {});
       } else {
-        killDaemonJob(dispatch.controlSock, dispatch.daemonShort).catch(
-          () => {},
-        );
+        buildDaemonControlAuth(dispatch.daemonPaths?.configDir)
+          .catch(() => ({}))
+          .then((controlAuth) =>
+            killDaemonJob(
+              dispatch.controlSock,
+              dispatch.daemonShort,
+              controlAuth,
+            ),
+          )
+          .catch(() => {});
       }
       resolve(finalCompletion);
     };

--- a/tests/unit/bridge-daemon-verbs.test.mjs
+++ b/tests/unit/bridge-daemon-verbs.test.mjs
@@ -323,6 +323,12 @@ test("daemon-probe normalizes Claude agent-view state/status row variants", asyn
 
 test("daemon-attach resolves sessionId, sends prompt, and returns assistant text", async () => {
   await withTempConfig(async (configDir) => {
+    await fs.mkdir(path.join(configDir, "daemon"), { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, "daemon", "control.key"),
+      "bridge-attach-secret\n",
+      "utf8",
+    );
     const paths = deriveClaudeDaemonPaths({ configDir });
     const fake = await listenFakeDaemon(paths.controlSock, {
       jobs: [{ short: "facefeed", sessionId: "session-attach" }],
@@ -361,6 +367,7 @@ test("daemon-attach resolves sessionId, sends prompt, and returns assistant text
           cols: 132,
           rows: 37,
           caps: { terminal: null, mux: null, ssh: false },
+          auth: "bridge-attach-secret",
         },
       ]);
     } finally {
@@ -399,6 +406,12 @@ test("daemon-attach returns the full failure response shape before input", async
 
 test("daemon-interrupt attaches to a daemon PTY and sends Escape", async () => {
   await withTempConfig(async (configDir) => {
+    await fs.mkdir(path.join(configDir, "daemon"), { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, "daemon", "control.key"),
+      "bridge-interrupt-secret\n",
+      "utf8",
+    );
     const paths = deriveClaudeDaemonPaths({ configDir });
     const fake = await listenFakeInterruptDaemon(paths.controlSock, {
       jobs: [{ short: "facefeed", sessionId: "interrupt-session" }],
@@ -430,6 +443,7 @@ test("daemon-interrupt attaches to a daemon PTY and sends Escape", async () => {
           cols: 240,
           rows: 40,
           caps: { terminal: null, mux: null, ssh: false },
+          auth: "bridge-interrupt-secret",
         },
       ]);
     } finally {

--- a/tests/unit/claude-daemon-control.test.mjs
+++ b/tests/unit/claude-daemon-control.test.mjs
@@ -13,6 +13,7 @@ import {
   deriveClaudeDaemonPaths,
   extractClaudeDaemonAttachText,
   findDaemonJobByShort,
+  interruptClaudeDaemonSession,
   resolveDaemonBridgeSessionId,
   sendClaudeControlRequest,
   sendKillBySessionId,
@@ -125,6 +126,23 @@ test("buildDaemonAttachRequest creates the live PTY attach request shape", () =>
       cols: 140,
       rows: 45,
       caps: { terminal: null, mux: null, ssh: false },
+    },
+  );
+  assert.deepEqual(
+    buildDaemonAttachRequest({
+      short: "deadbeef",
+      cols: 140,
+      rows: 45,
+      auth: "control-secret",
+    }),
+    {
+      proto: 1,
+      op: "attach",
+      short: "deadbeef",
+      cols: 140,
+      rows: 45,
+      caps: { terminal: null, mux: null, ssh: false },
+      auth: "control-secret",
     },
   );
   assert.throws(() => buildDaemonAttachRequest(), /short is required/);
@@ -331,6 +349,123 @@ test("attachClaudeDaemonSession pastes into a live daemon PTY and returns respon
     assert.equal(result.inputSent, true);
     assert.equal(result.matchedCompletion, true);
     assert.equal(result.text, "ATTACH_RESPONSE");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("attachClaudeDaemonSession includes auth in attach request when provided", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-attach-auth-"));
+  const sockPath = path.join(dir, "control.sock");
+  let attachedRequest = null;
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let firstLine = "";
+    socket.on("data", (chunk) => {
+      if (attachedRequest) return;
+      firstLine += chunk;
+      if (!firstLine.includes("\n")) return;
+      attachedRequest = JSON.parse(firstLine.slice(0, firstLine.indexOf("\n")));
+      socket.end(
+        `${JSON.stringify({
+          ok: true,
+          op: "attach",
+          via: "spare",
+          tempo: "idle",
+          state: "done",
+        })}\n`,
+      );
+    });
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(sockPath, resolve);
+    });
+
+    const result = await attachClaudeDaemonSession({
+      controlSock: sockPath,
+      short: "authface",
+      auth: "attach-secret",
+      timeoutMs: 1000,
+    });
+
+    assert.deepEqual(attachedRequest, {
+      proto: 1,
+      op: "attach",
+      short: "authface",
+      cols: 240,
+      rows: 40,
+      caps: { terminal: null, mux: null, ssh: false },
+      auth: "attach-secret",
+    });
+    assert.equal(result.handshake.ok, true);
+    assert.equal(result.closed, true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("interruptClaudeDaemonSession includes auth in attach request when provided", async () => {
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "claude-interrupt-auth-"),
+  );
+  const sockPath = path.join(dir, "control.sock");
+  let attachedRequest = null;
+  let attachedInput = "";
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    let firstLine = "";
+    let attached = false;
+    socket.on("data", (chunk) => {
+      if (attached) {
+        attachedInput += chunk;
+        if (attachedInput.includes("\x1b")) socket.end("interrupted\n");
+        return;
+      }
+      firstLine += chunk;
+      if (!firstLine.includes("\n")) return;
+      attachedRequest = JSON.parse(firstLine.slice(0, firstLine.indexOf("\n")));
+      socket.write(
+        `${JSON.stringify({
+          ok: true,
+          op: "attach",
+          via: "spare",
+          tempo: "active",
+          state: "working",
+        })}\n`,
+      );
+      attached = true;
+    });
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(sockPath, resolve);
+    });
+
+    const result = await interruptClaudeDaemonSession({
+      controlSock: sockPath,
+      short: "stopface",
+      auth: "interrupt-secret",
+      timeoutMs: 1000,
+    });
+
+    assert.deepEqual(attachedRequest, {
+      proto: 1,
+      op: "attach",
+      short: "stopface",
+      cols: 240,
+      rows: 40,
+      caps: { terminal: null, mux: null, ssh: false },
+      auth: "interrupt-secret",
+    });
+    assert.equal(result.inputSent, true);
+    assert.match(attachedInput, /\x1b/);
   } finally {
     await new Promise((resolve) => server.close(resolve));
     await fs.rm(dir, { recursive: true, force: true });
@@ -825,6 +960,13 @@ test("resolveDaemonBridgeSessionId reads Claude job state bridge id", async () =
 test("killDaemonJobBySessionId resolves short then sends kill", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-kill-session-"));
   const sockPath = path.join(dir, "control.sock");
+  const configDir = path.join(dir, "claude");
+  await fs.mkdir(path.join(configDir, "daemon"), { recursive: true });
+  await fs.writeFile(
+    path.join(configDir, "daemon", "control.key"),
+    "kill-secret\n",
+    "utf8",
+  );
   const seen = [];
   const { server } = await listenJsonServer(sockPath, (request) => {
     seen.push(request);
@@ -843,7 +985,7 @@ test("killDaemonJobBySessionId resolves short then sends kill", async () => {
 
   try {
     const result = await sendKillBySessionId({
-      daemonPaths: { controlSock: sockPath },
+      daemonPaths: { controlSock: sockPath, configDir },
       sessionId: "session-target",
     });
 
@@ -851,7 +993,42 @@ test("killDaemonJobBySessionId resolves short then sends kill", async () => {
     assert.equal(result.killed, "kill2222");
     assert.deepEqual(seen, [
       { proto: 1, op: "list" },
-      { proto: 1, op: "kill", short: "kill2222" },
+      { proto: 1, op: "kill", short: "kill2222", auth: "kill-secret" },
+    ]);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("killDaemonJobBySessionId omits auth when control.key is absent", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-kill-noauth-"));
+  const sockPath = path.join(dir, "control.sock");
+  const configDir = path.join(dir, "claude");
+  const seen = [];
+  const { server } = await listenJsonServer(sockPath, (request) => {
+    seen.push(request);
+    if (request.op === "list") {
+      return {
+        ok: true,
+        op: "list",
+        jobs: [{ short: "kill3333", sessionId: "session-target" }],
+      };
+    }
+    return { ok: true, op: request.op, killed: request.short };
+  });
+
+  try {
+    const result = await sendKillBySessionId({
+      daemonPaths: { controlSock: sockPath, configDir },
+      sessionId: "session-target",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.killed, "kill3333");
+    assert.deepEqual(seen, [
+      { proto: 1, op: "list" },
+      { proto: 1, op: "kill", short: "kill3333" },
     ]);
   } finally {
     await new Promise((resolve) => server.close(resolve));

--- a/tests/unit/claude-daemon-dispatch-job.test.mjs
+++ b/tests/unit/claude-daemon-dispatch-job.test.mjs
@@ -209,6 +209,36 @@ test("teardownClaudeDaemonJob attempts every step even when killDaemonJob throws
   ]);
 });
 
+test("teardownClaudeDaemonJob passes daemon control auth to short kill", async () => {
+  const calls = [];
+  await teardownClaudeDaemonJob({
+    paths: {
+      controlSock: "/tmp/does-not-matter.sock",
+      configDir: "/tmp/claude-auth-scope",
+    },
+    short: "tear5678",
+    _deps: {
+      buildDaemonControlAuth: async (configDir) => {
+        calls.push(["buildAuth", configDir]);
+        return { auth: "teardown-secret" };
+      },
+      killDaemonJob: async (controlSock, short, options) => {
+        calls.push(["killDaemonJob", controlSock, short, options]);
+      },
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ["buildAuth", "/tmp/claude-auth-scope"],
+    [
+      "killDaemonJob",
+      "/tmp/does-not-matter.sock",
+      "tear5678",
+      { auth: "teardown-secret" },
+    ],
+  ]);
+});
+
 test("dispatchClaudeDaemonJob presents daemon control.key as auth when present", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-dispatch-auth-"));
   const configDir = path.join(tmp, "claude");


### PR DESCRIPTION
## Summary
fable5 backlog B01 (P1) — PR #396 follow-up. #396이 dispatch에만 control-key를 배선해 `tfx-live ask`가 `didn't present the daemon control key`(EAUTH)로 거부됐다. attach/interrupt/kill mutating 경로 전부에 auth를 배선한다.

## Changes
- `buildDaemonAttachRequest` / `attachClaudeDaemonSession` / `interruptClaudeDaemonSession`: optional `auth` 추가 (있을 때만 필드 포함)
- `sendKillBySessionId`: kill op에 auth 자체 계산 부착 (`daemonPaths.configDir` 기반) — list op는 read-only라 무auth 유지
- `teardownClaudeDaemonJob`: DI(`_deps.buildDaemonControlAuth`)로 killJob에 auth 전달
- `hub/bridge.mjs` `cmdDaemonAttach`/`cmdDaemonInterrupt`: probe된 daemon의 `configDir`로 auth 계산 후 전달
- `hub/team/headless.mjs`: cleanup/completion kill 경로 auth 부착 (fire-and-forget 의미 보존)
- fail-open 계약 유지: `control.key` 부재 시 auth 필드 자체 생략 (구버전 daemon 호환)

## Mirrors
core(byte) + triflux(byte) + remote(Edit, `@triflux/core` import 보존)

## Verification
- 가드 5종 `node --test`: **66 pass / 0 fail** (#396 dispatch 테스트 무수정 green)
- `npm run release:check-mirror`: Mirror OK
- 신규 테스트: attach/interrupt auth 포함/생략, kill auth, teardown DI — 전부 mkdtemp 격리
- 구현 Codex (gpt55_high), 교차리뷰 Claude (fable5)

## 후속
live `tfx-live ask/attach` smoke는 머지 후 별도 기록 (#367 분류는 이 PR 이후 판단)