### PR TITLE
feat(cto): add normalized hygiene events

### DIFF
--- a/cto/events.mjs
+++ b/cto/events.mjs
@@ -1,0 +1,217 @@
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
+export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
+
+export const CTO_EVENT_TYPES = Object.freeze([
+  "session_started",
+  "session_heartbeat",
+  "session_stale",
+  "checkpoint_saved",
+  "checkpoint_restored",
+  "task_claimed",
+  "task_completed",
+  "pr_created",
+  "pr_merged_or_closed",
+  "worktree_created",
+  "worktree_removed",
+]);
+
+export const CTO_HYGIENE_STATUSES = Object.freeze([
+  "active",
+  "idle",
+  "stale",
+  "superseded",
+  "orphaned",
+  "completed",
+  "blocked",
+  "unknown_owner",
+  "hidden",
+  "needs_attention",
+]);
+
+const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
+const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function maybeString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function shortHash(value) {
+  const str = String(value ?? "");
+  let h = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function pathLabel(value) {
+  const str = String(value ?? "").replace(/[/\\]+$/u, "");
+  if (!str) return null;
+  const segments = str.split(/[/\\]+/u);
+  return segments[segments.length - 1] || null;
+}
+
+function normalizeNumericRefs(values) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : values == null
+      ? []
+      : [values];
+  const refs = [];
+  for (const value of rawValues) {
+    const parsed =
+      typeof value === "number" && Number.isInteger(value)
+        ? value
+        : typeof value === "string"
+          ? Number(value.trim().replace(/^#/u, ""))
+          : NaN;
+    if (Number.isInteger(parsed) && parsed > 0 && !refs.includes(parsed)) {
+      refs.push(parsed);
+    }
+  }
+  return refs;
+}
+
+function normalizeActor(actor) {
+  if (!actor || typeof actor !== "object" || Array.isArray(actor)) return null;
+  const normalized = {};
+  for (const key of ["cli", "session_id", "agent_id", "host"]) {
+    const value = maybeString(actor[key]);
+    if (value) normalized[key] = value;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function putString(target, key, value) {
+  const normalized = maybeString(value);
+  if (normalized) target[key] = normalized;
+}
+
+function defaultSummary(eventType, ref) {
+  if (ref.task_id) return `${eventType} ${ref.task_id}`;
+  if (ref.checkpoint_id) return `${eventType} ${ref.checkpoint_id}`;
+  if (ref.session_id) return `${eventType} ${ref.session_id}`;
+  return eventType;
+}
+
+export function normalizeCtoEvent(input = {}) {
+  const eventType = maybeString(input.event ?? input.event_type);
+  if (!eventType || !EVENT_TYPE_SET.has(eventType)) {
+    throw new Error(`unknown CTO event: ${eventType || "<empty>"}`);
+  }
+
+  const status = maybeString(input.status);
+  if (status && !STATUS_SET.has(status)) {
+    throw new Error(`invalid CTO status: ${status}`);
+  }
+
+  const ts = toIsoTime(input.now ?? input.ts);
+  const ref = {
+    schema_version: CTO_EVENT_SCHEMA_VERSION,
+    event_type: eventType,
+  };
+
+  putString(ref, "session_id", input.session_id);
+  putString(ref, "parent_session_id", input.parent_session_id);
+  putString(ref, "restored_from_session_id", input.restored_from_session_id);
+  putString(ref, "checkpoint_id", input.checkpoint_id);
+  putString(ref, "artifact_path", input.artifact_path);
+  putString(ref, "task_id", input.task_id);
+  putString(ref, "branch", input.branch);
+  putString(ref, "last_seen_at", input.last_seen_at);
+  putString(ref, "stale_reason", input.stale_reason);
+  if (status) ref.status = status;
+
+  const projectRoot = maybeString(input.project_root);
+  if (projectRoot) {
+    ref.project_root_hash = shortHash(projectRoot);
+    ref.project_root_label = pathLabel(projectRoot) || basename(projectRoot);
+  }
+
+  const worktreePath = maybeString(input.worktree_path ?? input.worktreePath);
+  if (worktreePath) {
+    ref.worktree_path_hash = shortHash(worktreePath);
+    ref.worktree_label = pathLabel(worktreePath) || basename(worktreePath);
+  }
+
+  const issueRefs = normalizeNumericRefs(input.issue_refs ?? input.issueRefs);
+  if (issueRefs.length > 0) ref.issue_refs = issueRefs;
+  const prRefs = normalizeNumericRefs(input.pr_refs ?? input.prRefs);
+  if (prRefs.length > 0) ref.pr_refs = prRefs;
+
+  const actor = normalizeActor(input.actor);
+  if (actor) ref.actor = actor;
+
+  return {
+    ts,
+    event: eventType,
+    source: maybeString(input.source) || DEFAULT_CTO_EVENT_SOURCE,
+    summary: maybeString(input.summary) || defaultSummary(eventType, ref),
+    ref,
+  };
+}
+
+export async function appendCtoEvent(lakeRoot, input, opts = {}) {
+  const event = normalizeCtoEvent(input);
+  const stderr = opts.stderr || process.stderr;
+  const lockRetries = Number.isInteger(opts.lockRetries) ? opts.lockRetries : 3;
+  const lockRetryDelayMs = Number.isFinite(opts.lockRetryDelayMs)
+    ? opts.lockRetryDelayMs
+    : 100;
+
+  mkdirSync(lakeRoot, { recursive: true });
+  const ledgerPath = join(lakeRoot, "ledger.jsonl");
+  const lockPath = join(lakeRoot, "ledger.jsonl.lock");
+  let fd = null;
+
+  for (let attempt = 0; attempt < lockRetries; attempt += 1) {
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (attempt < lockRetries - 1) await sleep(lockRetryDelayMs);
+    }
+  }
+
+  if (fd === null) {
+    stderr.write(
+      "[tfx cto event] warning: ledger lock timeout; skipped ledger append\n",
+    );
+    return { appended: false, event };
+  }
+
+  try {
+    appendFileSync(ledgerPath, `${JSON.stringify(event)}\n`, "utf8");
+    return { appended: true, event };
+  } finally {
+    closeSync(fd);
+    try {
+      unlinkSync(lockPath);
+    } catch {}
+  }
+}

--- a/packages/remote/cto/events.mjs
+++ b/packages/remote/cto/events.mjs
@@ -1,0 +1,217 @@
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
+export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
+
+export const CTO_EVENT_TYPES = Object.freeze([
+  "session_started",
+  "session_heartbeat",
+  "session_stale",
+  "checkpoint_saved",
+  "checkpoint_restored",
+  "task_claimed",
+  "task_completed",
+  "pr_created",
+  "pr_merged_or_closed",
+  "worktree_created",
+  "worktree_removed",
+]);
+
+export const CTO_HYGIENE_STATUSES = Object.freeze([
+  "active",
+  "idle",
+  "stale",
+  "superseded",
+  "orphaned",
+  "completed",
+  "blocked",
+  "unknown_owner",
+  "hidden",
+  "needs_attention",
+]);
+
+const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
+const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function maybeString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function shortHash(value) {
+  const str = String(value ?? "");
+  let h = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function pathLabel(value) {
+  const str = String(value ?? "").replace(/[/\\]+$/u, "");
+  if (!str) return null;
+  const segments = str.split(/[/\\]+/u);
+  return segments[segments.length - 1] || null;
+}
+
+function normalizeNumericRefs(values) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : values == null
+      ? []
+      : [values];
+  const refs = [];
+  for (const value of rawValues) {
+    const parsed =
+      typeof value === "number" && Number.isInteger(value)
+        ? value
+        : typeof value === "string"
+          ? Number(value.trim().replace(/^#/u, ""))
+          : NaN;
+    if (Number.isInteger(parsed) && parsed > 0 && !refs.includes(parsed)) {
+      refs.push(parsed);
+    }
+  }
+  return refs;
+}
+
+function normalizeActor(actor) {
+  if (!actor || typeof actor !== "object" || Array.isArray(actor)) return null;
+  const normalized = {};
+  for (const key of ["cli", "session_id", "agent_id", "host"]) {
+    const value = maybeString(actor[key]);
+    if (value) normalized[key] = value;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function putString(target, key, value) {
+  const normalized = maybeString(value);
+  if (normalized) target[key] = normalized;
+}
+
+function defaultSummary(eventType, ref) {
+  if (ref.task_id) return `${eventType} ${ref.task_id}`;
+  if (ref.checkpoint_id) return `${eventType} ${ref.checkpoint_id}`;
+  if (ref.session_id) return `${eventType} ${ref.session_id}`;
+  return eventType;
+}
+
+export function normalizeCtoEvent(input = {}) {
+  const eventType = maybeString(input.event ?? input.event_type);
+  if (!eventType || !EVENT_TYPE_SET.has(eventType)) {
+    throw new Error(`unknown CTO event: ${eventType || "<empty>"}`);
+  }
+
+  const status = maybeString(input.status);
+  if (status && !STATUS_SET.has(status)) {
+    throw new Error(`invalid CTO status: ${status}`);
+  }
+
+  const ts = toIsoTime(input.now ?? input.ts);
+  const ref = {
+    schema_version: CTO_EVENT_SCHEMA_VERSION,
+    event_type: eventType,
+  };
+
+  putString(ref, "session_id", input.session_id);
+  putString(ref, "parent_session_id", input.parent_session_id);
+  putString(ref, "restored_from_session_id", input.restored_from_session_id);
+  putString(ref, "checkpoint_id", input.checkpoint_id);
+  putString(ref, "artifact_path", input.artifact_path);
+  putString(ref, "task_id", input.task_id);
+  putString(ref, "branch", input.branch);
+  putString(ref, "last_seen_at", input.last_seen_at);
+  putString(ref, "stale_reason", input.stale_reason);
+  if (status) ref.status = status;
+
+  const projectRoot = maybeString(input.project_root);
+  if (projectRoot) {
+    ref.project_root_hash = shortHash(projectRoot);
+    ref.project_root_label = pathLabel(projectRoot) || basename(projectRoot);
+  }
+
+  const worktreePath = maybeString(input.worktree_path ?? input.worktreePath);
+  if (worktreePath) {
+    ref.worktree_path_hash = shortHash(worktreePath);
+    ref.worktree_label = pathLabel(worktreePath) || basename(worktreePath);
+  }
+
+  const issueRefs = normalizeNumericRefs(input.issue_refs ?? input.issueRefs);
+  if (issueRefs.length > 0) ref.issue_refs = issueRefs;
+  const prRefs = normalizeNumericRefs(input.pr_refs ?? input.prRefs);
+  if (prRefs.length > 0) ref.pr_refs = prRefs;
+
+  const actor = normalizeActor(input.actor);
+  if (actor) ref.actor = actor;
+
+  return {
+    ts,
+    event: eventType,
+    source: maybeString(input.source) || DEFAULT_CTO_EVENT_SOURCE,
+    summary: maybeString(input.summary) || defaultSummary(eventType, ref),
+    ref,
+  };
+}
+
+export async function appendCtoEvent(lakeRoot, input, opts = {}) {
+  const event = normalizeCtoEvent(input);
+  const stderr = opts.stderr || process.stderr;
+  const lockRetries = Number.isInteger(opts.lockRetries) ? opts.lockRetries : 3;
+  const lockRetryDelayMs = Number.isFinite(opts.lockRetryDelayMs)
+    ? opts.lockRetryDelayMs
+    : 100;
+
+  mkdirSync(lakeRoot, { recursive: true });
+  const ledgerPath = join(lakeRoot, "ledger.jsonl");
+  const lockPath = join(lakeRoot, "ledger.jsonl.lock");
+  let fd = null;
+
+  for (let attempt = 0; attempt < lockRetries; attempt += 1) {
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (attempt < lockRetries - 1) await sleep(lockRetryDelayMs);
+    }
+  }
+
+  if (fd === null) {
+    stderr.write(
+      "[tfx cto event] warning: ledger lock timeout; skipped ledger append\n",
+    );
+    return { appended: false, event };
+  }
+
+  try {
+    appendFileSync(ledgerPath, `${JSON.stringify(event)}\n`, "utf8");
+    return { appended: true, event };
+  } finally {
+    closeSync(fd);
+    try {
+      unlinkSync(lockPath);
+    } catch {}
+  }
+}

--- a/packages/triflux/cto/events.mjs
+++ b/packages/triflux/cto/events.mjs
@@ -1,0 +1,217 @@
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
+export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
+
+export const CTO_EVENT_TYPES = Object.freeze([
+  "session_started",
+  "session_heartbeat",
+  "session_stale",
+  "checkpoint_saved",
+  "checkpoint_restored",
+  "task_claimed",
+  "task_completed",
+  "pr_created",
+  "pr_merged_or_closed",
+  "worktree_created",
+  "worktree_removed",
+]);
+
+export const CTO_HYGIENE_STATUSES = Object.freeze([
+  "active",
+  "idle",
+  "stale",
+  "superseded",
+  "orphaned",
+  "completed",
+  "blocked",
+  "unknown_owner",
+  "hidden",
+  "needs_attention",
+]);
+
+const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
+const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function maybeString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function shortHash(value) {
+  const str = String(value ?? "");
+  let h = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(36);
+}
+
+function pathLabel(value) {
+  const str = String(value ?? "").replace(/[/\\]+$/u, "");
+  if (!str) return null;
+  const segments = str.split(/[/\\]+/u);
+  return segments[segments.length - 1] || null;
+}
+
+function normalizeNumericRefs(values) {
+  const rawValues = Array.isArray(values)
+    ? values
+    : values == null
+      ? []
+      : [values];
+  const refs = [];
+  for (const value of rawValues) {
+    const parsed =
+      typeof value === "number" && Number.isInteger(value)
+        ? value
+        : typeof value === "string"
+          ? Number(value.trim().replace(/^#/u, ""))
+          : NaN;
+    if (Number.isInteger(parsed) && parsed > 0 && !refs.includes(parsed)) {
+      refs.push(parsed);
+    }
+  }
+  return refs;
+}
+
+function normalizeActor(actor) {
+  if (!actor || typeof actor !== "object" || Array.isArray(actor)) return null;
+  const normalized = {};
+  for (const key of ["cli", "session_id", "agent_id", "host"]) {
+    const value = maybeString(actor[key]);
+    if (value) normalized[key] = value;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function putString(target, key, value) {
+  const normalized = maybeString(value);
+  if (normalized) target[key] = normalized;
+}
+
+function defaultSummary(eventType, ref) {
+  if (ref.task_id) return `${eventType} ${ref.task_id}`;
+  if (ref.checkpoint_id) return `${eventType} ${ref.checkpoint_id}`;
+  if (ref.session_id) return `${eventType} ${ref.session_id}`;
+  return eventType;
+}
+
+export function normalizeCtoEvent(input = {}) {
+  const eventType = maybeString(input.event ?? input.event_type);
+  if (!eventType || !EVENT_TYPE_SET.has(eventType)) {
+    throw new Error(`unknown CTO event: ${eventType || "<empty>"}`);
+  }
+
+  const status = maybeString(input.status);
+  if (status && !STATUS_SET.has(status)) {
+    throw new Error(`invalid CTO status: ${status}`);
+  }
+
+  const ts = toIsoTime(input.now ?? input.ts);
+  const ref = {
+    schema_version: CTO_EVENT_SCHEMA_VERSION,
+    event_type: eventType,
+  };
+
+  putString(ref, "session_id", input.session_id);
+  putString(ref, "parent_session_id", input.parent_session_id);
+  putString(ref, "restored_from_session_id", input.restored_from_session_id);
+  putString(ref, "checkpoint_id", input.checkpoint_id);
+  putString(ref, "artifact_path", input.artifact_path);
+  putString(ref, "task_id", input.task_id);
+  putString(ref, "branch", input.branch);
+  putString(ref, "last_seen_at", input.last_seen_at);
+  putString(ref, "stale_reason", input.stale_reason);
+  if (status) ref.status = status;
+
+  const projectRoot = maybeString(input.project_root);
+  if (projectRoot) {
+    ref.project_root_hash = shortHash(projectRoot);
+    ref.project_root_label = pathLabel(projectRoot) || basename(projectRoot);
+  }
+
+  const worktreePath = maybeString(input.worktree_path ?? input.worktreePath);
+  if (worktreePath) {
+    ref.worktree_path_hash = shortHash(worktreePath);
+    ref.worktree_label = pathLabel(worktreePath) || basename(worktreePath);
+  }
+
+  const issueRefs = normalizeNumericRefs(input.issue_refs ?? input.issueRefs);
+  if (issueRefs.length > 0) ref.issue_refs = issueRefs;
+  const prRefs = normalizeNumericRefs(input.pr_refs ?? input.prRefs);
+  if (prRefs.length > 0) ref.pr_refs = prRefs;
+
+  const actor = normalizeActor(input.actor);
+  if (actor) ref.actor = actor;
+
+  return {
+    ts,
+    event: eventType,
+    source: maybeString(input.source) || DEFAULT_CTO_EVENT_SOURCE,
+    summary: maybeString(input.summary) || defaultSummary(eventType, ref),
+    ref,
+  };
+}
+
+export async function appendCtoEvent(lakeRoot, input, opts = {}) {
+  const event = normalizeCtoEvent(input);
+  const stderr = opts.stderr || process.stderr;
+  const lockRetries = Number.isInteger(opts.lockRetries) ? opts.lockRetries : 3;
+  const lockRetryDelayMs = Number.isFinite(opts.lockRetryDelayMs)
+    ? opts.lockRetryDelayMs
+    : 100;
+
+  mkdirSync(lakeRoot, { recursive: true });
+  const ledgerPath = join(lakeRoot, "ledger.jsonl");
+  const lockPath = join(lakeRoot, "ledger.jsonl.lock");
+  let fd = null;
+
+  for (let attempt = 0; attempt < lockRetries; attempt += 1) {
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (attempt < lockRetries - 1) await sleep(lockRetryDelayMs);
+    }
+  }
+
+  if (fd === null) {
+    stderr.write(
+      "[tfx cto event] warning: ledger lock timeout; skipped ledger append\n",
+    );
+    return { appended: false, event };
+  }
+
+  try {
+    appendFileSync(ledgerPath, `${JSON.stringify(event)}\n`, "utf8");
+    return { appended: true, event };
+  } finally {
+    closeSync(fd);
+    try {
+      unlinkSync(lockPath);
+    } catch {}
+  }
+}

--- a/tests/cto/events.test.mjs
+++ b/tests/cto/events.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  appendCtoEvent,
+  CTO_EVENT_SCHEMA_VERSION,
+  normalizeCtoEvent,
+} from "../../cto/events.mjs";
+
+function tempRoot() {
+  return mkdtempSync(join(tmpdir(), "tfx-cto-events-"));
+}
+
+function readJsonl(filePath) {
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe("CTO normalized events", () => {
+  it("normalizes checkpoint lineage into a compact ledger-compatible event", () => {
+    const event = normalizeCtoEvent({
+      event: "checkpoint_restored",
+      now: "2026-06-17T06:00:00.000Z",
+      actor: { cli: "gstack", session_id: "restore-session" },
+      checkpoint_id: "checkpoint-123",
+      restored_from_session_id: "source-session",
+      session_id: "restore-session",
+      worktree_path: "/Users/example/project/.worktrees/worker-a",
+      branch: "feat/worker-a",
+      status: "active",
+      issue_refs: [422, "#421", "not-an-issue"],
+      pr_refs: [421, "#420", "bad"],
+      summary: "restore checkpoint checkpoint-123",
+    });
+
+    assert.equal(event.ts, "2026-06-17T06:00:00.000Z");
+    assert.equal(event.event, "checkpoint_restored");
+    assert.equal(event.source, "tfx_cto_event");
+    assert.equal(event.summary, "restore checkpoint checkpoint-123");
+    assert.equal(event.ref.schema_version, CTO_EVENT_SCHEMA_VERSION);
+    assert.equal(event.ref.event_type, "checkpoint_restored");
+    assert.equal(event.ref.session_id, "restore-session");
+    assert.equal(event.ref.restored_from_session_id, "source-session");
+    assert.equal(event.ref.checkpoint_id, "checkpoint-123");
+    assert.equal(event.ref.worktree_label, "worker-a");
+    assert.equal(typeof event.ref.worktree_path_hash, "string");
+    assert.ok(event.ref.worktree_path_hash.length > 0);
+    assert.equal(Object.hasOwn(event.ref, "worktree_path"), false);
+    assert.deepEqual(event.ref.issue_refs, [422, 421]);
+    assert.deepEqual(event.ref.pr_refs, [421, 420]);
+    assert.deepEqual(event.ref.actor, {
+      cli: "gstack",
+      session_id: "restore-session",
+    });
+  });
+
+  it("rejects unknown event types and invalid hygiene status", () => {
+    assert.throws(
+      () => normalizeCtoEvent({ event: "random_event" }),
+      /unknown CTO event/i,
+    );
+    assert.throws(
+      () => normalizeCtoEvent({ event: "task_completed", status: "maybe" }),
+      /invalid CTO status/i,
+    );
+  });
+
+  it("appends normalized CTO events to the lake ledger with the existing lock contract", async () => {
+    const root = tempRoot();
+    const lakeRoot = join(root, ".triflux", "lake");
+    const warnings = [];
+    try {
+      const first = await appendCtoEvent(lakeRoot, {
+        event: "task_claimed",
+        now: "2026-06-17T06:01:00.000Z",
+        session_id: "session-a",
+        task_id: "task-a",
+        summary: "claim task-a",
+      });
+      assert.equal(first.appended, true);
+
+      const ledgerPath = join(lakeRoot, "ledger.jsonl");
+      const rows = readJsonl(ledgerPath);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].event, "task_claimed");
+      assert.equal(rows[0].ref.task_id, "task-a");
+
+      writeFileSync(join(lakeRoot, "ledger.jsonl.lock"), "held\n", "utf8");
+      const second = await appendCtoEvent(
+        lakeRoot,
+        { event: "task_completed", task_id: "task-a" },
+        {
+          stderr: { write: (msg) => warnings.push(msg) },
+          lockRetries: 1,
+          lockRetryDelayMs: 1,
+        },
+      );
+      assert.equal(second.appended, false);
+      assert.equal(readJsonl(ledgerPath).length, 1);
+      assert.match(warnings.join(""), /ledger.*lock.*timeout/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("creates no ledger file when all append attempts are blocked by an existing lock", async () => {
+    const root = tempRoot();
+    const lakeRoot = join(root, ".triflux", "lake");
+    try {
+      mkdirSync(lakeRoot, { recursive: true });
+      writeFileSync(join(lakeRoot, "ledger.jsonl.lock"), "held\n", "utf8");
+
+      const result = await appendCtoEvent(
+        lakeRoot,
+        { event: "session_stale", session_id: "session-a" },
+        { stderr: { write() {} }, lockRetries: 1, lockRetryDelayMs: 1 },
+      );
+
+      assert.equal(result.appended, false);
+      assert.equal(existsSync(join(lakeRoot, "ledger.jsonl")), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `cto/events.mjs` with a normalized CTO event schema (`cto-event.v1`)
- add `normalizeCtoEvent()` for compact event refs: session/checkpoint/task IDs, issue/PR refs, status, actor, and hashed/labeled project/worktree paths
- add `appendCtoEvent()` to write normalized events into `.triflux/lake/ledger.jsonl` using the existing single-writer lock contract
- mirror the new CTO event helper into packaged surfaces

## Why
This is the first implementation slice for #422. Hooks should emit small normalized events; cleanup/reconciliation will be handled later by a single CTO steward. This PR adds the common event contract and append helper without adding janitor behavior yet.

## Test Plan
- [x] `node scripts/test-lock.mjs --test --test-force-exit tests/cto/events.test.mjs tests/cto/collect.test.mjs tests/cto/status.test.mjs` (12 pass, 0 fail)
- [x] `npm run release:check-mirror`
- [x] `npm run release:check-sync`
- [x] `npx biome check cto/events.mjs packages/triflux/cto/events.mjs packages/remote/cto/events.mjs tests/cto/events.test.mjs`
- [x] `git diff --check`

## Scope
No hook emitters, Hub lease, hygiene dry-run/apply, or tray/status UI changes yet. Those remain follow-up slices under #422.

Refs #422
