### PR TITLE
test(q-learning): make epsilon=0 routers deterministic (fix CI flaky)

### DIFF
--- a/tests/unit/q-learning.test.mjs
+++ b/tests/unit/q-learning.test.mjs
@@ -89,6 +89,9 @@ describe("QLearningRouter", () => {
   beforeEach(() => {
     router = new QLearningRouter({
       epsilon: 0, // 탐색 비활성화 (결정적 테스트)
+      // update 의 decay 가 epsilon 을 epsilonMin(미지정 시 0.01)으로 끌어올려
+      // predict 에서 탐색이 재발하는 flaky 를 막는다.
+      epsilonMin: 0,
       modelPath: tmpModelPath,
     });
   });
@@ -303,6 +306,7 @@ describe("Q-table 영속화", () => {
   it("save → load: Q-table 복원", () => {
     const router1 = new QLearningRouter({
       epsilon: 0,
+      epsilonMin: 0, // update decay 가 epsilon 을 올려 save/load 로 탐색이 누출되는 flaky 방지
       modelPath: tmpModelPath,
     });
     for (let i = 0; i < 20; i++) {
@@ -314,6 +318,7 @@ describe("Q-table 영속화", () => {
 
     const router2 = new QLearningRouter({
       epsilon: 0,
+      epsilonMin: 0,
       modelPath: tmpModelPath,
     });
     const loaded = router2.load();


### PR DESCRIPTION
## 문제
`QLearningRouter` 테스트가 결정성을 위해 `epsilon: 0`을 쓰지만, 생성자(q-learning.mjs:174-175)가 `epsilonMin` 미지정 시 **0.01로 강제**하고, `update()`의 decay(q-learning.mjs:289-291)가 `epsilon`을 다시 `epsilonMin`까지 끌어올린다. 그 결과 update/save/load 후 `predict()`가 ~1% 확률로 탐색해, CI(concurrency=8)에서 다음 두 테스트가 간헐 실패:
- `update 후 predict: 보상 높은 액션이 선택됨`
- `save → load: Q-table 복원`

(v10.35.3 main CI에서 원본+rerun 연속 재현. 로컬 단독 실행은 운으로 통과.)

## 수정
`epsilon:0`이면서 update/save/load로 epsilon이 변동되는 3개 router에 `epsilonMin: 0` 추가 (beforeEach + save→load router1/router2). `epsilon=0 → 항상 활용` 테스트(update 없음)는 영향 없어 제외.

**테스트 전용 변경** — 엔진의 pure-exploit 방지 기본동작(`epsilonMin = max(0.01, ...)`)은 그대로.

## 검증
- 수정 후 `q-learning.test.mjs` **100회 반복 0 failures** (수정 전 ~0.85% flaky, 17/2000 재현).
- biome clean.