### PR TITLE
fix(doctor): serena 체크 should-be-absent 전환 + setup critical 에러 로깅

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -3328,72 +3328,42 @@ async function cmdDoctor(options = {}) {
       }
     }
 
-    // 4.5 Serena MCP
+    // 4.5 Serena MCP — 2026-06-10 core 에서 제거됨([Serena Core Removal]).
+    // serena 부재가 정상 상태이며, 잔존 시 부활로 간주해 제거를 권고한다(should-be-absent).
     section("Serena MCP");
     if (existsSync(CODEX_CONFIG_PATH)) {
       const codexConfig = readFileSync(CODEX_CONFIG_PATH, "utf8");
       const serenaConfig = inspectSerenaMcpConfig(codexConfig);
       if (!serenaConfig.present) {
-        warn("serena MCP 설정 없음");
-        info(
-          "권장: [mcp_servers.serena]에 --project-from-cwd, --context codex, startup_timeout_sec=30+ 설정",
-        );
+        ok("serena 미설정 (정상 — 2026-06-10 core 제거)");
         addDoctorCheck(report, {
           name: "serena-mcp",
-          status: "missing",
+          status: "ok",
           path: CODEX_CONFIG_PATH,
-          fix: "Codex config에 Serena MCP 설정을 추가하세요.",
+          note: "serena removed from core 2026-06-10; absence is expected.",
+        });
+      } else {
+        // 제거 결정 이후 serena 가 다시 나타났다 — 부활 감지(should-be-absent 위반).
+        warn("serena MCP 설정 잔존 — core 에서 제거됨(2026-06-10). 부활 감지");
+        info("제거 권장: ~/.codex/config.toml 의 [mcp_servers.serena] 삭제");
+        addDoctorCheck(report, {
+          name: "serena-mcp",
+          status: "issues",
+          path: CODEX_CONFIG_PATH,
+          resurrected: true,
+          fix: "serena 는 core 에서 제거되었습니다. ~/.codex/config.toml 의 [mcp_servers.serena] 항목을 삭제하세요.",
         });
         issues++;
-      } else {
-        const hasSerenaIssues =
-          !serenaConfig.hasProjectBinding || !serenaConfig.timeoutRecommended;
-
-        if (serenaConfig.hasProjectBinding) ok("project binding: 정상");
-        else {
-          warn("project binding 없음");
-          info("권장: --project-from-cwd 또는 --project <path>");
-          issues++;
-        }
-
-        if (serenaConfig.hasContextCodex) info("context codex: 설정됨");
-        else info("context codex: 미설정");
-
-        if (serenaConfig.startupTimeoutSec === null) {
-          warn("startup_timeout_sec 미설정");
-          info("권장: startup_timeout_sec = 30 이상");
-          issues++;
-        } else if (serenaConfig.timeoutRecommended) {
-          ok(`startup timeout: ${serenaConfig.startupTimeoutSec}s`);
-        } else {
-          warn(`startup timeout 낮음: ${serenaConfig.startupTimeoutSec}s`);
-          info("권장: startup_timeout_sec = 30 이상");
-          issues++;
-        }
-
-        addDoctorCheck(report, {
-          name: "serena-mcp",
-          status: hasSerenaIssues ? "issues" : "ok",
-          path: CODEX_CONFIG_PATH,
-          project_binding: serenaConfig.hasProjectBinding,
-          context_codex: serenaConfig.hasContextCodex,
-          startup_timeout_sec: serenaConfig.startupTimeoutSec,
-          ...(hasSerenaIssues
-            ? {
-                fix: "Serena MCP에 --project-from-cwd 와 startup_timeout_sec=30+ 를 설정하세요.",
-              }
-            : {}),
-        });
       }
     } else {
+      // config.toml 미존재 — serena 부재는 정상. 이슈로 집계하지 않는다.
+      ok("config.toml 미존재 — serena 진단 불필요");
       addDoctorCheck(report, {
         name: "serena-mcp",
-        status: "missing",
+        status: "ok",
         path: CODEX_CONFIG_PATH,
-        fix: "Codex config를 생성하고 Serena MCP 설정을 추가하세요.",
+        note: "config.toml absent; serena not required.",
       });
-      warn("config.toml 미존재 — Serena MCP 진단 건너뜀");
-      issues++;
     }
 
     // 5. Antigravity CLI

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -3328,72 +3328,42 @@ async function cmdDoctor(options = {}) {
       }
     }
 
-    // 4.5 Serena MCP
+    // 4.5 Serena MCP — 2026-06-10 core 에서 제거됨([Serena Core Removal]).
+    // serena 부재가 정상 상태이며, 잔존 시 부활로 간주해 제거를 권고한다(should-be-absent).
     section("Serena MCP");
     if (existsSync(CODEX_CONFIG_PATH)) {
       const codexConfig = readFileSync(CODEX_CONFIG_PATH, "utf8");
       const serenaConfig = inspectSerenaMcpConfig(codexConfig);
       if (!serenaConfig.present) {
-        warn("serena MCP 설정 없음");
-        info(
-          "권장: [mcp_servers.serena]에 --project-from-cwd, --context codex, startup_timeout_sec=30+ 설정",
-        );
+        ok("serena 미설정 (정상 — 2026-06-10 core 제거)");
         addDoctorCheck(report, {
           name: "serena-mcp",
-          status: "missing",
+          status: "ok",
           path: CODEX_CONFIG_PATH,
-          fix: "Codex config에 Serena MCP 설정을 추가하세요.",
+          note: "serena removed from core 2026-06-10; absence is expected.",
+        });
+      } else {
+        // 제거 결정 이후 serena 가 다시 나타났다 — 부활 감지(should-be-absent 위반).
+        warn("serena MCP 설정 잔존 — core 에서 제거됨(2026-06-10). 부활 감지");
+        info("제거 권장: ~/.codex/config.toml 의 [mcp_servers.serena] 삭제");
+        addDoctorCheck(report, {
+          name: "serena-mcp",
+          status: "issues",
+          path: CODEX_CONFIG_PATH,
+          resurrected: true,
+          fix: "serena 는 core 에서 제거되었습니다. ~/.codex/config.toml 의 [mcp_servers.serena] 항목을 삭제하세요.",
         });
         issues++;
-      } else {
-        const hasSerenaIssues =
-          !serenaConfig.hasProjectBinding || !serenaConfig.timeoutRecommended;
-
-        if (serenaConfig.hasProjectBinding) ok("project binding: 정상");
-        else {
-          warn("project binding 없음");
-          info("권장: --project-from-cwd 또는 --project <path>");
-          issues++;
-        }
-
-        if (serenaConfig.hasContextCodex) info("context codex: 설정됨");
-        else info("context codex: 미설정");
-
-        if (serenaConfig.startupTimeoutSec === null) {
-          warn("startup_timeout_sec 미설정");
-          info("권장: startup_timeout_sec = 30 이상");
-          issues++;
-        } else if (serenaConfig.timeoutRecommended) {
-          ok(`startup timeout: ${serenaConfig.startupTimeoutSec}s`);
-        } else {
-          warn(`startup timeout 낮음: ${serenaConfig.startupTimeoutSec}s`);
-          info("권장: startup_timeout_sec = 30 이상");
-          issues++;
-        }
-
-        addDoctorCheck(report, {
-          name: "serena-mcp",
-          status: hasSerenaIssues ? "issues" : "ok",
-          path: CODEX_CONFIG_PATH,
-          project_binding: serenaConfig.hasProjectBinding,
-          context_codex: serenaConfig.hasContextCodex,
-          startup_timeout_sec: serenaConfig.startupTimeoutSec,
-          ...(hasSerenaIssues
-            ? {
-                fix: "Serena MCP에 --project-from-cwd 와 startup_timeout_sec=30+ 를 설정하세요.",
-              }
-            : {}),
-        });
       }
     } else {
+      // config.toml 미존재 — serena 부재는 정상. 이슈로 집계하지 않는다.
+      ok("config.toml 미존재 — serena 진단 불필요");
       addDoctorCheck(report, {
         name: "serena-mcp",
-        status: "missing",
+        status: "ok",
         path: CODEX_CONFIG_PATH,
-        fix: "Codex config를 생성하고 Serena MCP 설정을 추가하세요.",
+        note: "config.toml absent; serena not required.",
       });
-      warn("config.toml 미존재 — Serena MCP 진단 건너뜀");
-      issues++;
     }
 
     // 5. Antigravity CLI

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -1374,13 +1374,25 @@ function ensureCriticalSetup() {
 
   try {
     ensureCodexProfiles();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureCodexProfiles 실패: ${error?.message || error}\n`,
+    );
+  }
   try {
     ensureCodexHooks();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureCodexHooks 실패: ${error?.message || error}\n`,
+    );
+  }
   try {
     ensureAgyHooks();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureAgyHooks 실패: ${error?.message || error}\n`,
+    );
+  }
 }
 
 export {

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1374,13 +1374,25 @@ function ensureCriticalSetup() {
 
   try {
     ensureCodexProfiles();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureCodexProfiles 실패: ${error?.message || error}\n`,
+    );
+  }
   try {
     ensureCodexHooks();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureCodexHooks 실패: ${error?.message || error}\n`,
+    );
+  }
   try {
     ensureAgyHooks();
-  } catch {}
+  } catch (error) {
+    process.stderr.write(
+      `[tfx-setup] ensureAgyHooks 실패: ${error?.message || error}\n`,
+    );
+  }
 }
 
 export {

--- a/tests/integration/triflux-cli.test.mjs
+++ b/tests/integration/triflux-cli.test.mjs
@@ -189,7 +189,8 @@ describe("triflux CLI JSON and schema surface", { timeout: 30000 }, () => {
     assert.ok(payload.checks.some((check) => check.name === "warmup-cache"));
   });
 
-  it("doctor --json은 Serena MCP project binding / timeout 진단을 포함해야 한다", () => {
+  it("doctor --json은 serena 잔존을 부활(should-be-absent)로 감지해야 한다", () => {
+    // serena 는 2026-06-10 core 에서 제거됨. config 에 남아있으면 부활로 간주한다.
     const homeDir = createHomeDir();
     writeFileSync(
       join(homeDir, ".codex", "config.toml"),
@@ -209,8 +210,24 @@ describe("triflux CLI JSON and schema surface", { timeout: 30000 }, () => {
     );
     assert.ok(serenaCheck, "serena-mcp check missing");
     assert.equal(serenaCheck.status, "issues");
-    assert.equal(serenaCheck.project_binding, false);
-    assert.equal(serenaCheck.startup_timeout_sec, 10);
+    assert.equal(serenaCheck.resurrected, true);
+  });
+
+  it("doctor --json은 serena 부재를 정상(ok)으로 처리해야 한다", () => {
+    // serena 제거 후 부재가 정상 상태 — missing 으로 경고하지 않는다.
+    const homeDir = createHomeDir();
+    writeFileSync(
+      join(homeDir, ".codex", "config.toml"),
+      ['model = "gpt-5.5"', ""].join("\n"),
+      "utf8",
+    );
+
+    const payload = parseStdoutJson(runCli(["doctor", "--json"], { homeDir }));
+    const serenaCheck = payload.checks.find(
+      (check) => check.name === "serena-mcp",
+    );
+    assert.ok(serenaCheck, "serena-mcp check missing");
+    assert.equal(serenaCheck.status, "ok");
   });
 
   it("multi status --json은 팀 상태가 없을 때 offline JSON을 반환해야 한다", () => {


### PR DESCRIPTION
## 배경 — m2 진단

m2에서 `tfx update` 후에도 (1) codex 레인 재발 (2) serena 부활처럼 보이는 현상. 실측 진단:

- **codex 재발**: m2 `~/.codex/config.toml`에 legacy inline `[profiles.gpt55_*]` 잔존 → codex 0.134+가 `--profile` 거부(exit 1). doctor는 `legacy_inline`으로 정확히 감지했으나, `ensureCodexProfiles`가 SessionStart 자동경로에서 silent `catch{}`로 조용히 실패 → 방치. `tfx setup` 명시 실행으로 정리 확인(doctor `codex-profiles=ok`). **protected-env 누수는 아님**(m2 변수 전부 unset 실측).
- **serena "부활"**: 실제 부활 아님 — m2 클라이언트 config·캐시 어디에도 serena 없음. doctor의 `serena-mcp` 체크가 "없음=missing+추가하세요"로 방향이 거꾸로 남아 사용자가 부활로 오인. (`CORE_SERVERS=[]` 제거가 doctor 체크까지 못 미친 잔존 드리프트)

## 변경

1. **doctor serena-mcp should-be-absent 전환** (`bin/triflux.mjs`): 부재=ok(정상), 잔존=issues+`resurrected`(부활 감지), config.toml 미존재=ok. 사용자 오인의 직접 원인 제거 + 부활 감지 기능 추가.
2. **ensureCriticalSetup silent catch 로깅** (`scripts/setup.mjs`): SessionStart 중 `ensureCodexProfiles/Hooks/AgyHooks` 실패를 stderr로 노출 — codex 재발 은폐 방지.
3. **테스트 갱신** (`tests/integration/triflux-cli.test.mjs`): 부활 감지 / 부재 정상 케이스.
4. **미러**: `packages/triflux` byte-identical 동기화.

## Follow-up (별도 PR)

- `syncRegistryTargets` removal_allowlist (`mcp-guard-engine.mjs:2051`) — `safe:true` 서버를 `removals=[]`로 무조건 재추가, 제거 추적 부재 → 잠재 부활 벡터. 현재 serena는 registry에 없어 OFF.
- `GATEWAY_PORTS` `serena:8105` dormant 정리 (jira/notion도 dormant라 일괄).
- 로컬 m5 `~/.claude/cache/mcp-pre-gateway.json`의 serena=1 stale 캐시 정리.

## 검증

- 전체 `npm test`: **4302 pass / 0 fail / 17 skip**, lint:skills PASS
- 변경 연관: triflux-cli 14/0, setup-codex-profiles 28/0, mcp-gateway 37/0
- biome clean
- 교차검증: Claude 작성 — 머지 전 Codex 리뷰 또는 `/code-review ultra` 권장