### PR TITLE
fix(cto): group synapse sessions by derived repo root

### DIFF
--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -29,7 +29,61 @@ function toIsoTime(value) {
   return null;
 }
 
+function shortHash(value) {
+  const str = String(value ?? "");
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function pathLabel(value) {
+  const str = String(value ?? "").replace(/[/\\]+$/u, "");
+  if (!str) return "";
+  const segments = str.split(/[/\\]+/u);
+  return segments[segments.length - 1] || "";
+}
+
+export function deriveRepoRootFromCwd(cwd) {
+  if (typeof cwd !== "string" || !cwd) return "";
+  if (cwd.includes("\\") || /^[A-Za-z]:/u.test(cwd)) return cwd;
+
+  const normalized = cwd.replace(/\/+$/u, "");
+  const claudeMarker = "/.claude/worktrees/";
+  const claudeIndex = normalized.indexOf(claudeMarker);
+  if (claudeIndex > 0) {
+    const suffix = normalized.slice(claudeIndex + claudeMarker.length);
+    if (/^[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, claudeIndex);
+    }
+  }
+
+  const codexMarker = "/.codex-swarm/";
+  const codexIndex = normalized.indexOf(codexMarker);
+  if (codexIndex > 0) {
+    const suffix = normalized.slice(codexIndex + codexMarker.length);
+    if (/^wt-[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, codexIndex);
+    }
+  }
+
+  return cwd;
+}
+
+function redactedCwdFields(cwd) {
+  if (typeof cwd !== "string" || !cwd) return {};
+  const repoRoot = deriveRepoRootFromCwd(cwd);
+  return {
+    cwdLabel: pathLabel(cwd),
+    cwdHash: shortHash(cwd),
+    repoRootLabel: pathLabel(repoRoot),
+    repoRootHash: shortHash(repoRoot),
+  };
+}
+
 function normalizeLiveSession(session) {
+  const cwd = typeof session?.cwd === "string" ? session.cwd : "";
   return {
     sessionId: String(session?.sessionId || ""),
     host: typeof session?.host === "string" ? session.host : "local",
@@ -48,6 +102,7 @@ function normalizeLiveSession(session) {
     started_at: toIsoTime(
       session?.started_at ?? session?.startedAt ?? session?.lastHeartbeat,
     ),
+    ...redactedCwdFields(cwd),
   };
 }
 
@@ -164,7 +219,27 @@ function deriveActiveShards(current, overlay) {
   return shards.map(normalizeActiveShard).filter((shard) => shard.shard_name);
 }
 
+function deriveLiveSessionGroups(liveSessions) {
+  const groups = new Map();
+  for (const session of liveSessions || []) {
+    if (!session?.repoRootHash) continue;
+    if (!groups.has(session.repoRootHash)) {
+      groups.set(session.repoRootHash, {
+        repoRootLabel: session.repoRootLabel || "",
+        repoRootHash: session.repoRootHash,
+        session_count: 0,
+        sessions: [],
+      });
+    }
+    const group = groups.get(session.repoRootHash);
+    group.session_count += 1;
+    group.sessions.push(session.sessionId);
+  }
+  return [...groups.values()];
+}
+
 function projectStatus(current, overlay) {
+  const liveSessions = overlay.live_sessions;
   return {
     schema_version: current?.schema_version || SCHEMA_VERSION,
     generated_at: current?.generated_at || null,
@@ -172,7 +247,8 @@ function projectStatus(current, overlay) {
     sources: current?.sources || {},
     summary: current?.summary || {},
     ledger_tail: Array.isArray(current?.ledger_tail) ? current.ledger_tail : [],
-    live_sessions: overlay.live_sessions,
+    live_sessions: liveSessions,
+    live_session_groups: deriveLiveSessionGroups(liveSessions),
     active_shards: deriveActiveShards(current, overlay),
   };
 }

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -29,7 +29,61 @@ function toIsoTime(value) {
   return null;
 }
 
+function shortHash(value) {
+  const str = String(value ?? "");
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function pathLabel(value) {
+  const str = String(value ?? "").replace(/[/\\]+$/u, "");
+  if (!str) return "";
+  const segments = str.split(/[/\\]+/u);
+  return segments[segments.length - 1] || "";
+}
+
+export function deriveRepoRootFromCwd(cwd) {
+  if (typeof cwd !== "string" || !cwd) return "";
+  if (cwd.includes("\\") || /^[A-Za-z]:/u.test(cwd)) return cwd;
+
+  const normalized = cwd.replace(/\/+$/u, "");
+  const claudeMarker = "/.claude/worktrees/";
+  const claudeIndex = normalized.indexOf(claudeMarker);
+  if (claudeIndex > 0) {
+    const suffix = normalized.slice(claudeIndex + claudeMarker.length);
+    if (/^[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, claudeIndex);
+    }
+  }
+
+  const codexMarker = "/.codex-swarm/";
+  const codexIndex = normalized.indexOf(codexMarker);
+  if (codexIndex > 0) {
+    const suffix = normalized.slice(codexIndex + codexMarker.length);
+    if (/^wt-[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, codexIndex);
+    }
+  }
+
+  return cwd;
+}
+
+function redactedCwdFields(cwd) {
+  if (typeof cwd !== "string" || !cwd) return {};
+  const repoRoot = deriveRepoRootFromCwd(cwd);
+  return {
+    cwdLabel: pathLabel(cwd),
+    cwdHash: shortHash(cwd),
+    repoRootLabel: pathLabel(repoRoot),
+    repoRootHash: shortHash(repoRoot),
+  };
+}
+
 function normalizeLiveSession(session) {
+  const cwd = typeof session?.cwd === "string" ? session.cwd : "";
   return {
     sessionId: String(session?.sessionId || ""),
     host: typeof session?.host === "string" ? session.host : "local",
@@ -48,6 +102,7 @@ function normalizeLiveSession(session) {
     started_at: toIsoTime(
       session?.started_at ?? session?.startedAt ?? session?.lastHeartbeat,
     ),
+    ...redactedCwdFields(cwd),
   };
 }
 
@@ -164,7 +219,27 @@ function deriveActiveShards(current, overlay) {
   return shards.map(normalizeActiveShard).filter((shard) => shard.shard_name);
 }
 
+function deriveLiveSessionGroups(liveSessions) {
+  const groups = new Map();
+  for (const session of liveSessions || []) {
+    if (!session?.repoRootHash) continue;
+    if (!groups.has(session.repoRootHash)) {
+      groups.set(session.repoRootHash, {
+        repoRootLabel: session.repoRootLabel || "",
+        repoRootHash: session.repoRootHash,
+        session_count: 0,
+        sessions: [],
+      });
+    }
+    const group = groups.get(session.repoRootHash);
+    group.session_count += 1;
+    group.sessions.push(session.sessionId);
+  }
+  return [...groups.values()];
+}
+
 function projectStatus(current, overlay) {
+  const liveSessions = overlay.live_sessions;
   return {
     schema_version: current?.schema_version || SCHEMA_VERSION,
     generated_at: current?.generated_at || null,
@@ -172,7 +247,8 @@ function projectStatus(current, overlay) {
     sources: current?.sources || {},
     summary: current?.summary || {},
     ledger_tail: Array.isArray(current?.ledger_tail) ? current.ledger_tail : [],
-    live_sessions: overlay.live_sessions,
+    live_sessions: liveSessions,
+    live_session_groups: deriveLiveSessionGroups(liveSessions),
     active_shards: deriveActiveShards(current, overlay),
   };
 }

--- a/tests/cto/status.test.mjs
+++ b/tests/cto/status.test.mjs
@@ -106,7 +106,7 @@ describe("runStatus", () => {
       });
 
       const parsed = JSON.parse(out.read());
-      assert.deepEqual(Object.keys(parsed), [
+      const existingKeys = [
         "schema_version",
         "generated_at",
         "repo",
@@ -115,12 +115,16 @@ describe("runStatus", () => {
         "ledger_tail",
         "live_sessions",
         "active_shards",
-      ]);
+      ];
+      for (const key of existingKeys)
+        assert.ok(key in parsed, `${key} missing`);
+      assert.ok("live_session_groups" in parsed);
       assert.deepEqual(parsed, result);
       assert.equal(parsed.schema_version, "cto-lake.v1");
       assert.equal(parsed.repo.branch, "main");
       assert.equal(parsed.sources.git.available, true);
       assert.equal(parsed.ledger_tail.length, 1);
+      assert.deepEqual(parsed.live_session_groups, []);
       assert.deepEqual(parsed.live_sessions, [
         {
           sessionId: "sess-1",

--- a/tests/unit/cto-status.test.mjs
+++ b/tests/unit/cto-status.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
-import { runStatus } from "../../cto/status.mjs";
+import { deriveRepoRootFromCwd, runStatus } from "../../cto/status.mjs";
 
 function collectingStdout() {
   let buf = "";
@@ -161,5 +161,104 @@ describe("cto status active_shards / live_sessions projection", () => {
 
     assert.equal(status.active_shards.length, 1);
     assert.equal(status.active_shards[0].shard_name, "snap");
+  });
+
+  it("derives repo roots from known nested worktree cwd shapes without filesystem probes", () => {
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.claude/worktrees/feature"),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.claude/worktrees/feature/child"),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.claude/worktrees/feature/"),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd(
+        "/repo/app/.claude/worktrees/a/.claude/worktrees/b",
+      ),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.codex-swarm/wt-auth"),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.codex-swarm/wt-auth/src"),
+      "/repo/app",
+    );
+    assert.equal(deriveRepoRootFromCwd("/repo/sibling"), "/repo/sibling");
+    assert.equal(
+      deriveRepoRootFromCwd("C:\\Users\\dev\\repo\\.claude\\worktrees\\x"),
+      "C:\\Users\\dev\\repo\\.claude\\worktrees\\x",
+    );
+  });
+
+  it("groups nested synapse session cwd values by derived repo root without exposing raw cwd", async () => {
+    writeCurrent(lakeRoot, {
+      schema_version: "cto-lake.v1",
+      sources: {},
+    });
+
+    const parentCwd = join(sandboxDir, "parent-repo");
+    const claudeWorktreeCwd = join(
+      parentCwd,
+      ".claude",
+      "worktrees",
+      "feature-a",
+    );
+    const codexWorktreeCwd = join(
+      parentCwd,
+      ".codex-swarm",
+      "wt-feature-b",
+      "src",
+    );
+    const siblingCwd = join(sandboxDir, "sibling-repo");
+
+    const status = await runStatus(["--json"], {
+      rootDir: sandboxDir,
+      lakeRoot,
+      stdout: collectingStdout(),
+      synapseReader: async () => ({
+        sessions: [
+          { sessionId: "parent", cwd: parentCwd },
+          { sessionId: "claude-wt", cwd: claudeWorktreeCwd },
+          { sessionId: "codex-wt", cwd: codexWorktreeCwd },
+          { sessionId: "sibling", cwd: siblingCwd },
+        ],
+        active_shards: [],
+      }),
+    });
+
+    const byId = Object.fromEntries(
+      status.live_sessions.map((session) => [session.sessionId, session]),
+    );
+    assert.equal(byId.parent.cwdLabel, "parent-repo");
+    assert.equal(byId["claude-wt"].cwdLabel, "feature-a");
+    assert.equal(byId["codex-wt"].cwdLabel, "src");
+    assert.equal(byId.parent.repoRootLabel, "parent-repo");
+    assert.equal(byId["claude-wt"].repoRootHash, byId.parent.repoRootHash);
+    assert.equal(byId["codex-wt"].repoRootHash, byId.parent.repoRootHash);
+    assert.notEqual(byId.sibling.repoRootHash, byId.parent.repoRootHash);
+
+    assert.equal(status.live_session_groups.length, 2);
+    const groupsByLabel = Object.fromEntries(
+      status.live_session_groups.map((group) => [group.repoRootLabel, group]),
+    );
+    assert.deepEqual(groupsByLabel["parent-repo"].sessions, [
+      "parent",
+      "claude-wt",
+      "codex-wt",
+    ]);
+    assert.deepEqual(groupsByLabel["sibling-repo"].sessions, ["sibling"]);
+
+    const serialized = JSON.stringify(status);
+    assert.equal(serialized.includes(parentCwd), false);
+    assert.equal(serialized.includes(claudeWorktreeCwd), false);
+    assert.equal(serialized.includes(codexWorktreeCwd), false);
+    assert.equal(serialized.includes(siblingCwd), false);
   });
 });


### PR DESCRIPTION
## Summary
fable5 backlog B03 (P2). 부모 repo 세션과 worktree(`.claude/worktrees/*`, `.codex-swarm/wt-*`) 세션이 cwd-tag로 흩어져 `tfx cto status`에서 같은 프로젝트가 별개 그룹으로 보이던 문제. read-side 한정으로 cwd→repoRoot 파생 grouping 추가.

## Changes
- `deriveRepoRootFromCwd(cwd)`: 순수 문자열 파싱 (fs/git 무호출), Windows 경로는 명시적 fallback
- live session row에 redacted `cwdLabel/cwdHash/repoRootLabel/repoRootHash` 추가 (raw 경로 비노출 — synapse privacy 계약 준수)
- additive `live_session_groups` — 기존 `tfx cto status --json` 키 제거/개명 없음
- write-side(`hub/team/synapse-registry.mjs`) 무접촉

## Verification
- `node --test tests/cto tests/unit/cto-*`: **38 pass / 0 fail**
- fixture smoke: 2 sessions → 1 repo-root group, raw path absent
- `npm run release:check-mirror`: Mirror OK (packages/triflux/cto byte)
- 구현 Codex (gpt55_high), 교차리뷰 Claude (fable5)