### PR TITLE
fix(tray): macOS 트레이 죽은 ephemeral 허브 포트 → 빈 popover 수정

### DIFF
--- a/hub/mac-tray.swift
+++ b/hub/mac-tray.swift
@@ -47,6 +47,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
     var webView: WKWebView!
     var port: String = "27888"
+    let canonicalPort = "27888"
+    var consecutiveFailures = 0
     var retryWorkItem: DispatchWorkItem?
     var onFocusComplete: (() -> Void)?
 
@@ -101,6 +103,14 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         logError("Failed to load: \(error.localizedDescription)")
+        consecutiveFailures += 1
+        if consecutiveFailures >= 3 && port != canonicalPort {
+            port = canonicalPort
+            consecutiveFailures = 0
+            logError("Switching to canonical port \(canonicalPort) after repeated failures")
+            loadTray()
+            return
+        }
         let retry = DispatchWorkItem { [weak self] in
             self?.loadTray()
         }
@@ -111,6 +121,7 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         retryWorkItem?.cancel()
         retryWorkItem = nil
+        consecutiveFailures = 0
         logError("Successfully loaded URL")
     }
 

--- a/hub/tray.mjs
+++ b/hub/tray.mjs
@@ -9,11 +9,25 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveHubPortForContext } from "./hub-lifecycle.mjs";
 import { IS_MAC, IS_WINDOWS } from "./platform.mjs";
 import { ensureHubForTray } from "./tray-lifecycle.mjs";
 
 const HUB_PID_FILE = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
 const DEFAULT_HUB_PORT = "27888";
+
+export function resolveTrayHubPort({
+  env = process.env,
+  cwd = process.cwd(),
+} = {}) {
+  return String(
+    resolveHubPortForContext({
+      env,
+      cwd,
+      defaultPort: Number(DEFAULT_HUB_PORT),
+    }),
+  );
+}
 
 function sleep(ms) {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
@@ -416,7 +430,7 @@ async function shutdown(reason = "shutdown") {
 export async function startTray() {
   if (IS_MAC) {
     const trayScript = fileURLToPath(import.meta.url);
-    const port = process.env.TFX_HUB_PORT || DEFAULT_HUB_PORT;
+    const port = resolveTrayHubPort();
     const serverPath = join(dirname(trayScript), "server.mjs");
     await ensureHubForTray({ port, serverPath });
     const reaped = reapExistingMacTrayProcesses({ scriptPath: trayScript });

--- a/packages/remote/hub/mac-tray.swift
+++ b/packages/remote/hub/mac-tray.swift
@@ -47,6 +47,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
     var webView: WKWebView!
     var port: String = "27888"
+    let canonicalPort = "27888"
+    var consecutiveFailures = 0
     var retryWorkItem: DispatchWorkItem?
     var onFocusComplete: (() -> Void)?
 
@@ -101,6 +103,14 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         logError("Failed to load: \(error.localizedDescription)")
+        consecutiveFailures += 1
+        if consecutiveFailures >= 3 && port != canonicalPort {
+            port = canonicalPort
+            consecutiveFailures = 0
+            logError("Switching to canonical port \(canonicalPort) after repeated failures")
+            loadTray()
+            return
+        }
         let retry = DispatchWorkItem { [weak self] in
             self?.loadTray()
         }
@@ -111,6 +121,7 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         retryWorkItem?.cancel()
         retryWorkItem = nil
+        consecutiveFailures = 0
         logError("Successfully loaded URL")
     }
 

--- a/packages/remote/hub/tray.mjs
+++ b/packages/remote/hub/tray.mjs
@@ -9,11 +9,25 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveHubPortForContext } from "./hub-lifecycle.mjs";
 import { IS_MAC, IS_WINDOWS } from "@triflux/core/hub/platform.mjs";
 import { ensureHubForTray } from "./tray-lifecycle.mjs";
 
 const HUB_PID_FILE = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
 const DEFAULT_HUB_PORT = "27888";
+
+export function resolveTrayHubPort({
+  env = process.env,
+  cwd = process.cwd(),
+} = {}) {
+  return String(
+    resolveHubPortForContext({
+      env,
+      cwd,
+      defaultPort: Number(DEFAULT_HUB_PORT),
+    }),
+  );
+}
 
 function sleep(ms) {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
@@ -416,7 +430,7 @@ async function shutdown(reason = "shutdown") {
 export async function startTray() {
   if (IS_MAC) {
     const trayScript = fileURLToPath(import.meta.url);
-    const port = process.env.TFX_HUB_PORT || DEFAULT_HUB_PORT;
+    const port = resolveTrayHubPort();
     const serverPath = join(dirname(trayScript), "server.mjs");
     await ensureHubForTray({ port, serverPath });
     const reaped = reapExistingMacTrayProcesses({ scriptPath: trayScript });

--- a/packages/triflux/hub/mac-tray.swift
+++ b/packages/triflux/hub/mac-tray.swift
@@ -47,6 +47,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
     var webView: WKWebView!
     var port: String = "27888"
+    let canonicalPort = "27888"
+    var consecutiveFailures = 0
     var retryWorkItem: DispatchWorkItem?
     var onFocusComplete: (() -> Void)?
 
@@ -101,6 +103,14 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         logError("Failed to load: \(error.localizedDescription)")
+        consecutiveFailures += 1
+        if consecutiveFailures >= 3 && port != canonicalPort {
+            port = canonicalPort
+            consecutiveFailures = 0
+            logError("Switching to canonical port \(canonicalPort) after repeated failures")
+            loadTray()
+            return
+        }
         let retry = DispatchWorkItem { [weak self] in
             self?.loadTray()
         }
@@ -111,6 +121,7 @@ class WebViewController: NSViewController, WKNavigationDelegate, WKScriptMessage
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         retryWorkItem?.cancel()
         retryWorkItem = nil
+        consecutiveFailures = 0
         logError("Successfully loaded URL")
     }
 

--- a/packages/triflux/hub/tray.mjs
+++ b/packages/triflux/hub/tray.mjs
@@ -9,11 +9,25 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveHubPortForContext } from "./hub-lifecycle.mjs";
 import { IS_MAC, IS_WINDOWS } from "./platform.mjs";
 import { ensureHubForTray } from "./tray-lifecycle.mjs";
 
 const HUB_PID_FILE = join(homedir(), ".claude", "cache", "tfx-hub", "hub.pid");
 const DEFAULT_HUB_PORT = "27888";
+
+export function resolveTrayHubPort({
+  env = process.env,
+  cwd = process.cwd(),
+} = {}) {
+  return String(
+    resolveHubPortForContext({
+      env,
+      cwd,
+      defaultPort: Number(DEFAULT_HUB_PORT),
+    }),
+  );
+}
 
 function sleep(ms) {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
@@ -416,7 +430,7 @@ async function shutdown(reason = "shutdown") {
 export async function startTray() {
   if (IS_MAC) {
     const trayScript = fileURLToPath(import.meta.url);
-    const port = process.env.TFX_HUB_PORT || DEFAULT_HUB_PORT;
+    const port = resolveTrayHubPort();
     const serverPath = join(dirname(trayScript), "server.mjs");
     await ensureHubForTray({ port, serverPath });
     const reaped = reapExistingMacTrayProcesses({ scriptPath: trayScript });

--- a/tests/unit/tray-port-resolve.test.mjs
+++ b/tests/unit/tray-port-resolve.test.mjs
@@ -1,0 +1,45 @@
+// tests/unit/tray-port-resolve.test.mjs — tray hub port resolution regressions
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveTrayHubPort } from "../../hub/tray.mjs";
+
+describe("tray hub port resolution", () => {
+  it("clamps leaked env ports in worktree contexts to the canonical default", () => {
+    assert.equal(
+      resolveTrayHubPort({
+        cwd: "/x/.claude/worktrees/y",
+        env: { TFX_HUB_PORT: "28255" },
+      }),
+      "27888",
+    );
+  });
+
+  it("honors env ports outside worktree contexts", () => {
+    assert.equal(
+      resolveTrayHubPort({
+        cwd: "/x/proj",
+        env: { TFX_HUB_PORT: "29000" },
+      }),
+      "29000",
+    );
+  });
+
+  it("uses the canonical default when no env port is present", () => {
+    assert.equal(resolveTrayHubPort({ cwd: "/x/proj", env: {} }), "27888");
+  });
+
+  it("honors explicit ephemeral port opt-in inside worktree contexts", () => {
+    assert.equal(
+      resolveTrayHubPort({
+        cwd: "/x/.claude/worktrees/y",
+        env: {
+          TFX_HUB_ALLOW_EPHEMERAL_PORT: "1",
+          TFX_HUB_PORT: "28255",
+        },
+      }),
+      "28255",
+    );
+  });
+});


### PR DESCRIPTION
## 증상

macOS 메뉴바 트레이를 눌러도 빈 popover 만 떴음.

## 근본 원인

워크트리/ephemeral 세션의 이미 종료된 허브 포트(예: `28255`)가 env(`TFX_HUB_PORT`)에 남아, 트레이 Swift WebView 가 죽은 포트를 로드해 0.35초마다 영원히 재시도(정규 허브는 `27888`). 두 갭:

1. `hub/tray.mjs` `startTray()` mac 분기가 raw `process.env.TFX_HUB_PORT` 를 가드 없이 swift 에 전달 (hub 생성 경로는 이미 `resolveHubPortForContext` 가드가 있으나 트레이 spawn 경로는 누락 — hotfix PRD 가 별도 TODO 로 미뤄둔 잔여분).
2. Swift 에 self-heal 부재 — 한번 박힌 죽은 포트를 영원히 재시도.

## 수정

- **`hub/tray.mjs`**: `resolveTrayHubPort()` 추가 → macOS spawn 포트를 `resolveHubPortForContext` 로 가드해 워크트리/ephemeral 누수 포트를 canonical `27888` 로 clamp.
- **`hub/mac-tray.swift`**: 죽은 포트에서 3회 연속 실패 시 canonical `27888` 로 self-heal, 성공 시 실패 카운터 reset (어떤 경로로 stale 포트가 박혀도 자가 복구).
- **`packages/{triflux,remote}`**: published 레이어 미러 동기화 (remote 는 platform import 만 상이).
- **`tests/unit/tray-port-resolve.test.mjs`**: 회귀 테스트 4건 (worktree clamp / 비-worktree honor / default / ephemeral opt-in).

## 검증

- tray 테스트 **41/41 pass** (신규 4건 포함)
- biome lint exit 0, `swiftc -parse` exit 0
- 미러 byte-identity 확인 (root vs triflux 완전 동일, remote 는 platform import 1줄만 차이)
- **swift self-heal 라이브 실측**: `39999(dead) ×3 실패 → 27888 전환 → 라이브 허브 로드 성공`
