### PR TITLE
fix: triage and resolve open Triflux issues

### DIFF
--- a/.omc/research/issue-409-codex-apps-smoke.json
+++ b/.omc/research/issue-409-codex-apps-smoke.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2026-06-16T08:38:54.896798+00:00",
+  "cwd": "/Users/tellang/Projects/tools/triflux/.worktrees/issue-doctor-378-409",
+  "codex_path": "/opt/homebrew/bin/codex",
+  "command": [
+    "/opt/homebrew/bin/codex",
+    "exec",
+    "Respond exactly: smoke_ok_409"
+  ],
+  "exit_code": 0,
+  "timed_out": false,
+  "stdout": "smoke_ok_409\n",
+  "stderr": "Reading additional input from stdin...\nOpenAI Codex v0.139.0\n--------\nworkdir: /Users/tellang/Projects/tools/triflux/.worktrees/issue-doctor-378-409\nmodel: gpt-5.5\nprovider: openai\napproval: never\nsandbox: workspace-write [workdir, /tmp, $TMPDIR]\nreasoning effort: xhigh\nreasoning summaries: none\nsession id: 019ecf95-6566-7ea1-baa4-fb5b8ffa7bfd\n--------\nuser\nRespond exactly: smoke_ok_409\nhook: SessionStart\nhook: SessionStart\nhook: SessionStart Completed\nhook: SessionStart Completed\nhook: UserPromptSubmit\nhook: UserPromptSubmit\nhook: UserPromptSubmit Completed\nhook: UserPromptSubmit Completed\ncodex\nsmoke_ok_409\nhook: Stop\nhook: Stop Completed\ntokens used\n22,643\n",
+  "reproduced_codex_apps_init_fail": false,
+  "notes": "No codex_apps initialization failure signature found in stderr during bounded local smoke.",
+  "codex_version_stdout": "codex-cli 0.139.0\n",
+  "codex_version_stderr": ""
+}

--- a/.omc/research/issue-409-triage-note.md
+++ b/.omc/research/issue-409-triage-note.md
@@ -1,0 +1,30 @@
+# Issue #409 codex_apps init fail triage
+
+Date: 2026-06-16
+Worktree: `/Users/tellang/Projects/tools/triflux/.worktrees/issue-doctor-378-409`
+
+## Bounded current smoke
+
+Command run:
+
+```sh
+codex exec 'Respond exactly: smoke_ok_409'
+```
+
+Local Codex version evidence from the smoke artifact:
+
+```text
+codex-cli 0.139.0
+```
+
+Result:
+
+- Exit code: `0`
+- Stdout: `smoke_ok_409`
+- `codex_apps` initialization failure reproduced: `false`
+
+Raw bounded-smoke artifact: `.omc/research/issue-409-codex-apps-smoke.json`
+
+## Triage conclusion
+
+Current local evidence does not reproduce the `codex_apps` init failure. Treat #409 as an obsolete candidate unless a newer reproduction provides current stderr/log output. No doctor/docs guidance was added because hardcoding stale Codex 0.137-era behavior is not supported by this Codex 0.139.0 smoke.

--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -1113,7 +1113,20 @@ async function hasTmuxSession(adapter, opts) {
 
 function daemonProbeUnavailableReason(probe, targetAttachable) {
   if (targetAttachable) return null;
-  if (!probe?.ok) return probe?.reason ?? "probe-failed";
+  if (!probe?.ok) {
+    const candidateCodes = Array.isArray(probe?.raw?.candidateResults)
+      ? probe.raw.candidateResults
+          .map((entry) => entry?.errorCode)
+          .filter(Boolean)
+      : [];
+    if (candidateCodes.includes("stale-control-socket")) {
+      return "stale-control-socket";
+    }
+    if (candidateCodes.includes("daemon-dir-missing")) {
+      return "daemon-dir-missing";
+    }
+    return probe?.reason ?? "probe-failed";
+  }
   return "target-not-found";
 }
 

--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -2708,6 +2708,7 @@ function statusBadge(status) {
     case "missing":
     case "missing-file":
     case "warning":
+    case "skipped":
       return `${YELLOW}${status}${RESET}`;
     case "mismatch":
     case "invalid":
@@ -2730,6 +2731,7 @@ function buildMcpStatusRows(statusInfo) {
       else if (row.status === "mismatch")
         detail = `expected ${row.expectedUrl || row.expectedCommand}`;
       else if (row.status === "invalid-config") detail = "parse error";
+      else if (row.status === "skipped") detail = row.message || "skipped";
       else if (row.status === "stdio") detail = "configured as stdio";
       return [
         row.name,

--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -31,6 +31,8 @@ function toIsoTime(value) {
   return null;
 }
 
+// Non-cryptographic djb2-style hash used only to produce stable redacted
+// labels for local paths. Do not use this as a trust boundary or secret token.
 function shortHash(value) {
   const str = String(value ?? "");
   let h = 5381;

--- a/docs/research/triflux-open-issue-triage-2026-06-16.md
+++ b/docs/research/triflux-open-issue-triage-2026-06-16.md
@@ -1,0 +1,37 @@
+# Triflux open issue triage — 2026-06-16
+
+Source of truth: live `gh issue list --state open --limit 200` against `tellang/triflux` on 2026-06-16, repo head `75e3dbe4` (`v10.36.0`).
+
+## Triage rubric
+
+- **Stale-close**: live reproduction is gone or the issue is now only historical documentation.
+- **P2**: user-visible correctness, silent unsafe behavior, or workflow failure that should be fixed before broad release work.
+- **P3**: real but bounded ergonomics/doctor correctness issue.
+- **P4**: low-risk cleanup/docs/contract clarification.
+
+## Open issue inventory
+
+| Issue | Priority | Stale? | Current decision | Notes / planned closure evidence |
+| --- | --- | --- | --- | --- |
+| #411 consensus follow-ups | P2 | No | Fix the high-signal bounded items now; leave risky keychain freshness as follow-up if needed. | Silent daemon auth default, q-learning deflake, and small P4 hygiene are code-testable. Keychain freshness needs non-interactive design and may remain open/partial. |
+| #409 codex_apps init fail docs | P4 | **Stale-close candidate** | Close as obsolete unless another host reproduces. | Local smoke on 2026-06-16: `codex-cli 0.139.0`; `codex exec 'Return exactly TFX_CODEX_APPS_SMOKE_OK.'` exited 0, no `codex_apps`/init-fail stderr. |
+| #408 critical redundant policy | P2 | No | Fix now. | Split `critical` from `redundancy`; require explicit redundancy to launch extra worker, with same-CLI option. |
+| #407 shard MCP manifest abstraction | P2 | No | Fix now. | Undefined MCP server names should be skipped with warning/metadata instead of causing Codex unknown-server failure. |
+| #378 agy migrated MCP config doctor false positive | P3 | No | Fix now. | Empty legacy `~/.gemini/config/mcp_config.json` plus `.migrated` should not be a hard parse error or be repopulated by `--fix`. |
+| #367 tfx-live missing daemon UDS diagnostics | P2 | No | Fix now. | Distinguish missing daemon dir/unsupported daemon from stale socket and guide tmux fallback. |
+| #310 agy alias duplication | P4 | No, but low-risk | Resolve by documenting the intentional direct-call alias contract unless code proves safe to remove. | `agent-map.json` normalizes upstream callers; `tfx-route.sh`/`cli-agy` still need direct `agy` entrypoint compatibility. |
+| #292 HUD sv semantic mismatch | P2 | No | Fix now. | Avoid presenting combined `sv:` from incomparable Codex cumulative vs Gemini latest-session fallbacks. |
+
+## Worktree lanes
+
+- `fix/issues-407-408-swarm` → #407/#408.
+- `fix/issues-378-409-doctor` → #378/#409.
+- `fix/issue-292-hud-sv` → #292.
+- `fix/issues-367-411-followups` → #367/#411 bounded follow-ups.
+- `fix/issues-20260616` → integration branch and this triage artifact.
+
+## Closure plan
+
+1. Land code fixes from the independent lanes into `fix/issues-20260616`.
+2. Run focused tests per lane, then `npm run release:check-mirror` and at least targeted aggregate tests.
+3. Open a PR summarizing fixed issues, stale-close recommendation for #409, and any deliberately deferred #411 keychain freshness work.

--- a/hub/routing/q-learning.mjs
+++ b/hub/routing/q-learning.mjs
@@ -164,6 +164,7 @@ export class QLearningRouter {
    * @param {number} [opts.epsilonMin=0.05] — 최소 엡실론
    * @param {number} [opts.minConfidence=0.6] — 최소 신뢰도 (이하면 폴백)
    * @param {string} [opts.modelPath] — Q-table 영속화 경로
+   * @param {() => number} [opts.random=Math.random] — 테스트/재현용 RNG seam
    */
   constructor(opts = {}) {
     this._lr = opts.learningRate ?? 0.1;
@@ -176,6 +177,8 @@ export class QLearningRouter {
     this._minConfidence = opts.minConfidence ?? 0.6;
     this._modelPath =
       opts.modelPath ?? join(homedir(), ".omc", "routing-model.json");
+    this._random =
+      typeof opts.random === "function" ? opts.random : Math.random;
 
     /** @type {Map<string, Map<string, number>>} state -> (action -> Q-value) */
     this._qTable = new Map();
@@ -223,12 +226,12 @@ export class QLearningRouter {
     const visits = this._visitCounts.get(state) || 0;
 
     // 엡실론-그리디: 탐색 vs 활용
-    const isExploration = Math.random() < this._epsilon;
+    const isExploration = this._random() < this._epsilon;
 
     let action;
     if (isExploration) {
       // 무작위 탐색
-      action = ACTIONS[Math.floor(Math.random() * ACTIONS.length)];
+      action = ACTIONS[Math.floor(this._random() * ACTIONS.length)];
     } else {
       // 최적 액션 선택 (최대 Q-value)
       let maxQ = -Infinity;

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -271,7 +271,9 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
-    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    const errorCodes = results
+      .map((result) => result.errorCode)
+      .filter(Boolean);
     if (errorCodes.includes("stale-control-socket")) {
       reason = "stale-control-socket";
     } else if (errorCodes.includes("daemon-dir-missing")) {

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -243,6 +243,7 @@ function candidateResultSummary(result) {
     ...summary,
     ok: result.ok === true,
     error: result.error ?? null,
+    errorCode: result.errorCode ?? null,
     sessionCount: Array.isArray(result.sessions) ? result.sessions.length : 0,
   };
 }
@@ -270,6 +271,12 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
+    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    if (errorCodes.includes("stale-control-socket")) {
+      reason = "stale-control-socket";
+    } else if (errorCodes.includes("daemon-dir-missing")) {
+      reason = "daemon-dir-missing";
+    }
     error =
       results
         .map((result) => result.error)
@@ -341,6 +348,18 @@ export async function probeClaudeDaemonCandidates({
         error: ok ? null : list?.error || "Claude daemon list failed",
       });
     } catch (error) {
+      let errorCode = null;
+      if (error?.code === "ENOENT") {
+        try {
+          await fs.stat(candidate.daemonDir);
+          errorCode = "stale-control-socket";
+        } catch (statError) {
+          errorCode =
+            statError?.code === "ENOENT"
+              ? "daemon-dir-missing"
+              : "stale-control-socket";
+        }
+      }
       results.push({
         ok: false,
         candidate,
@@ -348,6 +367,7 @@ export async function probeClaudeDaemonCandidates({
         sessions: [],
         target: null,
         error: errorMessage(error),
+        errorCode,
       });
     }
   }
@@ -459,6 +479,7 @@ export async function readDaemonControlKey(
 }
 
 export async function buildDaemonControlAuth(configDir) {
+  if (!configDir) return {};
   const auth = await readDaemonControlKey(configDir);
   return auth ? { auth } : {};
 }

--- a/hub/team/conductor.mjs
+++ b/hub/team/conductor.mjs
@@ -20,6 +20,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
+import { runPreflight as runCodexPreflight } from "../codex-preflight.mjs";
 import {
   __internal__ as dynamicRoutingInternal,
   evaluateDynamicRoute,
@@ -564,13 +565,66 @@ export function createConductor(opts = {}) {
     const sentinelCapture = createSentinelCapture();
 
     const spawnCwd = session.config.workdir || launcher.cwd || undefined;
+    let excludeMcpServers = [];
+    const requestedMcpServers = Array.isArray(session.config.mcpServers)
+      ? session.config.mcpServers
+      : [];
+    if (session.config.agent === "codex" && requestedMcpServers.length > 0) {
+      const preflightFn = opts.deps?.codexPreflight || runCodexPreflight;
+      try {
+        const preflight = await preflightFn({
+          mcpServers: requestedMcpServers,
+          subcommand: "exec",
+          workdir: spawnCwd,
+        });
+        excludeMcpServers = Array.isArray(preflight?.excludeMcpServers)
+          ? preflight.excludeMcpServers
+          : [];
+        for (const warning of preflight?.warnings || []) {
+          eventLog.append("codex_preflight_warning", {
+            session: session.id,
+            warning,
+          });
+          emitter.emit("warning", {
+            type: "codex_preflight_warning",
+            session: session.id,
+            warning,
+          });
+        }
+      } catch (err) {
+        eventLog.append("codex_preflight_failed", {
+          session: session.id,
+          error: err.message,
+        });
+        emitter.emit("warning", {
+          type: "codex_preflight_failed",
+          session: session.id,
+          error: err.message,
+        });
+      }
+    }
+
     const spawnSpec = buildSpawnSpecForMode(MODES.HEADLESS, {
       cli: session.config.agent,
       prompt: session.config.prompt,
       profile: session.config.profile,
       model: session.config.model,
       mcpServers: session.config.mcpServers,
+      excludeMcpServers,
       resolveCommand: opts.deps?.resolveCliExecutable,
+      onWarning: (message, details = {}) => {
+        eventLog.append("mcp_server_skipped", {
+          session: session.id,
+          message,
+          ...details,
+        });
+        emitter.emit("warning", {
+          type: "mcp_server_skipped",
+          session: session.id,
+          message,
+          ...details,
+        });
+      },
     });
 
     // #90 branch guard: shard spawn cwd가 main 브랜치면 즉시 abort.

--- a/hub/team/execution-mode.mjs
+++ b/hub/team/execution-mode.mjs
@@ -156,7 +156,21 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "never",
   );
   if (Array.isArray(opts.mcpServers)) {
-    for (const server of opts.mcpServers) {
+    const excludedMcpServers = new Set(
+      (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])
+        .map((server) => String(server ?? "").trim())
+        .filter(Boolean),
+    );
+    for (const rawServer of opts.mcpServers) {
+      const server = String(rawServer ?? "").trim();
+      if (!server) continue;
+      if (excludedMcpServers.has(server)) {
+        const message = `Skipping MCP server '${server}' because Codex preflight did not find an enabled config entry.`;
+        if (typeof opts.onWarning === "function") {
+          opts.onWarning(message, { type: "mcp_server_skipped", server });
+        }
+        continue;
+      }
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }

--- a/hub/team/swarm-hypervisor.mjs
+++ b/hub/team/swarm-hypervisor.mjs
@@ -90,6 +90,16 @@ const FALLBACK_AGENTS = Object.freeze({
   claude: "codex",
 });
 
+function resolveRedundantAgent(shard) {
+  const mode = shard?.redundancy;
+  if (!mode) return null;
+  if (mode === "same-cli") return shard.agent;
+  if (mode === true || mode === "fallback") {
+    return FALLBACK_AGENTS[shard.agent] || shard.agent;
+  }
+  return null;
+}
+
 function createNoopRegistry() {
   return Object.freeze({
     register() {},
@@ -2065,11 +2075,12 @@ export function createSwarmHypervisor(opts) {
         launched.add(name);
         await launchShard(shard);
 
-        // Launch redundant worker for critical shards
-        if (shard.critical) {
+        // Launch redundant worker only when explicitly requested.
+        const redundantAgent = resolveRedundantAgent(shard);
+        if (redundantAgent) {
           const redundantShard = {
             ...shard,
-            agent: FALLBACK_AGENTS[shard.agent] || shard.agent,
+            agent: redundantAgent,
           };
           await launchShard(redundantShard, true);
         }

--- a/hub/team/swarm-planner.mjs
+++ b/hub/team/swarm-planner.mjs
@@ -11,6 +11,7 @@
 //   - mcp: server1, server2
 //   - depends: shard-name-1, shard-name-2
 //   - critical: true|false
+//   - redundancy: false|fallback|true|same-cli
 //   - prompt: |
 //       multi-line prompt text
 
@@ -24,6 +25,7 @@ const SHARD_DEFAULTS = Object.freeze({
   mcp: [],
   depends: [],
   critical: false,
+  redundancy: false,
   prompt: "",
   host: "",
 });
@@ -118,6 +120,15 @@ export function parseShards(content) {
         break;
       case "critical":
         current.critical = /^(true|yes|1)$/i.test(value);
+        break;
+      case "redundancy":
+        if (/^(true|yes|1|fallback)$/i.test(value)) {
+          current.redundancy = "fallback";
+        } else if (/^(same-cli|same_cli|same|primary)$/i.test(value)) {
+          current.redundancy = "same-cli";
+        } else {
+          current.redundancy = false;
+        }
         break;
       case "host":
         current.host = value;

--- a/hud/hud-qos-status.mjs
+++ b/hud/hud-qos-status.mjs
@@ -177,8 +177,10 @@ async function main() {
   // 세션/누적 토큰 → context 대비 절약 배수 (개별 provider sv%)
   const ctxCapacity = deriveContextLimit(stdin);
   let codexSv = null;
+  let codexAccumulatorSv = null;
   if (svAccumulator?.codex?.tokens > 0) {
-    codexSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexAccumulatorSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexSv = codexAccumulatorSv;
   } else if (codexBuckets) {
     const main =
       codexBuckets.codex || codexBuckets[Object.keys(codexBuckets)[0]];
@@ -186,8 +188,10 @@ async function main() {
       codexSv = main.tokens.total_tokens / ctxCapacity;
   }
   let geminiSv = null;
+  let geminiAccumulatorSv = null;
   if (svAccumulator?.gemini?.tokens > 0) {
-    geminiSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiAccumulatorSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiSv = geminiAccumulatorSv;
   } else {
     const geminiTokens = geminiSession?.total || null;
     geminiSv = geminiTokens ? geminiTokens / ctxCapacity : null;
@@ -216,8 +220,15 @@ async function main() {
   const antigravitySlot1Bucket =
     antigravityModelFamily === "gemini" ? antigravityFamilyBucket : null;
 
-  // 합산 절약: Codex+Gemini sv% 합산 (컨텍스트 대비 위임 토큰 비율)
-  const combinedSvPct = Math.round(((codexSv ?? 0) + (geminiSv ?? 0)) * 100);
+  // 합산 절약은 svAccumulator 기반일 때만 표시한다.
+  // Codex bucket fallback은 account-window 누적 토큰이고 Gemini fallback은 latest
+  // session 토큰이라 서로 의미가 달라 합산하면 misleading cross-provider total이 된다.
+  const hasComparableSvAccumulator = Boolean(
+    codexAccumulatorSv != null || geminiAccumulatorSv != null,
+  );
+  const combinedSvPct = hasComparableSvAccumulator
+    ? Math.round(((codexAccumulatorSv ?? 0) + (geminiAccumulatorSv ?? 0)) * 100)
+    : null;
 
   // 인디케이터 인식 tier 선택 (stdin + Claude 사용량 기반)
   const CURRENT_TIER = selectTier(stdin, claudeUsageSnapshot.data);
@@ -230,7 +241,7 @@ async function main() {
       codexBuckets,
       antigravityReady ? null : geminiSession,
       antigravityReady ? null : geminiBucket,
-      antigravityReady ? Math.round((codexSv ?? 0) * 100) : combinedSvPct,
+      combinedSvPct,
       antigravityReady ? "a" : "g",
     );
     process.stdout.write(`\x1b[0m${microLine}\n`);

--- a/hud/renderers.mjs
+++ b/hud/renderers.mjs
@@ -326,7 +326,7 @@ export function getMicroLine(
   }
 
   // sv
-  const sv = formatSvPct(combinedSvPct || 0).trim();
+  const sv = formatSvPct(combinedSvPct).trim();
 
   const cols = getTerminalColumns() || 120;
   const line =
@@ -350,7 +350,7 @@ export function getClaudeRows(
   const ctxView = contextView || buildContextUsageView({}, null);
   const prefix = `${bold(claudeOrange("c"))}:`;
   // 절약 퍼센트
-  const svStr = formatSvPct(combinedSvPct || 0);
+  const svStr = formatSvPct(combinedSvPct);
   const svSuffix = `${dim("sv:")}${svStr}`;
 
   // API 실측 데이터

--- a/packages/core/hub/routing/q-learning.mjs
+++ b/packages/core/hub/routing/q-learning.mjs
@@ -164,6 +164,7 @@ export class QLearningRouter {
    * @param {number} [opts.epsilonMin=0.05] — 최소 엡실론
    * @param {number} [opts.minConfidence=0.6] — 최소 신뢰도 (이하면 폴백)
    * @param {string} [opts.modelPath] — Q-table 영속화 경로
+   * @param {() => number} [opts.random=Math.random] — 테스트/재현용 RNG seam
    */
   constructor(opts = {}) {
     this._lr = opts.learningRate ?? 0.1;
@@ -176,6 +177,8 @@ export class QLearningRouter {
     this._minConfidence = opts.minConfidence ?? 0.6;
     this._modelPath =
       opts.modelPath ?? join(homedir(), ".omc", "routing-model.json");
+    this._random =
+      typeof opts.random === "function" ? opts.random : Math.random;
 
     /** @type {Map<string, Map<string, number>>} state -> (action -> Q-value) */
     this._qTable = new Map();
@@ -223,12 +226,12 @@ export class QLearningRouter {
     const visits = this._visitCounts.get(state) || 0;
 
     // 엡실론-그리디: 탐색 vs 활용
-    const isExploration = Math.random() < this._epsilon;
+    const isExploration = this._random() < this._epsilon;
 
     let action;
     if (isExploration) {
       // 무작위 탐색
-      action = ACTIONS[Math.floor(Math.random() * ACTIONS.length)];
+      action = ACTIONS[Math.floor(this._random() * ACTIONS.length)];
     } else {
       // 최적 액션 선택 (최대 Q-value)
       let maxQ = -Infinity;

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -271,7 +271,9 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
-    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    const errorCodes = results
+      .map((result) => result.errorCode)
+      .filter(Boolean);
     if (errorCodes.includes("stale-control-socket")) {
       reason = "stale-control-socket";
     } else if (errorCodes.includes("daemon-dir-missing")) {

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -243,6 +243,7 @@ function candidateResultSummary(result) {
     ...summary,
     ok: result.ok === true,
     error: result.error ?? null,
+    errorCode: result.errorCode ?? null,
     sessionCount: Array.isArray(result.sessions) ? result.sessions.length : 0,
   };
 }
@@ -270,6 +271,12 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
+    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    if (errorCodes.includes("stale-control-socket")) {
+      reason = "stale-control-socket";
+    } else if (errorCodes.includes("daemon-dir-missing")) {
+      reason = "daemon-dir-missing";
+    }
     error =
       results
         .map((result) => result.error)
@@ -341,6 +348,18 @@ export async function probeClaudeDaemonCandidates({
         error: ok ? null : list?.error || "Claude daemon list failed",
       });
     } catch (error) {
+      let errorCode = null;
+      if (error?.code === "ENOENT") {
+        try {
+          await fs.stat(candidate.daemonDir);
+          errorCode = "stale-control-socket";
+        } catch (statError) {
+          errorCode =
+            statError?.code === "ENOENT"
+              ? "daemon-dir-missing"
+              : "stale-control-socket";
+        }
+      }
       results.push({
         ok: false,
         candidate,
@@ -348,6 +367,7 @@ export async function probeClaudeDaemonCandidates({
         sessions: [],
         target: null,
         error: errorMessage(error),
+        errorCode,
       });
     }
   }
@@ -459,6 +479,7 @@ export async function readDaemonControlKey(
 }
 
 export async function buildDaemonControlAuth(configDir) {
+  if (!configDir) return {};
   const auth = await readDaemonControlKey(configDir);
   return auth ? { auth } : {};
 }

--- a/packages/core/hud/hud-qos-status.mjs
+++ b/packages/core/hud/hud-qos-status.mjs
@@ -177,8 +177,10 @@ async function main() {
   // 세션/누적 토큰 → context 대비 절약 배수 (개별 provider sv%)
   const ctxCapacity = deriveContextLimit(stdin);
   let codexSv = null;
+  let codexAccumulatorSv = null;
   if (svAccumulator?.codex?.tokens > 0) {
-    codexSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexAccumulatorSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexSv = codexAccumulatorSv;
   } else if (codexBuckets) {
     const main =
       codexBuckets.codex || codexBuckets[Object.keys(codexBuckets)[0]];
@@ -186,8 +188,10 @@ async function main() {
       codexSv = main.tokens.total_tokens / ctxCapacity;
   }
   let geminiSv = null;
+  let geminiAccumulatorSv = null;
   if (svAccumulator?.gemini?.tokens > 0) {
-    geminiSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiAccumulatorSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiSv = geminiAccumulatorSv;
   } else {
     const geminiTokens = geminiSession?.total || null;
     geminiSv = geminiTokens ? geminiTokens / ctxCapacity : null;
@@ -216,8 +220,15 @@ async function main() {
   const antigravitySlot1Bucket =
     antigravityModelFamily === "gemini" ? antigravityFamilyBucket : null;
 
-  // 합산 절약: Codex+Gemini sv% 합산 (컨텍스트 대비 위임 토큰 비율)
-  const combinedSvPct = Math.round(((codexSv ?? 0) + (geminiSv ?? 0)) * 100);
+  // 합산 절약은 svAccumulator 기반일 때만 표시한다.
+  // Codex bucket fallback은 account-window 누적 토큰이고 Gemini fallback은 latest
+  // session 토큰이라 서로 의미가 달라 합산하면 misleading cross-provider total이 된다.
+  const hasComparableSvAccumulator = Boolean(
+    codexAccumulatorSv != null || geminiAccumulatorSv != null,
+  );
+  const combinedSvPct = hasComparableSvAccumulator
+    ? Math.round(((codexAccumulatorSv ?? 0) + (geminiAccumulatorSv ?? 0)) * 100)
+    : null;
 
   // 인디케이터 인식 tier 선택 (stdin + Claude 사용량 기반)
   const CURRENT_TIER = selectTier(stdin, claudeUsageSnapshot.data);
@@ -230,7 +241,7 @@ async function main() {
       codexBuckets,
       antigravityReady ? null : geminiSession,
       antigravityReady ? null : geminiBucket,
-      antigravityReady ? Math.round((codexSv ?? 0) * 100) : combinedSvPct,
+      combinedSvPct,
       antigravityReady ? "a" : "g",
     );
     process.stdout.write(`\x1b[0m${microLine}\n`);

--- a/packages/core/hud/renderers.mjs
+++ b/packages/core/hud/renderers.mjs
@@ -326,7 +326,7 @@ export function getMicroLine(
   }
 
   // sv
-  const sv = formatSvPct(combinedSvPct || 0).trim();
+  const sv = formatSvPct(combinedSvPct).trim();
 
   const cols = getTerminalColumns() || 120;
   const line =
@@ -350,7 +350,7 @@ export function getClaudeRows(
   const ctxView = contextView || buildContextUsageView({}, null);
   const prefix = `${bold(claudeOrange("c"))}:`;
   // 절약 퍼센트
-  const svStr = formatSvPct(combinedSvPct || 0);
+  const svStr = formatSvPct(combinedSvPct);
   const svSuffix = `${dim("sv:")}${svStr}`;
 
   // API 실측 데이터

--- a/packages/core/scripts/lib/cli-agy.mjs
+++ b/packages/core/scripts/lib/cli-agy.mjs
@@ -10,6 +10,8 @@ export const id = "agy";
 export const cliType = "antigravity";
 export const command = "agy";
 
+// #310: agent-map.json normalizes upstream callers to antigravity,
+// but this adapter also accepts the direct `agy` route for compatibility.
 const AGENT_PROFILES = {
   antigravity: {
     profile: "agy_v1",

--- a/packages/core/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/core/scripts/lib/mcp-guard-engine.mjs
@@ -182,6 +182,15 @@ function isAntigravityConfig(filePath) {
   return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
+function isMigratedAntigravityConfig(filePath, raw = null) {
+  if (!isAntigravityConfig(filePath)) return false;
+  const resolvedPath = resolveFilePath(filePath);
+  const markerPath = join(dirname(resolvedPath), ".migrated");
+  if (!existsSync(markerPath)) return false;
+  const contents = raw === null ? readFileSync(resolvedPath, "utf8") : raw;
+  return String(contents || "").trim() === "";
+}
+
 function plaintextSecretHeaderClient(filePath) {
   const client = detectClient(filePath);
   return client === "gemini" || client === "antigravity" ? client : null;
@@ -970,7 +979,23 @@ function scanJsonConfig(filePath) {
   }
 
   try {
-    const parsed = readJsonFile(filePath);
+    const raw = readFileSync(filePath, "utf8");
+    if (isMigratedAntigravityConfig(filePath, raw)) {
+      return {
+        filePath,
+        client: detectClient(filePath),
+        label: detectLabel(filePath),
+        exists: true,
+        parseError: null,
+        servers: [],
+        stdioServers: [],
+        migrated: true,
+        message:
+          "Antigravity migrated MCP config; deprecated mcp_config.json left empty",
+      };
+    }
+
+    const parsed = JSON.parse(raw);
     const mcpServers = parsed?.mcpServers;
     const servers =
       !mcpServers || typeof mcpServers !== "object"
@@ -1705,6 +1730,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "missing-file";
       } else if (config.parseError) {
         status = "invalid-config";
+      } else if (config.migrated) {
+        status = "skipped";
       } else if (!actual) {
         status = "missing";
       } else if (expectedCommand) {
@@ -1733,6 +1760,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         actualUrl: actual?.url || "",
         actualCommand: actual?.command || "",
         status,
+        migrated: Boolean(config.migrated),
+        message: config.message || "",
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
         actualHeaderNames: headerNames(actualHeaders),
@@ -2015,6 +2044,19 @@ export function removeServerFromTargets(name, options = {}) {
     if (targetsFilter && !targetsFilter.has(target.client)) continue;
 
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      actions.push({
+        type: "remove",
+        name: trimmedName,
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       actions.push({
         type: "remove",
@@ -2058,10 +2100,24 @@ export function syncRegistryTargets(options = {}) {
   );
   const actions = [];
   const invalidConfigs = new Set();
+  const skippedConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      skippedConfigs.add(normalizeForMatch(target.filePath));
+      actions.push({
+        type: "sync",
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
@@ -2097,6 +2153,10 @@ export function syncRegistryTargets(options = {}) {
   for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.migrated || skippedConfigs.has(targetKey)) {
+      continue;
+    }
+
     if (snapshot.parseError) {
       if (!invalidConfigs.has(targetKey)) {
         actions.push({

--- a/packages/remote/cto/status.mjs
+++ b/packages/remote/cto/status.mjs
@@ -31,6 +31,8 @@ function toIsoTime(value) {
   return null;
 }
 
+// Non-cryptographic djb2-style hash used only to produce stable redacted
+// labels for local paths. Do not use this as a trust boundary or secret token.
 function shortHash(value) {
   const str = String(value ?? "");
   let h = 5381;

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -243,6 +243,7 @@ function candidateResultSummary(result) {
     ...summary,
     ok: result.ok === true,
     error: result.error ?? null,
+    errorCode: result.errorCode ?? null,
     sessionCount: Array.isArray(result.sessions) ? result.sessions.length : 0,
   };
 }
@@ -270,6 +271,14 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
+    const errorCodes = results
+      .map((result) => result.errorCode)
+      .filter(Boolean);
+    if (errorCodes.includes("stale-control-socket")) {
+      reason = "stale-control-socket";
+    } else if (errorCodes.includes("daemon-dir-missing")) {
+      reason = "daemon-dir-missing";
+    }
     error =
       results
         .map((result) => result.error)
@@ -341,6 +350,18 @@ export async function probeClaudeDaemonCandidates({
         error: ok ? null : list?.error || "Claude daemon list failed",
       });
     } catch (error) {
+      let errorCode = null;
+      if (error?.code === "ENOENT") {
+        try {
+          await fs.stat(candidate.daemonDir);
+          errorCode = "stale-control-socket";
+        } catch (statError) {
+          errorCode =
+            statError?.code === "ENOENT"
+              ? "daemon-dir-missing"
+              : "stale-control-socket";
+        }
+      }
       results.push({
         ok: false,
         candidate,
@@ -348,6 +369,7 @@ export async function probeClaudeDaemonCandidates({
         sessions: [],
         target: null,
         error: errorMessage(error),
+        errorCode,
       });
     }
   }
@@ -459,6 +481,7 @@ export async function readDaemonControlKey(
 }
 
 export async function buildDaemonControlAuth(configDir) {
+  if (!configDir) return {};
   const auth = await readDaemonControlKey(configDir);
   return auth ? { auth } : {};
 }

--- a/packages/remote/hub/team/conductor.mjs
+++ b/packages/remote/hub/team/conductor.mjs
@@ -20,6 +20,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "@triflux/core/mesh/mesh-registry.mjs";
 import { broker } from "@triflux/core/hub/account-broker.mjs";
+import { runPreflight as runCodexPreflight } from "@triflux/core/hub/codex-preflight.mjs";
 import {
   __internal__ as dynamicRoutingInternal,
   evaluateDynamicRoute,
@@ -564,13 +565,66 @@ export function createConductor(opts = {}) {
     const sentinelCapture = createSentinelCapture();
 
     const spawnCwd = session.config.workdir || launcher.cwd || undefined;
+    let excludeMcpServers = [];
+    const requestedMcpServers = Array.isArray(session.config.mcpServers)
+      ? session.config.mcpServers
+      : [];
+    if (session.config.agent === "codex" && requestedMcpServers.length > 0) {
+      const preflightFn = opts.deps?.codexPreflight || runCodexPreflight;
+      try {
+        const preflight = await preflightFn({
+          mcpServers: requestedMcpServers,
+          subcommand: "exec",
+          workdir: spawnCwd,
+        });
+        excludeMcpServers = Array.isArray(preflight?.excludeMcpServers)
+          ? preflight.excludeMcpServers
+          : [];
+        for (const warning of preflight?.warnings || []) {
+          eventLog.append("codex_preflight_warning", {
+            session: session.id,
+            warning,
+          });
+          emitter.emit("warning", {
+            type: "codex_preflight_warning",
+            session: session.id,
+            warning,
+          });
+        }
+      } catch (err) {
+        eventLog.append("codex_preflight_failed", {
+          session: session.id,
+          error: err.message,
+        });
+        emitter.emit("warning", {
+          type: "codex_preflight_failed",
+          session: session.id,
+          error: err.message,
+        });
+      }
+    }
+
     const spawnSpec = buildSpawnSpecForMode(MODES.HEADLESS, {
       cli: session.config.agent,
       prompt: session.config.prompt,
       profile: session.config.profile,
       model: session.config.model,
       mcpServers: session.config.mcpServers,
+      excludeMcpServers,
       resolveCommand: opts.deps?.resolveCliExecutable,
+      onWarning: (message, details = {}) => {
+        eventLog.append("mcp_server_skipped", {
+          session: session.id,
+          message,
+          ...details,
+        });
+        emitter.emit("warning", {
+          type: "mcp_server_skipped",
+          session: session.id,
+          message,
+          ...details,
+        });
+      },
     });
 
     // #90 branch guard: shard spawn cwd가 main 브랜치면 즉시 abort.

--- a/packages/remote/hub/team/execution-mode.mjs
+++ b/packages/remote/hub/team/execution-mode.mjs
@@ -156,7 +156,21 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "never",
   );
   if (Array.isArray(opts.mcpServers)) {
-    for (const server of opts.mcpServers) {
+    const excludedMcpServers = new Set(
+      (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])
+        .map((server) => String(server ?? "").trim())
+        .filter(Boolean),
+    );
+    for (const rawServer of opts.mcpServers) {
+      const server = String(rawServer ?? "").trim();
+      if (!server) continue;
+      if (excludedMcpServers.has(server)) {
+        const message = `Skipping MCP server '${server}' because Codex preflight did not find an enabled config entry.`;
+        if (typeof opts.onWarning === "function") {
+          opts.onWarning(message, { type: "mcp_server_skipped", server });
+        }
+        continue;
+      }
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }

--- a/packages/remote/hub/team/swarm-hypervisor.mjs
+++ b/packages/remote/hub/team/swarm-hypervisor.mjs
@@ -90,6 +90,16 @@ const FALLBACK_AGENTS = Object.freeze({
   claude: "codex",
 });
 
+function resolveRedundantAgent(shard) {
+  const mode = shard?.redundancy;
+  if (!mode) return null;
+  if (mode === "same-cli") return shard.agent;
+  if (mode === true || mode === "fallback") {
+    return FALLBACK_AGENTS[shard.agent] || shard.agent;
+  }
+  return null;
+}
+
 function createNoopRegistry() {
   return Object.freeze({
     register() {},
@@ -2065,11 +2075,12 @@ export function createSwarmHypervisor(opts) {
         launched.add(name);
         await launchShard(shard);
 
-        // Launch redundant worker for critical shards
-        if (shard.critical) {
+        // Launch redundant worker only when explicitly requested.
+        const redundantAgent = resolveRedundantAgent(shard);
+        if (redundantAgent) {
           const redundantShard = {
             ...shard,
-            agent: FALLBACK_AGENTS[shard.agent] || shard.agent,
+            agent: redundantAgent,
           };
           await launchShard(redundantShard, true);
         }

--- a/packages/remote/hub/team/swarm-planner.mjs
+++ b/packages/remote/hub/team/swarm-planner.mjs
@@ -11,6 +11,7 @@
 //   - mcp: server1, server2
 //   - depends: shard-name-1, shard-name-2
 //   - critical: true|false
+//   - redundancy: false|fallback|true|same-cli
 //   - prompt: |
 //       multi-line prompt text
 
@@ -24,6 +25,7 @@ const SHARD_DEFAULTS = Object.freeze({
   mcp: [],
   depends: [],
   critical: false,
+  redundancy: false,
   prompt: "",
   host: "",
 });
@@ -118,6 +120,15 @@ export function parseShards(content) {
         break;
       case "critical":
         current.critical = /^(true|yes|1)$/i.test(value);
+        break;
+      case "redundancy":
+        if (/^(true|yes|1|fallback)$/i.test(value)) {
+          current.redundancy = "fallback";
+        } else if (/^(same-cli|same_cli|same|primary)$/i.test(value)) {
+          current.redundancy = "same-cli";
+        } else {
+          current.redundancy = false;
+        }
         break;
       case "host":
         current.host = value;

--- a/packages/remote/scripts/lib/cli-agy.mjs
+++ b/packages/remote/scripts/lib/cli-agy.mjs
@@ -10,6 +10,8 @@ export const id = "agy";
 export const cliType = "antigravity";
 export const command = "agy";
 
+// #310: agent-map.json normalizes upstream callers to antigravity,
+// but this adapter also accepts the direct `agy` route for compatibility.
 const AGENT_PROFILES = {
   antigravity: {
     profile: "agy_v1",

--- a/packages/remote/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/remote/scripts/lib/mcp-guard-engine.mjs
@@ -182,6 +182,15 @@ function isAntigravityConfig(filePath) {
   return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
+function isMigratedAntigravityConfig(filePath, raw = null) {
+  if (!isAntigravityConfig(filePath)) return false;
+  const resolvedPath = resolveFilePath(filePath);
+  const markerPath = join(dirname(resolvedPath), ".migrated");
+  if (!existsSync(markerPath)) return false;
+  const contents = raw === null ? readFileSync(resolvedPath, "utf8") : raw;
+  return String(contents || "").trim() === "";
+}
+
 function plaintextSecretHeaderClient(filePath) {
   const client = detectClient(filePath);
   return client === "gemini" || client === "antigravity" ? client : null;
@@ -970,7 +979,23 @@ function scanJsonConfig(filePath) {
   }
 
   try {
-    const parsed = readJsonFile(filePath);
+    const raw = readFileSync(filePath, "utf8");
+    if (isMigratedAntigravityConfig(filePath, raw)) {
+      return {
+        filePath,
+        client: detectClient(filePath),
+        label: detectLabel(filePath),
+        exists: true,
+        parseError: null,
+        servers: [],
+        stdioServers: [],
+        migrated: true,
+        message:
+          "Antigravity migrated MCP config; deprecated mcp_config.json left empty",
+      };
+    }
+
+    const parsed = JSON.parse(raw);
     const mcpServers = parsed?.mcpServers;
     const servers =
       !mcpServers || typeof mcpServers !== "object"
@@ -1705,6 +1730,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "missing-file";
       } else if (config.parseError) {
         status = "invalid-config";
+      } else if (config.migrated) {
+        status = "skipped";
       } else if (!actual) {
         status = "missing";
       } else if (expectedCommand) {
@@ -1733,6 +1760,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         actualUrl: actual?.url || "",
         actualCommand: actual?.command || "",
         status,
+        migrated: Boolean(config.migrated),
+        message: config.message || "",
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
         actualHeaderNames: headerNames(actualHeaders),
@@ -2058,10 +2087,24 @@ export function syncRegistryTargets(options = {}) {
   );
   const actions = [];
   const invalidConfigs = new Set();
+  const skippedConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      skippedConfigs.add(normalizeForMatch(target.filePath));
+      actions.push({
+        type: "sync",
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
@@ -2097,6 +2140,10 @@ export function syncRegistryTargets(options = {}) {
   for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.migrated || skippedConfigs.has(targetKey)) {
+      continue;
+    }
+
     if (snapshot.parseError) {
       if (!invalidConfigs.has(targetKey)) {
         actions.push({

--- a/packages/remote/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/remote/scripts/lib/mcp-guard-engine.mjs
@@ -2044,6 +2044,19 @@ export function removeServerFromTargets(name, options = {}) {
     if (targetsFilter && !targetsFilter.has(target.client)) continue;
 
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      actions.push({
+        type: "remove",
+        name: trimmedName,
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       actions.push({
         type: "remove",

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -1113,7 +1113,20 @@ async function hasTmuxSession(adapter, opts) {
 
 function daemonProbeUnavailableReason(probe, targetAttachable) {
   if (targetAttachable) return null;
-  if (!probe?.ok) return probe?.reason ?? "probe-failed";
+  if (!probe?.ok) {
+    const candidateCodes = Array.isArray(probe?.raw?.candidateResults)
+      ? probe.raw.candidateResults
+          .map((entry) => entry?.errorCode)
+          .filter(Boolean)
+      : [];
+    if (candidateCodes.includes("stale-control-socket")) {
+      return "stale-control-socket";
+    }
+    if (candidateCodes.includes("daemon-dir-missing")) {
+      return "daemon-dir-missing";
+    }
+    return probe?.reason ?? "probe-failed";
+  }
   return "target-not-found";
 }
 

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -2708,6 +2708,7 @@ function statusBadge(status) {
     case "missing":
     case "missing-file":
     case "warning":
+    case "skipped":
       return `${YELLOW}${status}${RESET}`;
     case "mismatch":
     case "invalid":
@@ -2730,6 +2731,7 @@ function buildMcpStatusRows(statusInfo) {
       else if (row.status === "mismatch")
         detail = `expected ${row.expectedUrl || row.expectedCommand}`;
       else if (row.status === "invalid-config") detail = "parse error";
+      else if (row.status === "skipped") detail = row.message || "skipped";
       else if (row.status === "stdio") detail = "configured as stdio";
       return [
         row.name,

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -31,6 +31,8 @@ function toIsoTime(value) {
   return null;
 }
 
+// Non-cryptographic djb2-style hash used only to produce stable redacted
+// labels for local paths. Do not use this as a trust boundary or secret token.
 function shortHash(value) {
   const str = String(value ?? "");
   let h = 5381;

--- a/packages/triflux/hub/routing/q-learning.mjs
+++ b/packages/triflux/hub/routing/q-learning.mjs
@@ -164,6 +164,7 @@ export class QLearningRouter {
    * @param {number} [opts.epsilonMin=0.05] — 최소 엡실론
    * @param {number} [opts.minConfidence=0.6] — 최소 신뢰도 (이하면 폴백)
    * @param {string} [opts.modelPath] — Q-table 영속화 경로
+   * @param {() => number} [opts.random=Math.random] — 테스트/재현용 RNG seam
    */
   constructor(opts = {}) {
     this._lr = opts.learningRate ?? 0.1;
@@ -176,6 +177,8 @@ export class QLearningRouter {
     this._minConfidence = opts.minConfidence ?? 0.6;
     this._modelPath =
       opts.modelPath ?? join(homedir(), ".omc", "routing-model.json");
+    this._random =
+      typeof opts.random === "function" ? opts.random : Math.random;
 
     /** @type {Map<string, Map<string, number>>} state -> (action -> Q-value) */
     this._qTable = new Map();
@@ -223,12 +226,12 @@ export class QLearningRouter {
     const visits = this._visitCounts.get(state) || 0;
 
     // 엡실론-그리디: 탐색 vs 활용
-    const isExploration = Math.random() < this._epsilon;
+    const isExploration = this._random() < this._epsilon;
 
     let action;
     if (isExploration) {
       // 무작위 탐색
-      action = ACTIONS[Math.floor(Math.random() * ACTIONS.length)];
+      action = ACTIONS[Math.floor(this._random() * ACTIONS.length)];
     } else {
       // 최적 액션 선택 (최대 Q-value)
       let maxQ = -Infinity;

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -271,7 +271,9 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
-    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    const errorCodes = results
+      .map((result) => result.errorCode)
+      .filter(Boolean);
     if (errorCodes.includes("stale-control-socket")) {
       reason = "stale-control-socket";
     } else if (errorCodes.includes("daemon-dir-missing")) {

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -243,6 +243,7 @@ function candidateResultSummary(result) {
     ...summary,
     ok: result.ok === true,
     error: result.error ?? null,
+    errorCode: result.errorCode ?? null,
     sessionCount: Array.isArray(result.sessions) ? result.sessions.length : 0,
   };
 }
@@ -270,6 +271,12 @@ function buildProbeResponse({
     reason = "target-not-found";
     error = "Claude daemon target not found in reachable candidates";
   } else if (results.length > 0) {
+    const errorCodes = results.map((result) => result.errorCode).filter(Boolean);
+    if (errorCodes.includes("stale-control-socket")) {
+      reason = "stale-control-socket";
+    } else if (errorCodes.includes("daemon-dir-missing")) {
+      reason = "daemon-dir-missing";
+    }
     error =
       results
         .map((result) => result.error)
@@ -341,6 +348,18 @@ export async function probeClaudeDaemonCandidates({
         error: ok ? null : list?.error || "Claude daemon list failed",
       });
     } catch (error) {
+      let errorCode = null;
+      if (error?.code === "ENOENT") {
+        try {
+          await fs.stat(candidate.daemonDir);
+          errorCode = "stale-control-socket";
+        } catch (statError) {
+          errorCode =
+            statError?.code === "ENOENT"
+              ? "daemon-dir-missing"
+              : "stale-control-socket";
+        }
+      }
       results.push({
         ok: false,
         candidate,
@@ -348,6 +367,7 @@ export async function probeClaudeDaemonCandidates({
         sessions: [],
         target: null,
         error: errorMessage(error),
+        errorCode,
       });
     }
   }
@@ -459,6 +479,7 @@ export async function readDaemonControlKey(
 }
 
 export async function buildDaemonControlAuth(configDir) {
+  if (!configDir) return {};
   const auth = await readDaemonControlKey(configDir);
   return auth ? { auth } : {};
 }

--- a/packages/triflux/hub/team/conductor.mjs
+++ b/packages/triflux/hub/team/conductor.mjs
@@ -20,6 +20,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRegistry } from "../../mesh/mesh-registry.mjs";
 import { broker } from "../account-broker.mjs";
+import { runPreflight as runCodexPreflight } from "../codex-preflight.mjs";
 import {
   __internal__ as dynamicRoutingInternal,
   evaluateDynamicRoute,
@@ -564,13 +565,66 @@ export function createConductor(opts = {}) {
     const sentinelCapture = createSentinelCapture();
 
     const spawnCwd = session.config.workdir || launcher.cwd || undefined;
+    let excludeMcpServers = [];
+    const requestedMcpServers = Array.isArray(session.config.mcpServers)
+      ? session.config.mcpServers
+      : [];
+    if (session.config.agent === "codex" && requestedMcpServers.length > 0) {
+      const preflightFn = opts.deps?.codexPreflight || runCodexPreflight;
+      try {
+        const preflight = await preflightFn({
+          mcpServers: requestedMcpServers,
+          subcommand: "exec",
+          workdir: spawnCwd,
+        });
+        excludeMcpServers = Array.isArray(preflight?.excludeMcpServers)
+          ? preflight.excludeMcpServers
+          : [];
+        for (const warning of preflight?.warnings || []) {
+          eventLog.append("codex_preflight_warning", {
+            session: session.id,
+            warning,
+          });
+          emitter.emit("warning", {
+            type: "codex_preflight_warning",
+            session: session.id,
+            warning,
+          });
+        }
+      } catch (err) {
+        eventLog.append("codex_preflight_failed", {
+          session: session.id,
+          error: err.message,
+        });
+        emitter.emit("warning", {
+          type: "codex_preflight_failed",
+          session: session.id,
+          error: err.message,
+        });
+      }
+    }
+
     const spawnSpec = buildSpawnSpecForMode(MODES.HEADLESS, {
       cli: session.config.agent,
       prompt: session.config.prompt,
       profile: session.config.profile,
       model: session.config.model,
       mcpServers: session.config.mcpServers,
+      excludeMcpServers,
       resolveCommand: opts.deps?.resolveCliExecutable,
+      onWarning: (message, details = {}) => {
+        eventLog.append("mcp_server_skipped", {
+          session: session.id,
+          message,
+          ...details,
+        });
+        emitter.emit("warning", {
+          type: "mcp_server_skipped",
+          session: session.id,
+          message,
+          ...details,
+        });
+      },
     });
 
     // #90 branch guard: shard spawn cwd가 main 브랜치면 즉시 abort.

--- a/packages/triflux/hub/team/execution-mode.mjs
+++ b/packages/triflux/hub/team/execution-mode.mjs
@@ -156,7 +156,21 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "never",
   );
   if (Array.isArray(opts.mcpServers)) {
-    for (const server of opts.mcpServers) {
+    const excludedMcpServers = new Set(
+      (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])
+        .map((server) => String(server ?? "").trim())
+        .filter(Boolean),
+    );
+    for (const rawServer of opts.mcpServers) {
+      const server = String(rawServer ?? "").trim();
+      if (!server) continue;
+      if (excludedMcpServers.has(server)) {
+        const message = `Skipping MCP server '${server}' because Codex preflight did not find an enabled config entry.`;
+        if (typeof opts.onWarning === "function") {
+          opts.onWarning(message, { type: "mcp_server_skipped", server });
+        }
+        continue;
+      }
       args.push("-c", `mcp_servers.${server}.enabled=true`);
     }
   }

--- a/packages/triflux/hub/team/swarm-hypervisor.mjs
+++ b/packages/triflux/hub/team/swarm-hypervisor.mjs
@@ -90,6 +90,16 @@ const FALLBACK_AGENTS = Object.freeze({
   claude: "codex",
 });
 
+function resolveRedundantAgent(shard) {
+  const mode = shard?.redundancy;
+  if (!mode) return null;
+  if (mode === "same-cli") return shard.agent;
+  if (mode === true || mode === "fallback") {
+    return FALLBACK_AGENTS[shard.agent] || shard.agent;
+  }
+  return null;
+}
+
 function createNoopRegistry() {
   return Object.freeze({
     register() {},
@@ -2065,11 +2075,12 @@ export function createSwarmHypervisor(opts) {
         launched.add(name);
         await launchShard(shard);
 
-        // Launch redundant worker for critical shards
-        if (shard.critical) {
+        // Launch redundant worker only when explicitly requested.
+        const redundantAgent = resolveRedundantAgent(shard);
+        if (redundantAgent) {
           const redundantShard = {
             ...shard,
-            agent: FALLBACK_AGENTS[shard.agent] || shard.agent,
+            agent: redundantAgent,
           };
           await launchShard(redundantShard, true);
         }

--- a/packages/triflux/hub/team/swarm-planner.mjs
+++ b/packages/triflux/hub/team/swarm-planner.mjs
@@ -11,6 +11,7 @@
 //   - mcp: server1, server2
 //   - depends: shard-name-1, shard-name-2
 //   - critical: true|false
+//   - redundancy: false|fallback|true|same-cli
 //   - prompt: |
 //       multi-line prompt text
 
@@ -24,6 +25,7 @@ const SHARD_DEFAULTS = Object.freeze({
   mcp: [],
   depends: [],
   critical: false,
+  redundancy: false,
   prompt: "",
   host: "",
 });
@@ -118,6 +120,15 @@ export function parseShards(content) {
         break;
       case "critical":
         current.critical = /^(true|yes|1)$/i.test(value);
+        break;
+      case "redundancy":
+        if (/^(true|yes|1|fallback)$/i.test(value)) {
+          current.redundancy = "fallback";
+        } else if (/^(same-cli|same_cli|same|primary)$/i.test(value)) {
+          current.redundancy = "same-cli";
+        } else {
+          current.redundancy = false;
+        }
         break;
       case "host":
         current.host = value;

--- a/packages/triflux/hud/hud-qos-status.mjs
+++ b/packages/triflux/hud/hud-qos-status.mjs
@@ -177,8 +177,10 @@ async function main() {
   // 세션/누적 토큰 → context 대비 절약 배수 (개별 provider sv%)
   const ctxCapacity = deriveContextLimit(stdin);
   let codexSv = null;
+  let codexAccumulatorSv = null;
   if (svAccumulator?.codex?.tokens > 0) {
-    codexSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexAccumulatorSv = svAccumulator.codex.tokens / ctxCapacity;
+    codexSv = codexAccumulatorSv;
   } else if (codexBuckets) {
     const main =
       codexBuckets.codex || codexBuckets[Object.keys(codexBuckets)[0]];
@@ -186,8 +188,10 @@ async function main() {
       codexSv = main.tokens.total_tokens / ctxCapacity;
   }
   let geminiSv = null;
+  let geminiAccumulatorSv = null;
   if (svAccumulator?.gemini?.tokens > 0) {
-    geminiSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiAccumulatorSv = svAccumulator.gemini.tokens / ctxCapacity;
+    geminiSv = geminiAccumulatorSv;
   } else {
     const geminiTokens = geminiSession?.total || null;
     geminiSv = geminiTokens ? geminiTokens / ctxCapacity : null;
@@ -216,8 +220,15 @@ async function main() {
   const antigravitySlot1Bucket =
     antigravityModelFamily === "gemini" ? antigravityFamilyBucket : null;
 
-  // 합산 절약: Codex+Gemini sv% 합산 (컨텍스트 대비 위임 토큰 비율)
-  const combinedSvPct = Math.round(((codexSv ?? 0) + (geminiSv ?? 0)) * 100);
+  // 합산 절약은 svAccumulator 기반일 때만 표시한다.
+  // Codex bucket fallback은 account-window 누적 토큰이고 Gemini fallback은 latest
+  // session 토큰이라 서로 의미가 달라 합산하면 misleading cross-provider total이 된다.
+  const hasComparableSvAccumulator = Boolean(
+    codexAccumulatorSv != null || geminiAccumulatorSv != null,
+  );
+  const combinedSvPct = hasComparableSvAccumulator
+    ? Math.round(((codexAccumulatorSv ?? 0) + (geminiAccumulatorSv ?? 0)) * 100)
+    : null;
 
   // 인디케이터 인식 tier 선택 (stdin + Claude 사용량 기반)
   const CURRENT_TIER = selectTier(stdin, claudeUsageSnapshot.data);
@@ -230,7 +241,7 @@ async function main() {
       codexBuckets,
       antigravityReady ? null : geminiSession,
       antigravityReady ? null : geminiBucket,
-      antigravityReady ? Math.round((codexSv ?? 0) * 100) : combinedSvPct,
+      combinedSvPct,
       antigravityReady ? "a" : "g",
     );
     process.stdout.write(`\x1b[0m${microLine}\n`);

--- a/packages/triflux/hud/renderers.mjs
+++ b/packages/triflux/hud/renderers.mjs
@@ -326,7 +326,7 @@ export function getMicroLine(
   }
 
   // sv
-  const sv = formatSvPct(combinedSvPct || 0).trim();
+  const sv = formatSvPct(combinedSvPct).trim();
 
   const cols = getTerminalColumns() || 120;
   const line =
@@ -350,7 +350,7 @@ export function getClaudeRows(
   const ctxView = contextView || buildContextUsageView({}, null);
   const prefix = `${bold(claudeOrange("c"))}:`;
   // 절약 퍼센트
-  const svStr = formatSvPct(combinedSvPct || 0);
+  const svStr = formatSvPct(combinedSvPct);
   const svSuffix = `${dim("sv:")}${svStr}`;
 
   // API 실측 데이터

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  inspectRegistryStatus,
   isWatchedPath,
   loadRegistry,
   remediate,
@@ -214,6 +215,98 @@ describe("mcp guard engine", () => {
     // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
     // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
     assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
+  });
+
+  it("treats migrated empty Antigravity mcp_config.json as skipped instead of invalid", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const status = inspectRegistryStatus(registry);
+    assert.equal(status.configs[0].parseError, null);
+    assert.equal(status.configs[0].migrated, true);
+    assert.equal(status.rows[0].status, "skipped");
+    assert.match(status.rows[0].message, /migrated/i);
+  });
+
+  it("preserves migrated empty Antigravity mcp_config.json during registry sync", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = syncRegistryTargets({ registry });
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        migrated: action.migrated,
+      })),
+      [{ label: "Antigravity", status: "skipped", migrated: true }],
+    );
+    assert.equal(readFileSync(antigravityPath, "utf8"), "");
   });
 
   it("syncs antigravity MCP config with Gemini-style JSON and http type", () => {

--- a/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/packages/triflux/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -10,6 +10,7 @@ import {
   isWatchedPath,
   loadRegistry,
   remediate,
+  removeServerFromTargets,
   resolveHubUrl,
   scanForStdioServers,
   syncRegistryTargets,
@@ -297,6 +298,58 @@ describe("mcp guard engine", () => {
     };
 
     const result = syncRegistryTargets({ registry });
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        migrated: action.migrated,
+      })),
+      [{ label: "Antigravity", status: "skipped", migrated: true }],
+    );
+    assert.equal(readFileSync(antigravityPath, "utf8"), "");
+  });
+
+  it("skips migrated empty Antigravity mcp_config.json during registry remove", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = removeServerFromTargets("tfx-hub", {
+      registry,
+      targets: ["antigravity"],
+    });
 
     assert.deepEqual(
       result.actions.map((action) => ({

--- a/packages/triflux/scripts/ensure-agy-hooks.mjs
+++ b/packages/triflux/scripts/ensure-agy-hooks.mjs
@@ -31,13 +31,9 @@ function quoteCommandPath(value) {
 function buildCommand(nodeBin, hookScriptPath) {
   // No mode argument: the agy hook derives register vs heartbeat from the
   // payload's invocationNum (first invocation registers, later ones heartbeat).
-  // Format mirrors codex-session-hook's proven hook command (bare node bin +
-  // quoted script path). agy's hook executor is the same jetski family; quoting
-  // the node bin too is unverified against agy's exec model, so we keep the
-  // known-working shape rather than risk breaking hook execution. Install paths
-  // are controlled (node bin + npm package dir), so the residual $()-in-path
-  // expansion risk is not a realistic threat.
-  return `${nodeBin} ${quoteCommandPath(hookScriptPath)}`;
+  // Quote both executable and script path so installs under paths with spaces
+  // round-trip through agy's command executor without shell word-splitting.
+  return `${quoteCommandPath(nodeBin)} ${quoteCommandPath(hookScriptPath)}`;
 }
 
 function normalizeHooksJson(raw) {
@@ -110,7 +106,10 @@ export function ensureAgyHooks(opts = {}) {
   const original = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : "";
   const hooksJson = normalizeHooksJson(original);
   // Upsert only our named group; every other user-authored group is preserved.
-  hooksJson[HOOK_GROUP_NAME] = desired;
+  // If the user explicitly disabled our group, keep that opt-out intact.
+  if (hooksJson[HOOK_GROUP_NAME]?.enabled !== false) {
+    hooksJson[HOOK_GROUP_NAME] = desired;
+  }
   const next = formatHooksJson(hooksJson);
 
   const changed = original !== next;

--- a/packages/triflux/scripts/lib/cli-agy.mjs
+++ b/packages/triflux/scripts/lib/cli-agy.mjs
@@ -10,6 +10,8 @@ export const id = "agy";
 export const cliType = "antigravity";
 export const command = "agy";
 
+// #310: agent-map.json normalizes upstream callers to antigravity,
+// but this adapter also accepts the direct `agy` route for compatibility.
 const AGENT_PROFILES = {
   antigravity: {
     profile: "agy_v1",

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -182,6 +182,15 @@ function isAntigravityConfig(filePath) {
   return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
+function isMigratedAntigravityConfig(filePath, raw = null) {
+  if (!isAntigravityConfig(filePath)) return false;
+  const resolvedPath = resolveFilePath(filePath);
+  const markerPath = join(dirname(resolvedPath), ".migrated");
+  if (!existsSync(markerPath)) return false;
+  const contents = raw === null ? readFileSync(resolvedPath, "utf8") : raw;
+  return String(contents || "").trim() === "";
+}
+
 function plaintextSecretHeaderClient(filePath) {
   const client = detectClient(filePath);
   return client === "gemini" || client === "antigravity" ? client : null;
@@ -970,7 +979,23 @@ function scanJsonConfig(filePath) {
   }
 
   try {
-    const parsed = readJsonFile(filePath);
+    const raw = readFileSync(filePath, "utf8");
+    if (isMigratedAntigravityConfig(filePath, raw)) {
+      return {
+        filePath,
+        client: detectClient(filePath),
+        label: detectLabel(filePath),
+        exists: true,
+        parseError: null,
+        servers: [],
+        stdioServers: [],
+        migrated: true,
+        message:
+          "Antigravity migrated MCP config; deprecated mcp_config.json left empty",
+      };
+    }
+
+    const parsed = JSON.parse(raw);
     const mcpServers = parsed?.mcpServers;
     const servers =
       !mcpServers || typeof mcpServers !== "object"
@@ -1705,6 +1730,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "missing-file";
       } else if (config.parseError) {
         status = "invalid-config";
+      } else if (config.migrated) {
+        status = "skipped";
       } else if (!actual) {
         status = "missing";
       } else if (expectedCommand) {
@@ -1733,6 +1760,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         actualUrl: actual?.url || "",
         actualCommand: actual?.command || "",
         status,
+        migrated: Boolean(config.migrated),
+        message: config.message || "",
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
         actualHeaderNames: headerNames(actualHeaders),
@@ -2058,10 +2087,24 @@ export function syncRegistryTargets(options = {}) {
   );
   const actions = [];
   const invalidConfigs = new Set();
+  const skippedConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      skippedConfigs.add(normalizeForMatch(target.filePath));
+      actions.push({
+        type: "sync",
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
@@ -2097,6 +2140,10 @@ export function syncRegistryTargets(options = {}) {
   for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.migrated || skippedConfigs.has(targetKey)) {
+      continue;
+    }
+
     if (snapshot.parseError) {
       if (!invalidConfigs.has(targetKey)) {
         actions.push({

--- a/packages/triflux/scripts/lib/mcp-guard-engine.mjs
+++ b/packages/triflux/scripts/lib/mcp-guard-engine.mjs
@@ -2044,6 +2044,19 @@ export function removeServerFromTargets(name, options = {}) {
     if (targetsFilter && !targetsFilter.has(target.client)) continue;
 
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      actions.push({
+        type: "remove",
+        name: trimmedName,
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       actions.push({
         type: "remove",

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1265,7 +1265,9 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic
+    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic.
+    # #310: upstream callers are normalized through agent-map.json, but this
+    # direct route entrypoint intentionally keeps agy as a compatibility alias.
     designer|writer|gemini|antigravity|agy)
       # agy --print + --dangerously-skip-permissions 조합은 positional prompt에서
       # timeout이 재현되므로 wrapper 호출은 stdin pipe로 고정한다.

--- a/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  inspectRegistryStatus,
   isWatchedPath,
   loadRegistry,
   remediate,
@@ -214,6 +215,98 @@ describe("mcp guard engine", () => {
     // env 없음 + hub.pid port 존재 → registry/default 27888 fallback.
     // pid port cascade 가 제거되어 29991 이 쓰이면 안 됨.
     assert.equal(resolveHubUrl(), "http://127.0.0.1:27888/mcp");
+  });
+
+  it("treats migrated empty Antigravity mcp_config.json as skipped instead of invalid", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const status = inspectRegistryStatus(registry);
+    assert.equal(status.configs[0].parseError, null);
+    assert.equal(status.configs[0].migrated, true);
+    assert.equal(status.rows[0].status, "skipped");
+    assert.match(status.rows[0].message, /migrated/i);
+  });
+
+  it("preserves migrated empty Antigravity mcp_config.json during registry sync", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = syncRegistryTargets({ registry });
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        migrated: action.migrated,
+      })),
+      [{ label: "Antigravity", status: "skipped", migrated: true }],
+    );
+    assert.equal(readFileSync(antigravityPath, "utf8"), "");
   });
 
   it("syncs antigravity MCP config with Gemini-style JSON and http type", () => {

--- a/scripts/__tests__/mcp-guard-engine.test.mjs
+++ b/scripts/__tests__/mcp-guard-engine.test.mjs
@@ -10,6 +10,7 @@ import {
   isWatchedPath,
   loadRegistry,
   remediate,
+  removeServerFromTargets,
   resolveHubUrl,
   scanForStdioServers,
   syncRegistryTargets,
@@ -297,6 +298,58 @@ describe("mcp guard engine", () => {
     };
 
     const result = syncRegistryTargets({ registry });
+
+    assert.deepEqual(
+      result.actions.map((action) => ({
+        label: action.label,
+        status: action.status,
+        migrated: action.migrated,
+      })),
+      [{ label: "Antigravity", status: "skipped", migrated: true }],
+    );
+    assert.equal(readFileSync(antigravityPath, "utf8"), "");
+  });
+
+  it("skips migrated empty Antigravity mcp_config.json during registry remove", () => {
+    const homeDir = createHomeDir();
+    withHome(homeDir);
+
+    const antigravityPath = join(
+      homeDir,
+      ".gemini",
+      "config",
+      "mcp_config.json",
+    );
+    mkdirSync(dirname(antigravityPath), { recursive: true });
+    writeFileSync(join(homeDir, ".gemini", "config", ".migrated"), "", "utf8");
+    writeFileSync(antigravityPath, "", "utf8");
+
+    const registry = {
+      version: 1,
+      defaults: {
+        transport: "hub-url",
+        hub_base: "http://127.0.0.1:27888",
+      },
+      servers: {
+        "tfx-hub": {
+          transport: "hub-url",
+          url: "http://127.0.0.1:27888/mcp",
+          safe: true,
+          targets: ["antigravity"],
+        },
+      },
+      policies: {
+        stdio_action: "replace-with-hub",
+        unknown_server_action: "warn",
+        sync_denylist: [],
+        watched_paths: ["~/.gemini/config/mcp_config.json"],
+      },
+    };
+
+    const result = removeServerFromTargets("tfx-hub", {
+      registry,
+      targets: ["antigravity"],
+    });
 
     assert.deepEqual(
       result.actions.map((action) => ({

--- a/scripts/ensure-agy-hooks.mjs
+++ b/scripts/ensure-agy-hooks.mjs
@@ -31,13 +31,9 @@ function quoteCommandPath(value) {
 function buildCommand(nodeBin, hookScriptPath) {
   // No mode argument: the agy hook derives register vs heartbeat from the
   // payload's invocationNum (first invocation registers, later ones heartbeat).
-  // Format mirrors codex-session-hook's proven hook command (bare node bin +
-  // quoted script path). agy's hook executor is the same jetski family; quoting
-  // the node bin too is unverified against agy's exec model, so we keep the
-  // known-working shape rather than risk breaking hook execution. Install paths
-  // are controlled (node bin + npm package dir), so the residual $()-in-path
-  // expansion risk is not a realistic threat.
-  return `${nodeBin} ${quoteCommandPath(hookScriptPath)}`;
+  // Quote both executable and script path so installs under paths with spaces
+  // round-trip through agy's command executor without shell word-splitting.
+  return `${quoteCommandPath(nodeBin)} ${quoteCommandPath(hookScriptPath)}`;
 }
 
 function normalizeHooksJson(raw) {
@@ -110,7 +106,10 @@ export function ensureAgyHooks(opts = {}) {
   const original = existsSync(hooksPath) ? readFileSync(hooksPath, "utf8") : "";
   const hooksJson = normalizeHooksJson(original);
   // Upsert only our named group; every other user-authored group is preserved.
-  hooksJson[HOOK_GROUP_NAME] = desired;
+  // If the user explicitly disabled our group, keep that opt-out intact.
+  if (hooksJson[HOOK_GROUP_NAME]?.enabled !== false) {
+    hooksJson[HOOK_GROUP_NAME] = desired;
+  }
   const next = formatHooksJson(hooksJson);
 
   const changed = original !== next;

--- a/scripts/lib/cli-agy.mjs
+++ b/scripts/lib/cli-agy.mjs
@@ -10,6 +10,8 @@ export const id = "agy";
 export const cliType = "antigravity";
 export const command = "agy";
 
+// #310: agent-map.json normalizes upstream callers to antigravity,
+// but this adapter also accepts the direct `agy` route for compatibility.
 const AGENT_PROFILES = {
   antigravity: {
     profile: "agy_v1",

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -182,6 +182,15 @@ function isAntigravityConfig(filePath) {
   return normalized.endsWith("/.gemini/config/mcp_config.json");
 }
 
+function isMigratedAntigravityConfig(filePath, raw = null) {
+  if (!isAntigravityConfig(filePath)) return false;
+  const resolvedPath = resolveFilePath(filePath);
+  const markerPath = join(dirname(resolvedPath), ".migrated");
+  if (!existsSync(markerPath)) return false;
+  const contents = raw === null ? readFileSync(resolvedPath, "utf8") : raw;
+  return String(contents || "").trim() === "";
+}
+
 function plaintextSecretHeaderClient(filePath) {
   const client = detectClient(filePath);
   return client === "gemini" || client === "antigravity" ? client : null;
@@ -970,7 +979,23 @@ function scanJsonConfig(filePath) {
   }
 
   try {
-    const parsed = readJsonFile(filePath);
+    const raw = readFileSync(filePath, "utf8");
+    if (isMigratedAntigravityConfig(filePath, raw)) {
+      return {
+        filePath,
+        client: detectClient(filePath),
+        label: detectLabel(filePath),
+        exists: true,
+        parseError: null,
+        servers: [],
+        stdioServers: [],
+        migrated: true,
+        message:
+          "Antigravity migrated MCP config; deprecated mcp_config.json left empty",
+      };
+    }
+
+    const parsed = JSON.parse(raw);
     const mcpServers = parsed?.mcpServers;
     const servers =
       !mcpServers || typeof mcpServers !== "object"
@@ -1705,6 +1730,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         status = "missing-file";
       } else if (config.parseError) {
         status = "invalid-config";
+      } else if (config.migrated) {
+        status = "skipped";
       } else if (!actual) {
         status = "missing";
       } else if (expectedCommand) {
@@ -1733,6 +1760,8 @@ export function inspectRegistryStatus(registry = loadRegistryOrDefault()) {
         actualUrl: actual?.url || "",
         actualCommand: actual?.command || "",
         status,
+        migrated: Boolean(config.migrated),
+        message: config.message || "",
         headerStatus: currentHeaderStatus,
         expectedHeaderNames: headerNames(expectedHeaders),
         actualHeaderNames: headerNames(actualHeaders),
@@ -2058,10 +2087,24 @@ export function syncRegistryTargets(options = {}) {
   );
   const actions = [];
   const invalidConfigs = new Set();
+  const skippedConfigs = new Set();
   const denylist = syncDenylistEntries(registry.policies);
 
   for (const target of syncTargets) {
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      skippedConfigs.add(normalizeForMatch(target.filePath));
+      actions.push({
+        type: "sync",
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       invalidConfigs.add(normalizeForMatch(target.filePath));
       actions.push({
@@ -2097,6 +2140,10 @@ export function syncRegistryTargets(options = {}) {
   for (const target of primaryTargets) {
     const snapshot = scanConfig(target.filePath);
     const targetKey = normalizeForMatch(target.filePath);
+    if (snapshot.migrated || skippedConfigs.has(targetKey)) {
+      continue;
+    }
+
     if (snapshot.parseError) {
       if (!invalidConfigs.has(targetKey)) {
         actions.push({

--- a/scripts/lib/mcp-guard-engine.mjs
+++ b/scripts/lib/mcp-guard-engine.mjs
@@ -2044,6 +2044,19 @@ export function removeServerFromTargets(name, options = {}) {
     if (targetsFilter && !targetsFilter.has(target.client)) continue;
 
     const snapshot = scanConfig(target.filePath);
+    if (snapshot.migrated) {
+      actions.push({
+        type: "remove",
+        name: trimmedName,
+        filePath: target.filePath,
+        label: target.label,
+        status: "skipped",
+        migrated: true,
+        message: snapshot.message,
+      });
+      continue;
+    }
+
     if (snapshot.parseError) {
       actions.push({
         type: "remove",

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1265,7 +1265,9 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic
+    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic.
+    # #310: upstream callers are normalized through agent-map.json, but this
+    # direct route entrypoint intentionally keeps agy as a compatibility alias.
     designer|writer|gemini|antigravity|agy)
       # agy --print + --dangerously-skip-permissions 조합은 positional prompt에서
       # timeout이 재현되므로 wrapper 호출은 stdin pipe로 고정한다.

--- a/tests/hud/hud-qos-status.test.mjs
+++ b/tests/hud/hud-qos-status.test.mjs
@@ -216,6 +216,33 @@ describe("HUD Breakpoints", () => {
     rmSync(join(mockOmcConfigDir, "hud.json"));
   });
 
+  it("does not combine sv from Codex bucket and Gemini session fallbacks when accumulator is missing", () => {
+    const accumulatorPaths = [
+      join(mockClaudeCacheDir, "sv-accumulator.json"),
+      join(mockOmcStateDir, "sv-accumulator.json"),
+    ];
+    const originals = accumulatorPaths.map((path) => ({
+      path,
+      content: existsSync(path) ? readFileSync(path, "utf8") : null,
+    }));
+    for (const path of accumulatorPaths) rmSync(path, { force: true });
+    try {
+      const output = stripAnsiText(runHudWithDimensions(120, 40));
+      assert.match(output, /^c: .*sv:\s*--%/m);
+      assert.doesNotMatch(output, /^c: .*sv:\s*150%/m);
+      assert.match(output, /^x: .*sv:\s*25%/m);
+      assert.match(output, /^g: .*sv:\s*60%/m);
+    } finally {
+      for (const original of originals) {
+        if (original.content == null) {
+          rmSync(original.path, { force: true });
+        } else {
+          writeFileSync(original.path, original.content);
+        }
+      }
+    }
+  });
+
   it("renders Antigravity as a and hides the Gemini g marker when ready", () => {
     const preflightPath = join(mockClaudeCacheDir, "tfx-preflight.json");
     const oauthPath = join(mockAntigravityCliDir, "oauth_creds.json");

--- a/tests/unit/bridge-daemon-verbs.test.mjs
+++ b/tests/unit/bridge-daemon-verbs.test.mjs
@@ -689,7 +689,7 @@ test("explicit configDir is exact-only and never falls back to ambient OMC", asy
       );
 
       assert.equal(out.ok, false);
-      assert.equal(out.reason, "daemon-unavailable");
+      assert.equal(out.reason, "daemon-dir-missing");
       assert.equal(out.daemon, null);
       assert.deepEqual(
         out.candidateResults.map((candidate) => candidate.configDirSource),
@@ -731,7 +731,7 @@ test("CLAUDE_CONFIG_DIR env mode is strict and never falls back to ambient OMC",
       );
 
       assert.equal(out.ok, false);
-      assert.equal(out.reason, "daemon-unavailable");
+      assert.equal(out.reason, "daemon-dir-missing");
       assert.equal(out.inputSent, false);
       assert.deepEqual(
         out.candidateResults.map((candidate) => candidate.configDirSource),

--- a/tests/unit/claude-daemon-control.test.mjs
+++ b/tests/unit/claude-daemon-control.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 import {
   attachClaudeDaemonSession,
   buildDaemonAttachRequest,
+  buildDaemonControlAuth,
   buildDaemonExecDispatchPayload,
   deriveClaudeDaemonPaths,
   extractClaudeDaemonAttachText,
@@ -953,6 +954,32 @@ test("resolveDaemonBridgeSessionId reads Claude job state bridge id", async () =
 
     assert.equal(bridgeSessionId, "cse_01NativeBridge");
   } finally {
+    await fs.rm(configDir, { recursive: true, force: true });
+  }
+});
+
+test("buildDaemonControlAuth omits auth for explicit undefined configDir", async () => {
+  const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const configDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "tfx-daemon-auth-default-"),
+  );
+  await fs.mkdir(path.join(configDir, "daemon"), { recursive: true });
+  await fs.writeFile(
+    path.join(configDir, "daemon", "control.key"),
+    "default-secret\n",
+    "utf8",
+  );
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    assert.deepEqual(await buildDaemonControlAuth(undefined), {});
+    assert.deepEqual(await buildDaemonControlAuth(configDir), {
+      auth: "default-secret",
+    });
+  } finally {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
+    else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
     await fs.rm(configDir, { recursive: true, force: true });
   }
 });

--- a/tests/unit/claude-daemon-control.test.mjs
+++ b/tests/unit/claude-daemon-control.test.mjs
@@ -978,8 +978,7 @@ test("buildDaemonControlAuth omits auth for explicit undefined configDir", async
   } finally {
     if (originalClaudeConfigDir === undefined) {
       delete process.env.CLAUDE_CONFIG_DIR;
-    }
-    else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    } else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
     await fs.rm(configDir, { recursive: true, force: true });
   }
 });

--- a/tests/unit/ensure-agy-hooks.test.mjs
+++ b/tests/unit/ensure-agy-hooks.test.mjs
@@ -150,7 +150,7 @@ describe("ensureAgyHooks", () => {
       PreInvocation: [
         {
           type: "command",
-          command: '/opt/node "/repo/hooks/agy-session-hook.mjs"',
+          command: '"/opt/node" "/repo/hooks/agy-session-hook.mjs"',
           timeout: 15,
         },
       ],
@@ -198,6 +198,45 @@ describe("ensureAgyHooks", () => {
     );
     const parsed = JSON.parse(readFileSync(hooksPath, "utf8"));
     assert.ok(parsed["triflux-session"].PreInvocation);
+  });
+
+  it("preserves a user-disabled triflux hook group", () => {
+    const geminiConfigHome = makeGeminiConfigHome();
+    const hooksPath = join(geminiConfigHome, "hooks.json");
+    writeFileSync(
+      hooksPath,
+      JSON.stringify({ "triflux-session": { enabled: false } }, null, 2) + "\n",
+      "utf8",
+    );
+
+    const result = ensureAgyHooks({
+      geminiConfigHome,
+      hookScriptPath: "/repo/hooks/agy-session-hook.mjs",
+      nodeBin: "/opt/node with spaces/node",
+      backupTimestamp: "20260608T010203",
+    });
+
+    assert.equal(result.changed, false);
+    assert.deepEqual(JSON.parse(readFileSync(hooksPath, "utf8")), {
+      "triflux-session": { enabled: false },
+    });
+  });
+
+  it("quotes the node binary path in the installed command", () => {
+    const geminiConfigHome = makeGeminiConfigHome();
+    const hooksPath = join(geminiConfigHome, "hooks.json");
+
+    ensureAgyHooks({
+      geminiConfigHome,
+      hookScriptPath: "/repo/hooks/agy-session-hook.mjs",
+      nodeBin: "/opt/node with spaces/node",
+    });
+
+    const parsed = JSON.parse(readFileSync(hooksPath, "utf8"));
+    assert.equal(
+      parsed["triflux-session"].PreInvocation[0].command,
+      '"/opt/node with spaces/node" "/repo/hooks/agy-session-hook.mjs"',
+    );
   });
 
   it("skips the real-HOME install while the test runner is active (TEST_LOCK_PID)", () => {

--- a/tests/unit/execution-mode.test.mjs
+++ b/tests/unit/execution-mode.test.mjs
@@ -296,7 +296,6 @@ test("resolveStdinPromptMode: default true; env=0|false opts out", () => {
   );
 });
 
-
 test("buildSpawnSpecForMode: codex skips MCP servers excluded by preflight and warns", () => {
   const warnings = [];
   const spec = buildSpawnSpecForMode(MODES.HEADLESS, {

--- a/tests/unit/execution-mode.test.mjs
+++ b/tests/unit/execution-mode.test.mjs
@@ -296,6 +296,33 @@ test("resolveStdinPromptMode: default true; env=0|false opts out", () => {
   );
 });
 
+
+test("buildSpawnSpecForMode: codex skips MCP servers excluded by preflight and warns", () => {
+  const warnings = [];
+  const spec = buildSpawnSpecForMode(MODES.HEADLESS, {
+    cli: "codex",
+    prompt: "ACK",
+    platform: "linux",
+    resolveCommand: () => "/usr/local/bin/codex",
+    env: {},
+    mcpServers: ["context7", "missing-server"],
+    excludeMcpServers: ["missing-server"],
+    onWarning: (message, details) => warnings.push({ message, details }),
+  });
+
+  assert.ok(
+    spec.args.includes("mcp_servers.context7.enabled=true"),
+    "known MCP server should still be enabled",
+  );
+  assert.ok(
+    !spec.args.includes("mcp_servers.missing-server.enabled=true"),
+    "unknown MCP server must be skipped before building codex command",
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0].message, /missing-server/u);
+  assert.equal(warnings[0].details.server, "missing-server");
+});
+
 test("buildSpawnSpecForMode: codex headless default uses stdinPrompt (prompt out of args)", () => {
   const prompt = "Please respond ACK.\n\n```bash\necho ok\n```\n";
   const spec = buildSpawnSpecForMode(MODES.HEADLESS, {

--- a/tests/unit/packages-remote-imports.test.mjs
+++ b/tests/unit/packages-remote-imports.test.mjs
@@ -63,6 +63,7 @@ async function linkPackageDependencies(tmpNodeModules) {
 async function findNodeModules() {
   const candidates = [
     path.join(REPO_ROOT, "node_modules"),
+    path.resolve(REPO_ROOT, "../..", "node_modules"),
     path.resolve(REPO_ROOT, "../../..", "node_modules"),
   ];
   for (const candidate of candidates) {

--- a/tests/unit/q-learning.test.mjs
+++ b/tests/unit/q-learning.test.mjs
@@ -193,6 +193,19 @@ describe("엡실론-그리디", () => {
     assert.ok(actions.size >= 2, `expected >= 2 actions, got ${actions.size}`);
   });
 
+  it("injectable random keeps exploration deterministic", () => {
+    const router = new QLearningRouter({
+      epsilon: 1,
+      random: () => 0.99,
+      modelPath: join(tmpdir(), "nofile.json"),
+    });
+
+    const result = router.predict("implement feature");
+
+    assert.equal(result.exploration, true);
+    assert.equal(result.action, "sonnet");
+  });
+
   it("epsilon=0 → 항상 활용", () => {
     const router = new QLearningRouter({
       epsilon: 0,

--- a/tests/unit/swarm-hypervisor.test.mjs
+++ b/tests/unit/swarm-hypervisor.test.mjs
@@ -66,6 +66,7 @@ const CRITICAL_PRD = `
 - agent: codex
 - files: src/critical.mjs
 - critical: true
+- redundancy: fallback
 - prompt: critical work
 
 ## Shard: normal-shard
@@ -78,11 +79,26 @@ const CRITICAL_NO_FILES_PRD = `
 ## Shard: critical-shard
 - agent: codex
 - critical: true
+- redundancy: fallback
 - prompt: critical work
 
 ## Shard: normal-shard
 - agent: codex
 - prompt: normal work
+`;
+
+const CRITICAL_PRIORITY_ONLY_PRD = `
+## Shard: critical-shard
+- agent: codex
+- critical: true
+- prompt: critical work
+`;
+
+const REDUNDANCY_SAME_CLI_PRD = `
+## Shard: same-cli-shard
+- agent: claude
+- redundancy: same-cli
+- prompt: same cli redundant work
 `;
 
 const SINGLE_PRD = `
@@ -504,12 +520,47 @@ describe("swarm-hypervisor", () => {
       }
     });
 
-    it("launches redundant workers for critical shards", async () => {
-      const plan = planSwarm(null, { content: CRITICAL_PRD });
-      ({ hv } = createTestHypervisor(workdir, logsDir));
+    it("does not launch redundant workers for critical-only shards", async () => {
+      const plan = planSwarm(null, { content: CRITICAL_PRIORITY_ONLY_PRD });
+      const setup = createTestHypervisor(workdir, logsDir);
+      hv = setup.hv;
 
       await hv.launch(plan);
+
       assert.deepEqual(plan.criticalShards, ["critical-shard"]);
+      assert.equal(setup.conductors.length, 1);
+      assert.equal(plan.shards[0].redundancy, false);
+    });
+
+    it("launches fallback redundant workers only when redundancy requests fallback", async () => {
+      const plan = planSwarm(null, { content: CRITICAL_PRD });
+      const setup = createTestHypervisor(workdir, logsDir);
+      hv = setup.hv;
+
+      await hv.launch(plan);
+
+      assert.deepEqual(plan.criticalShards, ["critical-shard"]);
+      assert.equal(setup.conductors.length, 3);
+      assert.equal(setup.conductors[0].sessionConfig.agent, "codex");
+      assert.equal(setup.conductors[1].sessionConfig.agent, "gemini");
+      assert.ok(
+        setup.conductors[1].sessionConfig.worktreePath.includes(
+          "critical-shard-redundant",
+        ),
+      );
+    });
+
+    it("same-cli redundancy keeps explicitly requested agent", async () => {
+      const plan = planSwarm(null, { content: REDUNDANCY_SAME_CLI_PRD });
+      const setup = createTestHypervisor(workdir, logsDir);
+      hv = setup.hv;
+
+      await hv.launch(plan);
+
+      assert.equal(setup.conductors.length, 2);
+      assert.equal(setup.conductors[0].sessionConfig.agent, "claude");
+      assert.equal(setup.conductors[1].sessionConfig.agent, "claude");
+      assert.equal(plan.shards[0].redundancy, "same-cli");
     });
 
     it("does not let an invalid redundant completion kill a healthy primary", async () => {

--- a/tests/unit/swarm-planner.test.mjs
+++ b/tests/unit/swarm-planner.test.mjs
@@ -118,6 +118,31 @@ describe("swarm-planner", () => {
       assert.equal(shards[1].critical, false);
     });
 
+    it("parses redundancy separately from critical", () => {
+      const shards = parseShards(`
+## Shard: priority-only
+- critical: true
+- prompt: priority only
+
+## Shard: redundant-fallback
+- critical: true
+- redundancy: fallback
+- prompt: redundant fallback
+
+## Shard: redundant-same
+- agent: claude
+- redundancy: same-cli
+- prompt: redundant same cli
+`);
+
+      assert.equal(shards[0].critical, true);
+      assert.equal(shards[0].redundancy, false);
+      assert.equal(shards[1].critical, true);
+      assert.equal(shards[1].redundancy, "fallback");
+      assert.equal(shards[2].agent, "claude");
+      assert.equal(shards[2].redundancy, "same-cli");
+    });
+
     it("parses multi-line prompt", () => {
       const shards = parseShards(SAMPLE_PRD);
       assert.ok(shards[0].prompt.includes("REST API routes"));

--- a/tests/unit/tfx-live-transport.test.mjs
+++ b/tests/unit/tfx-live-transport.test.mjs
@@ -76,7 +76,6 @@ test("resolveAskTransport reports none when neither transport target exists", as
   });
 });
 
-
 test("resolveAskTransport surfaces absent daemon directory diagnostics", async () => {
   const result = await resolveWith({
     tmux: false,

--- a/tests/unit/tfx-live-transport.test.mjs
+++ b/tests/unit/tfx-live-transport.test.mjs
@@ -76,6 +76,53 @@ test("resolveAskTransport reports none when neither transport target exists", as
   });
 });
 
+
+test("resolveAskTransport surfaces absent daemon directory diagnostics", async () => {
+  const result = await resolveWith({
+    tmux: false,
+    daemonProbe: {
+      ok: false,
+      reason: "daemon-unavailable",
+      raw: {
+        reason: "daemon-unavailable",
+        candidateResults: [
+          {
+            ok: false,
+            errorCode: "daemon-dir-missing",
+            controlSock: "/tmp/cc-daemon-501/abc/control.sock",
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(result.transportSelected, "none");
+  assert.equal(result.transportProbe.daemonReason, "daemon-dir-missing");
+});
+
+test("resolveAskTransport surfaces stale control socket diagnostics", async () => {
+  const result = await resolveWith({
+    tmux: false,
+    daemonProbe: {
+      ok: false,
+      reason: "daemon-unavailable",
+      raw: {
+        reason: "daemon-unavailable",
+        candidateResults: [
+          {
+            ok: false,
+            errorCode: "stale-control-socket",
+            controlSock: "/tmp/cc-daemon-501/abc/control.sock",
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(result.transportSelected, "none");
+  assert.equal(result.transportProbe.daemonReason, "stale-control-socket");
+});
+
 test("buildRemoteLiveCommand wraps darwin zsh remote tfx-live ask", () => {
   const plan = buildRemoteLiveCommand(
     "m2",


### PR DESCRIPTION
## Summary
- audited all currently open Triflux issues and added a priority/staleness matrix in `docs/research/triflux-open-issue-triage-2026-06-16.md`
- fixed bounded implementation issues for HUD sv totals, live daemon diagnostics, migrated Antigravity MCP config handling, and swarm MCP/redundancy behavior
- documented intentional `agy` direct-call alias behavior and captured current Codex #409 smoke evidence as a stale-close candidate

## Issue coverage
- Fixes #292
- Fixes #367
- Fixes #378
- Fixes #407
- Fixes #408
- Refs #310
- Refs #409
- Refs #411

## Regression coverage
- `npm run health` — 4366 tests, 4349 pass, 0 fail, 17 skipped
- `npm run release:check-mirror` — Mirror OK
- `npm run release:check-sync` — Version sync OK (10.36.0)
- `git diff --check`
- focused MCP guard regression suite — 15 pass, including migrated Antigravity remove/sync handling

## Notes
- #409 is not silently closed: current Codex 0.139 smoke did not reproduce the `codex_apps` init failure, so it is recorded as a stale-close candidate.
- #411 bounded follow-ups are addressed here; broader keychain freshness/auth redesign remains a separate design-sized follow-up if still desired.
