### PR TITLE
fix(cto): resolve lake root to git toplevel from any subdir

### DIFF
--- a/cto/collect.mjs
+++ b/cto/collect.mjs
@@ -17,6 +17,7 @@ import { basename, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { renderBrief } from "./brief.mjs";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
 const SOURCE_REGISTRY = [
@@ -785,7 +786,7 @@ function hasFlag(args, flag) {
 }
 
 export async function runCollect(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const stderr = opts.stderr || process.stderr;

--- a/cto/dashboard.mjs
+++ b/cto/dashboard.mjs
@@ -7,6 +7,8 @@ import {
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
 const DEFAULT_INTERVAL_MS = 60_000;
 
 function hasFlag(args, flag) {
@@ -360,7 +362,7 @@ async function renderOnce({ lakeRoot, stdout, stdoutHtml, renders }) {
 }
 
 export async function runDashboard(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const watch = opts.watch === true || hasFlag(args, "--watch");

--- a/cto/lake-root.mjs
+++ b/cto/lake-root.mjs
@@ -1,0 +1,44 @@
+// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+//
+// CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
+// runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
+// repo 루트가 아닌 하위 폴더(예: packages/triflux)에서 `tfx cto` 를 부르면 lake
+// 를 못 찾아 "run tfx cto collect" 가 반복되고, collect 는 엉뚱한 하위 폴더에
+// 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
+// 올려 이 불일치를 없앤다.
+//
+// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
+// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
+// 반환해 기존 동작을 보존한다.
+
+import { existsSync as defaultExistsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+const MAX_DEPTH = 64;
+
+/**
+ * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
+ * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ *
+ * @param {string} cwd 시작 디렉토리(보통 process.cwd())
+ * @param {object} [opts]
+ * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @returns {string}
+ */
+export function resolveLakeRootDir(cwd, opts = {}) {
+  const exists = opts?.existsSync || defaultExistsSync;
+  // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
+  // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
+  if (typeof cwd !== "string" || !cwd) return "";
+
+  let dir = cwd;
+  const { root } = parse(dir);
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (exists(join(dir, ".git"))) return dir;
+    if (dir === root) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return cwd;
+}

--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
 const SCHEMA_VERSION = "cto-lake.v1";
 const SYNAPSE_TIMEOUT_MS = 1500;
 
@@ -304,7 +306,7 @@ function renderHumanStatus(status) {
 }
 
 export async function runStatus(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");

--- a/hub/team/cto-auto-collect.mjs
+++ b/hub/team/cto-auto-collect.mjs
@@ -1,6 +1,8 @@
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "../../cto/lake-root.mjs";
+
 const DEFAULT_DEBOUNCE_MS = 120_000;
 const OFF_VALUES = new Set(["0", "false", "off", "no"]);
 
@@ -45,7 +47,7 @@ export function createCtoAutoCollector(opts = {}) {
     const cwd = typeof session?.cwd === "string" ? session.cwd : "";
     const worktree =
       typeof session?.worktreePath === "string" ? session.worktreePath : "";
-    const projectRoot = worktree || cwd;
+    const projectRoot = resolveLakeRootDir(worktree || cwd);
     if (!projectRoot)
       return { triggered: false, reason: "missing-project-root" };
 
@@ -61,11 +63,19 @@ export function createCtoAutoCollector(opts = {}) {
         { sessionId, err: String(error?.message || error) },
         "cto.auto_collect.query_failed",
       );
-      return { triggered: false, reason: "query-failed" };
+      // peer 조회 실패는 collect 를 막지 않는다 — peer 정보는 이제 라벨 용도뿐이라
+      // registry 일시 장애에도 solo 로 진행해 collect 회복력을 유지한다.
+      peers = [];
     }
-    if (!Array.isArray(peers) || peers.length < 1) {
-      return { triggered: false, reason: "no-peers" };
-    }
+    // 단일 세션(peer 0개)도 허용한다 — 사용자 선택. peer 유무와 무관하게
+    // 아래 debounce + fresh-lake 게이트가 collect 빈도를 제어한다.
+    //
+    // 주의: peerCount 는 best-effort 라벨이다. querySessions 는 raw
+    // cwd/worktreePath 로 매칭하지만 projectRoot 는 resolved git toplevel 이라,
+    // 같은 repo 의 다른 하위 폴더 세션은 peer 로 안 잡혀 triggered-solo 로 보고될
+    // 수 있다. 즉 라벨은 repo-scoped 가 아니라 exact-cwd-scoped 다 — 향후 peer
+    // 기반 로직을 이 라벨 위에 다시 올릴 때 주의한다.
+    const peerCount = Array.isArray(peers) ? peers.length : 0;
 
     const currentTime = now();
     const last = lastCollectMs.get(projectRoot) || 0;
@@ -92,9 +102,9 @@ export function createCtoAutoCollector(opts = {}) {
     inFlight.add(promise);
     return {
       triggered: true,
-      reason: "triggered",
+      reason: peerCount > 0 ? "triggered" : "triggered-solo",
       projectRoot,
-      peerCount: peers.length,
+      peerCount,
     };
   }
 

--- a/packages/remote/cto/collect.mjs
+++ b/packages/remote/cto/collect.mjs
@@ -17,6 +17,7 @@ import { basename, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { renderBrief } from "./brief.mjs";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
 const SOURCE_REGISTRY = [
@@ -785,7 +786,7 @@ function hasFlag(args, flag) {
 }
 
 export async function runCollect(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const stderr = opts.stderr || process.stderr;

--- a/packages/remote/cto/lake-root.mjs
+++ b/packages/remote/cto/lake-root.mjs
@@ -1,0 +1,44 @@
+// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+//
+// CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
+// runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
+// repo 루트가 아닌 하위 폴더(예: packages/triflux)에서 `tfx cto` 를 부르면 lake
+// 를 못 찾아 "run tfx cto collect" 가 반복되고, collect 는 엉뚱한 하위 폴더에
+// 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
+// 올려 이 불일치를 없앤다.
+//
+// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
+// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
+// 반환해 기존 동작을 보존한다.
+
+import { existsSync as defaultExistsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+const MAX_DEPTH = 64;
+
+/**
+ * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
+ * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ *
+ * @param {string} cwd 시작 디렉토리(보통 process.cwd())
+ * @param {object} [opts]
+ * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @returns {string}
+ */
+export function resolveLakeRootDir(cwd, opts = {}) {
+  const exists = opts?.existsSync || defaultExistsSync;
+  // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
+  // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
+  if (typeof cwd !== "string" || !cwd) return "";
+
+  let dir = cwd;
+  const { root } = parse(dir);
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (exists(join(dir, ".git"))) return dir;
+    if (dir === root) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return cwd;
+}

--- a/packages/remote/cto/status.mjs
+++ b/packages/remote/cto/status.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
 const SCHEMA_VERSION = "cto-lake.v1";
 const SYNAPSE_TIMEOUT_MS = 1500;
 
@@ -304,7 +306,7 @@ function renderHumanStatus(status) {
 }
 
 export async function runStatus(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");

--- a/packages/remote/hub/team/cto-auto-collect.mjs
+++ b/packages/remote/hub/team/cto-auto-collect.mjs
@@ -1,6 +1,8 @@
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "../../cto/lake-root.mjs";
+
 const DEFAULT_DEBOUNCE_MS = 120_000;
 const OFF_VALUES = new Set(["0", "false", "off", "no"]);
 
@@ -45,7 +47,7 @@ export function createCtoAutoCollector(opts = {}) {
     const cwd = typeof session?.cwd === "string" ? session.cwd : "";
     const worktree =
       typeof session?.worktreePath === "string" ? session.worktreePath : "";
-    const projectRoot = worktree || cwd;
+    const projectRoot = resolveLakeRootDir(worktree || cwd);
     if (!projectRoot)
       return { triggered: false, reason: "missing-project-root" };
 
@@ -61,11 +63,19 @@ export function createCtoAutoCollector(opts = {}) {
         { sessionId, err: String(error?.message || error) },
         "cto.auto_collect.query_failed",
       );
-      return { triggered: false, reason: "query-failed" };
+      // peer 조회 실패는 collect 를 막지 않는다 — peer 정보는 이제 라벨 용도뿐이라
+      // registry 일시 장애에도 solo 로 진행해 collect 회복력을 유지한다.
+      peers = [];
     }
-    if (!Array.isArray(peers) || peers.length < 1) {
-      return { triggered: false, reason: "no-peers" };
-    }
+    // 단일 세션(peer 0개)도 허용한다 — 사용자 선택. peer 유무와 무관하게
+    // 아래 debounce + fresh-lake 게이트가 collect 빈도를 제어한다.
+    //
+    // 주의: peerCount 는 best-effort 라벨이다. querySessions 는 raw
+    // cwd/worktreePath 로 매칭하지만 projectRoot 는 resolved git toplevel 이라,
+    // 같은 repo 의 다른 하위 폴더 세션은 peer 로 안 잡혀 triggered-solo 로 보고될
+    // 수 있다. 즉 라벨은 repo-scoped 가 아니라 exact-cwd-scoped 다 — 향후 peer
+    // 기반 로직을 이 라벨 위에 다시 올릴 때 주의한다.
+    const peerCount = Array.isArray(peers) ? peers.length : 0;
 
     const currentTime = now();
     const last = lastCollectMs.get(projectRoot) || 0;
@@ -92,9 +102,9 @@ export function createCtoAutoCollector(opts = {}) {
     inFlight.add(promise);
     return {
       triggered: true,
-      reason: "triggered",
+      reason: peerCount > 0 ? "triggered" : "triggered-solo",
       projectRoot,
-      peerCount: peers.length,
+      peerCount,
     };
   }
 

--- a/packages/triflux/cto/collect.mjs
+++ b/packages/triflux/cto/collect.mjs
@@ -17,6 +17,7 @@ import { basename, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { renderBrief } from "./brief.mjs";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
 const SOURCE_REGISTRY = [
@@ -785,7 +786,7 @@ function hasFlag(args, flag) {
 }
 
 export async function runCollect(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const stderr = opts.stderr || process.stderr;

--- a/packages/triflux/cto/dashboard.mjs
+++ b/packages/triflux/cto/dashboard.mjs
@@ -7,6 +7,8 @@ import {
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
 const DEFAULT_INTERVAL_MS = 60_000;
 
 function hasFlag(args, flag) {
@@ -360,7 +362,7 @@ async function renderOnce({ lakeRoot, stdout, stdoutHtml, renders }) {
 }
 
 export async function runDashboard(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const watch = opts.watch === true || hasFlag(args, "--watch");

--- a/packages/triflux/cto/lake-root.mjs
+++ b/packages/triflux/cto/lake-root.mjs
@@ -1,0 +1,44 @@
+// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+//
+// CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
+// runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
+// repo 루트가 아닌 하위 폴더(예: packages/triflux)에서 `tfx cto` 를 부르면 lake
+// 를 못 찾아 "run tfx cto collect" 가 반복되고, collect 는 엉뚱한 하위 폴더에
+// 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
+// 올려 이 불일치를 없앤다.
+//
+// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
+// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
+// 반환해 기존 동작을 보존한다.
+
+import { existsSync as defaultExistsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+const MAX_DEPTH = 64;
+
+/**
+ * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
+ * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ *
+ * @param {string} cwd 시작 디렉토리(보통 process.cwd())
+ * @param {object} [opts]
+ * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @returns {string}
+ */
+export function resolveLakeRootDir(cwd, opts = {}) {
+  const exists = opts?.existsSync || defaultExistsSync;
+  // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
+  // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
+  if (typeof cwd !== "string" || !cwd) return "";
+
+  let dir = cwd;
+  const { root } = parse(dir);
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    if (exists(join(dir, ".git"))) return dir;
+    if (dir === root) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return cwd;
+}

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
 const SCHEMA_VERSION = "cto-lake.v1";
 const SYNAPSE_TIMEOUT_MS = 1500;
 
@@ -304,7 +306,7 @@ function renderHumanStatus(status) {
 }
 
 export async function runStatus(args = [], opts = {}) {
-  const rootDir = opts.rootDir || process.cwd();
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");

--- a/packages/triflux/hub/team/cto-auto-collect.mjs
+++ b/packages/triflux/hub/team/cto-auto-collect.mjs
@@ -1,6 +1,8 @@
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { resolveLakeRootDir } from "../../cto/lake-root.mjs";
+
 const DEFAULT_DEBOUNCE_MS = 120_000;
 const OFF_VALUES = new Set(["0", "false", "off", "no"]);
 
@@ -45,7 +47,7 @@ export function createCtoAutoCollector(opts = {}) {
     const cwd = typeof session?.cwd === "string" ? session.cwd : "";
     const worktree =
       typeof session?.worktreePath === "string" ? session.worktreePath : "";
-    const projectRoot = worktree || cwd;
+    const projectRoot = resolveLakeRootDir(worktree || cwd);
     if (!projectRoot)
       return { triggered: false, reason: "missing-project-root" };
 
@@ -61,11 +63,19 @@ export function createCtoAutoCollector(opts = {}) {
         { sessionId, err: String(error?.message || error) },
         "cto.auto_collect.query_failed",
       );
-      return { triggered: false, reason: "query-failed" };
+      // peer 조회 실패는 collect 를 막지 않는다 — peer 정보는 이제 라벨 용도뿐이라
+      // registry 일시 장애에도 solo 로 진행해 collect 회복력을 유지한다.
+      peers = [];
     }
-    if (!Array.isArray(peers) || peers.length < 1) {
-      return { triggered: false, reason: "no-peers" };
-    }
+    // 단일 세션(peer 0개)도 허용한다 — 사용자 선택. peer 유무와 무관하게
+    // 아래 debounce + fresh-lake 게이트가 collect 빈도를 제어한다.
+    //
+    // 주의: peerCount 는 best-effort 라벨이다. querySessions 는 raw
+    // cwd/worktreePath 로 매칭하지만 projectRoot 는 resolved git toplevel 이라,
+    // 같은 repo 의 다른 하위 폴더 세션은 peer 로 안 잡혀 triggered-solo 로 보고될
+    // 수 있다. 즉 라벨은 repo-scoped 가 아니라 exact-cwd-scoped 다 — 향후 peer
+    // 기반 로직을 이 라벨 위에 다시 올릴 때 주의한다.
+    const peerCount = Array.isArray(peers) ? peers.length : 0;
 
     const currentTime = now();
     const last = lastCollectMs.get(projectRoot) || 0;
@@ -92,9 +102,9 @@ export function createCtoAutoCollector(opts = {}) {
     inFlight.add(promise);
     return {
       triggered: true,
-      reason: "triggered",
+      reason: peerCount > 0 ? "triggered" : "triggered-solo",
       projectRoot,
-      peerCount: peers.length,
+      peerCount,
     };
   }
 

--- a/tests/unit/cto-auto-collect.test.mjs
+++ b/tests/unit/cto-auto-collect.test.mjs
@@ -20,6 +20,10 @@ const tmpRoots = [];
 function makeProjectRoot() {
   const root = mkdtempSync(join(tmpdir(), "tfx-cto-auto-test-"));
   tmpRoots.push(root);
+  // resolveLakeRootDir 가 toplevel 로 안 올라가도록 임시 root 를 git toplevel 로
+  // 만든다(.git 마커). 이게 없으면 mkdtemp 상위에서 우연히 .git 을 만날 때
+  // rootDir 가 흔들려 테스트가 비결정적이 된다.
+  mkdirSync(join(root, ".git"), { recursive: true });
   return root;
 }
 
@@ -59,7 +63,7 @@ describe("cto-auto-collect", () => {
     assert.equal(isCtoAutoCollectDisabled({}), false);
   });
 
-  it("triggers runCollect only when a same-project peer exists", async () => {
+  it("triggers runCollect with reason 'triggered' when a same-project peer exists", async () => {
     const root = makeProjectRoot();
     const calls = [];
     const collector = makeCollector({
@@ -83,24 +87,53 @@ describe("cto-auto-collect", () => {
     await collector.drain();
 
     assert.equal(result.triggered, true);
+    assert.equal(result.reason, "triggered");
+    assert.equal(result.peerCount, 1);
     assert.deepEqual(calls, [{ args: [], opts: { rootDir: root } }]);
   });
 
-  it("skips when there are no peers, when env disables it, and while debounced", async () => {
+  it("triggers solo collect when there are no peers (single-session)", async () => {
+    const root = makeProjectRoot();
+    const soloCalls = [];
+    const solo = makeCollector({
+      registry: { querySessions: () => [] },
+      runCollect: async (args, opts) => soloCalls.push({ args, opts }),
+    });
+    const result = solo.handleSessionStarted({
+      sessionId: "solo",
+      session: { cwd: root, worktreePath: root },
+    });
+    await solo.drain();
+    assert.equal(result.triggered, true);
+    assert.equal(result.reason, "triggered-solo");
+    assert.equal(result.peerCount, 0);
+    assert.deepEqual(soloCalls, [{ args: [], opts: { rootDir: root } }]);
+  });
+
+  it("falls through to solo collect when querySessions throws", async () => {
     const root = makeProjectRoot();
     const calls = [];
-    const noPeer = makeCollector({
-      registry: { querySessions: () => [] },
-      runCollect: async () => calls.push("no-peer"),
+    const collector = makeCollector({
+      registry: {
+        querySessions() {
+          throw new Error("registry down");
+        },
+      },
+      runCollect: async (args, opts) => calls.push({ args, opts }),
     });
-    assert.equal(
-      noPeer.handleSessionStarted({
-        sessionId: "solo",
-        session: { cwd: root, worktreePath: root },
-      }).reason,
-      "no-peers",
-    );
+    const result = collector.handleSessionStarted({
+      sessionId: "x",
+      session: { cwd: root, worktreePath: root },
+    });
+    await collector.drain();
+    assert.equal(result.triggered, true);
+    assert.equal(result.reason, "triggered-solo");
+    assert.deepEqual(calls, [{ args: [], opts: { rootDir: root } }]);
+  });
 
+  it("skips when env disables it, and while debounced", async () => {
+    const root = makeProjectRoot();
+    const calls = [];
     const disabled = makeCollector({
       env: { TFX_CTO_AUTO_COLLECT: "off" },
       registry: { querySessions: () => [{ sessionId: "peer" }] },

--- a/tests/unit/cto-lake-root.test.mjs
+++ b/tests/unit/cto-lake-root.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { resolveLakeRootDir } from "../../cto/lake-root.mjs";
+
+describe("resolveLakeRootDir", () => {
+  it("returns cwd when .git is directly present", () => {
+    const exists = (p) => p === join("/repo", ".git");
+    assert.equal(resolveLakeRootDir("/repo", { existsSync: exists }), "/repo");
+  });
+
+  it("walks up to the nearest .git toplevel from a subdir", () => {
+    const exists = (p) => p === join("/repo", ".git");
+    assert.equal(
+      resolveLakeRootDir("/repo/packages/triflux", { existsSync: exists }),
+      "/repo",
+    );
+  });
+
+  it("stops at a git worktree (.git file) instead of the main repo", () => {
+    // worktree 루트에 .git 파일이 있으므로 거기서 멈춘다 (lake 격리 유지).
+    const worktree = "/repo/.claude/worktrees/foo";
+    const exists = (p) =>
+      p === join(worktree, ".git") || p === join("/repo", ".git");
+    assert.equal(
+      resolveLakeRootDir(join(worktree, "packages"), { existsSync: exists }),
+      worktree,
+    );
+  });
+
+  it("falls back to cwd when no .git is found", () => {
+    const exists = () => false;
+    assert.equal(
+      resolveLakeRootDir("/tmp/not-a-repo/sub", { existsSync: exists }),
+      "/tmp/not-a-repo/sub",
+    );
+  });
+
+  it("handles empty or non-string input", () => {
+    const exists = () => false;
+    assert.equal(resolveLakeRootDir("", { existsSync: exists }), "");
+    assert.equal(resolveLakeRootDir(undefined, { existsSync: exists }), "");
+    assert.equal(resolveLakeRootDir(null, { existsSync: exists }), "");
+    // truthy 비문자열도 "" 로 — 객체/숫자/배열을 그대로 누설하지 않는다.
+    assert.equal(resolveLakeRootDir({}, { existsSync: exists }), "");
+    assert.equal(resolveLakeRootDir(123, { existsSync: exists }), "");
+    assert.equal(resolveLakeRootDir(["/x"], { existsSync: exists }), "");
+  });
+
+  it("terminates on a relative path without infinite loop", () => {
+    const exists = () => false;
+    // dirname 이 "." 에 도달하면 parent === dir 로 루프가 종료되고 cwd fallback.
+    assert.equal(
+      resolveLakeRootDir("foo/bar", { existsSync: exists }),
+      "foo/bar",
+    );
+  });
+
+  it("does not throw when opts is null", () => {
+    // opts?.existsSync 가 null 을 안전하게 처리하고 실제 fs fallback 을 쓴다.
+    assert.doesNotThrow(() =>
+      resolveLakeRootDir("/nonexistent/deep/path", null),
+    );
+  });
+
+  it("resolves a real repo toplevel from a nested dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "tfx-lake-root-test-"));
+    try {
+      mkdirSync(join(root, ".git"), { recursive: true });
+      const nested = join(root, "packages", "triflux");
+      mkdirSync(nested, { recursive: true });
+      assert.equal(resolveLakeRootDir(nested), root);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 문제
CTO(`tfx cto status/collect/dashboard`)가 `.triflux/lake`를 `process.cwd()` 기준으로만 탐색해, repo 루트가 아닌 하위 폴더(예: `packages/triflux`)에서 부르면 루트 lake를 놓치고 `run tfx cto collect`가 반복됐다. collect는 하위 폴더에 stray `.triflux/lake`를 새로 썼다. 단일 세션에서는 auto-collect도 `no-peers`로 발동하지 않아 snapshot이 더 자주 비어 보였다.

## 변경
- **`cto/lake-root.mjs` 신규** — `resolveLakeRootDir()`가 cwd에서 `.git` 마커를 위로 탐색해 git toplevel 반환. git worktree는 자체 `.git` 파일에서 멈춰 lake 격리 유지. `.git` 미발견 시 cwd로 fallback(기존 동작 보존).
- `runStatus`/`runCollect`/`runDashboard`의 `rootDir` 기본값에 적용 (`opts.rootDir` 명시 주입 seam 보존).
- 단일 세션 auto-collect 허용 — `no-peers` 차단 제거(`triggered-solo`), `projectRoot`도 toplevel로 해결. 빈도는 기존 debounce + fresh-lake가 제어.
- query 실패가 solo collect를 막지 않도록 fall through. `peerCount`는 best-effort 라벨(exact-cwd 매칭).
- `packages/{triflux,remote}` 미러 (remote는 subset이라 dashboard 미포함).

## 검증
- 단위 테스트 신규/보강 + 전체 스위트 **4321 pass / 0 fail** (17 skip), `lint:skills` PASS, biome clean.
- 라이브 e2e: 하위 폴더에서 status가 before `unavailable` → after 루트 lake 정상 표시, lake가 하위 폴더가 아닌 repo 루트에 안착.
- 3-CLI 교차리뷰: Codex(보안/성능) 0 findings, Claude(로직/아키텍처) APPROVE, Antigravity(가독성) 지적(타입 반환·방어·테스트) 반영. CRITICAL/HIGH 없음.