### PR TITLE
fix(cto): share lake across linked worktrees

### DIFF
--- a/cto/lake-root.mjs
+++ b/cto/lake-root.mjs
@@ -1,4 +1,4 @@
-// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+// cto/lake-root.mjs - resolve the canonical project root for the CTO lake.
 //
 // CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
 // runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
@@ -7,29 +7,70 @@
 // 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
 // 올려 이 불일치를 없앤다.
 //
-// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
-// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
-// 반환해 기존 동작을 보존한다.
+// git worktree 는 별도 프로젝트가 아니라 같은 프로젝트의 작업 디렉터리다. 따라서
+// linked worktree 안에서 호출하더라도 `git rev-parse --git-common-dir` 로 canonical
+// project root(일반적으로 main checkout)를 찾아 같은 CTO lake 를 공유한다. git 명령을
+// 사용할 수 없으면 기존의 `.git` 상향 탐색으로 fallback 한다.
 
+import { execFileSync as defaultExecFileSync } from "node:child_process";
 import { existsSync as defaultExistsSync } from "node:fs";
-import { dirname, join, parse } from "node:path";
+import { basename, dirname, join, parse } from "node:path";
 
 const MAX_DEPTH = 64;
 
+function execGit(cwd, args, execFileSync) {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    windowsHide: true,
+  }).trim();
+}
+
+function resolveViaGitCommonDir(cwd, execFileSync) {
+  try {
+    const commonDir = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      execFileSync,
+    );
+    if (commonDir && basename(commonDir) === ".git") {
+      return dirname(commonDir);
+    }
+
+    // Bare repos and submodules can have non-`.git` common dirs. In that case,
+    // `--show-toplevel` is the safest project root signal.
+    const topLevel = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      execFileSync,
+    );
+    return topLevel || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
- * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ * 찾아 반환한다. linked worktree 에서는 worktree 루트가 아니라 git common dir 의
+ * project root 를 반환해 프로젝트당 CTO lake 하나를 유지한다. 못 찾으면 cwd 를
+ * 그대로 돌려준다(기존 동작 보존).
  *
  * @param {string} cwd 시작 디렉토리(보통 process.cwd())
  * @param {object} [opts]
  * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @param {typeof defaultExecFileSync} [opts.execFileSync] 테스트용 git seam
  * @returns {string}
  */
 export function resolveLakeRootDir(cwd, opts = {}) {
   const exists = opts?.existsSync || defaultExistsSync;
+  const execFileSync = opts?.execFileSync || defaultExecFileSync;
   // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
   // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
   if (typeof cwd !== "string" || !cwd) return "";
+
+  const gitRoot = resolveViaGitCommonDir(cwd, execFileSync);
+  if (gitRoot) return gitRoot;
 
   let dir = cwd;
   const { root } = parse(dir);

--- a/packages/remote/cto/lake-root.mjs
+++ b/packages/remote/cto/lake-root.mjs
@@ -1,4 +1,4 @@
-// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+// cto/lake-root.mjs - resolve the canonical project root for the CTO lake.
 //
 // CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
 // runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
@@ -7,29 +7,70 @@
 // 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
 // 올려 이 불일치를 없앤다.
 //
-// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
-// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
-// 반환해 기존 동작을 보존한다.
+// git worktree 는 별도 프로젝트가 아니라 같은 프로젝트의 작업 디렉터리다. 따라서
+// linked worktree 안에서 호출하더라도 `git rev-parse --git-common-dir` 로 canonical
+// project root(일반적으로 main checkout)를 찾아 같은 CTO lake 를 공유한다. git 명령을
+// 사용할 수 없으면 기존의 `.git` 상향 탐색으로 fallback 한다.
 
+import { execFileSync as defaultExecFileSync } from "node:child_process";
 import { existsSync as defaultExistsSync } from "node:fs";
-import { dirname, join, parse } from "node:path";
+import { basename, dirname, join, parse } from "node:path";
 
 const MAX_DEPTH = 64;
 
+function execGit(cwd, args, execFileSync) {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    windowsHide: true,
+  }).trim();
+}
+
+function resolveViaGitCommonDir(cwd, execFileSync) {
+  try {
+    const commonDir = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      execFileSync,
+    );
+    if (commonDir && basename(commonDir) === ".git") {
+      return dirname(commonDir);
+    }
+
+    // Bare repos and submodules can have non-`.git` common dirs. In that case,
+    // `--show-toplevel` is the safest project root signal.
+    const topLevel = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      execFileSync,
+    );
+    return topLevel || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
- * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ * 찾아 반환한다. linked worktree 에서는 worktree 루트가 아니라 git common dir 의
+ * project root 를 반환해 프로젝트당 CTO lake 하나를 유지한다. 못 찾으면 cwd 를
+ * 그대로 돌려준다(기존 동작 보존).
  *
  * @param {string} cwd 시작 디렉토리(보통 process.cwd())
  * @param {object} [opts]
  * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @param {typeof defaultExecFileSync} [opts.execFileSync] 테스트용 git seam
  * @returns {string}
  */
 export function resolveLakeRootDir(cwd, opts = {}) {
   const exists = opts?.existsSync || defaultExistsSync;
+  const execFileSync = opts?.execFileSync || defaultExecFileSync;
   // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
   // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
   if (typeof cwd !== "string" || !cwd) return "";
+
+  const gitRoot = resolveViaGitCommonDir(cwd, execFileSync);
+  if (gitRoot) return gitRoot;
 
   let dir = cwd;
   const { root } = parse(dir);

--- a/packages/triflux/cto/lake-root.mjs
+++ b/packages/triflux/cto/lake-root.mjs
@@ -1,4 +1,4 @@
-// cto/lake-root.mjs - resolve the git repo toplevel for the CTO lake.
+// cto/lake-root.mjs - resolve the canonical project root for the CTO lake.
 //
 // CTO lake (.triflux/lake/current.json) 는 repo 루트에 하나만 둔다. 그런데
 // runStatus/runCollect/runDashboard 는 process.cwd() 를 기본 rootDir 로 쓰므로,
@@ -7,29 +7,70 @@
 // 새 .triflux/lake 를 만든다. cwd 에서 `.git` 마커를 위로 탐색해 toplevel 로
 // 올려 이 불일치를 없앤다.
 //
-// git worktree 는 자체 `.git` 파일을 가지므로 worktree 루트에서 멈춘다 — lake
-// 격리(워크트리별 collect)가 그대로 유지된다. `.git` 을 못 찾으면 cwd 를 그대로
-// 반환해 기존 동작을 보존한다.
+// git worktree 는 별도 프로젝트가 아니라 같은 프로젝트의 작업 디렉터리다. 따라서
+// linked worktree 안에서 호출하더라도 `git rev-parse --git-common-dir` 로 canonical
+// project root(일반적으로 main checkout)를 찾아 같은 CTO lake 를 공유한다. git 명령을
+// 사용할 수 없으면 기존의 `.git` 상향 탐색으로 fallback 한다.
 
+import { execFileSync as defaultExecFileSync } from "node:child_process";
 import { existsSync as defaultExistsSync } from "node:fs";
-import { dirname, join, parse } from "node:path";
+import { basename, dirname, join, parse } from "node:path";
 
 const MAX_DEPTH = 64;
 
+function execGit(cwd, args, execFileSync) {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    windowsHide: true,
+  }).trim();
+}
+
+function resolveViaGitCommonDir(cwd, execFileSync) {
+  try {
+    const commonDir = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+      execFileSync,
+    );
+    if (commonDir && basename(commonDir) === ".git") {
+      return dirname(commonDir);
+    }
+
+    // Bare repos and submodules can have non-`.git` common dirs. In that case,
+    // `--show-toplevel` is the safest project root signal.
+    const topLevel = execGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      execFileSync,
+    );
+    return topLevel || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * cwd 에서 가장 가까운 git toplevel(`.git` 디렉토리 또는 파일이 있는 폴더)을
- * 찾아 반환한다. 못 찾으면 cwd 를 그대로 돌려준다(기존 동작 보존).
+ * 찾아 반환한다. linked worktree 에서는 worktree 루트가 아니라 git common dir 의
+ * project root 를 반환해 프로젝트당 CTO lake 하나를 유지한다. 못 찾으면 cwd 를
+ * 그대로 돌려준다(기존 동작 보존).
  *
  * @param {string} cwd 시작 디렉토리(보통 process.cwd())
  * @param {object} [opts]
  * @param {(path: string) => boolean} [opts.existsSync] 테스트용 주입 seam
+ * @param {typeof defaultExecFileSync} [opts.execFileSync] 테스트용 git seam
  * @returns {string}
  */
 export function resolveLakeRootDir(cwd, opts = {}) {
   const exists = opts?.existsSync || defaultExistsSync;
+  const execFileSync = opts?.execFileSync || defaultExecFileSync;
   // 비문자열(객체/숫자 등 truthy 포함) 또는 빈 문자열이면 항상 "" 를 반환해
   // @returns {string} 계약을 지킨다 — truthy 비문자열을 그대로 누설하지 않는다.
   if (typeof cwd !== "string" || !cwd) return "";
+
+  const gitRoot = resolveViaGitCommonDir(cwd, execFileSync);
+  if (gitRoot) return gitRoot;
 
   let dir = cwd;
   const { root } = parse(dir);

--- a/tests/unit/cto-lake-root.test.mjs
+++ b/tests/unit/cto-lake-root.test.mjs
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -20,14 +27,28 @@ describe("resolveLakeRootDir", () => {
     );
   });
 
-  it("stops at a git worktree (.git file) instead of the main repo", () => {
-    // worktree 루트에 .git 파일이 있으므로 거기서 멈춘다 (lake 격리 유지).
+  it("resolves a linked git worktree to the canonical project root", () => {
+    // worktree 루트에 .git 파일이 있더라도 프로젝트당 CTO lake 는 하나여야 한다.
     const worktree = "/repo/.claude/worktrees/foo";
     const exists = (p) =>
       p === join(worktree, ".git") || p === join("/repo", ".git");
+    const fakeGit = (cmd, args) => {
+      assert.equal(cmd, "git");
+      assert.deepEqual(args, [
+        "-C",
+        join(worktree, "packages"),
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+      ]);
+      return `${join("/repo", ".git")}\n`;
+    };
     assert.equal(
-      resolveLakeRootDir(join(worktree, "packages"), { existsSync: exists }),
-      worktree,
+      resolveLakeRootDir(join(worktree, "packages"), {
+        existsSync: exists,
+        execFileSync: fakeGit,
+      }),
+      "/repo",
     );
   });
 
@@ -73,6 +94,47 @@ describe("resolveLakeRootDir", () => {
       const nested = join(root, "packages", "triflux");
       mkdirSync(nested, { recursive: true });
       assert.equal(resolveLakeRootDir(nested), root);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a real linked worktree to the main checkout root", () => {
+    const root = mkdtempSync(join(tmpdir(), "tfx-lake-root-worktree-test-"));
+    const main = join(root, "main");
+    const linked = join(root, "linked");
+    try {
+      mkdirSync(main, { recursive: true });
+      execFileSync("git", ["init"], {
+        cwd: main,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      writeFileSync(join(main, "README.md"), "# fixture\n", "utf8");
+      execFileSync("git", ["add", "README.md"], {
+        cwd: main,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.email=tfx@example.invalid",
+          "-c",
+          "user.name=TFX Test",
+          "commit",
+          "-m",
+          "init",
+        ],
+        { cwd: main, stdio: ["ignore", "ignore", "ignore"] },
+      );
+      execFileSync("git", ["worktree", "add", linked, "-b", "linked"], {
+        cwd: main,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      const nested = join(linked, "packages", "triflux");
+      mkdirSync(nested, { recursive: true });
+
+      assert.equal(resolveLakeRootDir(nested), realpathSync(main));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- resolve CTO lake root through `git rev-parse --git-common-dir` before falling back to `.git` marker walking
- treat linked git worktrees as the same project CTO lake instead of creating/reading worktree-local `.triflux/lake`
- mirror the resolver into packaged surfaces and add real linked-worktree regression coverage

## Why
A git worktree is a working directory for the same project, not a separate CTO. Worktree-local CTO lakes caused status/checkpoint hygiene drift because each shard/session could collect and read a different `.triflux/lake`.

## Test Plan
- [x] `node scripts/test-lock.mjs --test --test-force-exit tests/unit/cto-lake-root.test.mjs tests/cto/status.test.mjs tests/cto/collect.test.mjs` (17 pass, 0 fail)
- [x] `npm run release:check-mirror`
- [x] `npm run release:check-sync`
- [x] `npx biome check cto/lake-root.mjs packages/triflux/cto/lake-root.mjs packages/remote/cto/lake-root.mjs tests/unit/cto-lake-root.test.mjs`
- [x] `git diff --check`
- [x] runtime probe from this linked worktree: `resolveLakeRootDir(process.cwd())` returns `/Users/tellang/Projects/tools/triflux`

## Notes
This intentionally does not make CTO an active coordinator yet. It only restores the intended project-level single CTO state root so later checkpoint/task hygiene work has one authority to reconcile against.
