### PR TITLE
fix(preflight): reject stale Antigravity OAuth, accept live Keychain tokens (#306)

### DIFF
--- a/packages/triflux/scripts/preflight-cache.mjs
+++ b/packages/triflux/scripts/preflight-cache.mjs
@@ -6,6 +6,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  ANTIGRAVITY_KEYCHAIN_ACCOUNT,
+  ANTIGRAVITY_KEYCHAIN_SERVICE,
+} from "../hud/constants.mjs";
 import { checkHub, detectCodexPlan, probeClis } from "./lib/env-probe.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,69 +19,217 @@ const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
 const ANTIGRAVITY_AUTH_READY_SKEW_MS = CACHE_TTL_MS + 60_000;
+const ANTIGRAVITY_OAUTH_PATHS = (homeDir) => [
+  join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
+  join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
+  join(homeDir, ".gemini", "oauth_creds.json"),
+];
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
   return { ok: existsSyncFn(routePath), path: routePath };
 }
 
+function firstPresent(...values) {
+  for (const value of values) {
+    if (value != null && value !== "") return value;
+  }
+  return null;
+}
+
+function normalizeExpiryDate(value) {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value < 1_000_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return normalizeExpiryDate(numeric);
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function normalizeAntigravityCredential(parsed) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const accessToken = firstPresent(
+    parsed.access_token,
+    parsed.accessToken,
+    parsed.access?.token,
+    parsed.token,
+  );
+  const normalized = { ...parsed };
+  if (accessToken) normalized.access_token = accessToken;
+  const expiryDate = normalizeExpiryDate(
+    firstPresent(
+      parsed.expiry_date,
+      parsed.expiryDate,
+      parsed.expiry,
+      parsed.expires_at,
+      parsed.expiresAt,
+    ),
+  );
+  if (expiryDate != null) normalized.expiry_date = expiryDate;
+  return normalized;
+}
+
+function credentialReadiness(parsed, { source, path, now }) {
+  const credential = normalizeAntigravityCredential(parsed);
+  if (!credential) {
+    return {
+      ok: false,
+      status: "not_ready",
+      reason: "auth_invalid",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  if (!Number.isFinite(credential.expiry_date)) {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: "auth_expiry_unknown",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  if (credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS) {
+    return {
+      ok: true,
+      status: "ready",
+      reason: "ready",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  return {
+    ok: false,
+    status: "not_ready",
+    reason: "auth_expired",
+    auth_source: source,
+    ...(path ? { path } : {}),
+  };
+}
+
+function readAntigravityKeychainCredential({ spawnSyncFn, platformFn }) {
+  if (platformFn() !== "darwin") return { status: "skipped" };
+  try {
+    const result = spawnSyncFn(
+      "security",
+      [
+        "find-generic-password",
+        "-s",
+        ANTIGRAVITY_KEYCHAIN_SERVICE,
+        "-a",
+        ANTIGRAVITY_KEYCHAIN_ACCOUNT,
+        "-w",
+      ],
+      { encoding: "utf8", timeout: 2000, windowsHide: true },
+    );
+    if (result.error || result.signal) {
+      return { status: "unavailable", reason: "keychain_unavailable" };
+    }
+    if (result.status !== 0) {
+      return { status: "missing", reason: "keychain_missing" };
+    }
+    const stdout = String(result.stdout || "").trim();
+    if (!stdout) return { status: "missing", reason: "keychain_missing" };
+    try {
+      return { status: "found", credential: JSON.parse(stdout) };
+    } catch {
+      return { status: "found", credential: { access_token: stdout } };
+    }
+  } catch {
+    return { status: "unavailable", reason: "keychain_unavailable" };
+  }
+}
+
+function checkAntigravityFileCredential({
+  homeDir,
+  existsSyncFn,
+  readFileSyncFn,
+  now,
+}) {
+  let fallback = {
+    ok: false,
+    status: "not_ready",
+    reason: "auth_missing",
+    auth_source: "file",
+  };
+  for (const path of ANTIGRAVITY_OAUTH_PATHS(homeDir)) {
+    if (!existsSyncFn(path)) continue;
+
+    try {
+      const parsed = JSON.parse(readFileSyncFn(path, "utf8"));
+      const readiness = credentialReadiness(parsed, {
+        source: "file",
+        path,
+        now,
+      });
+      if (readiness.ok) return readiness;
+      fallback = readiness;
+    } catch {
+      fallback = {
+        ok: false,
+        status: "not_ready",
+        reason: "auth_invalid",
+        auth_source: "file",
+        path,
+      };
+    }
+  }
+
+  return fallback;
+}
+
 function checkAntigravityCredential({
   homeDir,
   existsSyncFn,
   readFileSyncFn,
+  spawnSyncFn,
+  platformFn,
   now = Date.now(),
 }) {
-  const paths = [
-    join(homeDir, ".gemini", "oauth_creds.json"),
-    join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
-    join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
-  ];
-
-  let reason = "auth_missing";
-  for (const path of paths) {
-    if (!existsSyncFn(path)) continue;
-
-    try {
-      const credential = JSON.parse(readFileSyncFn(path, "utf8"));
-      if (
-        Number.isFinite(credential?.expiry_date) &&
-        credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS
-      ) {
-        return { ok: true, path };
-      }
-      reason = "auth_expired";
-    } catch {
-      reason = "auth_invalid";
-    }
+  const keychain = readAntigravityKeychainCredential({
+    spawnSyncFn,
+    platformFn,
+  });
+  if (keychain.status === "found") {
+    return credentialReadiness(keychain.credential, {
+      source: "keychain",
+      now,
+    });
+  }
+  if (keychain.status === "unavailable") {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: keychain.reason,
+      auth_source: "keychain",
+    };
   }
 
-  return { ok: false, reason };
-}
+  const file = checkAntigravityFileCredential({
+    homeDir,
+    existsSyncFn,
+    readFileSyncFn,
+    now,
+  });
 
-function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
-  try {
-    const smoke = spawnSyncFn(
-      cliPath,
-      ["--print", "--dangerously-skip-permissions", "--print-timeout=3s"],
-      {
-        encoding: "utf8",
-        input: "Return exactly AGY_OK\n",
-        stdio: ["pipe", "pipe", "pipe"],
-        timeout,
-        windowsHide: true,
-      },
-    );
-    return (
-      !smoke.error &&
-      !smoke.signal &&
-      (smoke.status == null || smoke.status === 0) &&
-      String(smoke.stdout || "")
-        .split(/\r?\n/)
-        .some((line) => line.trim() === "AGY_OK")
-    );
-  } catch {
-    return false;
+  if (keychain.status === "missing" && file.ok && platformFn() === "darwin") {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: "keychain_missing",
+      auth_source: "file",
+      path: file.path,
+    };
   }
+
+  return file;
 }
 
 function checkAntigravityReadiness(
@@ -87,11 +239,12 @@ function checkAntigravityReadiness(
     existsSyncFn = existsSync,
     readFileSyncFn = readFileSync,
     spawnSyncFn = spawnSync,
+    platformFn = () => process.platform,
     timeout = 2000,
   } = {},
 ) {
   if (!cliResult?.ok || !cliResult.path)
-    return { ok: false, reason: "missing" };
+    return { ok: false, status: "not_ready", reason: "missing" };
 
   let helpText = "";
   try {
@@ -102,36 +255,47 @@ function checkAntigravityReadiness(
       windowsHide: true,
     });
     if (help.error || (help.status != null && help.status !== 0)) {
-      return { ok: false, path: cliResult.path, reason: "help_failed" };
+      return {
+        ok: false,
+        status: "not_ready",
+        path: cliResult.path,
+        reason: "help_failed",
+      };
     }
     helpText = [help.stdout, help.stderr].filter(Boolean).join("\n");
   } catch {
-    return { ok: false, path: cliResult.path, reason: "help_failed" };
+    return {
+      ok: false,
+      status: "not_ready",
+      path: cliResult.path,
+      reason: "help_failed",
+    };
   }
 
   const hasHeadlessFlags =
     helpText.includes("--print") &&
     helpText.includes("--dangerously-skip-permissions");
   if (!hasHeadlessFlags) {
-    return { ok: false, path: cliResult.path, reason: "headless_unsupported" };
+    return {
+      ok: false,
+      status: "not_ready",
+      path: cliResult.path,
+      reason: "headless_unsupported",
+    };
   }
 
   const credential = checkAntigravityCredential({
     homeDir,
     existsSyncFn,
     readFileSyncFn,
+    spawnSyncFn,
+    platformFn,
   });
   if (!credential.ok) {
-    if (
-      credential.reason === "auth_expired" &&
-      checkAntigravitySmoke(cliResult.path, { spawnSyncFn })
-    ) {
-      return { ok: true, path: cliResult.path, reason: "ready" };
-    }
-    return { ok: false, path: cliResult.path, reason: credential.reason };
+    return { ...credential, path: credential.path || cliResult.path };
   }
 
-  return { ok: true, path: cliResult.path, reason: "ready" };
+  return { ...credential, path: cliResult.path };
 }
 
 async function runPreflight({
@@ -143,6 +307,7 @@ async function runPreflight({
   existsSyncFn = existsSync,
   readFileSyncFn = readFileSync,
   spawnSyncFn = spawnSync,
+  platformFn = () => process.platform,
 } = {}) {
   const cliChecks = await probeClisFn(["codex", "gemini", "agy"]);
   const antigravity = checkAntigravityReadiness(cliChecks.agy, {
@@ -150,6 +315,7 @@ async function runPreflight({
     existsSyncFn,
     readFileSyncFn,
     spawnSyncFn,
+    platformFn,
   });
   const result = {
     timestamp: Date.now(),

--- a/packages/triflux/scripts/preflight-cache.mjs
+++ b/packages/triflux/scripts/preflight-cache.mjs
@@ -88,6 +88,15 @@ function credentialReadiness(parsed, { source, path, now }) {
     };
   }
   if (!Number.isFinite(credential.expiry_date)) {
+    if (source === "keychain" && credential.access_token) {
+      return {
+        ok: true,
+        status: "ready",
+        reason: "keychain_token_present",
+        auth_source: source,
+        ...(path ? { path } : {}),
+      };
+    }
     return {
       ok: false,
       status: "unknown",

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1316,7 +1316,7 @@ TFX_CODEX_TRANSPORT="${TFX_CODEX_TRANSPORT:-auto}"
 if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
   # eval 제거 — \x1e (ASCII 30, Record Separator) delimited read로 인젝션 위험 차단
   # F05: `|`에서 `\x1e`로 변경 — 계정 tier/agent 이름 등 값에 `|` 포함 시 필드 분리 오류 방지
-  IFS=$'\x1e' read -r _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents < <(
+  IFS=$'\x1e' read -r _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents _pf_antigravity_status _pf_antigravity_source _pf_antigravity_reason < <(
     "$NODE_BIN" -e '
       try {
         const c = JSON.parse(require("fs").readFileSync(require("path").join(require("os").homedir(),".claude","cache","tfx-preflight.json"),"utf8"));
@@ -1326,20 +1326,26 @@ if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
           c?.antigravity?.ok ? "1" : "0",
           c?.hub?.ok ? "1" : "0",
           (c?.codex_plan?.plan && c.codex_plan.plan !== "unknown" && c.codex_plan.plan !== "api") ? c.codex_plan.plan : "",
-          Array.isArray(c?.available_agents) ? c.available_agents.join(",") : ""
+          Array.isArray(c?.available_agents) ? c.available_agents.join(",") : "",
+          c?.antigravity?.status || "",
+          c?.antigravity?.auth_source || "",
+          c?.antigravity?.reason || ""
         ];
         process.stdout.write(parts.join("\x1e"));
-      } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e"); }
+      } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e\x1e\x1e\x1e"); }
     ' 2>/dev/null
   ) || true
   export TFX_CODEX_OK="${TFX_CODEX_OK:-${_pf_codex:-0}}"
   export TFX_GEMINI_OK="${TFX_GEMINI_OK:-${_pf_gemini:-0}}"
   export TFX_ANTIGRAVITY_OK="${TFX_ANTIGRAVITY_OK:-${_pf_antigravity:-0}}"
   export TFX_HUB_OK="${TFX_HUB_OK:-${_pf_hub:-0}}"
+  [[ -n "${_pf_antigravity_status:-}" ]] && export TFX_ANTIGRAVITY_STATUS="$_pf_antigravity_status"
+  [[ -n "${_pf_antigravity_source:-}" ]] && export TFX_ANTIGRAVITY_AUTH_SOURCE="$_pf_antigravity_source"
+  [[ -n "${_pf_antigravity_reason:-}" ]] && export TFX_ANTIGRAVITY_REASON="$_pf_antigravity_reason"
   [[ -n "${_pf_plan:-}" ]] && export TFX_CODEX_PLAN="$_pf_plan"
   [[ -n "${_pf_agents:-}" ]] && export TFX_AVAILABLE_AGENTS="$_pf_agents"
   export TFX_PREFLIGHT_LOADED=1
-  unset _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents
+  unset _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents _pf_antigravity_status _pf_antigravity_source _pf_antigravity_reason
   TFX_CODEX_PLAN="${TFX_CODEX_PLAN:-pro}"
 fi
 TFX_WORKER_INDEX="${TFX_WORKER_INDEX:-}"

--- a/scripts/preflight-cache.mjs
+++ b/scripts/preflight-cache.mjs
@@ -6,6 +6,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  ANTIGRAVITY_KEYCHAIN_ACCOUNT,
+  ANTIGRAVITY_KEYCHAIN_SERVICE,
+} from "../hud/constants.mjs";
 import { checkHub, detectCodexPlan, probeClis } from "./lib/env-probe.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,69 +19,217 @@ const CACHE_DIR = join(homedir(), ".claude", "cache");
 const CACHE_FILE = join(CACHE_DIR, "tfx-preflight.json");
 const CACHE_TTL_MS = 3_600_000; // 1시간 (세션당 1회, SessionStart 훅에서 갱신)
 const ANTIGRAVITY_AUTH_READY_SKEW_MS = CACHE_TTL_MS + 60_000;
+const ANTIGRAVITY_OAUTH_PATHS = (homeDir) => [
+  join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
+  join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
+  join(homeDir, ".gemini", "oauth_creds.json"),
+];
 
 function checkRoute({ homeDir = homedir(), existsSyncFn = existsSync } = {}) {
   const routePath = join(homeDir, ".claude", "scripts", "tfx-route.sh");
   return { ok: existsSyncFn(routePath), path: routePath };
 }
 
+function firstPresent(...values) {
+  for (const value of values) {
+    if (value != null && value !== "") return value;
+  }
+  return null;
+}
+
+function normalizeExpiryDate(value) {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value < 1_000_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return normalizeExpiryDate(numeric);
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function normalizeAntigravityCredential(parsed) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const accessToken = firstPresent(
+    parsed.access_token,
+    parsed.accessToken,
+    parsed.access?.token,
+    parsed.token,
+  );
+  const normalized = { ...parsed };
+  if (accessToken) normalized.access_token = accessToken;
+  const expiryDate = normalizeExpiryDate(
+    firstPresent(
+      parsed.expiry_date,
+      parsed.expiryDate,
+      parsed.expiry,
+      parsed.expires_at,
+      parsed.expiresAt,
+    ),
+  );
+  if (expiryDate != null) normalized.expiry_date = expiryDate;
+  return normalized;
+}
+
+function credentialReadiness(parsed, { source, path, now }) {
+  const credential = normalizeAntigravityCredential(parsed);
+  if (!credential) {
+    return {
+      ok: false,
+      status: "not_ready",
+      reason: "auth_invalid",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  if (!Number.isFinite(credential.expiry_date)) {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: "auth_expiry_unknown",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  if (credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS) {
+    return {
+      ok: true,
+      status: "ready",
+      reason: "ready",
+      auth_source: source,
+      ...(path ? { path } : {}),
+    };
+  }
+  return {
+    ok: false,
+    status: "not_ready",
+    reason: "auth_expired",
+    auth_source: source,
+    ...(path ? { path } : {}),
+  };
+}
+
+function readAntigravityKeychainCredential({ spawnSyncFn, platformFn }) {
+  if (platformFn() !== "darwin") return { status: "skipped" };
+  try {
+    const result = spawnSyncFn(
+      "security",
+      [
+        "find-generic-password",
+        "-s",
+        ANTIGRAVITY_KEYCHAIN_SERVICE,
+        "-a",
+        ANTIGRAVITY_KEYCHAIN_ACCOUNT,
+        "-w",
+      ],
+      { encoding: "utf8", timeout: 2000, windowsHide: true },
+    );
+    if (result.error || result.signal) {
+      return { status: "unavailable", reason: "keychain_unavailable" };
+    }
+    if (result.status !== 0) {
+      return { status: "missing", reason: "keychain_missing" };
+    }
+    const stdout = String(result.stdout || "").trim();
+    if (!stdout) return { status: "missing", reason: "keychain_missing" };
+    try {
+      return { status: "found", credential: JSON.parse(stdout) };
+    } catch {
+      return { status: "found", credential: { access_token: stdout } };
+    }
+  } catch {
+    return { status: "unavailable", reason: "keychain_unavailable" };
+  }
+}
+
+function checkAntigravityFileCredential({
+  homeDir,
+  existsSyncFn,
+  readFileSyncFn,
+  now,
+}) {
+  let fallback = {
+    ok: false,
+    status: "not_ready",
+    reason: "auth_missing",
+    auth_source: "file",
+  };
+  for (const path of ANTIGRAVITY_OAUTH_PATHS(homeDir)) {
+    if (!existsSyncFn(path)) continue;
+
+    try {
+      const parsed = JSON.parse(readFileSyncFn(path, "utf8"));
+      const readiness = credentialReadiness(parsed, {
+        source: "file",
+        path,
+        now,
+      });
+      if (readiness.ok) return readiness;
+      fallback = readiness;
+    } catch {
+      fallback = {
+        ok: false,
+        status: "not_ready",
+        reason: "auth_invalid",
+        auth_source: "file",
+        path,
+      };
+    }
+  }
+
+  return fallback;
+}
+
 function checkAntigravityCredential({
   homeDir,
   existsSyncFn,
   readFileSyncFn,
+  spawnSyncFn,
+  platformFn,
   now = Date.now(),
 }) {
-  const paths = [
-    join(homeDir, ".gemini", "oauth_creds.json"),
-    join(homeDir, ".gemini", "antigravity-cli", "oauth_creds.json"),
-    join(homeDir, ".gemini", "antigravity-cli", "credentials.json"),
-  ];
-
-  let reason = "auth_missing";
-  for (const path of paths) {
-    if (!existsSyncFn(path)) continue;
-
-    try {
-      const credential = JSON.parse(readFileSyncFn(path, "utf8"));
-      if (
-        Number.isFinite(credential?.expiry_date) &&
-        credential.expiry_date > now + ANTIGRAVITY_AUTH_READY_SKEW_MS
-      ) {
-        return { ok: true, path };
-      }
-      reason = "auth_expired";
-    } catch {
-      reason = "auth_invalid";
-    }
+  const keychain = readAntigravityKeychainCredential({
+    spawnSyncFn,
+    platformFn,
+  });
+  if (keychain.status === "found") {
+    return credentialReadiness(keychain.credential, {
+      source: "keychain",
+      now,
+    });
+  }
+  if (keychain.status === "unavailable") {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: keychain.reason,
+      auth_source: "keychain",
+    };
   }
 
-  return { ok: false, reason };
-}
+  const file = checkAntigravityFileCredential({
+    homeDir,
+    existsSyncFn,
+    readFileSyncFn,
+    now,
+  });
 
-function checkAntigravitySmoke(cliPath, { spawnSyncFn, timeout = 8000 } = {}) {
-  try {
-    const smoke = spawnSyncFn(
-      cliPath,
-      ["--print", "--dangerously-skip-permissions", "--print-timeout=3s"],
-      {
-        encoding: "utf8",
-        input: "Return exactly AGY_OK\n",
-        stdio: ["pipe", "pipe", "pipe"],
-        timeout,
-        windowsHide: true,
-      },
-    );
-    return (
-      !smoke.error &&
-      !smoke.signal &&
-      (smoke.status == null || smoke.status === 0) &&
-      String(smoke.stdout || "")
-        .split(/\r?\n/)
-        .some((line) => line.trim() === "AGY_OK")
-    );
-  } catch {
-    return false;
+  if (keychain.status === "missing" && file.ok && platformFn() === "darwin") {
+    return {
+      ok: false,
+      status: "unknown",
+      reason: "keychain_missing",
+      auth_source: "file",
+      path: file.path,
+    };
   }
+
+  return file;
 }
 
 function checkAntigravityReadiness(
@@ -87,11 +239,12 @@ function checkAntigravityReadiness(
     existsSyncFn = existsSync,
     readFileSyncFn = readFileSync,
     spawnSyncFn = spawnSync,
+    platformFn = () => process.platform,
     timeout = 2000,
   } = {},
 ) {
   if (!cliResult?.ok || !cliResult.path)
-    return { ok: false, reason: "missing" };
+    return { ok: false, status: "not_ready", reason: "missing" };
 
   let helpText = "";
   try {
@@ -102,36 +255,47 @@ function checkAntigravityReadiness(
       windowsHide: true,
     });
     if (help.error || (help.status != null && help.status !== 0)) {
-      return { ok: false, path: cliResult.path, reason: "help_failed" };
+      return {
+        ok: false,
+        status: "not_ready",
+        path: cliResult.path,
+        reason: "help_failed",
+      };
     }
     helpText = [help.stdout, help.stderr].filter(Boolean).join("\n");
   } catch {
-    return { ok: false, path: cliResult.path, reason: "help_failed" };
+    return {
+      ok: false,
+      status: "not_ready",
+      path: cliResult.path,
+      reason: "help_failed",
+    };
   }
 
   const hasHeadlessFlags =
     helpText.includes("--print") &&
     helpText.includes("--dangerously-skip-permissions");
   if (!hasHeadlessFlags) {
-    return { ok: false, path: cliResult.path, reason: "headless_unsupported" };
+    return {
+      ok: false,
+      status: "not_ready",
+      path: cliResult.path,
+      reason: "headless_unsupported",
+    };
   }
 
   const credential = checkAntigravityCredential({
     homeDir,
     existsSyncFn,
     readFileSyncFn,
+    spawnSyncFn,
+    platformFn,
   });
   if (!credential.ok) {
-    if (
-      credential.reason === "auth_expired" &&
-      checkAntigravitySmoke(cliResult.path, { spawnSyncFn })
-    ) {
-      return { ok: true, path: cliResult.path, reason: "ready" };
-    }
-    return { ok: false, path: cliResult.path, reason: credential.reason };
+    return { ...credential, path: credential.path || cliResult.path };
   }
 
-  return { ok: true, path: cliResult.path, reason: "ready" };
+  return { ...credential, path: cliResult.path };
 }
 
 async function runPreflight({
@@ -143,6 +307,7 @@ async function runPreflight({
   existsSyncFn = existsSync,
   readFileSyncFn = readFileSync,
   spawnSyncFn = spawnSync,
+  platformFn = () => process.platform,
 } = {}) {
   const cliChecks = await probeClisFn(["codex", "gemini", "agy"]);
   const antigravity = checkAntigravityReadiness(cliChecks.agy, {
@@ -150,6 +315,7 @@ async function runPreflight({
     existsSyncFn,
     readFileSyncFn,
     spawnSyncFn,
+    platformFn,
   });
   const result = {
     timestamp: Date.now(),

--- a/scripts/preflight-cache.mjs
+++ b/scripts/preflight-cache.mjs
@@ -88,6 +88,15 @@ function credentialReadiness(parsed, { source, path, now }) {
     };
   }
   if (!Number.isFinite(credential.expiry_date)) {
+    if (source === "keychain" && credential.access_token) {
+      return {
+        ok: true,
+        status: "ready",
+        reason: "keychain_token_present",
+        auth_source: source,
+        ...(path ? { path } : {}),
+      };
+    }
     return {
       ok: false,
       status: "unknown",

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1316,7 +1316,7 @@ TFX_CODEX_TRANSPORT="${TFX_CODEX_TRANSPORT:-auto}"
 if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
   # eval 제거 — \x1e (ASCII 30, Record Separator) delimited read로 인젝션 위험 차단
   # F05: `|`에서 `\x1e`로 변경 — 계정 tier/agent 이름 등 값에 `|` 포함 시 필드 분리 오류 방지
-  IFS=$'\x1e' read -r _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents < <(
+  IFS=$'\x1e' read -r _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents _pf_antigravity_status _pf_antigravity_source _pf_antigravity_reason < <(
     "$NODE_BIN" -e '
       try {
         const c = JSON.parse(require("fs").readFileSync(require("path").join(require("os").homedir(),".claude","cache","tfx-preflight.json"),"utf8"));
@@ -1326,20 +1326,26 @@ if [[ -z "${TFX_PREFLIGHT_LOADED:-}" ]]; then
           c?.antigravity?.ok ? "1" : "0",
           c?.hub?.ok ? "1" : "0",
           (c?.codex_plan?.plan && c.codex_plan.plan !== "unknown" && c.codex_plan.plan !== "api") ? c.codex_plan.plan : "",
-          Array.isArray(c?.available_agents) ? c.available_agents.join(",") : ""
+          Array.isArray(c?.available_agents) ? c.available_agents.join(",") : "",
+          c?.antigravity?.status || "",
+          c?.antigravity?.auth_source || "",
+          c?.antigravity?.reason || ""
         ];
         process.stdout.write(parts.join("\x1e"));
-      } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e"); }
+      } catch { process.stdout.write("0\x1e0\x1e0\x1e0\x1e\x1e\x1e\x1e\x1e"); }
     ' 2>/dev/null
   ) || true
   export TFX_CODEX_OK="${TFX_CODEX_OK:-${_pf_codex:-0}}"
   export TFX_GEMINI_OK="${TFX_GEMINI_OK:-${_pf_gemini:-0}}"
   export TFX_ANTIGRAVITY_OK="${TFX_ANTIGRAVITY_OK:-${_pf_antigravity:-0}}"
   export TFX_HUB_OK="${TFX_HUB_OK:-${_pf_hub:-0}}"
+  [[ -n "${_pf_antigravity_status:-}" ]] && export TFX_ANTIGRAVITY_STATUS="$_pf_antigravity_status"
+  [[ -n "${_pf_antigravity_source:-}" ]] && export TFX_ANTIGRAVITY_AUTH_SOURCE="$_pf_antigravity_source"
+  [[ -n "${_pf_antigravity_reason:-}" ]] && export TFX_ANTIGRAVITY_REASON="$_pf_antigravity_reason"
   [[ -n "${_pf_plan:-}" ]] && export TFX_CODEX_PLAN="$_pf_plan"
   [[ -n "${_pf_agents:-}" ]] && export TFX_AVAILABLE_AGENTS="$_pf_agents"
   export TFX_PREFLIGHT_LOADED=1
-  unset _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents
+  unset _pf_codex _pf_gemini _pf_antigravity _pf_hub _pf_plan _pf_agents _pf_antigravity_status _pf_antigravity_source _pf_antigravity_reason
   TFX_CODEX_PLAN="${TFX_CODEX_PLAN:-pro}"
 fi
 TFX_WORKER_INDEX="${TFX_WORKER_INDEX:-}"

--- a/tests/unit/preflight-cache-antigravity.test.mjs
+++ b/tests/unit/preflight-cache-antigravity.test.mjs
@@ -179,6 +179,82 @@ describe("preflight-cache Antigravity readiness", () => {
     }
   });
 
+  it("accepts raw macOS Keychain tokens without expiry metadata", async () => {
+    const homeDir = makeHome();
+    const rawToken = "x".repeat(682);
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          {
+            platform: "darwin",
+            keychainCredential: rawToken,
+          },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, true);
+      assert.equal(result.antigravity.status, "ready");
+      assert.equal(result.antigravity.auth_source, "keychain");
+      assert.equal(result.antigravity.reason, "keychain_token_present");
+      assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts macOS Keychain JSON tokens without expiry metadata", async () => {
+    const homeDir = makeHome();
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          {
+            platform: "darwin",
+            keychainCredential: { accessToken: "keychain-access-token" },
+          },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, true);
+      assert.equal(result.antigravity.status, "ready");
+      assert.equal(result.antigravity.auth_source, "keychain");
+      assert.equal(result.antigravity.reason, "keychain_token_present");
+      assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects expired macOS Keychain JSON auth", async () => {
+    const homeDir = makeHome();
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          {
+            platform: "darwin",
+            keychainCredential: {
+              accessToken: "expired-keychain-token",
+              expiry_date: Date.now() - 30_000,
+            },
+          },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.status, "not_ready");
+      assert.equal(result.antigravity.auth_source, "keychain");
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.ok(!result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts Antigravity headless help flags emitted on stderr", async () => {
     const homeDir = makeHome({
       antigravityAuth: { expiry_date: Date.now() + READY_EXPIRY_MS },

--- a/tests/unit/preflight-cache-antigravity.test.mjs
+++ b/tests/unit/preflight-cache-antigravity.test.mjs
@@ -36,7 +36,13 @@ function makeHome({ antigravityAuth } = {}) {
 function makePreflightOptions(
   homeDir,
   helpText,
-  { helpStderr = "", smoke = { status: 1, stdout: "", stderr: "" } } = {},
+  {
+    helpStderr = "",
+    keychainCredential = null,
+    platform = "linux",
+    smoke = { status: 1, stdout: "", stderr: "" },
+    smokeCalls = null,
+  } = {},
 ) {
   return {
     homeDir,
@@ -47,10 +53,25 @@ function makePreflightOptions(
     }),
     checkHubFn: () => ({ ok: true, state: "healthy" }),
     detectCodexPlanFn: () => ({ plan: "pro", source: "test" }),
-    spawnSyncFn: (_command, args) => {
+    platformFn: () => platform,
+    spawnSyncFn: (command, args) => {
+      if (command === "security") {
+        if (keychainCredential == null) {
+          return { status: 44, stdout: "", stderr: "not found" };
+        }
+        return {
+          status: 0,
+          stdout:
+            typeof keychainCredential === "string"
+              ? keychainCredential
+              : JSON.stringify(keychainCredential),
+          stderr: "",
+        };
+      }
       if (args.includes("--help")) {
         return { status: 0, stdout: helpText, stderr: helpStderr };
       }
+      if (smokeCalls) smokeCalls.count += 1;
       return smoke;
     },
   };
@@ -72,7 +93,9 @@ describe("preflight-cache Antigravity readiness", () => {
       assert.deepEqual(result.antigravity, {
         ok: true,
         path: "/fake/bin/agy",
+        status: "ready",
         reason: "ready",
+        auth_source: "file",
       });
       assert.ok(result.available_agents.includes("antigravity"));
     } finally {
@@ -100,6 +123,62 @@ describe("preflight-cache Antigravity readiness", () => {
     }
   });
 
+  it("does not rescue stale file auth with an agy smoke call", async () => {
+    const smokeCalls = { count: 0 };
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() - 30_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          {
+            smokeCalls,
+            smoke: { status: 0, stdout: "AGY_OK\n", stderr: "" },
+          },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.status, "not_ready");
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.equal(smokeCalls.count, 0);
+      assert.ok(!result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses fresh macOS Keychain auth before stale file auth", async () => {
+    const homeDir = makeHome({
+      antigravityAuth: { expiry_date: Date.now() - 30_000 },
+    });
+    try {
+      const result = await runPreflight(
+        makePreflightOptions(
+          homeDir,
+          "Usage: agy\n  --print\n  --dangerously-skip-permissions\n",
+          {
+            platform: "darwin",
+            keychainCredential: {
+              accessToken: "fresh-token",
+              expires_at: new Date(Date.now() + READY_EXPIRY_MS).toISOString(),
+            },
+          },
+        ),
+      );
+
+      assert.equal(result.antigravity.ok, true);
+      assert.equal(result.antigravity.status, "ready");
+      assert.equal(result.antigravity.auth_source, "keychain");
+      assert.equal(result.antigravity.reason, "ready");
+      assert.ok(result.available_agents.includes("antigravity"));
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts Antigravity headless help flags emitted on stderr", async () => {
     const homeDir = makeHome({
       antigravityAuth: { expiry_date: Date.now() + READY_EXPIRY_MS },
@@ -120,7 +199,7 @@ describe("preflight-cache Antigravity readiness", () => {
     }
   });
 
-  it("accepts expired Antigravity auth when non-interactive smoke succeeds", async () => {
+  it("does not accept expired Antigravity auth when non-interactive smoke succeeds", async () => {
     const homeDir = makeHome({
       antigravityAuth: { expiry_date: Date.now() - 30_000 },
     });
@@ -139,9 +218,10 @@ describe("preflight-cache Antigravity readiness", () => {
         ),
       );
 
-      assert.equal(result.antigravity.ok, true);
-      assert.equal(result.antigravity.reason, "ready");
-      assert.ok(result.available_agents.includes("antigravity"));
+      assert.equal(result.antigravity.ok, false);
+      assert.equal(result.antigravity.status, "not_ready");
+      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.ok(!result.available_agents.includes("antigravity"));
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -168,7 +248,7 @@ describe("preflight-cache Antigravity readiness", () => {
     }
   });
 
-  it("does not enable Antigravity auto fallback for auth files without expiry_date", async () => {
+  it("reports unknown Antigravity readiness for auth files without expiry_date", async () => {
     const homeDir = makeHome({ antigravityAuth: {} });
     try {
       const result = await runPreflight(
@@ -179,7 +259,8 @@ describe("preflight-cache Antigravity readiness", () => {
       );
 
       assert.equal(result.antigravity.ok, false);
-      assert.equal(result.antigravity.reason, "auth_expired");
+      assert.equal(result.antigravity.status, "unknown");
+      assert.equal(result.antigravity.reason, "auth_expiry_unknown");
       assert.ok(!result.available_agents.includes("antigravity"));
     } finally {
       rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Issue #306 (fable5 backlog B06). readiness gate가 stale OAuth credential을 ready로 통과시키던 문제 + 수정 과정에서 발견된 darwin false-negative까지 처리.

## Changes (commit 1: `ade8f766`)
- **Keychain-first (darwin)**: `service=gemini/account=antigravity`를 file보다 먼저 확인 (#379 HUD 패턴과 정합)
- expiry 정규화: `expiry_date/expiryDate/expiry/expires_at/expiresAt` + epoch-sec/ms/ISO 수용
- **expired file credential을 `agy --print` live smoke로 구제하던 자동 판정 제거** — #306의 핵심 false-positive 경로. SessionStart에서 8s smoke spawn도 함께 제거됨
- 판정 불가는 명시적 `status:unknown` — `TFX_ANTIGRAVITY_OK` boolean 호환 유지, `TFX_ANTIGRAVITY_STATUS/AUTH_SOURCE/REASON` additive
- DI seam (`spawnSyncFn`/`platformFn`) — 테스트 hermetic

## Changes (commit 2: `1cd6a97c` — 교차리뷰가 잡은 false negative)
라이브 리뷰 실측: agy 1.0.7의 실제 Keychain 항목은 **raw 비-JSON 토큰(682자, expiry 메타데이터 없음)** → commit 1 로직이 정상 로그인 머신에서 `unknown→ok:false`로 agy lane을 꺼버림. Keychain 항목 실존은 agy 자신이 유지·회전하는 로그인 증거이므로 `ready/keychain_token_present`로 수용. **file** 측 무expiry는 여전히 unknown (stale 가능성 — #306 본래 failure mode 차단 유지).

## Verification
- focused regression **14 pass / 0 fail** (raw token / no-expiry JSON / expired JSON 케이스 포함)
- live sanity (이 머신, agy 1.0.7 정상 로그인): `{"ok":true,"status":"ready","reason":"keychain_token_present","auth_source":"keychain"}` — Claude가 직접 재실행 확인
- `npm run release:check-mirror`: Mirror OK (packages/triflux byte)
- 전체 test:unit 3504/3513 pass — fail 4는 worktree-cwd ambient 클래스(env-probe/tray-lifecycle), B05(hub-port hermetic)에서 처리 중
- 구현 Codex (gpt55_high), 교차리뷰 Claude (fable5, live-probe 포함)

## 남은 수동 단계
live agy OAuth refresh smoke (네트워크)는 테스트 범위 밖 — 필요 시 수동 1회.