### PR TITLE
feat(research): add CloakBrowser stealth-fetch backend

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -75,6 +75,7 @@ import {
   formatPsmuxUpdateGuidance,
   probePsmuxSupport,
 } from "../scripts/lib/psmux-info.mjs";
+import { main as stealthFetchMain } from "../scripts/lib/stealth-fetch.mjs";
 import {
   buildWindowsHubAutostartCommand,
   cleanupStaleSkills,
@@ -188,6 +189,11 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
           "Windows 로그인 시 tfx-hub를 보장하는 Task Scheduler 항목 등록",
       },
     ],
+  },
+  "stealth-fetch": {
+    usage: "tfx stealth-fetch <url>",
+    description:
+      "cloakbrowser 기반 단일 URL fetch (http/https only, JSON stdout)",
   },
   doctor: {
     usage:
@@ -6357,6 +6363,7 @@ ${updateNotice}
     ${DIM}  --reset${RESET}      ${GRAY}캐시 전체 초기화${RESET}
     ${DIM}  --json${RESET}       ${GRAY}구조화된 진단 결과 JSON 출력${RESET}
     ${WHITE_BRIGHT}tfx auto${RESET}       ${GRAY}tfx-auto 라우팅 결정 미리보기 (--cli codex|antigravity|claude)${RESET}
+    ${WHITE_BRIGHT}tfx stealth-fetch${RESET} ${GRAY}cloakbrowser 기반 URL fetch (JSON stdout)${RESET}
     ${WHITE_BRIGHT}tfx mcp${RESET}        ${GRAY}MCP registry 관리 (list/sync/add/remove)${RESET}
     ${WHITE_BRIGHT}tfx update${RESET}     ${GRAY}최신 안정 버전으로 업데이트${RESET}
     ${DIM}  --dev / dev${RESET}   ${GRAY}dev 태그로 업데이트${RESET}
@@ -7310,6 +7317,13 @@ async function main() {
         dryRun: cmdArgs.includes("--dry-run"),
         enableHubAutostart: cmdArgs.includes("--enable-hub-autostart"),
       });
+      return;
+    case "stealth-fetch":
+      if (cmdArgs.some(isHelpArg)) {
+        printCommandHelp("stealth-fetch");
+        return;
+      }
+      await stealthFetchMain([process.argv[0], "stealth-fetch", ...cmdArgs]);
       return;
     case "doctor": {
       if (cmdArgs.some(isHelpArg)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,10 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "cloakbrowser": "^0.3.31",
+        "playwright-core": "^1.53.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -260,6 +264,19 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -1230,6 +1247,42 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cloakbrowser": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.31.tgz",
+      "integrity": "sha512-HtwlpwFKd5FJh4jjCS5awsScWIKB9ofNSTkHLSEh/9JH0Hv1L79zu0MExSMOCP1nzOsgrohbacwwWocuKloQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tar": "^7.0.0"
+      },
+      "bin": {
+        "cloakbrowser": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "mmdb-lib": ">=2.0.0",
+        "playwright-core": ">=1.53.0",
+        "puppeteer-core": ">=21.0.0",
+        "socks-proxy-agent": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mmdb-lib": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "puppeteer-core": {
+          "optional": true
+        },
+        "socks-proxy-agent": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -2199,6 +2252,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -2487,6 +2563,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {
@@ -3052,6 +3141,23 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -3078,6 +3184,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thread-stream": {
@@ -3235,6 +3351,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -3326,6 +3452,10 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "cloakbrowser": "^0.3.31",
+        "playwright-core": "^1.53.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
     "tree-kill": "^1.2.2",
     "zod": "^4.0.0"
   },
+  "optionalDependencies": {
+    "cloakbrowser": "^0.3.31",
+    "playwright-core": "^1.53.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "knip": "^6.3.0"

--- a/packages/core/scripts/lib/stealth-fetch.mjs
+++ b/packages/core/scripts/lib/stealth-fetch.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// SSRF boundary: stealthFetch only accepts http: and https: URLs. It does not
+// guard private IPs, metadata hosts such as 169.254.x.x, or localhost; callers
+// must treat the URL as already inside their trust boundary.
+
+import { pathToFileURL } from "node:url";
+
+export class CloakBrowserUnavailableError extends Error {}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_WAIT_UNTIL = "load";
+const SUPPORTED_PLATFORMS = new Set([
+  "linux:x64",
+  "linux:arm64",
+  "darwin:x64",
+  "darwin:arm64",
+  "win32:x64",
+]);
+const EXIT_CODES = {
+  not_installed: 3,
+  unsupported_platform: 4,
+  runtime_error: 5,
+  blocked_scheme: 6,
+};
+
+function isSupportedPlatform(platform, arch) {
+  return SUPPORTED_PLATFORMS.has(`${platform}:${arch}`);
+}
+
+function isModuleNotFound(error) {
+  return (
+    error?.code === "ERR_MODULE_NOT_FOUND" || error?.code === "MODULE_NOT_FOUND"
+  );
+}
+
+function htmlToText(html) {
+  return String(html || "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/&nbsp;/giu, " ")
+    .replace(/&amp;/giu, "&")
+    .replace(/&lt;/giu, "<")
+    .replace(/&gt;/giu, ">")
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function responseStatus(response) {
+  if (!response) return null;
+  if (typeof response.status === "function") return response.status();
+  return response.status ?? null;
+}
+
+function responseUrl(response, fallbackUrl) {
+  if (!response) return fallbackUrl;
+  if (typeof response.url === "function") return response.url();
+  return response.url ?? fallbackUrl;
+}
+
+function parseAllowedFetchUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, scheme: null };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, scheme: parsed.protocol };
+  }
+  return { ok: true, href: parsed.href };
+}
+
+async function closeBrowser(browser) {
+  if (!browser || typeof browser.close !== "function") return;
+  try {
+    await browser.close();
+  } catch {
+    // best effort: fetch callers only need the primary result signal
+  }
+}
+
+export async function stealthFetch(url, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const waitUntil = opts.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const loadCloakBrowser = opts._import ?? (() => import("cloakbrowser"));
+  const platform = opts._platform ?? process.platform;
+  const arch = opts._arch ?? process.arch;
+
+  if (!isSupportedPlatform(platform, arch)) {
+    return {
+      ok: false,
+      reason: "unsupported_platform",
+      platform,
+      arch,
+    };
+  }
+
+  const parsedUrl = parseAllowedFetchUrl(url);
+  if (!parsedUrl.ok) {
+    return {
+      ok: false,
+      reason: "blocked_scheme",
+      scheme: parsedUrl.scheme,
+    };
+  }
+
+  let cloakbrowser;
+  try {
+    cloakbrowser = await loadCloakBrowser();
+  } catch (error) {
+    if (isModuleNotFound(error)) return { ok: false, reason: "not_installed" };
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  }
+
+  let browser;
+  try {
+    const launch = cloakbrowser?.launch;
+    if (typeof launch !== "function") {
+      throw new CloakBrowserUnavailableError("cloakbrowser launch unavailable");
+    }
+    browser = await launch();
+    const page = await browser.newPage();
+    const response = await page.goto(parsedUrl.href, {
+      waitUntil,
+      timeout: timeoutMs,
+    });
+    const html = await page.content();
+    return {
+      ok: true,
+      engine: "cloakbrowser",
+      url: parsedUrl.href,
+      finalUrl: responseUrl(response, parsedUrl.href),
+      status: responseStatus(response),
+      html,
+      text: htmlToText(html),
+    };
+  } catch (error) {
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+export function exitCodeFor(result) {
+  return EXIT_CODES[result?.reason] ?? 5;
+}
+
+export async function main(argv = process.argv) {
+  const url = argv[2];
+  if (!url) {
+    console.error("usage: stealth-fetch <url>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await stealthFetch(url);
+  if (result.ok) {
+    console.log(JSON.stringify(result));
+    process.exitCode = 0;
+    return;
+  }
+
+  console.error(`[stealth-fetch] 폴백: ${result.reason}`);
+  console.log(JSON.stringify(result));
+  process.exitCode = exitCodeFor(result);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/packages/remote/scripts/lib/stealth-fetch.mjs
+++ b/packages/remote/scripts/lib/stealth-fetch.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// SSRF boundary: stealthFetch only accepts http: and https: URLs. It does not
+// guard private IPs, metadata hosts such as 169.254.x.x, or localhost; callers
+// must treat the URL as already inside their trust boundary.
+
+import { pathToFileURL } from "node:url";
+
+export class CloakBrowserUnavailableError extends Error {}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_WAIT_UNTIL = "load";
+const SUPPORTED_PLATFORMS = new Set([
+  "linux:x64",
+  "linux:arm64",
+  "darwin:x64",
+  "darwin:arm64",
+  "win32:x64",
+]);
+const EXIT_CODES = {
+  not_installed: 3,
+  unsupported_platform: 4,
+  runtime_error: 5,
+  blocked_scheme: 6,
+};
+
+function isSupportedPlatform(platform, arch) {
+  return SUPPORTED_PLATFORMS.has(`${platform}:${arch}`);
+}
+
+function isModuleNotFound(error) {
+  return (
+    error?.code === "ERR_MODULE_NOT_FOUND" || error?.code === "MODULE_NOT_FOUND"
+  );
+}
+
+function htmlToText(html) {
+  return String(html || "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/&nbsp;/giu, " ")
+    .replace(/&amp;/giu, "&")
+    .replace(/&lt;/giu, "<")
+    .replace(/&gt;/giu, ">")
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function responseStatus(response) {
+  if (!response) return null;
+  if (typeof response.status === "function") return response.status();
+  return response.status ?? null;
+}
+
+function responseUrl(response, fallbackUrl) {
+  if (!response) return fallbackUrl;
+  if (typeof response.url === "function") return response.url();
+  return response.url ?? fallbackUrl;
+}
+
+function parseAllowedFetchUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, scheme: null };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, scheme: parsed.protocol };
+  }
+  return { ok: true, href: parsed.href };
+}
+
+async function closeBrowser(browser) {
+  if (!browser || typeof browser.close !== "function") return;
+  try {
+    await browser.close();
+  } catch {
+    // best effort: fetch callers only need the primary result signal
+  }
+}
+
+export async function stealthFetch(url, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const waitUntil = opts.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const loadCloakBrowser = opts._import ?? (() => import("cloakbrowser"));
+  const platform = opts._platform ?? process.platform;
+  const arch = opts._arch ?? process.arch;
+
+  if (!isSupportedPlatform(platform, arch)) {
+    return {
+      ok: false,
+      reason: "unsupported_platform",
+      platform,
+      arch,
+    };
+  }
+
+  const parsedUrl = parseAllowedFetchUrl(url);
+  if (!parsedUrl.ok) {
+    return {
+      ok: false,
+      reason: "blocked_scheme",
+      scheme: parsedUrl.scheme,
+    };
+  }
+
+  let cloakbrowser;
+  try {
+    cloakbrowser = await loadCloakBrowser();
+  } catch (error) {
+    if (isModuleNotFound(error)) return { ok: false, reason: "not_installed" };
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  }
+
+  let browser;
+  try {
+    const launch = cloakbrowser?.launch;
+    if (typeof launch !== "function") {
+      throw new CloakBrowserUnavailableError("cloakbrowser launch unavailable");
+    }
+    browser = await launch();
+    const page = await browser.newPage();
+    const response = await page.goto(parsedUrl.href, {
+      waitUntil,
+      timeout: timeoutMs,
+    });
+    const html = await page.content();
+    return {
+      ok: true,
+      engine: "cloakbrowser",
+      url: parsedUrl.href,
+      finalUrl: responseUrl(response, parsedUrl.href),
+      status: responseStatus(response),
+      html,
+      text: htmlToText(html),
+    };
+  } catch (error) {
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+export function exitCodeFor(result) {
+  return EXIT_CODES[result?.reason] ?? 5;
+}
+
+export async function main(argv = process.argv) {
+  const url = argv[2];
+  if (!url) {
+    console.error("usage: stealth-fetch <url>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await stealthFetch(url);
+  if (result.ok) {
+    console.log(JSON.stringify(result));
+    process.exitCode = 0;
+    return;
+  }
+
+  console.error(`[stealth-fetch] 폴백: ${result.reason}`);
+  console.log(JSON.stringify(result));
+  process.exitCode = exitCodeFor(result);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -75,6 +75,7 @@ import {
   formatPsmuxUpdateGuidance,
   probePsmuxSupport,
 } from "../scripts/lib/psmux-info.mjs";
+import { main as stealthFetchMain } from "../scripts/lib/stealth-fetch.mjs";
 import {
   buildWindowsHubAutostartCommand,
   cleanupStaleSkills,
@@ -188,6 +189,11 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
           "Windows 로그인 시 tfx-hub를 보장하는 Task Scheduler 항목 등록",
       },
     ],
+  },
+  "stealth-fetch": {
+    usage: "tfx stealth-fetch <url>",
+    description:
+      "cloakbrowser 기반 단일 URL fetch (http/https only, JSON stdout)",
   },
   doctor: {
     usage:
@@ -6357,6 +6363,7 @@ ${updateNotice}
     ${DIM}  --reset${RESET}      ${GRAY}캐시 전체 초기화${RESET}
     ${DIM}  --json${RESET}       ${GRAY}구조화된 진단 결과 JSON 출력${RESET}
     ${WHITE_BRIGHT}tfx auto${RESET}       ${GRAY}tfx-auto 라우팅 결정 미리보기 (--cli codex|antigravity|claude)${RESET}
+    ${WHITE_BRIGHT}tfx stealth-fetch${RESET} ${GRAY}cloakbrowser 기반 URL fetch (JSON stdout)${RESET}
     ${WHITE_BRIGHT}tfx mcp${RESET}        ${GRAY}MCP registry 관리 (list/sync/add/remove)${RESET}
     ${WHITE_BRIGHT}tfx update${RESET}     ${GRAY}최신 안정 버전으로 업데이트${RESET}
     ${DIM}  --dev / dev${RESET}   ${GRAY}dev 태그로 업데이트${RESET}
@@ -7310,6 +7317,13 @@ async function main() {
         dryRun: cmdArgs.includes("--dry-run"),
         enableHubAutostart: cmdArgs.includes("--enable-hub-autostart"),
       });
+      return;
+    case "stealth-fetch":
+      if (cmdArgs.some(isHelpArg)) {
+        printCommandHelp("stealth-fetch");
+        return;
+      }
+      await stealthFetchMain([process.argv[0], "stealth-fetch", ...cmdArgs]);
       return;
     case "doctor": {
       if (cmdArgs.some(isHelpArg)) {

--- a/packages/triflux/package.json
+++ b/packages/triflux/package.json
@@ -23,6 +23,10 @@
     "@triflux/remote": "^10.25.0",
     "tree-kill": "^1.2.2"
   },
+  "optionalDependencies": {
+    "cloakbrowser": "^0.3.31",
+    "playwright-core": "^1.53.0"
+  },
   "files": [
     "bin",
     "tui",

--- a/packages/triflux/scripts/lib/stealth-fetch.mjs
+++ b/packages/triflux/scripts/lib/stealth-fetch.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// SSRF boundary: stealthFetch only accepts http: and https: URLs. It does not
+// guard private IPs, metadata hosts such as 169.254.x.x, or localhost; callers
+// must treat the URL as already inside their trust boundary.
+
+import { pathToFileURL } from "node:url";
+
+export class CloakBrowserUnavailableError extends Error {}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_WAIT_UNTIL = "load";
+const SUPPORTED_PLATFORMS = new Set([
+  "linux:x64",
+  "linux:arm64",
+  "darwin:x64",
+  "darwin:arm64",
+  "win32:x64",
+]);
+const EXIT_CODES = {
+  not_installed: 3,
+  unsupported_platform: 4,
+  runtime_error: 5,
+  blocked_scheme: 6,
+};
+
+function isSupportedPlatform(platform, arch) {
+  return SUPPORTED_PLATFORMS.has(`${platform}:${arch}`);
+}
+
+function isModuleNotFound(error) {
+  return (
+    error?.code === "ERR_MODULE_NOT_FOUND" || error?.code === "MODULE_NOT_FOUND"
+  );
+}
+
+function htmlToText(html) {
+  return String(html || "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/&nbsp;/giu, " ")
+    .replace(/&amp;/giu, "&")
+    .replace(/&lt;/giu, "<")
+    .replace(/&gt;/giu, ">")
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function responseStatus(response) {
+  if (!response) return null;
+  if (typeof response.status === "function") return response.status();
+  return response.status ?? null;
+}
+
+function responseUrl(response, fallbackUrl) {
+  if (!response) return fallbackUrl;
+  if (typeof response.url === "function") return response.url();
+  return response.url ?? fallbackUrl;
+}
+
+function parseAllowedFetchUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, scheme: null };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, scheme: parsed.protocol };
+  }
+  return { ok: true, href: parsed.href };
+}
+
+async function closeBrowser(browser) {
+  if (!browser || typeof browser.close !== "function") return;
+  try {
+    await browser.close();
+  } catch {
+    // best effort: fetch callers only need the primary result signal
+  }
+}
+
+export async function stealthFetch(url, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const waitUntil = opts.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const loadCloakBrowser = opts._import ?? (() => import("cloakbrowser"));
+  const platform = opts._platform ?? process.platform;
+  const arch = opts._arch ?? process.arch;
+
+  if (!isSupportedPlatform(platform, arch)) {
+    return {
+      ok: false,
+      reason: "unsupported_platform",
+      platform,
+      arch,
+    };
+  }
+
+  const parsedUrl = parseAllowedFetchUrl(url);
+  if (!parsedUrl.ok) {
+    return {
+      ok: false,
+      reason: "blocked_scheme",
+      scheme: parsedUrl.scheme,
+    };
+  }
+
+  let cloakbrowser;
+  try {
+    cloakbrowser = await loadCloakBrowser();
+  } catch (error) {
+    if (isModuleNotFound(error)) return { ok: false, reason: "not_installed" };
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  }
+
+  let browser;
+  try {
+    const launch = cloakbrowser?.launch;
+    if (typeof launch !== "function") {
+      throw new CloakBrowserUnavailableError("cloakbrowser launch unavailable");
+    }
+    browser = await launch();
+    const page = await browser.newPage();
+    const response = await page.goto(parsedUrl.href, {
+      waitUntil,
+      timeout: timeoutMs,
+    });
+    const html = await page.content();
+    return {
+      ok: true,
+      engine: "cloakbrowser",
+      url: parsedUrl.href,
+      finalUrl: responseUrl(response, parsedUrl.href),
+      status: responseStatus(response),
+      html,
+      text: htmlToText(html),
+    };
+  } catch (error) {
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+export function exitCodeFor(result) {
+  return EXIT_CODES[result?.reason] ?? 5;
+}
+
+export async function main(argv = process.argv) {
+  const url = argv[2];
+  if (!url) {
+    console.error("usage: stealth-fetch <url>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await stealthFetch(url);
+  if (result.ok) {
+    console.log(JSON.stringify(result));
+    process.exitCode = 0;
+    return;
+  }
+
+  console.error(`[stealth-fetch] 폴백: ${result.reason}`);
+  console.log(JSON.stringify(result));
+  process.exitCode = exitCodeFor(result);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/packages/triflux/scripts/setup.mjs
+++ b/packages/triflux/scripts/setup.mjs
@@ -18,6 +18,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
+import { createRequire } from "module";
 import { homedir } from "os";
 import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -32,6 +33,7 @@ import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
 // Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
 // 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
 // production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
@@ -696,6 +698,90 @@ function isProtectedCodexConfigMutationEnv(env = process.env) {
     env.TFX_TEST === "1" ||
     Boolean(env.TRIFLUX_TEST_HOME)
   );
+}
+
+function isProtectedCloakBrowserInstallEnv(env = process.env) {
+  return (
+    env.NODE_ENV === "test" ||
+    env.CI === "true" ||
+    env.TFX_TEST === "1" ||
+    Boolean(env.TRIFLUX_TEST_HOME) ||
+    Boolean(env.TEST_LOCK_PID) ||
+    Boolean(env.NODE_TEST_CONTEXT) ||
+    Boolean(env.NODE_TEST_WORKER_ID) ||
+    env.TFX_SKIP_CLOAKBROWSER_SETUP === "1"
+  );
+}
+
+function isCloakBrowserSupportedPlatform(platform, arch) {
+  return (
+    (platform === "linux" && (arch === "x64" || arch === "arm64")) ||
+    (platform === "darwin" && (arch === "x64" || arch === "arm64")) ||
+    (platform === "win32" && arch === "x64")
+  );
+}
+
+function ensureCloakBrowser({
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+  requireResolve = require.resolve,
+  execFileSyncFn = execFileSync,
+  warn = (message) => console.warn(message),
+} = {}) {
+  if (isProtectedCloakBrowserInstallEnv(env)) {
+    return {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "protected-env",
+    };
+  }
+
+  if (!isCloakBrowserSupportedPlatform(platform, arch)) {
+    warn(
+      `[setup] cloakbrowser optional setup skipped: unsupported_platform (${platform}/${arch})`,
+    );
+    return {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "unsupported_platform",
+    };
+  }
+
+  try {
+    requireResolve("cloakbrowser", { paths: [PLUGIN_ROOT] });
+    return { ok: true, installed: true, skipped: false, reason: "installed" };
+  } catch {
+    // CloakBrowser downloads its browser binary lazily on first launch; there is
+    // no separate browser install command to run here.
+  }
+
+  try {
+    execFileSyncFn(
+      "npm",
+      ["install", "--no-save", "cloakbrowser", "playwright-core"],
+      {
+        cwd: PLUGIN_ROOT,
+        stdio: "ignore",
+        env,
+        timeout: 120_000,
+      },
+    );
+    return { ok: true, installed: true, skipped: false, reason: "installed" };
+  } catch (error) {
+    warn(
+      `[setup] cloakbrowser optional setup failed: ${_normalizeErrorMessage(error)}`,
+    );
+    return {
+      ok: false,
+      installed: false,
+      skipped: false,
+      reason: "install_failed",
+      error: _normalizeErrorMessage(error),
+    };
+  }
 }
 
 /**
@@ -1392,6 +1478,7 @@ export {
   DEPRECATED_SKILLS,
   detectDevMode,
   ensureAgyHooks,
+  ensureCloakBrowser,
   ensureCodexHooks,
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
@@ -1478,6 +1565,15 @@ export async function runDeferred(stdinData) {
       result.action === "updated" ||
       result.action === "removed",
   ).length;
+  const cloakBrowserResult = ensureCloakBrowser({
+    warn: (message) => io.log(`  \x1b[33m⚠\x1b[0m ${message}`),
+  });
+  if (
+    cloakBrowserResult.reason === "installed" &&
+    cloakBrowserResult.installed
+  ) {
+    io.log("  \x1b[32m✓\x1b[0m cloakbrowser optional backend ready");
+  }
   if (pkgVersion && marker?.version === pkgVersion && !isForce) {
     if (claudeRoutingChangedCount > 0) {
       io.log(

--- a/packages/triflux/skills/tfx-research/SKILL.md
+++ b/packages/triflux/skills/tfx-research/SKILL.md
@@ -123,6 +123,13 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
+## URL 콘텐츠 수집 (stealth-first)
+
+Quick 모드 Step 1.5 에서 `5. URL 콘텐츠 추출` 을 선택했거나 Deep 모드에서 소스 URL 본문이 필요하면:
+1. 기본 경로로 먼저 `node scripts/lib/stealth-fetch.mjs <url>` 를 실행한다.
+2. exit 0 이면 stdout JSON 의 `html` 또는 `text` 를 URL 본문 근거로 사용한다.
+3. exit 3/4/5 이면 stderr/stdout 의 reason 을 확인하고 `stealth-fetch 폴백: <이유>` 1줄 경고 후 기존 폴백을 사용한다: WebFetch → Tavily extract → Exa fetch.
+
 ### Step 2: Antigravity Google Search 위임
 
 ```

--- a/scripts/lib/stealth-fetch.mjs
+++ b/scripts/lib/stealth-fetch.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// SSRF boundary: stealthFetch only accepts http: and https: URLs. It does not
+// guard private IPs, metadata hosts such as 169.254.x.x, or localhost; callers
+// must treat the URL as already inside their trust boundary.
+
+import { pathToFileURL } from "node:url";
+
+export class CloakBrowserUnavailableError extends Error {}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_WAIT_UNTIL = "load";
+const SUPPORTED_PLATFORMS = new Set([
+  "linux:x64",
+  "linux:arm64",
+  "darwin:x64",
+  "darwin:arm64",
+  "win32:x64",
+]);
+const EXIT_CODES = {
+  not_installed: 3,
+  unsupported_platform: 4,
+  runtime_error: 5,
+  blocked_scheme: 6,
+};
+
+function isSupportedPlatform(platform, arch) {
+  return SUPPORTED_PLATFORMS.has(`${platform}:${arch}`);
+}
+
+function isModuleNotFound(error) {
+  return (
+    error?.code === "ERR_MODULE_NOT_FOUND" || error?.code === "MODULE_NOT_FOUND"
+  );
+}
+
+function htmlToText(html) {
+  return String(html || "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/&nbsp;/giu, " ")
+    .replace(/&amp;/giu, "&")
+    .replace(/&lt;/giu, "<")
+    .replace(/&gt;/giu, ">")
+    .replace(/&quot;/giu, '"')
+    .replace(/&#39;/gu, "'")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function responseStatus(response) {
+  if (!response) return null;
+  if (typeof response.status === "function") return response.status();
+  return response.status ?? null;
+}
+
+function responseUrl(response, fallbackUrl) {
+  if (!response) return fallbackUrl;
+  if (typeof response.url === "function") return response.url();
+  return response.url ?? fallbackUrl;
+}
+
+function parseAllowedFetchUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, scheme: null };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, scheme: parsed.protocol };
+  }
+  return { ok: true, href: parsed.href };
+}
+
+async function closeBrowser(browser) {
+  if (!browser || typeof browser.close !== "function") return;
+  try {
+    await browser.close();
+  } catch {
+    // best effort: fetch callers only need the primary result signal
+  }
+}
+
+export async function stealthFetch(url, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const waitUntil = opts.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const loadCloakBrowser = opts._import ?? (() => import("cloakbrowser"));
+  const platform = opts._platform ?? process.platform;
+  const arch = opts._arch ?? process.arch;
+
+  if (!isSupportedPlatform(platform, arch)) {
+    return {
+      ok: false,
+      reason: "unsupported_platform",
+      platform,
+      arch,
+    };
+  }
+
+  const parsedUrl = parseAllowedFetchUrl(url);
+  if (!parsedUrl.ok) {
+    return {
+      ok: false,
+      reason: "blocked_scheme",
+      scheme: parsedUrl.scheme,
+    };
+  }
+
+  let cloakbrowser;
+  try {
+    cloakbrowser = await loadCloakBrowser();
+  } catch (error) {
+    if (isModuleNotFound(error)) return { ok: false, reason: "not_installed" };
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  }
+
+  let browser;
+  try {
+    const launch = cloakbrowser?.launch;
+    if (typeof launch !== "function") {
+      throw new CloakBrowserUnavailableError("cloakbrowser launch unavailable");
+    }
+    browser = await launch();
+    const page = await browser.newPage();
+    const response = await page.goto(parsedUrl.href, {
+      waitUntil,
+      timeout: timeoutMs,
+    });
+    const html = await page.content();
+    return {
+      ok: true,
+      engine: "cloakbrowser",
+      url: parsedUrl.href,
+      finalUrl: responseUrl(response, parsedUrl.href),
+      status: responseStatus(response),
+      html,
+      text: htmlToText(html),
+    };
+  } catch (error) {
+    return { ok: false, reason: "runtime_error", error: String(error) };
+  } finally {
+    await closeBrowser(browser);
+  }
+}
+
+export function exitCodeFor(result) {
+  return EXIT_CODES[result?.reason] ?? 5;
+}
+
+export async function main(argv = process.argv) {
+  const url = argv[2];
+  if (!url) {
+    console.error("usage: stealth-fetch <url>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await stealthFetch(url);
+  if (result.ok) {
+    console.log(JSON.stringify(result));
+    process.exitCode = 0;
+    return;
+  }
+
+  console.error(`[stealth-fetch] 폴백: ${result.reason}`);
+  console.log(JSON.stringify(result));
+  process.exitCode = exitCodeFor(result);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -18,6 +18,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
+import { createRequire } from "module";
 import { homedir } from "os";
 import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -32,6 +33,7 @@ import { addPluginRootFallbackToCommand } from "./lib/doctor-env-checks.mjs";
 import { cleanupTmpFiles } from "./tmp-cleanup.mjs";
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const require = createRequire(import.meta.url);
 // Windows 에서 os.homedir() 가 USERPROFILE 만 보고 process.env.HOME swap 을
 // 무시하기 때문에, integration test 가 fixture 격리한 spawn child 에서도
 // production ~/.codex/config.toml 을 건드릴 수 있다. (#193 회귀)
@@ -696,6 +698,90 @@ function isProtectedCodexConfigMutationEnv(env = process.env) {
     env.TFX_TEST === "1" ||
     Boolean(env.TRIFLUX_TEST_HOME)
   );
+}
+
+function isProtectedCloakBrowserInstallEnv(env = process.env) {
+  return (
+    env.NODE_ENV === "test" ||
+    env.CI === "true" ||
+    env.TFX_TEST === "1" ||
+    Boolean(env.TRIFLUX_TEST_HOME) ||
+    Boolean(env.TEST_LOCK_PID) ||
+    Boolean(env.NODE_TEST_CONTEXT) ||
+    Boolean(env.NODE_TEST_WORKER_ID) ||
+    env.TFX_SKIP_CLOAKBROWSER_SETUP === "1"
+  );
+}
+
+function isCloakBrowserSupportedPlatform(platform, arch) {
+  return (
+    (platform === "linux" && (arch === "x64" || arch === "arm64")) ||
+    (platform === "darwin" && (arch === "x64" || arch === "arm64")) ||
+    (platform === "win32" && arch === "x64")
+  );
+}
+
+function ensureCloakBrowser({
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+  requireResolve = require.resolve,
+  execFileSyncFn = execFileSync,
+  warn = (message) => console.warn(message),
+} = {}) {
+  if (isProtectedCloakBrowserInstallEnv(env)) {
+    return {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "protected-env",
+    };
+  }
+
+  if (!isCloakBrowserSupportedPlatform(platform, arch)) {
+    warn(
+      `[setup] cloakbrowser optional setup skipped: unsupported_platform (${platform}/${arch})`,
+    );
+    return {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "unsupported_platform",
+    };
+  }
+
+  try {
+    requireResolve("cloakbrowser", { paths: [PLUGIN_ROOT] });
+    return { ok: true, installed: true, skipped: false, reason: "installed" };
+  } catch {
+    // CloakBrowser downloads its browser binary lazily on first launch; there is
+    // no separate browser install command to run here.
+  }
+
+  try {
+    execFileSyncFn(
+      "npm",
+      ["install", "--no-save", "cloakbrowser", "playwright-core"],
+      {
+        cwd: PLUGIN_ROOT,
+        stdio: "ignore",
+        env,
+        timeout: 120_000,
+      },
+    );
+    return { ok: true, installed: true, skipped: false, reason: "installed" };
+  } catch (error) {
+    warn(
+      `[setup] cloakbrowser optional setup failed: ${_normalizeErrorMessage(error)}`,
+    );
+    return {
+      ok: false,
+      installed: false,
+      skipped: false,
+      reason: "install_failed",
+      error: _normalizeErrorMessage(error),
+    };
+  }
 }
 
 /**
@@ -1392,6 +1478,7 @@ export {
   DEPRECATED_SKILLS,
   detectDevMode,
   ensureAgyHooks,
+  ensureCloakBrowser,
   ensureCodexHooks,
   ensureCodexHubServerConfig,
   ensureCodexProfiles,
@@ -1478,6 +1565,15 @@ export async function runDeferred(stdinData) {
       result.action === "updated" ||
       result.action === "removed",
   ).length;
+  const cloakBrowserResult = ensureCloakBrowser({
+    warn: (message) => io.log(`  \x1b[33m⚠\x1b[0m ${message}`),
+  });
+  if (
+    cloakBrowserResult.reason === "installed" &&
+    cloakBrowserResult.installed
+  ) {
+    io.log("  \x1b[32m✓\x1b[0m cloakbrowser optional backend ready");
+  }
   if (pkgVersion && marker?.version === pkgVersion && !isForce) {
     if (claudeRoutingChangedCount > 0) {
       io.log(

--- a/skills/tfx-research/SKILL.md
+++ b/skills/tfx-research/SKILL.md
@@ -123,6 +123,13 @@ AskUserQuestion:
   5. URL 콘텐츠 추출
 ```
 
+## URL 콘텐츠 수집 (stealth-first)
+
+Quick 모드 Step 1.5 에서 `5. URL 콘텐츠 추출` 을 선택했거나 Deep 모드에서 소스 URL 본문이 필요하면:
+1. 기본 경로로 먼저 `node scripts/lib/stealth-fetch.mjs <url>` 를 실행한다.
+2. exit 0 이면 stdout JSON 의 `html` 또는 `text` 를 URL 본문 근거로 사용한다.
+3. exit 3/4/5 이면 stderr/stdout 의 reason 을 확인하고 `stealth-fetch 폴백: <이유>` 1줄 경고 후 기존 폴백을 사용한다: WebFetch → Tavily extract → Exa fetch.
+
 ### Step 2: Antigravity Google Search 위임
 
 ```

--- a/tests/unit/stealth-fetch.test.mjs
+++ b/tests/unit/stealth-fetch.test.mjs
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { exitCodeFor, stealthFetch } from "../../scripts/lib/stealth-fetch.mjs";
+import { ensureCloakBrowser } from "../../scripts/setup.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN_PATH = resolve(__dirname, "..", "..", "bin", "triflux.mjs");
+
+describe("stealthFetch", () => {
+  it("returns not_installed when cloakbrowser cannot be imported", async () => {
+    const error = new Error("Cannot find package 'cloakbrowser'");
+    error.code = "ERR_MODULE_NOT_FOUND";
+
+    const result = await stealthFetch("https://example.com", {
+      _import: async () => {
+        throw error;
+      },
+    });
+
+    assert.deepEqual(result, { ok: false, reason: "not_installed" });
+  });
+
+  it("returns unsupported_platform before importing cloakbrowser", async () => {
+    let imported = false;
+
+    const result = await stealthFetch("https://example.com", {
+      _platform: "freebsd",
+      _arch: "x64",
+      _import: async () => {
+        imported = true;
+        return {};
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "unsupported_platform",
+      platform: "freebsd",
+      arch: "x64",
+    });
+    assert.equal(imported, false);
+  });
+
+  for (const [url, scheme] of [
+    ["file:///etc/passwd", "file:"],
+    ["data:text/plain,hello", "data:"],
+    ["not a url", null],
+  ]) {
+    it(`blocks ${url} before importing cloakbrowser`, async () => {
+      let imported = false;
+
+      const result = await stealthFetch(url, {
+        _import: async () => {
+          imported = true;
+          return {};
+        },
+      });
+
+      assert.deepEqual(result, { ok: false, reason: "blocked_scheme", scheme });
+      assert.equal(imported, false);
+    });
+  }
+
+  it("returns html/text/status/finalUrl and closes the browser on success", async () => {
+    let closed = false;
+    const result = await stealthFetch("https://example.com/start", {
+      _import: async () => ({
+        launch: async () => ({
+          newPage: async () => ({
+            goto: async (url, options) => {
+              assert.equal(url, "https://example.com/start");
+              assert.deepEqual(options, { waitUntil: "load", timeout: 30000 });
+              return {
+                status: () => 204,
+                url: () => "https://example.com/final",
+              };
+            },
+            content: async () =>
+              "<html><body><h1>Hello</h1><p>Stealth fetch</p></body></html>",
+          }),
+          close: async () => {
+            closed = true;
+          },
+        }),
+      }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.engine, "cloakbrowser");
+    assert.equal(result.url, "https://example.com/start");
+    assert.equal(result.finalUrl, "https://example.com/final");
+    assert.equal(result.status, 204);
+    assert.equal(
+      result.html,
+      "<html><body><h1>Hello</h1><p>Stealth fetch</p></body></html>",
+    );
+    assert.equal(result.text, "Hello Stealth fetch");
+    assert.equal(closed, true);
+  });
+
+  it("returns runtime_error and closes the browser when navigation fails", async () => {
+    let closed = false;
+
+    const result = await stealthFetch("https://example.com", {
+      _import: async () => ({
+        launch: async () => ({
+          newPage: async () => ({
+            goto: async () => {
+              throw new Error("blocked");
+            },
+            content: async () => "<html></html>",
+          }),
+          close: async () => {
+            closed = true;
+          },
+        }),
+      }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "runtime_error");
+    assert.match(result.error, /blocked/);
+    assert.equal(closed, true);
+  });
+});
+
+describe("exitCodeFor", () => {
+  it("maps stealth fetch failure reasons to CLI exit codes", () => {
+    assert.equal(exitCodeFor({ reason: "not_installed" }), 3);
+    assert.equal(exitCodeFor({ reason: "unsupported_platform" }), 4);
+    assert.equal(exitCodeFor({ reason: "runtime_error" }), 5);
+    assert.equal(exitCodeFor({ reason: "blocked_scheme" }), 6);
+    assert.equal(exitCodeFor({ reason: "unknown" }), 5);
+    assert.equal(exitCodeFor({}), 5);
+  });
+});
+
+describe("ensureCloakBrowser", () => {
+  it("skips optional install in protected environments", () => {
+    let resolved = false;
+    let installed = false;
+    let warned = false;
+
+    const result = ensureCloakBrowser({
+      env: { TFX_SKIP_CLOAKBROWSER_SETUP: "1" },
+      requireResolve: () => {
+        resolved = true;
+      },
+      execFileSyncFn: () => {
+        installed = true;
+      },
+      warn: () => {
+        warned = true;
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "protected-env",
+    });
+    assert.equal(resolved, false);
+    assert.equal(installed, false);
+    assert.equal(warned, false);
+  });
+
+  it("skips optional install on unsupported platforms", () => {
+    const warnings = [];
+    let resolved = false;
+    let installed = false;
+
+    const result = ensureCloakBrowser({
+      env: {},
+      platform: "freebsd",
+      arch: "x64",
+      requireResolve: () => {
+        resolved = true;
+      },
+      execFileSyncFn: () => {
+        installed = true;
+      },
+      warn: (message) => warnings.push(message),
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      installed: false,
+      skipped: true,
+      reason: "unsupported_platform",
+    });
+    assert.equal(resolved, false);
+    assert.equal(installed, false);
+    assert.match(warnings.join("\n"), /unsupported_platform/);
+  });
+
+  it("does not install when cloakbrowser resolves", () => {
+    let installed = false;
+
+    const result = ensureCloakBrowser({
+      env: {},
+      platform: "darwin",
+      arch: "arm64",
+      requireResolve: () => "/tmp/node_modules/cloakbrowser/index.js",
+      execFileSyncFn: () => {
+        installed = true;
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      installed: true,
+      skipped: false,
+      reason: "installed",
+    });
+    assert.equal(installed, false);
+  });
+
+  it("warns when optional install fails", () => {
+    const warnings = [];
+    let installed = false;
+
+    const result = ensureCloakBrowser({
+      env: {},
+      platform: "darwin",
+      arch: "arm64",
+      requireResolve: () => {
+        throw new Error("missing");
+      },
+      execFileSyncFn: () => {
+        installed = true;
+        throw new Error("npm failed");
+      },
+      warn: (message) => warnings.push(message),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.installed, false);
+    assert.equal(result.skipped, false);
+    assert.equal(result.reason, "install_failed");
+    assert.match(result.error, /npm failed/);
+    assert.equal(installed, true);
+    assert.match(warnings.join("\n"), /optional setup failed/);
+  });
+});
+
+describe("tfx stealth-fetch", () => {
+  it("is listed in top-level help", () => {
+    const result = spawnSync(process.execPath, [BIN_PATH, "--help"], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /tfx stealth-fetch/);
+  });
+
+  it("reuses stealthFetch CLI behavior for blocked schemes", () => {
+    const result = spawnSync(
+      process.execPath,
+      [BIN_PATH, "stealth-fetch", "data:text/plain,hello"],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 6);
+    assert.match(
+      result.stderr.trim(),
+      /^\[stealth-fetch\] 폴백: blocked_scheme$/,
+    );
+    assert.deepEqual(JSON.parse(result.stdout), {
+      ok: false,
+      reason: "blocked_scheme",
+      scheme: "data:",
+    });
+  });
+});

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -805,7 +805,7 @@ describe("swarm-hypervisor", () => {
             if (args[0] === "rev-parse") return "deadbeefcafe";
             if (args[0] === "status") {
               // Only the redundant worktree carries uncommitted changes.
-              return cwd && cwd.includes("redundant") ? "?? src/junk.mjs" : "";
+              return cwd?.includes("redundant") ? "?? src/junk.mjs" : "";
             }
             return "";
           },


### PR DESCRIPTION
## 요약

tfx-research(및 `tfx stealth-fetch` 경유로 multilingual-parallel-research)에 CloakBrowser 기반 stealth fetch 백엔드를 추가한다. **검색은 기존 MCP(Exa/Brave/Tavily) 경로를 그대로 유지**하고, URL 콘텐츠를 직접 수집하는 단계에서만 봇탐지 우회 브라우저를 stealth-first로 사용한다. 미설치/미지원/실패 시 기존 WebFetch/MCP-crawl로 graceful 폴백한다.

> 배경: 두 리서치 스킬은 원래 브라우저를 전혀 쓰지 않고 검색 API로 결과 목록만 받아왔다. CloakBrowser는 Playwright drop-in stealth Chromium이라 '검색 교체'가 아니라 'URL 본문 수집' 레이어에 백엔드로 추가된다.

## 변경

- `scripts/lib/stealth-fetch.mjs` (신규): `stealthFetch()` + CLI entrypoint. graceful degradation reason = not_installed/unsupported_platform/runtime_error/blocked_scheme, exit code 0/2/3/4/5/6. `browser.close()` finally 보장.
- `bin/triflux.mjs`: `tfx stealth-fetch <url>` 서브커맨드 (`main()` 재사용, DRY). 전역 tfx로 다른 프로젝트(multilingual 등)에서도 호출 가능.
- **SSRF 경계**: http/https scheme allow-list, cloakbrowser import 전에 거부 (우회 불가). 사설IP/메타데이터 가드는 미적용 — 호출자가 URL을 신뢰경계 내로 취급(헤더 주석 명시).
- `scripts/setup.mjs`: `ensureCloakBrowser()` warn-only + `optionalDependencies`(cloakbrowser ^0.3.31, playwright-core ^1.53.0). 바이너리는 첫 launch 시 자동 다운로드. hermetic test 가드(`TEST_LOCK_PID` seam 상위집합).
- `skills/tfx-research/SKILL.md`: stealth-first URL 콘텐츠 수집 경로 (frontmatter 불변).
- `tests/unit/stealth-fetch.test.mjs` (신규): hermetic, 6분기 + exitCodeFor + ensureCloakBrowser + CLI route(spawnSync).
- `packages/{core,remote,triflux}` byte-identical mirror.

## 검증

- `npm test`: 4299 pass / 0 fail / 17 skip (lint:skills 43 포함)
- `npm run lint`: 0 error (1 pre-existing warning)
- mirror `diff -q`: 6개 byte-identical
- 교차검증: Codex 작성 → Claude code-reviewer 독립 리뷰 **APPROVED** (Phase 1, Phase 2 각각). SSRF 가드 import-전-거부, exit code end-to-end, Phase 1 회귀 없음 실측.

## Follow-up (비차단)

- reviewer LOW: `//example.com`/`javascript:` scheme 거부 테스트 케이스 추가(런타임은 이미 정상), `exitCodeFor({ok:true})` early-return 0.
- multilingual-parallel-research SKILL.md는 plugin 캐시(repo 밖)라 로컬 수정은 휘발성 — 영구 반영하려면 plugin 소스 repo에 별도 PR 필요.

라이선스 주의: CloakBrowser 바이너리는 proprietary/non-redistributable/free-use-only이라 번들하지 않고 optionalDependencies로 사용자 머신에서 공식 소스로부터 받는다(래퍼는 MIT).