### PR TITLE
feat(cto): emit participant session events

### DIFF
--- a/hooks/agy-session-hook.mjs
+++ b/hooks/agy-session-hook.mjs
@@ -45,7 +45,7 @@ export function toSessionPayload(payload) {
     typeof workspacePaths[0] === "string" && workspacePaths[0]
       ? workspacePaths[0]
       : process.cwd();
-  return JSON.stringify({ session_id: sessionId, cwd });
+  return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
 // agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
@@ -98,7 +98,7 @@ export async function runAgySessionHook(stdinData, opts = {}) {
         await hubEnsureRun(sessionPayload);
       } catch {}
       try {
-        registerInteractiveSession(sessionPayload);
+        await Promise.resolve(registerInteractiveSession(sessionPayload));
       } catch {}
       try {
         await drainPendingSynapse(1000);

--- a/hooks/codex-session-hook.mjs
+++ b/hooks/codex-session-hook.mjs
@@ -99,7 +99,7 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
           await hubEnsureRun(stdinData);
         } catch {}
         try {
-          registerInteractiveSession(stdinData);
+          await Promise.resolve(registerInteractiveSession(stdinData));
         } catch {}
         try {
           await drainPendingSynapse(1000);

--- a/hooks/session-start-fast.mjs
+++ b/hooks/session-start-fast.mjs
@@ -40,6 +40,98 @@ function parseStartPayload(stdinData) {
   }
 }
 
+function inferParticipantCli(payload) {
+  const direct = String(
+    payload?.actor_cli || payload?.cli || payload?.actor?.cli || "",
+  )
+    .trim()
+    .toLowerCase();
+  if (direct) return direct;
+
+  const eventName = String(payload?.hook_event_name || "").trim();
+  if (eventName === "SessionStart") return "claude";
+  if (eventName.toLowerCase().replace(/-/g, "_") === "session_start") {
+    return "codex";
+  }
+  return "participant";
+}
+
+async function defaultAppendParticipantCtoEvent(lakeRoot, event) {
+  const { appendCtoEvent } = await import("../cto/events.mjs");
+  return appendCtoEvent(lakeRoot, event, {
+    lockRetries: 1,
+    lockRetryDelayMs: 0,
+  });
+}
+
+async function defaultResolveParticipantLakeRoot(cwd) {
+  const { resolveLakeRootDir } = await import("../cto/lake-root.mjs");
+  const projectRoot = resolveLakeRootDir(cwd, {
+    execFileSync: (cmd, args, options = {}) =>
+      execFileSync(cmd, args, {
+        ...options,
+        timeout: 500,
+        killSignal: "SIGKILL",
+      }),
+  });
+  return {
+    projectRoot,
+    lakeRoot: projectRoot ? join(projectRoot, ".triflux", "lake") : "",
+  };
+}
+
+/**
+ * Append a compact CTO `session_started` event for participant hooks.
+ * This is intentionally observational only: no cleanup, reconciliation, or
+ * summarization policy is performed here. Callers may fire-and-forget it.
+ *
+ * @param {string} stdinData SessionStart-shaped stdin JSON
+ * @param {object} [seams] test seams
+ * @returns {Promise<object|null>}
+ */
+export async function emitParticipantSessionStarted(stdinData, seams = {}) {
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return null;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const resolveLakeRoot =
+      seams.resolveLakeRoot || defaultResolveParticipantLakeRoot;
+    const resolved = await resolveLakeRoot(cwd);
+    const projectRoot =
+      typeof resolved === "string"
+        ? resolved
+        : String(resolved?.projectRoot || "");
+    const lakeRoot =
+      typeof resolved === "string"
+        ? join(resolved, ".triflux", "lake")
+        : String(resolved?.lakeRoot || "");
+    if (!lakeRoot) return null;
+
+    const event = {
+      event: "session_started",
+      source: "tfx_participant_hook",
+      session_id: sessionId,
+      project_root: projectRoot || cwd,
+      worktree_path: cwd,
+      branch: typeof payload?.branch === "string" ? payload.branch : "",
+      status: "active",
+      actor: {
+        cli: inferParticipantCli(payload),
+        session_id: sessionId,
+        host: typeof payload?.host === "string" ? payload.host : "local",
+      },
+      summary: `${inferParticipantCli(payload)} session_started ${sessionId}`,
+      now: seams.now,
+    };
+
+    const append = seams.ctoAppend || defaultAppendParticipantCtoEvent;
+    return await append(lakeRoot, event);
+  } catch {
+    return null;
+  }
+}
+
 function readAncestorCommands(pid = process.ppid, maxDepth = 6) {
   if (process.platform === "win32") return [];
   const commands = [];
@@ -146,17 +238,18 @@ function defaultGitRunner(cwd, args, cb) {
  * @param {Function} [seams.register]  registerSynapseSession 대체
  * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
  * @param {Function} [seams.gitRunner] git runner 대체
- * @returns {void} (enrich 는 백그라운드에서 완료)
+ * @returns {Promise<object|null>|null} CTO append promise; enrich 는 백그라운드에서 완료
  */
 export function registerInteractiveSession(stdinData, seams = {}) {
+  let ctoEvent = null;
   const register = seams.register || registerSynapseSession;
   const heartbeat = seams.heartbeat || heartbeatSynapseSession;
   const gitRunner = seams.gitRunner || defaultGitRunner;
   try {
     const payload = parseStartPayload(stdinData);
     const sessionId = String(payload?.session_id || "").trim();
-    if (!sessionId) return;
-    if (shouldSkipInteractiveRegistration(payload, seams)) return;
+    if (!sessionId) return null;
+    if (shouldSkipInteractiveRegistration(payload, seams)) return null;
     const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
 
     // 1) cwd 만으로 즉시 minimal register (블로킹 git 없음, latency 0).
@@ -170,6 +263,10 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       isRemote: false,
     });
 
+    ctoEvent = emitParticipantSessionStarted(stdinData, seams).catch(
+      () => null,
+    );
+
     // 2) worktree/branch 는 블로킹 경로 밖에서 비동기 enrich → heartbeat partial.
     gitContextAsync(cwd, gitRunner)
       .then(({ worktreePath, branch }) => {
@@ -180,6 +277,7 @@ export function registerInteractiveSession(stdinData, seams = {}) {
   } catch {
     /* best-effort — never affects session start */
   }
+  return ctoEvent;
 }
 
 /**
@@ -371,9 +469,10 @@ function runBackground(stdinData) {
     .catch(() => {}); // 완전 무시
 
   // Synapse: 인터랙티브 세션 self-register (fire-and-forget, hub 미응답 무시)
-  registerInteractiveSession(stdinData);
+  const ctoEvent = registerInteractiveSession(stdinData);
 
   // session-vault은 external source — hook-orchestrator가 execFile로 실행
+  return { ctoEvent };
 }
 
 /**
@@ -392,7 +491,7 @@ export async function execute(stdinData, externalHooks = []) {
 
   // DEFERRED + BACKGROUND: fire-and-forget
   runDeferred(stdinData);
-  runBackground(stdinData);
+  const background = runBackground(stdinData);
 
   // hook-orchestrator process.exit(0)s immediately after we return, which would
   // drop the just-fired Synapse register POST before it flushes to the loopback
@@ -401,7 +500,10 @@ export async function execute(stdinData, externalHooks = []) {
   // and the ceiling caps a hub stall so SessionStart never hangs. The async
   // git-enrich heartbeat stays best-effort (it may not have fired yet) — losing
   // it only drops worktree/branch enrichment, not the core registration.
-  await drainPendingSynapse(1000);
+  await Promise.allSettled([
+    drainPendingSynapse(1000),
+    background?.ctoEvent || Promise.resolve(null),
+  ]);
 
   const totalDur = performance.now() - totalStart;
   log.info(

--- a/packages/core/hooks/agy-session-hook.mjs
+++ b/packages/core/hooks/agy-session-hook.mjs
@@ -45,7 +45,7 @@ export function toSessionPayload(payload) {
     typeof workspacePaths[0] === "string" && workspacePaths[0]
       ? workspacePaths[0]
       : process.cwd();
-  return JSON.stringify({ session_id: sessionId, cwd });
+  return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
 // agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
@@ -98,7 +98,7 @@ export async function runAgySessionHook(stdinData, opts = {}) {
         await hubEnsureRun(sessionPayload);
       } catch {}
       try {
-        registerInteractiveSession(sessionPayload);
+        await Promise.resolve(registerInteractiveSession(sessionPayload));
       } catch {}
       try {
         await drainPendingSynapse(1000);

--- a/packages/core/hooks/codex-session-hook.mjs
+++ b/packages/core/hooks/codex-session-hook.mjs
@@ -99,7 +99,7 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
           await hubEnsureRun(stdinData);
         } catch {}
         try {
-          registerInteractiveSession(stdinData);
+          await Promise.resolve(registerInteractiveSession(stdinData));
         } catch {}
         try {
           await drainPendingSynapse(1000);

--- a/packages/core/hooks/session-start-fast.mjs
+++ b/packages/core/hooks/session-start-fast.mjs
@@ -40,6 +40,98 @@ function parseStartPayload(stdinData) {
   }
 }
 
+function inferParticipantCli(payload) {
+  const direct = String(
+    payload?.actor_cli || payload?.cli || payload?.actor?.cli || "",
+  )
+    .trim()
+    .toLowerCase();
+  if (direct) return direct;
+
+  const eventName = String(payload?.hook_event_name || "").trim();
+  if (eventName === "SessionStart") return "claude";
+  if (eventName.toLowerCase().replace(/-/g, "_") === "session_start") {
+    return "codex";
+  }
+  return "participant";
+}
+
+async function defaultAppendParticipantCtoEvent(lakeRoot, event) {
+  const { appendCtoEvent } = await import("../cto/events.mjs");
+  return appendCtoEvent(lakeRoot, event, {
+    lockRetries: 1,
+    lockRetryDelayMs: 0,
+  });
+}
+
+async function defaultResolveParticipantLakeRoot(cwd) {
+  const { resolveLakeRootDir } = await import("../cto/lake-root.mjs");
+  const projectRoot = resolveLakeRootDir(cwd, {
+    execFileSync: (cmd, args, options = {}) =>
+      execFileSync(cmd, args, {
+        ...options,
+        timeout: 500,
+        killSignal: "SIGKILL",
+      }),
+  });
+  return {
+    projectRoot,
+    lakeRoot: projectRoot ? join(projectRoot, ".triflux", "lake") : "",
+  };
+}
+
+/**
+ * Append a compact CTO `session_started` event for participant hooks.
+ * This is intentionally observational only: no cleanup, reconciliation, or
+ * summarization policy is performed here. Callers may fire-and-forget it.
+ *
+ * @param {string} stdinData SessionStart-shaped stdin JSON
+ * @param {object} [seams] test seams
+ * @returns {Promise<object|null>}
+ */
+export async function emitParticipantSessionStarted(stdinData, seams = {}) {
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return null;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const resolveLakeRoot =
+      seams.resolveLakeRoot || defaultResolveParticipantLakeRoot;
+    const resolved = await resolveLakeRoot(cwd);
+    const projectRoot =
+      typeof resolved === "string"
+        ? resolved
+        : String(resolved?.projectRoot || "");
+    const lakeRoot =
+      typeof resolved === "string"
+        ? join(resolved, ".triflux", "lake")
+        : String(resolved?.lakeRoot || "");
+    if (!lakeRoot) return null;
+
+    const event = {
+      event: "session_started",
+      source: "tfx_participant_hook",
+      session_id: sessionId,
+      project_root: projectRoot || cwd,
+      worktree_path: cwd,
+      branch: typeof payload?.branch === "string" ? payload.branch : "",
+      status: "active",
+      actor: {
+        cli: inferParticipantCli(payload),
+        session_id: sessionId,
+        host: typeof payload?.host === "string" ? payload.host : "local",
+      },
+      summary: `${inferParticipantCli(payload)} session_started ${sessionId}`,
+      now: seams.now,
+    };
+
+    const append = seams.ctoAppend || defaultAppendParticipantCtoEvent;
+    return await append(lakeRoot, event);
+  } catch {
+    return null;
+  }
+}
+
 function readAncestorCommands(pid = process.ppid, maxDepth = 6) {
   if (process.platform === "win32") return [];
   const commands = [];
@@ -146,17 +238,18 @@ function defaultGitRunner(cwd, args, cb) {
  * @param {Function} [seams.register]  registerSynapseSession 대체
  * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
  * @param {Function} [seams.gitRunner] git runner 대체
- * @returns {void} (enrich 는 백그라운드에서 완료)
+ * @returns {Promise<object|null>|null} CTO append promise; enrich 는 백그라운드에서 완료
  */
 export function registerInteractiveSession(stdinData, seams = {}) {
+  let ctoEvent = null;
   const register = seams.register || registerSynapseSession;
   const heartbeat = seams.heartbeat || heartbeatSynapseSession;
   const gitRunner = seams.gitRunner || defaultGitRunner;
   try {
     const payload = parseStartPayload(stdinData);
     const sessionId = String(payload?.session_id || "").trim();
-    if (!sessionId) return;
-    if (shouldSkipInteractiveRegistration(payload, seams)) return;
+    if (!sessionId) return null;
+    if (shouldSkipInteractiveRegistration(payload, seams)) return null;
     const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
 
     // 1) cwd 만으로 즉시 minimal register (블로킹 git 없음, latency 0).
@@ -170,6 +263,10 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       isRemote: false,
     });
 
+    ctoEvent = emitParticipantSessionStarted(stdinData, seams).catch(
+      () => null,
+    );
+
     // 2) worktree/branch 는 블로킹 경로 밖에서 비동기 enrich → heartbeat partial.
     gitContextAsync(cwd, gitRunner)
       .then(({ worktreePath, branch }) => {
@@ -180,6 +277,7 @@ export function registerInteractiveSession(stdinData, seams = {}) {
   } catch {
     /* best-effort — never affects session start */
   }
+  return ctoEvent;
 }
 
 /**
@@ -371,9 +469,10 @@ function runBackground(stdinData) {
     .catch(() => {}); // 완전 무시
 
   // Synapse: 인터랙티브 세션 self-register (fire-and-forget, hub 미응답 무시)
-  registerInteractiveSession(stdinData);
+  const ctoEvent = registerInteractiveSession(stdinData);
 
   // session-vault은 external source — hook-orchestrator가 execFile로 실행
+  return { ctoEvent };
 }
 
 /**
@@ -392,7 +491,7 @@ export async function execute(stdinData, externalHooks = []) {
 
   // DEFERRED + BACKGROUND: fire-and-forget
   runDeferred(stdinData);
-  runBackground(stdinData);
+  const background = runBackground(stdinData);
 
   // hook-orchestrator process.exit(0)s immediately after we return, which would
   // drop the just-fired Synapse register POST before it flushes to the loopback
@@ -401,7 +500,10 @@ export async function execute(stdinData, externalHooks = []) {
   // and the ceiling caps a hub stall so SessionStart never hangs. The async
   // git-enrich heartbeat stays best-effort (it may not have fired yet) — losing
   // it only drops worktree/branch enrichment, not the core registration.
-  await drainPendingSynapse(1000);
+  await Promise.allSettled([
+    drainPendingSynapse(1000),
+    background?.ctoEvent || Promise.resolve(null),
+  ]);
 
   const totalDur = performance.now() - totalStart;
   log.info(

--- a/packages/triflux/hooks/agy-session-hook.mjs
+++ b/packages/triflux/hooks/agy-session-hook.mjs
@@ -45,7 +45,7 @@ export function toSessionPayload(payload) {
     typeof workspacePaths[0] === "string" && workspacePaths[0]
       ? workspacePaths[0]
       : process.cwd();
-  return JSON.stringify({ session_id: sessionId, cwd });
+  return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
 // agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
@@ -98,7 +98,7 @@ export async function runAgySessionHook(stdinData, opts = {}) {
         await hubEnsureRun(sessionPayload);
       } catch {}
       try {
-        registerInteractiveSession(sessionPayload);
+        await Promise.resolve(registerInteractiveSession(sessionPayload));
       } catch {}
       try {
         await drainPendingSynapse(1000);

--- a/packages/triflux/hooks/codex-session-hook.mjs
+++ b/packages/triflux/hooks/codex-session-hook.mjs
@@ -99,7 +99,7 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
           await hubEnsureRun(stdinData);
         } catch {}
         try {
-          registerInteractiveSession(stdinData);
+          await Promise.resolve(registerInteractiveSession(stdinData));
         } catch {}
         try {
           await drainPendingSynapse(1000);

--- a/packages/triflux/hooks/session-start-fast.mjs
+++ b/packages/triflux/hooks/session-start-fast.mjs
@@ -40,6 +40,98 @@ function parseStartPayload(stdinData) {
   }
 }
 
+function inferParticipantCli(payload) {
+  const direct = String(
+    payload?.actor_cli || payload?.cli || payload?.actor?.cli || "",
+  )
+    .trim()
+    .toLowerCase();
+  if (direct) return direct;
+
+  const eventName = String(payload?.hook_event_name || "").trim();
+  if (eventName === "SessionStart") return "claude";
+  if (eventName.toLowerCase().replace(/-/g, "_") === "session_start") {
+    return "codex";
+  }
+  return "participant";
+}
+
+async function defaultAppendParticipantCtoEvent(lakeRoot, event) {
+  const { appendCtoEvent } = await import("../cto/events.mjs");
+  return appendCtoEvent(lakeRoot, event, {
+    lockRetries: 1,
+    lockRetryDelayMs: 0,
+  });
+}
+
+async function defaultResolveParticipantLakeRoot(cwd) {
+  const { resolveLakeRootDir } = await import("../cto/lake-root.mjs");
+  const projectRoot = resolveLakeRootDir(cwd, {
+    execFileSync: (cmd, args, options = {}) =>
+      execFileSync(cmd, args, {
+        ...options,
+        timeout: 500,
+        killSignal: "SIGKILL",
+      }),
+  });
+  return {
+    projectRoot,
+    lakeRoot: projectRoot ? join(projectRoot, ".triflux", "lake") : "",
+  };
+}
+
+/**
+ * Append a compact CTO `session_started` event for participant hooks.
+ * This is intentionally observational only: no cleanup, reconciliation, or
+ * summarization policy is performed here. Callers may fire-and-forget it.
+ *
+ * @param {string} stdinData SessionStart-shaped stdin JSON
+ * @param {object} [seams] test seams
+ * @returns {Promise<object|null>}
+ */
+export async function emitParticipantSessionStarted(stdinData, seams = {}) {
+  try {
+    const payload = parseStartPayload(stdinData);
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return null;
+    const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
+    const resolveLakeRoot =
+      seams.resolveLakeRoot || defaultResolveParticipantLakeRoot;
+    const resolved = await resolveLakeRoot(cwd);
+    const projectRoot =
+      typeof resolved === "string"
+        ? resolved
+        : String(resolved?.projectRoot || "");
+    const lakeRoot =
+      typeof resolved === "string"
+        ? join(resolved, ".triflux", "lake")
+        : String(resolved?.lakeRoot || "");
+    if (!lakeRoot) return null;
+
+    const event = {
+      event: "session_started",
+      source: "tfx_participant_hook",
+      session_id: sessionId,
+      project_root: projectRoot || cwd,
+      worktree_path: cwd,
+      branch: typeof payload?.branch === "string" ? payload.branch : "",
+      status: "active",
+      actor: {
+        cli: inferParticipantCli(payload),
+        session_id: sessionId,
+        host: typeof payload?.host === "string" ? payload.host : "local",
+      },
+      summary: `${inferParticipantCli(payload)} session_started ${sessionId}`,
+      now: seams.now,
+    };
+
+    const append = seams.ctoAppend || defaultAppendParticipantCtoEvent;
+    return await append(lakeRoot, event);
+  } catch {
+    return null;
+  }
+}
+
 function readAncestorCommands(pid = process.ppid, maxDepth = 6) {
   if (process.platform === "win32") return [];
   const commands = [];
@@ -146,17 +238,18 @@ function defaultGitRunner(cwd, args, cb) {
  * @param {Function} [seams.register]  registerSynapseSession 대체
  * @param {Function} [seams.heartbeat] heartbeatSynapseSession 대체
  * @param {Function} [seams.gitRunner] git runner 대체
- * @returns {void} (enrich 는 백그라운드에서 완료)
+ * @returns {Promise<object|null>|null} CTO append promise; enrich 는 백그라운드에서 완료
  */
 export function registerInteractiveSession(stdinData, seams = {}) {
+  let ctoEvent = null;
   const register = seams.register || registerSynapseSession;
   const heartbeat = seams.heartbeat || heartbeatSynapseSession;
   const gitRunner = seams.gitRunner || defaultGitRunner;
   try {
     const payload = parseStartPayload(stdinData);
     const sessionId = String(payload?.session_id || "").trim();
-    if (!sessionId) return;
-    if (shouldSkipInteractiveRegistration(payload, seams)) return;
+    if (!sessionId) return null;
+    if (shouldSkipInteractiveRegistration(payload, seams)) return null;
     const cwd = typeof payload?.cwd === "string" ? payload.cwd : process.cwd();
 
     // 1) cwd 만으로 즉시 minimal register (블로킹 git 없음, latency 0).
@@ -170,6 +263,10 @@ export function registerInteractiveSession(stdinData, seams = {}) {
       isRemote: false,
     });
 
+    ctoEvent = emitParticipantSessionStarted(stdinData, seams).catch(
+      () => null,
+    );
+
     // 2) worktree/branch 는 블로킹 경로 밖에서 비동기 enrich → heartbeat partial.
     gitContextAsync(cwd, gitRunner)
       .then(({ worktreePath, branch }) => {
@@ -180,6 +277,7 @@ export function registerInteractiveSession(stdinData, seams = {}) {
   } catch {
     /* best-effort — never affects session start */
   }
+  return ctoEvent;
 }
 
 /**
@@ -371,9 +469,10 @@ function runBackground(stdinData) {
     .catch(() => {}); // 완전 무시
 
   // Synapse: 인터랙티브 세션 self-register (fire-and-forget, hub 미응답 무시)
-  registerInteractiveSession(stdinData);
+  const ctoEvent = registerInteractiveSession(stdinData);
 
   // session-vault은 external source — hook-orchestrator가 execFile로 실행
+  return { ctoEvent };
 }
 
 /**
@@ -392,7 +491,7 @@ export async function execute(stdinData, externalHooks = []) {
 
   // DEFERRED + BACKGROUND: fire-and-forget
   runDeferred(stdinData);
-  runBackground(stdinData);
+  const background = runBackground(stdinData);
 
   // hook-orchestrator process.exit(0)s immediately after we return, which would
   // drop the just-fired Synapse register POST before it flushes to the loopback
@@ -401,7 +500,10 @@ export async function execute(stdinData, externalHooks = []) {
   // and the ceiling caps a hub stall so SessionStart never hangs. The async
   // git-enrich heartbeat stays best-effort (it may not have fired yet) — losing
   // it only drops worktree/branch enrichment, not the core registration.
-  await drainPendingSynapse(1000);
+  await Promise.allSettled([
+    drainPendingSynapse(1000),
+    background?.ctoEvent || Promise.resolve(null),
+  ]);
 
   const totalDur = performance.now() - totalStart;
   log.info(

--- a/tests/unit/agy-session-hook.test.mjs
+++ b/tests/unit/agy-session-hook.test.mjs
@@ -6,6 +6,7 @@ import {
   runAgySessionHook,
   toSessionPayload,
 } from "../../hooks/agy-session-hook.mjs";
+import { registerInteractiveSession } from "../../hooks/session-start-fast.mjs";
 
 function agyPayload(overrides = {}) {
   return JSON.stringify({
@@ -31,13 +32,18 @@ describe("agy-session-hook adapter", () => {
         workspacePaths: ["/a", "/b"],
       }),
     );
-    assert.deepEqual(out, { session_id: "conv-1", cwd: "/a" });
+    assert.deepEqual(out, {
+      session_id: "conv-1",
+      cwd: "/a",
+      actor_cli: "agy",
+    });
   });
 
   it("toSessionPayload falls back to process.cwd() when no workspace path is present", () => {
     const out = JSON.parse(toSessionPayload({ conversationId: "conv-2" }));
     assert.equal(out.session_id, "conv-2");
     assert.equal(out.cwd, process.cwd());
+    assert.equal(out.actor_cli, "agy");
   });
 
   it("normalizeMode gates on invocationNum: first call registers, later calls heartbeat", () => {
@@ -99,6 +105,36 @@ describe("agy-session-hook adapter", () => {
       drainPendingSynapse: async () => calls.push("drain"),
     });
     assert.deepEqual(calls, ["ensure", "register", "drain"]);
+  });
+
+  it("register path emits an agy participant CTO session_started event", async () => {
+    const events = [];
+    await runAgySessionHook(agyPayload({ invocationNum: 1 }), {
+      writeStdout: false,
+      hubEnsureRun: async () => {},
+      registerInteractiveSession: (stdinData) =>
+        registerInteractiveSession(stdinData, {
+          register: () => {},
+          heartbeat: () => {},
+          gitRunner: () => {},
+          resolveLakeRoot: () => ({
+            projectRoot: "/work/triflux",
+            lakeRoot: "/work/triflux/.triflux/lake",
+          }),
+          ctoAppend: (lakeRoot, event) => events.push({ lakeRoot, event }),
+        }),
+      drainPendingSynapse: async () => {},
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.length, 1);
+    assert.equal(events[0].lakeRoot, "/work/triflux/.triflux/lake");
+    assert.equal(events[0].event.event, "session_started");
+    assert.equal(events[0].event.actor.cli, "agy");
+    assert.equal(
+      events[0].event.session_id,
+      "ec33ebf9-0cba-4100-8142-c61503f6c587",
+    );
   });
 
   it("stays a silent no-op when conversationId is missing", async () => {

--- a/tests/unit/codex-session-hook.test.mjs
+++ b/tests/unit/codex-session-hook.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { runCodexSessionHook } from "../../hooks/codex-session-hook.mjs";
+import { registerInteractiveSession } from "../../hooks/session-start-fast.mjs";
 
 function payload(overrides = {}) {
   return JSON.stringify({
@@ -70,6 +71,34 @@ describe("codex-session-hook", () => {
     );
 
     assert.deepEqual(calls, ["heartbeat"]);
+  });
+
+  it("register path emits a codex participant CTO session_started event", async () => {
+    const events = [];
+    await runCodexSessionHook(payload(), {
+      argvMode: "register",
+      writeStdout: false,
+      hubEnsureRun: async () => {},
+      registerInteractiveSession: (stdinData) =>
+        registerInteractiveSession(stdinData, {
+          register: () => {},
+          heartbeat: () => {},
+          gitRunner: () => {},
+          resolveLakeRoot: () => ({
+            projectRoot: "/work/triflux",
+            lakeRoot: "/work/triflux/.triflux/lake",
+          }),
+          ctoAppend: (lakeRoot, event) => events.push({ lakeRoot, event }),
+        }),
+      drainPendingSynapse: async () => {},
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.length, 1);
+    assert.equal(events[0].lakeRoot, "/work/triflux/.triflux/lake");
+    assert.equal(events[0].event.event, "session_started");
+    assert.equal(events[0].event.actor.cli, "codex");
+    assert.equal(events[0].event.session_id, "codex-session-1");
   });
 
   it("keeps hook stdout JSON-only even when side effects log to stdout", async () => {

--- a/tests/unit/session-start-synapse.test.mjs
+++ b/tests/unit/session-start-synapse.test.mjs
@@ -7,9 +7,13 @@
 // (worktree/branch arrive asynchronously via heartbeat, never inline).
 
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import {
+  emitParticipantSessionStarted,
   heartbeatInteractiveSession,
   registerInteractiveSession,
 } from "../../hooks/session-start-fast.mjs";
@@ -21,6 +25,7 @@ function payloadJson(obj) {
 describe("registerInteractiveSession (SessionStart self-register)", () => {
   it("registers a minimal interactive payload from cwd alone (no git, no pid)", () => {
     const registered = [];
+    const ctoEvents = [];
     let gitCalled = false;
 
     registerInteractiveSession(
@@ -33,6 +38,11 @@ describe("registerInteractiveSession (SessionStart self-register)", () => {
         gitRunner: () => {
           gitCalled = true;
         },
+        ctoAppend: (lakeRoot, event) => ctoEvents.push({ lakeRoot, event }),
+        resolveLakeRoot: (cwd) => ({
+          projectRoot: cwd,
+          lakeRoot: `${cwd}/.triflux/lake`,
+        }),
       },
     );
 
@@ -50,6 +60,100 @@ describe("registerInteractiveSession (SessionStart self-register)", () => {
     assert.equal("pid" in meta, false);
     // git enrichment is scheduled (async), not run on the blocking path.
     assert.equal(gitCalled, true);
+    assert.equal(ctoEvents.length, 0, "CTO append is fire-and-forget");
+  });
+
+  it("emits a compact non-policy CTO session_started event", async () => {
+    const appended = [];
+
+    const result = await emitParticipantSessionStarted(
+      payloadJson({
+        session_id: "sess-cto",
+        cwd: "/home/dev/proj",
+        hook_event_name: "SessionStart",
+      }),
+      {
+        resolveLakeRoot: (cwd) => ({
+          projectRoot: "/home/dev/proj",
+          lakeRoot: `${cwd}/.triflux/lake`,
+        }),
+        ctoAppend: async (lakeRoot, event) => {
+          appended.push({ lakeRoot, event });
+          return { appended: true, event };
+        },
+        now: "2026-06-17T00:00:00.000Z",
+      },
+    );
+
+    assert.equal(result.appended, true);
+    assert.deepEqual(appended, [
+      {
+        lakeRoot: "/home/dev/proj/.triflux/lake",
+        event: {
+          event: "session_started",
+          source: "tfx_participant_hook",
+          session_id: "sess-cto",
+          project_root: "/home/dev/proj",
+          worktree_path: "/home/dev/proj",
+          branch: "",
+          status: "active",
+          actor: {
+            cli: "claude",
+            session_id: "sess-cto",
+            host: "local",
+          },
+          summary: "claude session_started sess-cto",
+          now: "2026-06-17T00:00:00.000Z",
+        },
+      },
+    ]);
+  });
+
+  it("swallows CTO append failures without blocking SessionStart", async () => {
+    const result = await emitParticipantSessionStarted(
+      payloadJson({ session_id: "sess-fail", cwd: "/home/dev/proj" }),
+      {
+        resolveLakeRoot: () => ({
+          projectRoot: "/home/dev/proj",
+          lakeRoot: "/home/dev/proj/.triflux/lake",
+        }),
+        ctoAppend: async () => {
+          throw new Error("ledger unavailable");
+        },
+      },
+    );
+
+    assert.equal(result, null);
+  });
+
+  it("appends session_started to the canonical project CTO ledger", async () => {
+    const root = mkdtempSync(join(tmpdir(), "tfx-participant-cto-"));
+    try {
+      await emitParticipantSessionStarted(
+        payloadJson({
+          session_id: "sess-ledger",
+          cwd: root,
+          hook_event_name: "SessionStart",
+        }),
+        { now: "2026-06-17T00:00:00.000Z" },
+      );
+
+      const lines = readFileSync(
+        join(root, ".triflux", "lake", "ledger.jsonl"),
+        "utf8",
+      )
+        .trim()
+        .split("\n");
+      assert.equal(lines.length, 1);
+      const event = JSON.parse(lines[0]);
+      assert.equal(event.event, "session_started");
+      assert.equal(event.source, "tfx_participant_hook");
+      assert.equal(event.ref.session_id, "sess-ledger");
+      assert.equal(event.ref.actor.cli, "claude");
+      assert.equal(event.ref.status, "active");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("is a no-op when the payload has no session_id", () => {
@@ -90,6 +194,11 @@ describe("registerInteractiveSession (SessionStart self-register)", () => {
         register: (meta) => registered.push(meta),
         heartbeat: (sessionId, partial) =>
           heartbeats.push({ sessionId, partial }),
+        ctoAppend: () => {},
+        resolveLakeRoot: (cwd) => ({
+          projectRoot: cwd,
+          lakeRoot: `${cwd}/lake`,
+        }),
         // Resolve git context out-of-band, simulating async execFile callbacks.
         gitRunner: (_cwd, args, cb) => {
           if (args[1] === "--show-toplevel") {
@@ -127,6 +236,11 @@ describe("registerInteractiveSession (SessionStart self-register)", () => {
         register: (meta) => registered.push(meta),
         heartbeat: (sessionId, partial) =>
           heartbeats.push({ sessionId, partial }),
+        ctoAppend: () => {},
+        resolveLakeRoot: (cwd) => ({
+          projectRoot: cwd,
+          lakeRoot: `${cwd}/lake`,
+        }),
         // Non-repo: both git calls fail → empty strings.
         gitRunner: (_cwd, _args, cb) => setImmediate(() => cb("")),
       },


### PR DESCRIPTION
## Summary
- Emit compact `session_started` CTO events from participant session registration via `appendCtoEvent` into the canonical project CTO lake.
- Keep hook behavior observational only: append failures are swallowed, ledger locking uses a no-wait attempt, and no cleanup/reconciliation/summarization policy is added.
- Adapt Codex and AGY register paths to await the lightweight event append before process exit; AGY tags events as `actor.cli=agy`.
- Leave `session_heartbeat` CTO events to Synapse for now to avoid prompt-level ledger spam; existing Synapse heartbeat behavior remains unchanged.

Refs #422

## Tests
- `node scripts/test-lock.mjs --test --test-force-exit tests/unit/session-start-synapse.test.mjs tests/unit/codex-session-hook.test.mjs tests/unit/agy-session-hook.test.mjs tests/cto/events.test.mjs`
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `npx biome check hooks/agy-session-hook.mjs hooks/codex-session-hook.mjs hooks/session-start-fast.mjs packages/core/hooks/agy-session-hook.mjs packages/core/hooks/codex-session-hook.mjs packages/core/hooks/session-start-fast.mjs packages/triflux/hooks/agy-session-hook.mjs packages/triflux/hooks/codex-session-hook.mjs packages/triflux/hooks/session-start-fast.mjs tests/unit/agy-session-hook.test.mjs tests/unit/codex-session-hook.test.mjs tests/unit/session-start-synapse.test.mjs`
- `git diff --check`
