### PR TITLE
feat(cto): add hygiene dry-run status

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -499,12 +499,13 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     },
   },
   cto: {
-    usage: "tfx cto <collect|status|dashboard> [options]",
+    usage: "tfx cto <collect|status|dashboard|hygiene> [options]",
     description: "repo-local authority layer console",
     subcommands: {
       collect: "refresh .triflux/lake/current.json from authority sources",
       status: "print the current authority summary",
       dashboard: "render the CTO console dashboard, optionally with --watch",
+      hygiene: "project CTO hygiene counts and actionable dry-run rows",
     },
   },
   multi: {

--- a/cto/hygiene.mjs
+++ b/cto/hygiene.mjs
@@ -1,0 +1,400 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
+const COUNT_KEYS = [
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+];
+
+function hasFlag(args, flag) {
+  return Array.isArray(args) && args.includes(flag);
+}
+
+function writeJson(stdout, payload) {
+  stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function firstExisting(paths) {
+  return paths.filter(Boolean).find((path) => existsSync(path)) || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return null;
+}
+
+function normalizeLiveSession(session) {
+  return {
+    sessionId: String(session?.sessionId || session?.session_id || ""),
+    phase:
+      typeof session?.phase === "string"
+        ? session.phase
+        : typeof session?.status === "string"
+          ? session.status
+          : "active",
+    agent_id:
+      typeof session?.agent_id === "string"
+        ? session.agent_id
+        : typeof session?.agentId === "string"
+          ? session.agentId
+          : null,
+    started_at: toIsoTime(
+      session?.started_at ?? session?.startedAt ?? session?.lastHeartbeat,
+    ),
+  };
+}
+
+function normalizeOverlay(value) {
+  const sessions = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.sessions)
+      ? value.sessions
+      : Array.isArray(value?.live_sessions)
+        ? value.live_sessions
+        : [];
+  return {
+    live_sessions: sessions
+      .map(normalizeLiveSession)
+      .filter((session) => session.sessionId),
+  };
+}
+
+async function readSynapseWithRegistry(opts = {}) {
+  const rootDir = opts.rootDir || process.cwd();
+  const persistPath = firstExisting([
+    opts.synapsePersistPath,
+    join(rootDir, ".triflux", "synapse-registry.json"),
+    join(rootDir, ".triflux", "synapse", "registry.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-sessions.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-registry.json"),
+  ]);
+  if (!persistPath) return { live_sessions: [] };
+
+  const { createSynapseRegistry } = await import(
+    "../hub/team/synapse-registry.mjs"
+  );
+  const registry = createSynapseRegistry({ persistPath });
+  return normalizeOverlay(registry.getActive());
+}
+
+async function readLiveOverlay(opts = {}) {
+  if (opts.overlay) return normalizeOverlay(opts.overlay);
+  try {
+    const reader = opts.synapseReader || readSynapseWithRegistry;
+    return normalizeOverlay(
+      await reader({
+        rootDir: opts.rootDir,
+        lakeRoot: opts.lakeRoot,
+        synapsePersistPath: opts.synapsePersistPath,
+      }),
+    );
+  } catch {
+    return { live_sessions: [] };
+  }
+}
+
+function readJsonLines(filePath) {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function eventTime(entry) {
+  return typeof entry?.ts === "string" ? entry.ts : "";
+}
+
+function eventRef(entry) {
+  return entry?.ref &&
+    typeof entry.ref === "object" &&
+    !Array.isArray(entry.ref)
+    ? entry.ref
+    : {};
+}
+
+function hasKnownOwner(ref) {
+  const actor = ref?.actor;
+  if (actor && typeof actor === "object" && !Array.isArray(actor)) {
+    for (const key of ["cli", "session_id", "agent_id", "host"]) {
+      if (typeof actor[key] === "string" && actor[key].trim()) return true;
+    }
+  }
+  for (const key of ["owner", "owner_id", "agent_id"]) {
+    if (typeof ref?.[key] === "string" && ref[key].trim()) return true;
+  }
+  return false;
+}
+
+function statusOf(ref, fallback) {
+  return typeof ref?.status === "string" && ref.status.trim()
+    ? ref.status.trim()
+    : fallback;
+}
+
+function rowFrom(kind, id, status, entry, ref, action) {
+  const row = {
+    kind,
+    id,
+    status,
+    last_event_at: eventTime(entry) || null,
+  };
+  if (entry?.summary) row.summary = String(entry.summary);
+  if (action) row.action = action;
+  if (action && !hasKnownOwner(ref)) row.owner = "unknown";
+  return row;
+}
+
+function upsertLatest(map, key, value) {
+  const existing = map.get(key);
+  if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
+    map.set(key, value);
+  }
+}
+
+function emptyCounts() {
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
+}
+
+export function compactHygieneCounts(projection) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, counts[key] || 0]));
+}
+
+export function projectCtoHygiene({
+  current = {},
+  ledger = null,
+  overlay = {},
+} = {}) {
+  const events = Array.isArray(ledger)
+    ? ledger
+    : Array.isArray(current?.ledger_tail)
+      ? current.ledger_tail
+      : [];
+  const tasks = new Map();
+  const staleSessions = new Map();
+  const worktrees = new Map();
+  const checkpointsBySession = new Map();
+  const explicitSupersededCheckpoints = new Map();
+
+  for (const entry of events) {
+    const ref = eventRef(entry);
+    switch (entry?.event) {
+      case "task_claimed":
+      case "task_completed": {
+        const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
+        if (!taskId) break;
+        upsertLatest(tasks, taskId, { entry, ref });
+        break;
+      }
+      case "session_stale": {
+        const sessionId =
+          typeof ref.session_id === "string" ? ref.session_id : null;
+        if (!sessionId) break;
+        upsertLatest(staleSessions, sessionId, { entry, ref });
+        break;
+      }
+      case "worktree_created":
+      case "worktree_removed": {
+        const key =
+          (typeof ref.worktree_path_hash === "string" &&
+            ref.worktree_path_hash) ||
+          (typeof ref.worktree_label === "string" && ref.worktree_label) ||
+          null;
+        if (!key) break;
+        upsertLatest(worktrees, key, { entry, ref });
+        break;
+      }
+      case "checkpoint_saved":
+      case "checkpoint_restored": {
+        const checkpointId =
+          typeof ref.checkpoint_id === "string" ? ref.checkpoint_id : null;
+        if (!checkpointId) break;
+        if (ref.status === "superseded") {
+          upsertLatest(explicitSupersededCheckpoints, checkpointId, {
+            entry,
+            ref,
+          });
+        }
+        const sessionId =
+          (typeof ref.session_id === "string" && ref.session_id) ||
+          (typeof ref.restored_from_session_id === "string" &&
+            ref.restored_from_session_id) ||
+          null;
+        if (!sessionId) break;
+        if (!checkpointsBySession.has(sessionId))
+          checkpointsBySession.set(sessionId, []);
+        checkpointsBySession.get(sessionId).push({ entry, ref, checkpointId });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const rows = [];
+  const counts = emptyCounts();
+
+  for (const [taskId, item] of tasks) {
+    const completed = item.entry?.event === "task_completed";
+    const status = statusOf(item.ref, completed ? "completed" : "active");
+    counts[
+      completed || status === "completed" ? "completed_tasks" : "active_tasks"
+    ] += 1;
+    rows.push(
+      rowFrom(
+        "task",
+        taskId,
+        completed || status === "completed" ? "completed" : status,
+        item.entry,
+        item.ref,
+        completed || status === "completed"
+          ? null
+          : "complete_or_reassign_task",
+      ),
+    );
+  }
+
+  for (const [sessionId, item] of staleSessions) {
+    counts.stale_sessions += 1;
+    rows.push(
+      rowFrom(
+        "session",
+        sessionId,
+        "stale",
+        item.entry,
+        item.ref,
+        "archive_or_resume_session",
+      ),
+    );
+  }
+
+  for (const session of overlay?.live_sessions || []) {
+    const phase = String(session?.phase || session?.status || "").toLowerCase();
+    if (phase !== "stale") continue;
+    const sessionId = String(
+      session?.sessionId || session?.session_id || "",
+    ).trim();
+    if (!sessionId || staleSessions.has(sessionId)) continue;
+    counts.stale_sessions += 1;
+    rows.push({
+      kind: "session",
+      id: sessionId,
+      status: "stale",
+      last_event_at: session?.started_at || null,
+      action: "archive_or_resume_session",
+      owner: session?.agent_id ? undefined : "unknown",
+    });
+  }
+
+  for (const [key, item] of worktrees) {
+    if (item.entry?.event === "worktree_removed") continue;
+    const status = statusOf(item.ref, "active");
+    if (status !== "orphaned") continue;
+    counts.orphan_worktrees += 1;
+    rows.push(
+      rowFrom(
+        "worktree",
+        item.ref.worktree_label || key,
+        "orphaned",
+        item.entry,
+        item.ref,
+        "remove_or_reassign_worktree",
+      ),
+    );
+  }
+
+  const superseded = new Map(explicitSupersededCheckpoints);
+  for (const checkpoints of checkpointsBySession.values()) {
+    const ordered = [...checkpoints].sort((a, b) =>
+      eventTime(a.entry).localeCompare(eventTime(b.entry)),
+    );
+    for (const item of ordered.slice(0, -1)) {
+      if (!superseded.has(item.checkpointId)) {
+        superseded.set(item.checkpointId, item);
+      }
+    }
+  }
+  for (const [checkpointId, item] of superseded) {
+    counts.superseded_checkpoints += 1;
+    rows.push(
+      rowFrom(
+        "checkpoint",
+        checkpointId,
+        "superseded",
+        item.entry,
+        item.ref,
+        "prune_superseded_checkpoint",
+      ),
+    );
+  }
+
+  const sortedRows = rows.map((row) => {
+    if (row.owner === undefined) {
+      const { owner: _owner, ...rest } = row;
+      return rest;
+    }
+    return row;
+  });
+  counts.unknown_owner = sortedRows.filter(
+    (row) => row.owner === "unknown",
+  ).length;
+
+  return {
+    schema_version: "cto-hygiene.v1",
+    dry_run: true,
+    counts,
+    rows: sortedRows,
+  };
+}
+
+export async function runHygiene(args = [], opts = {}) {
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || hasFlag(args, "--json");
+  const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
+  if (!dryRun) {
+    throw new Error("tfx cto hygiene only supports --dry-run");
+  }
+
+  const currentPath = join(lakeRoot, "current.json");
+  const current = existsSync(currentPath) ? readJson(currentPath) : {};
+  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+  const projection = projectCtoHygiene({
+    current,
+    ledger: ledger.length > 0 ? ledger : null,
+    overlay,
+  });
+
+  if (jsonOut) writeJson(stdout, projection);
+  else {
+    stdout.write(
+      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+    );
+  }
+
+  return projection;
+}

--- a/cto/index.mjs
+++ b/cto/index.mjs
@@ -1,4 +1,4 @@
-const SUBCOMMANDS = ["collect", "status", "dashboard"];
+const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene"];
 
 function printUsage(subcommand) {
   if (subcommand) {
@@ -6,12 +6,13 @@ function printUsage(subcommand) {
   }
   console.log(`
 Usage
-  tfx cto <collect|status|dashboard> [options]
+  tfx cto <collect|status|dashboard|hygiene> [options]
 
 Subcommands
   collect     Refresh .triflux/lake/current.json from repo-local authority sources
   status      Print the current authority summary
   dashboard   Render the CTO console dashboard, optionally with --watch
+  hygiene     Project CTO hygiene counts and actionable dry-run rows
 `);
 }
 
@@ -30,6 +31,10 @@ export async function cmdCto(cmdArgs, opts = {}) {
     case "dashboard": {
       const { runDashboard } = await import("./dashboard.mjs");
       return runDashboard(rest, opts);
+    }
+    case "hygiene": {
+      const { runHygiene } = await import("./hygiene.mjs");
+      return runHygiene(rest, opts);
     }
     case undefined:
     case "":

--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { compactHygieneCounts, projectCtoHygiene } from "./hygiene.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
@@ -254,6 +255,7 @@ function projectStatus(current, overlay) {
     live_sessions: liveSessions,
     live_session_groups: deriveLiveSessionGroups(liveSessions),
     active_shards: deriveActiveShards(current, overlay),
+    hygiene: compactHygieneCounts(projectCtoHygiene({ current, overlay })),
   };
 }
 

--- a/packages/remote/cto/hygiene.mjs
+++ b/packages/remote/cto/hygiene.mjs
@@ -1,0 +1,372 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
+const COUNT_KEYS = [
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+];
+
+function hasFlag(args, flag) {
+  return Array.isArray(args) && args.includes(flag);
+}
+
+function writeJson(stdout, payload) {
+  stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function firstExisting(paths) {
+  return paths.filter(Boolean).find((path) => existsSync(path)) || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return null;
+}
+
+function normalizeLiveSession(session) {
+  return {
+    sessionId: String(session?.sessionId || session?.session_id || ""),
+    phase:
+      typeof session?.phase === "string"
+        ? session.phase
+        : typeof session?.status === "string"
+          ? session.status
+          : "active",
+    agent_id:
+      typeof session?.agent_id === "string"
+        ? session.agent_id
+        : typeof session?.agentId === "string"
+          ? session.agentId
+          : null,
+    started_at: toIsoTime(
+      session?.started_at ?? session?.startedAt ?? session?.lastHeartbeat,
+    ),
+  };
+}
+
+function normalizeOverlay(value) {
+  const sessions = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.sessions)
+      ? value.sessions
+      : Array.isArray(value?.live_sessions)
+        ? value.live_sessions
+        : [];
+  return {
+    live_sessions: sessions
+      .map(normalizeLiveSession)
+      .filter((session) => session.sessionId),
+  };
+}
+
+async function readSynapseWithRegistry(opts = {}) {
+  const rootDir = opts.rootDir || process.cwd();
+  const persistPath = firstExisting([
+    opts.synapsePersistPath,
+    join(rootDir, ".triflux", "synapse-registry.json"),
+    join(rootDir, ".triflux", "synapse", "registry.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-sessions.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-registry.json"),
+  ]);
+  if (!persistPath) return { live_sessions: [] };
+
+  const { createSynapseRegistry } = await import(
+    "../hub/team/synapse-registry.mjs"
+  );
+  const registry = createSynapseRegistry({ persistPath });
+  return normalizeOverlay(registry.getActive());
+}
+
+async function readLiveOverlay(opts = {}) {
+  if (opts.overlay) return normalizeOverlay(opts.overlay);
+  try {
+    const reader = opts.synapseReader || readSynapseWithRegistry;
+    return normalizeOverlay(
+      await reader({
+        rootDir: opts.rootDir,
+        lakeRoot: opts.lakeRoot,
+        synapsePersistPath: opts.synapsePersistPath,
+      }),
+    );
+  } catch {
+    return { live_sessions: [] };
+  }
+}
+
+function readJsonLines(filePath) {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function eventTime(entry) {
+  return typeof entry?.ts === "string" ? entry.ts : "";
+}
+
+function eventRef(entry) {
+  return entry?.ref && typeof entry.ref === "object" && !Array.isArray(entry.ref)
+    ? entry.ref
+    : {};
+}
+
+function hasKnownOwner(ref) {
+  const actor = ref?.actor;
+  if (actor && typeof actor === "object" && !Array.isArray(actor)) {
+    for (const key of ["cli", "session_id", "agent_id", "host"]) {
+      if (typeof actor[key] === "string" && actor[key].trim()) return true;
+    }
+  }
+  for (const key of ["owner", "owner_id", "agent_id"]) {
+    if (typeof ref?.[key] === "string" && ref[key].trim()) return true;
+  }
+  return false;
+}
+
+function statusOf(ref, fallback) {
+  return typeof ref?.status === "string" && ref.status.trim()
+    ? ref.status.trim()
+    : fallback;
+}
+
+function rowFrom(kind, id, status, entry, ref, action) {
+  const row = {
+    kind,
+    id,
+    status,
+    last_event_at: eventTime(entry) || null,
+  };
+  if (entry?.summary) row.summary = String(entry.summary);
+  if (action) row.action = action;
+  if (action && !hasKnownOwner(ref)) row.owner = "unknown";
+  return row;
+}
+
+function upsertLatest(map, key, value) {
+  const existing = map.get(key);
+  if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
+    map.set(key, value);
+  }
+}
+
+function emptyCounts() {
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
+}
+
+export function compactHygieneCounts(projection) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, counts[key] || 0]));
+}
+
+export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } = {}) {
+  const events = Array.isArray(ledger)
+    ? ledger
+    : Array.isArray(current?.ledger_tail)
+      ? current.ledger_tail
+      : [];
+  const tasks = new Map();
+  const staleSessions = new Map();
+  const worktrees = new Map();
+  const checkpointsBySession = new Map();
+  const explicitSupersededCheckpoints = new Map();
+
+  for (const entry of events) {
+    const ref = eventRef(entry);
+    switch (entry?.event) {
+      case "task_claimed":
+      case "task_completed": {
+        const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
+        if (!taskId) break;
+        upsertLatest(tasks, taskId, { entry, ref });
+        break;
+      }
+      case "session_stale": {
+        const sessionId = typeof ref.session_id === "string" ? ref.session_id : null;
+        if (!sessionId) break;
+        upsertLatest(staleSessions, sessionId, { entry, ref });
+        break;
+      }
+      case "worktree_created":
+      case "worktree_removed": {
+        const key =
+          (typeof ref.worktree_path_hash === "string" && ref.worktree_path_hash) ||
+          (typeof ref.worktree_label === "string" && ref.worktree_label) ||
+          null;
+        if (!key) break;
+        upsertLatest(worktrees, key, { entry, ref });
+        break;
+      }
+      case "checkpoint_saved":
+      case "checkpoint_restored": {
+        const checkpointId =
+          typeof ref.checkpoint_id === "string" ? ref.checkpoint_id : null;
+        if (!checkpointId) break;
+        if (ref.status === "superseded") {
+          upsertLatest(explicitSupersededCheckpoints, checkpointId, { entry, ref });
+        }
+        const sessionId =
+          (typeof ref.session_id === "string" && ref.session_id) ||
+          (typeof ref.restored_from_session_id === "string" && ref.restored_from_session_id) ||
+          null;
+        if (!sessionId) break;
+        if (!checkpointsBySession.has(sessionId)) checkpointsBySession.set(sessionId, []);
+        checkpointsBySession.get(sessionId).push({ entry, ref, checkpointId });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const rows = [];
+  const counts = emptyCounts();
+
+  for (const [taskId, item] of tasks) {
+    const completed = item.entry?.event === "task_completed";
+    const status = statusOf(item.ref, completed ? "completed" : "active");
+    counts[completed || status === "completed" ? "completed_tasks" : "active_tasks"] += 1;
+    rows.push(
+      rowFrom(
+        "task",
+        taskId,
+        completed || status === "completed" ? "completed" : status,
+        item.entry,
+        item.ref,
+        completed || status === "completed" ? null : "complete_or_reassign_task",
+      ),
+    );
+  }
+
+  for (const [sessionId, item] of staleSessions) {
+    counts.stale_sessions += 1;
+    rows.push(
+      rowFrom("session", sessionId, "stale", item.entry, item.ref, "archive_or_resume_session"),
+    );
+  }
+
+  for (const session of overlay?.live_sessions || []) {
+    const phase = String(session?.phase || session?.status || "").toLowerCase();
+    if (phase !== "stale") continue;
+    const sessionId = String(session?.sessionId || session?.session_id || "").trim();
+    if (!sessionId || staleSessions.has(sessionId)) continue;
+    counts.stale_sessions += 1;
+    rows.push({
+      kind: "session",
+      id: sessionId,
+      status: "stale",
+      last_event_at: session?.started_at || null,
+      action: "archive_or_resume_session",
+      owner: session?.agent_id ? undefined : "unknown",
+    });
+  }
+
+  for (const [key, item] of worktrees) {
+    if (item.entry?.event === "worktree_removed") continue;
+    const status = statusOf(item.ref, "active");
+    if (status !== "orphaned") continue;
+    counts.orphan_worktrees += 1;
+    rows.push(
+      rowFrom(
+        "worktree",
+        item.ref.worktree_label || key,
+        "orphaned",
+        item.entry,
+        item.ref,
+        "remove_or_reassign_worktree",
+      ),
+    );
+  }
+
+  const superseded = new Map(explicitSupersededCheckpoints);
+  for (const checkpoints of checkpointsBySession.values()) {
+    const ordered = [...checkpoints].sort((a, b) =>
+      eventTime(a.entry).localeCompare(eventTime(b.entry)),
+    );
+    for (const item of ordered.slice(0, -1)) {
+      if (!superseded.has(item.checkpointId)) {
+        superseded.set(item.checkpointId, item);
+      }
+    }
+  }
+  for (const [checkpointId, item] of superseded) {
+    counts.superseded_checkpoints += 1;
+    rows.push(
+      rowFrom(
+        "checkpoint",
+        checkpointId,
+        "superseded",
+        item.entry,
+        item.ref,
+        "prune_superseded_checkpoint",
+      ),
+    );
+  }
+
+  const sortedRows = rows.map((row) => {
+    if (row.owner === undefined) {
+      const { owner: _owner, ...rest } = row;
+      return rest;
+    }
+    return row;
+  });
+  counts.unknown_owner = sortedRows.filter((row) => row.owner === "unknown").length;
+
+  return {
+    schema_version: "cto-hygiene.v1",
+    dry_run: true,
+    counts,
+    rows: sortedRows,
+  };
+}
+
+export async function runHygiene(args = [], opts = {}) {
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || hasFlag(args, "--json");
+  const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
+  if (!dryRun) {
+    throw new Error("tfx cto hygiene only supports --dry-run");
+  }
+
+  const currentPath = join(lakeRoot, "current.json");
+  const current = existsSync(currentPath) ? readJson(currentPath) : {};
+  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+  const projection = projectCtoHygiene({
+    current,
+    ledger: ledger.length > 0 ? ledger : null,
+    overlay,
+  });
+
+  if (jsonOut) writeJson(stdout, projection);
+  else {
+    stdout.write(
+      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+    );
+  }
+
+  return projection;
+}

--- a/packages/remote/cto/status.mjs
+++ b/packages/remote/cto/status.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { compactHygieneCounts, projectCtoHygiene } from "./hygiene.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
@@ -254,6 +255,7 @@ function projectStatus(current, overlay) {
     live_sessions: liveSessions,
     live_session_groups: deriveLiveSessionGroups(liveSessions),
     active_shards: deriveActiveShards(current, overlay),
+    hygiene: compactHygieneCounts(projectCtoHygiene({ current, overlay })),
   };
 }
 

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -499,12 +499,13 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     },
   },
   cto: {
-    usage: "tfx cto <collect|status|dashboard> [options]",
+    usage: "tfx cto <collect|status|dashboard|hygiene> [options]",
     description: "repo-local authority layer console",
     subcommands: {
       collect: "refresh .triflux/lake/current.json from authority sources",
       status: "print the current authority summary",
       dashboard: "render the CTO console dashboard, optionally with --watch",
+      hygiene: "project CTO hygiene counts and actionable dry-run rows",
     },
   },
   multi: {

--- a/packages/triflux/cto/hygiene.mjs
+++ b/packages/triflux/cto/hygiene.mjs
@@ -1,0 +1,400 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLakeRootDir } from "./lake-root.mjs";
+
+const COUNT_KEYS = [
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+];
+
+function hasFlag(args, flag) {
+  return Array.isArray(args) && args.includes(flag);
+}
+
+function writeJson(stdout, payload) {
+  stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function firstExisting(paths) {
+  return paths.filter(Boolean).find((path) => existsSync(path)) || null;
+}
+
+function toIsoTime(value) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return null;
+}
+
+function normalizeLiveSession(session) {
+  return {
+    sessionId: String(session?.sessionId || session?.session_id || ""),
+    phase:
+      typeof session?.phase === "string"
+        ? session.phase
+        : typeof session?.status === "string"
+          ? session.status
+          : "active",
+    agent_id:
+      typeof session?.agent_id === "string"
+        ? session.agent_id
+        : typeof session?.agentId === "string"
+          ? session.agentId
+          : null,
+    started_at: toIsoTime(
+      session?.started_at ?? session?.startedAt ?? session?.lastHeartbeat,
+    ),
+  };
+}
+
+function normalizeOverlay(value) {
+  const sessions = Array.isArray(value)
+    ? value
+    : Array.isArray(value?.sessions)
+      ? value.sessions
+      : Array.isArray(value?.live_sessions)
+        ? value.live_sessions
+        : [];
+  return {
+    live_sessions: sessions
+      .map(normalizeLiveSession)
+      .filter((session) => session.sessionId),
+  };
+}
+
+async function readSynapseWithRegistry(opts = {}) {
+  const rootDir = opts.rootDir || process.cwd();
+  const persistPath = firstExisting([
+    opts.synapsePersistPath,
+    join(rootDir, ".triflux", "synapse-registry.json"),
+    join(rootDir, ".triflux", "synapse", "registry.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-sessions.json"),
+    join(homedir(), ".claude", "cache", "tfx-hub", "synapse-registry.json"),
+  ]);
+  if (!persistPath) return { live_sessions: [] };
+
+  const { createSynapseRegistry } = await import(
+    "../hub/team/synapse-registry.mjs"
+  );
+  const registry = createSynapseRegistry({ persistPath });
+  return normalizeOverlay(registry.getActive());
+}
+
+async function readLiveOverlay(opts = {}) {
+  if (opts.overlay) return normalizeOverlay(opts.overlay);
+  try {
+    const reader = opts.synapseReader || readSynapseWithRegistry;
+    return normalizeOverlay(
+      await reader({
+        rootDir: opts.rootDir,
+        lakeRoot: opts.lakeRoot,
+        synapsePersistPath: opts.synapsePersistPath,
+      }),
+    );
+  } catch {
+    return { live_sessions: [] };
+  }
+}
+
+function readJsonLines(filePath) {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function eventTime(entry) {
+  return typeof entry?.ts === "string" ? entry.ts : "";
+}
+
+function eventRef(entry) {
+  return entry?.ref &&
+    typeof entry.ref === "object" &&
+    !Array.isArray(entry.ref)
+    ? entry.ref
+    : {};
+}
+
+function hasKnownOwner(ref) {
+  const actor = ref?.actor;
+  if (actor && typeof actor === "object" && !Array.isArray(actor)) {
+    for (const key of ["cli", "session_id", "agent_id", "host"]) {
+      if (typeof actor[key] === "string" && actor[key].trim()) return true;
+    }
+  }
+  for (const key of ["owner", "owner_id", "agent_id"]) {
+    if (typeof ref?.[key] === "string" && ref[key].trim()) return true;
+  }
+  return false;
+}
+
+function statusOf(ref, fallback) {
+  return typeof ref?.status === "string" && ref.status.trim()
+    ? ref.status.trim()
+    : fallback;
+}
+
+function rowFrom(kind, id, status, entry, ref, action) {
+  const row = {
+    kind,
+    id,
+    status,
+    last_event_at: eventTime(entry) || null,
+  };
+  if (entry?.summary) row.summary = String(entry.summary);
+  if (action) row.action = action;
+  if (action && !hasKnownOwner(ref)) row.owner = "unknown";
+  return row;
+}
+
+function upsertLatest(map, key, value) {
+  const existing = map.get(key);
+  if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
+    map.set(key, value);
+  }
+}
+
+function emptyCounts() {
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
+}
+
+export function compactHygieneCounts(projection) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(COUNT_KEYS.map((key) => [key, counts[key] || 0]));
+}
+
+export function projectCtoHygiene({
+  current = {},
+  ledger = null,
+  overlay = {},
+} = {}) {
+  const events = Array.isArray(ledger)
+    ? ledger
+    : Array.isArray(current?.ledger_tail)
+      ? current.ledger_tail
+      : [];
+  const tasks = new Map();
+  const staleSessions = new Map();
+  const worktrees = new Map();
+  const checkpointsBySession = new Map();
+  const explicitSupersededCheckpoints = new Map();
+
+  for (const entry of events) {
+    const ref = eventRef(entry);
+    switch (entry?.event) {
+      case "task_claimed":
+      case "task_completed": {
+        const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
+        if (!taskId) break;
+        upsertLatest(tasks, taskId, { entry, ref });
+        break;
+      }
+      case "session_stale": {
+        const sessionId =
+          typeof ref.session_id === "string" ? ref.session_id : null;
+        if (!sessionId) break;
+        upsertLatest(staleSessions, sessionId, { entry, ref });
+        break;
+      }
+      case "worktree_created":
+      case "worktree_removed": {
+        const key =
+          (typeof ref.worktree_path_hash === "string" &&
+            ref.worktree_path_hash) ||
+          (typeof ref.worktree_label === "string" && ref.worktree_label) ||
+          null;
+        if (!key) break;
+        upsertLatest(worktrees, key, { entry, ref });
+        break;
+      }
+      case "checkpoint_saved":
+      case "checkpoint_restored": {
+        const checkpointId =
+          typeof ref.checkpoint_id === "string" ? ref.checkpoint_id : null;
+        if (!checkpointId) break;
+        if (ref.status === "superseded") {
+          upsertLatest(explicitSupersededCheckpoints, checkpointId, {
+            entry,
+            ref,
+          });
+        }
+        const sessionId =
+          (typeof ref.session_id === "string" && ref.session_id) ||
+          (typeof ref.restored_from_session_id === "string" &&
+            ref.restored_from_session_id) ||
+          null;
+        if (!sessionId) break;
+        if (!checkpointsBySession.has(sessionId))
+          checkpointsBySession.set(sessionId, []);
+        checkpointsBySession.get(sessionId).push({ entry, ref, checkpointId });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const rows = [];
+  const counts = emptyCounts();
+
+  for (const [taskId, item] of tasks) {
+    const completed = item.entry?.event === "task_completed";
+    const status = statusOf(item.ref, completed ? "completed" : "active");
+    counts[
+      completed || status === "completed" ? "completed_tasks" : "active_tasks"
+    ] += 1;
+    rows.push(
+      rowFrom(
+        "task",
+        taskId,
+        completed || status === "completed" ? "completed" : status,
+        item.entry,
+        item.ref,
+        completed || status === "completed"
+          ? null
+          : "complete_or_reassign_task",
+      ),
+    );
+  }
+
+  for (const [sessionId, item] of staleSessions) {
+    counts.stale_sessions += 1;
+    rows.push(
+      rowFrom(
+        "session",
+        sessionId,
+        "stale",
+        item.entry,
+        item.ref,
+        "archive_or_resume_session",
+      ),
+    );
+  }
+
+  for (const session of overlay?.live_sessions || []) {
+    const phase = String(session?.phase || session?.status || "").toLowerCase();
+    if (phase !== "stale") continue;
+    const sessionId = String(
+      session?.sessionId || session?.session_id || "",
+    ).trim();
+    if (!sessionId || staleSessions.has(sessionId)) continue;
+    counts.stale_sessions += 1;
+    rows.push({
+      kind: "session",
+      id: sessionId,
+      status: "stale",
+      last_event_at: session?.started_at || null,
+      action: "archive_or_resume_session",
+      owner: session?.agent_id ? undefined : "unknown",
+    });
+  }
+
+  for (const [key, item] of worktrees) {
+    if (item.entry?.event === "worktree_removed") continue;
+    const status = statusOf(item.ref, "active");
+    if (status !== "orphaned") continue;
+    counts.orphan_worktrees += 1;
+    rows.push(
+      rowFrom(
+        "worktree",
+        item.ref.worktree_label || key,
+        "orphaned",
+        item.entry,
+        item.ref,
+        "remove_or_reassign_worktree",
+      ),
+    );
+  }
+
+  const superseded = new Map(explicitSupersededCheckpoints);
+  for (const checkpoints of checkpointsBySession.values()) {
+    const ordered = [...checkpoints].sort((a, b) =>
+      eventTime(a.entry).localeCompare(eventTime(b.entry)),
+    );
+    for (const item of ordered.slice(0, -1)) {
+      if (!superseded.has(item.checkpointId)) {
+        superseded.set(item.checkpointId, item);
+      }
+    }
+  }
+  for (const [checkpointId, item] of superseded) {
+    counts.superseded_checkpoints += 1;
+    rows.push(
+      rowFrom(
+        "checkpoint",
+        checkpointId,
+        "superseded",
+        item.entry,
+        item.ref,
+        "prune_superseded_checkpoint",
+      ),
+    );
+  }
+
+  const sortedRows = rows.map((row) => {
+    if (row.owner === undefined) {
+      const { owner: _owner, ...rest } = row;
+      return rest;
+    }
+    return row;
+  });
+  counts.unknown_owner = sortedRows.filter(
+    (row) => row.owner === "unknown",
+  ).length;
+
+  return {
+    schema_version: "cto-hygiene.v1",
+    dry_run: true,
+    counts,
+    rows: sortedRows,
+  };
+}
+
+export async function runHygiene(args = [], opts = {}) {
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || hasFlag(args, "--json");
+  const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
+  if (!dryRun) {
+    throw new Error("tfx cto hygiene only supports --dry-run");
+  }
+
+  const currentPath = join(lakeRoot, "current.json");
+  const current = existsSync(currentPath) ? readJson(currentPath) : {};
+  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+  const projection = projectCtoHygiene({
+    current,
+    ledger: ledger.length > 0 ? ledger : null,
+    overlay,
+  });
+
+  if (jsonOut) writeJson(stdout, projection);
+  else {
+    stdout.write(
+      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+    );
+  }
+
+  return projection;
+}

--- a/packages/triflux/cto/index.mjs
+++ b/packages/triflux/cto/index.mjs
@@ -1,4 +1,4 @@
-const SUBCOMMANDS = ["collect", "status", "dashboard"];
+const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene"];
 
 function printUsage(subcommand) {
   if (subcommand) {
@@ -6,12 +6,13 @@ function printUsage(subcommand) {
   }
   console.log(`
 Usage
-  tfx cto <collect|status|dashboard> [options]
+  tfx cto <collect|status|dashboard|hygiene> [options]
 
 Subcommands
   collect     Refresh .triflux/lake/current.json from repo-local authority sources
   status      Print the current authority summary
   dashboard   Render the CTO console dashboard, optionally with --watch
+  hygiene     Project CTO hygiene counts and actionable dry-run rows
 `);
 }
 
@@ -30,6 +31,10 @@ export async function cmdCto(cmdArgs, opts = {}) {
     case "dashboard": {
       const { runDashboard } = await import("./dashboard.mjs");
       return runDashboard(rest, opts);
+    }
+    case "hygiene": {
+      const { runHygiene } = await import("./hygiene.mjs");
+      return runHygiene(rest, opts);
     }
     case undefined:
     case "":

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import { compactHygieneCounts, projectCtoHygiene } from "./hygiene.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const SCHEMA_VERSION = "cto-lake.v1";
@@ -254,6 +255,7 @@ function projectStatus(current, overlay) {
     live_sessions: liveSessions,
     live_session_groups: deriveLiveSessionGroups(liveSessions),
     active_shards: deriveActiveShards(current, overlay),
+    hygiene: compactHygieneCounts(projectCtoHygiene({ current, overlay })),
   };
 }
 

--- a/tests/cto/hygiene.test.mjs
+++ b/tests/cto/hygiene.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { projectCtoHygiene } from "../../cto/hygiene.mjs";
+
+const baseCurrent = {
+  ledger_tail: [],
+  sources: {},
+};
+
+function event(ts, name, ref = {}, summary = name) {
+  return { ts, event: name, source: "test", summary, ref };
+}
+
+describe("projectCtoHygiene", () => {
+  it("deterministically projects actionable hygiene counts from CTO events and live overlay", () => {
+    const ledger = [
+      event("2026-06-17T00:00:00.000Z", "task_claimed", {
+        task_id: "task-active",
+        actor: { agent_id: "agent-a" },
+      }),
+      event("2026-06-17T00:01:00.000Z", "task_claimed", {
+        task_id: "task-done",
+      }),
+      event("2026-06-17T00:02:00.000Z", "task_completed", {
+        task_id: "task-done",
+      }),
+      event("2026-06-17T00:03:00.000Z", "session_stale", {
+        session_id: "session-old",
+        stale_reason: "heartbeat_timeout",
+      }),
+      event("2026-06-17T00:04:00.000Z", "worktree_created", {
+        worktree_path_hash: "wt-hash",
+        worktree_label: "worker-a",
+        status: "orphaned",
+      }),
+      event("2026-06-17T00:05:00.000Z", "checkpoint_saved", {
+        checkpoint_id: "cp-old",
+        session_id: "session-old",
+      }),
+      event("2026-06-17T00:06:00.000Z", "checkpoint_saved", {
+        checkpoint_id: "cp-new",
+        session_id: "session-old",
+      }),
+    ];
+
+    const projection = projectCtoHygiene({
+      current: baseCurrent,
+      ledger,
+      overlay: {
+        live_sessions: [{ sessionId: "session-live", phase: "stale" }],
+      },
+    });
+
+    assert.equal(projection.dry_run, true);
+    assert.equal(projection.counts.active_tasks, 1);
+    assert.equal(projection.counts.completed_tasks, 1);
+    assert.equal(projection.counts.stale_sessions, 2);
+    assert.equal(projection.counts.orphan_worktrees, 1);
+    assert.equal(projection.counts.superseded_checkpoints, 1);
+    assert.equal(projection.counts.unknown_owner, 4);
+    assert.deepEqual(
+      projection.rows.map((row) => [row.kind, row.id, row.status]),
+      [
+        ["task", "task-active", "active"],
+        ["task", "task-done", "completed"],
+        ["session", "session-old", "stale"],
+        ["session", "session-live", "stale"],
+        ["worktree", "worker-a", "orphaned"],
+        ["checkpoint", "cp-old", "superseded"],
+      ],
+    );
+  });
+});

--- a/tests/cto/router.test.mjs
+++ b/tests/cto/router.test.mjs
@@ -22,10 +22,11 @@ describe("cmdCto", () => {
     const output = await captureStdout(() => cmdCto([]));
 
     assert.match(output, /Usage/u);
-    assert.match(output, /tfx cto <collect\|status\|dashboard>/u);
+    assert.match(output, /tfx cto <collect\|status\|dashboard\|hygiene>/u);
     assert.match(output, /collect/u);
     assert.match(output, /status/u);
     assert.match(output, /dashboard/u);
+    assert.match(output, /hygiene/u);
   });
 
   it("prints usage for an unknown subcommand without throwing", async () => {
@@ -33,5 +34,49 @@ describe("cmdCto", () => {
 
     assert.match(output, /Unknown cto subcommand: bogus/u);
     assert.match(output, /Usage/u);
+  });
+
+  it("routes hygiene dry-run JSON without mutating the ledger", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } =
+      await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const root = mkdtempSync(join(tmpdir(), "tfx-cto-router-hygiene-"));
+    const lakeRoot = join(root, ".triflux", "lake");
+    let output = "";
+    try {
+      mkdirSync(lakeRoot, { recursive: true });
+      const ledgerPath = join(lakeRoot, "ledger.jsonl");
+      writeFileSync(
+        ledgerPath,
+        `${JSON.stringify({
+          ts: "2026-06-17T00:00:00.000Z",
+          event: "task_claimed",
+          source: "test",
+          summary: "claim task-a",
+          ref: { task_id: "task-a" },
+        })}\n`,
+        "utf8",
+      );
+
+      const result = await cmdCto(["hygiene", "--dry-run", "--json"], {
+        lakeRoot,
+        stdout: {
+          write: (chunk) => {
+            output += String(chunk);
+          },
+        },
+        synapseReader: async () => ({ sessions: [] }),
+      });
+
+      assert.equal(result.dry_run, true);
+      assert.equal(JSON.parse(output).counts.active_tasks, 1);
+      assert.equal(
+        readFileSync(ledgerPath, "utf8").split(/\r?\n/u).filter(Boolean).length,
+        1,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cto/status.test.mjs
+++ b/tests/cto/status.test.mjs
@@ -115,6 +115,7 @@ describe("runStatus", () => {
         "ledger_tail",
         "live_sessions",
         "active_shards",
+        "hygiene",
       ];
       for (const key of existingKeys)
         assert.ok(key in parsed, `${key} missing`);
@@ -141,6 +142,14 @@ describe("runStatus", () => {
           members: ["agent-1"],
         },
       ]);
+      assert.deepEqual(parsed.hygiene, {
+        active_tasks: 0,
+        completed_tasks: 0,
+        stale_sessions: 0,
+        orphan_worktrees: 0,
+        superseded_checkpoints: 0,
+        unknown_owner: 0,
+      });
     } finally {
       cleanup(rootDir);
     }
@@ -203,6 +212,55 @@ describe("runStatus", () => {
       assert.deepEqual(parsed.live_sessions, []);
       assert.deepEqual(parsed.active_shards, []);
       assert.deepEqual(parsed.ledger_tail, current.ledger_tail);
+    } finally {
+      cleanup(rootDir);
+    }
+  });
+
+  it("includes compact hygiene summary derived from current ledger and live overlay", async () => {
+    const rootDir = makeTempDir();
+    const lakeRoot = join(rootDir, ".test-lake");
+    const out = captureStdout();
+    try {
+      writeJson(
+        join(lakeRoot, "current.json"),
+        fixtureCurrent({
+          ledger_tail: [
+            {
+              ts: "2026-06-17T00:00:00.000Z",
+              event: "task_claimed",
+              source: "test",
+              summary: "claim task-a",
+              ref: { task_id: "task-a" },
+            },
+            {
+              ts: "2026-06-17T00:01:00.000Z",
+              event: "session_stale",
+              source: "test",
+              summary: "session stale",
+              ref: { session_id: "session-old" },
+            },
+          ],
+        }),
+      );
+
+      await runStatus(["--json"], {
+        lakeRoot,
+        stdout: out.stdout,
+        synapseReader: async () => ({
+          sessions: [{ sessionId: "session-live", status: "active" }],
+        }),
+      });
+
+      const parsed = JSON.parse(out.read());
+      assert.deepEqual(parsed.hygiene, {
+        active_tasks: 1,
+        completed_tasks: 0,
+        stale_sessions: 1,
+        orphan_worktrees: 0,
+        superseded_checkpoints: 0,
+        unknown_owner: 2,
+      });
     } finally {
       cleanup(rootDir);
     }


### PR DESCRIPTION
## Summary\n- add deterministic CTO hygiene projection helper and dry-run JSON command\n- route `tfx cto hygiene --dry-run --json` without ledger mutation or apply behavior\n- include compact hygiene counts in `tfx cto status --json`\n- mirror CTO/bin changes into package outputs\n\n## Tests\n- `node scripts/test-lock.mjs --test --test-force-exit --test-concurrency=8 tests/cto/*.test.mjs`\n- `npm run release:check-mirror`\n- `npm run release:check-sync`\n- `git diff --check`\n- `npx biome check bin/triflux.mjs cto/index.mjs cto/status.mjs cto/hygiene.mjs packages/triflux/bin/triflux.mjs packages/triflux/cto/index.mjs packages/triflux/cto/status.mjs packages/triflux/cto/hygiene.mjs packages/remote/cto/status.mjs packages/remote/cto/hygiene.mjs tests/cto/hygiene.test.mjs tests/cto/router.test.mjs tests/cto/status.test.mjs`\n\nRefs #422