### PR TITLE
feat(cto): add hygiene steward apply

### DIFF
--- a/cto/events.mjs
+++ b/cto/events.mjs
@@ -22,6 +22,7 @@ export const CTO_EVENT_TYPES = Object.freeze([
   "pr_merged_or_closed",
   "worktree_created",
   "worktree_removed",
+  "hygiene_applied",
 ]);
 
 export const CTO_HYGIENE_STATUSES = Object.freeze([
@@ -144,6 +145,10 @@ export function normalizeCtoEvent(input = {}) {
   putString(ref, "branch", input.branch);
   putString(ref, "last_seen_at", input.last_seen_at);
   putString(ref, "stale_reason", input.stale_reason);
+  putString(ref, "hygiene_key", input.hygiene_key);
+  putString(ref, "hygiene_kind", input.hygiene_kind);
+  putString(ref, "hygiene_id", input.hygiene_id);
+  putString(ref, "hygiene_action", input.hygiene_action);
   if (status) ref.status = status;
 
   const projectRoot = maybeString(input.project_root);

--- a/cto/hygiene.mjs
+++ b/cto/hygiene.mjs
@@ -1,7 +1,18 @@
-import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
+import { appendCtoEvent } from "./events.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const COUNT_KEYS = [
@@ -15,6 +26,10 @@ const COUNT_KEYS = [
 
 function hasFlag(args, flag) {
   return Array.isArray(args) && args.includes(flag);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function writeJson(stdout, payload) {
@@ -166,6 +181,14 @@ function rowFrom(kind, id, status, entry, ref, action) {
   return row;
 }
 
+function rowKey(kind, id) {
+  return `${kind}:${id}`;
+}
+
+function hygieneKeyForRow(row) {
+  return rowKey(row.kind, row.id);
+}
+
 function upsertLatest(map, key, value) {
   const existing = map.get(key);
   if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
@@ -175,6 +198,24 @@ function upsertLatest(map, key, value) {
 
 function emptyCounts() {
   return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
+}
+
+function countsFromRows(rows) {
+  const counts = emptyCounts();
+  for (const row of rows) {
+    if (row.kind === "task") {
+      if (row.status === "completed") counts.completed_tasks += 1;
+      else counts.active_tasks += 1;
+    } else if (row.kind === "session" && row.status === "stale") {
+      counts.stale_sessions += 1;
+    } else if (row.kind === "worktree" && row.status === "orphaned") {
+      counts.orphan_worktrees += 1;
+    } else if (row.kind === "checkpoint" && row.status === "superseded") {
+      counts.superseded_checkpoints += 1;
+    }
+  }
+  counts.unknown_owner = rows.filter((row) => row.owner === "unknown").length;
+  return counts;
 }
 
 export function compactHygieneCounts(projection) {
@@ -197,10 +238,20 @@ export function projectCtoHygiene({
   const worktrees = new Map();
   const checkpointsBySession = new Map();
   const explicitSupersededCheckpoints = new Map();
+  const appliedByKey = new Map();
 
   for (const entry of events) {
     const ref = eventRef(entry);
     switch (entry?.event) {
+      case "hygiene_applied": {
+        const key =
+          typeof ref.hygiene_key === "string" && ref.hygiene_key.trim()
+            ? ref.hygiene_key.trim()
+            : null;
+        if (!key) break;
+        upsertLatest(appliedByKey, key, { entry, ref });
+        break;
+      }
       case "task_claimed":
       case "task_completed": {
         const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
@@ -254,14 +305,10 @@ export function projectCtoHygiene({
   }
 
   const rows = [];
-  const counts = emptyCounts();
 
   for (const [taskId, item] of tasks) {
     const completed = item.entry?.event === "task_completed";
     const status = statusOf(item.ref, completed ? "completed" : "active");
-    counts[
-      completed || status === "completed" ? "completed_tasks" : "active_tasks"
-    ] += 1;
     rows.push(
       rowFrom(
         "task",
@@ -277,7 +324,6 @@ export function projectCtoHygiene({
   }
 
   for (const [sessionId, item] of staleSessions) {
-    counts.stale_sessions += 1;
     rows.push(
       rowFrom(
         "session",
@@ -297,7 +343,6 @@ export function projectCtoHygiene({
       session?.sessionId || session?.session_id || "",
     ).trim();
     if (!sessionId || staleSessions.has(sessionId)) continue;
-    counts.stale_sessions += 1;
     rows.push({
       kind: "session",
       id: sessionId,
@@ -312,7 +357,6 @@ export function projectCtoHygiene({
     if (item.entry?.event === "worktree_removed") continue;
     const status = statusOf(item.ref, "active");
     if (status !== "orphaned") continue;
-    counts.orphan_worktrees += 1;
     rows.push(
       rowFrom(
         "worktree",
@@ -337,7 +381,6 @@ export function projectCtoHygiene({
     }
   }
   for (const [checkpointId, item] of superseded) {
-    counts.superseded_checkpoints += 1;
     rows.push(
       rowFrom(
         "checkpoint",
@@ -350,16 +393,20 @@ export function projectCtoHygiene({
     );
   }
 
-  const sortedRows = rows.map((row) => {
-    if (row.owner === undefined) {
-      const { owner: _owner, ...rest } = row;
-      return rest;
-    }
-    return row;
-  });
-  counts.unknown_owner = sortedRows.filter(
-    (row) => row.owner === "unknown",
-  ).length;
+  const sortedRows = rows
+    .filter((row) => {
+      const applied = appliedByKey.get(hygieneKeyForRow(row));
+      if (!applied) return true;
+      return eventTime(applied.entry) < String(row.last_event_at || "");
+    })
+    .map((row) => {
+      if (row.owner === undefined) {
+        const { owner: _owner, ...rest } = row;
+        return rest;
+      }
+      return row;
+    });
+  const counts = countsFromRows(sortedRows);
 
   return {
     schema_version: "cto-hygiene.v1",
@@ -369,30 +416,212 @@ export function projectCtoHygiene({
   };
 }
 
+function safeLabel(value) {
+  return (
+    String(value || "project")
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/gu, "-")
+      .replace(/^-+|-+$/gu, "")
+      .slice(0, 40) || "project"
+  );
+}
+
+function rootHash(rootDir) {
+  return createHash("sha256")
+    .update(String(rootDir || ""))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function ctoHygieneStewardLockPath(rootDir, lakeRoot) {
+  const label = safeLabel(basename(rootDir || "project"));
+  return join(lakeRoot, "stewards", `${label}-${rootHash(rootDir)}.apply.lock`);
+}
+
+export async function acquireCtoHygieneStewardLock(
+  rootDir,
+  lakeRoot,
+  opts = {},
+) {
+  const lockPath =
+    opts.lockPath || ctoHygieneStewardLockPath(rootDir, lakeRoot);
+  const timeoutMs = Math.max(0, Number(opts.timeoutMs) || 3000);
+  const retryMs = Math.max(1, Number(opts.retryMs) || 50);
+  const staleMs = Math.max(1000, Number(opts.staleMs) || 10 * 60_000);
+  const start = Date.now();
+
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  while (true) {
+    let fd = null;
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      writeFileSync(
+        fd,
+        `${JSON.stringify(
+          {
+            pid: process.pid,
+            project_root: rootDir,
+            project_root_hash: rootHash(rootDir),
+            created_at: new Date().toISOString(),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      return {
+        path: lockPath,
+        project_root: rootDir,
+        project_root_hash: rootHash(rootDir),
+        release() {
+          try {
+            closeSync(fd);
+          } catch {}
+          try {
+            unlinkSync(lockPath);
+          } catch {}
+        },
+      };
+    } catch (error) {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleMs) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch {}
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(`cto hygiene steward lock busy: ${lockPath}`);
+      }
+      await sleep(retryMs);
+    }
+  }
+}
+
+const APPLICABLE_STATUSES = new Set([
+  "active",
+  "stale",
+  "superseded",
+  "orphaned",
+  "hidden",
+  "completed",
+]);
+
+function isApplicableRow(row) {
+  return Boolean(row?.action) || APPLICABLE_STATUSES.has(row?.status);
+}
+
+async function applyHygieneRows({
+  rootDir,
+  lakeRoot,
+  projection,
+  steward,
+  opts,
+}) {
+  const rows = projection.rows.filter(isApplicableRow);
+  const appended = [];
+  const now = opts.now || new Date().toISOString();
+  for (const row of rows) {
+    const result = await appendCtoEvent(
+      lakeRoot,
+      {
+        event: "hygiene_applied",
+        now,
+        source: "tfx_cto_hygiene_apply",
+        project_root: rootDir,
+        status: row.status,
+        hygiene_key: hygieneKeyForRow(row),
+        hygiene_kind: row.kind,
+        hygiene_id: row.id,
+        hygiene_action: row.action || `acknowledge_${row.status}`,
+        summary: `hygiene apply ${row.kind}:${row.id} ${row.status}`,
+        actor: { cli: "tfx cto hygiene --apply" },
+      },
+      {
+        stderr: opts.stderr,
+        lockRetries: opts.ledgerLockRetries,
+        lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+      },
+    );
+    if (result.appended) appended.push(result.event);
+  }
+  return {
+    steward: {
+      lock_path: steward.path,
+      project_root: steward.project_root,
+      project_root_hash: steward.project_root_hash,
+    },
+    applicable_count: rows.length,
+    applied_count: appended.length,
+    events: appended,
+  };
+}
+
 export async function runHygiene(args = [], opts = {}) {
   const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");
   const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
-  if (!dryRun) {
-    throw new Error("tfx cto hygiene only supports --dry-run");
+  const apply = opts.apply === true || hasFlag(args, "--apply");
+  if (dryRun && apply) {
+    throw new Error("tfx cto hygiene accepts only one of --dry-run or --apply");
+  }
+  if (!dryRun && !apply) {
+    throw new Error("tfx cto hygiene requires --dry-run or --apply");
   }
 
-  const currentPath = join(lakeRoot, "current.json");
-  const current = existsSync(currentPath) ? readJson(currentPath) : {};
-  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
-  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
-  const projection = projectCtoHygiene({
-    current,
-    ledger: ledger.length > 0 ? ledger : null,
-    overlay,
-  });
+  const buildProjection = async () => {
+    const currentPath = join(lakeRoot, "current.json");
+    const current = existsSync(currentPath) ? readJson(currentPath) : {};
+    const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+    const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+    return projectCtoHygiene({
+      current,
+      ledger: ledger.length > 0 ? ledger : null,
+      overlay,
+    });
+  };
+
+  let steward = null;
+  let projection;
+  let applyResult = null;
+  if (apply) {
+    steward = await acquireCtoHygieneStewardLock(rootDir, lakeRoot, {
+      timeoutMs: opts.stewardLockTimeoutMs,
+      retryMs: opts.stewardLockRetryMs,
+      staleMs: opts.stewardLockStaleMs,
+      lockPath: opts.stewardLockPath,
+    });
+    try {
+      projection = await buildProjection();
+      applyResult = await applyHygieneRows({
+        rootDir,
+        lakeRoot,
+        projection,
+        steward,
+        opts,
+      });
+      projection = { ...projection, dry_run: false, apply: applyResult };
+    } finally {
+      steward.release();
+    }
+  } else {
+    projection = await buildProjection();
+  }
 
   if (jsonOut) writeJson(stdout, projection);
   else {
     stdout.write(
-      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+      apply
+        ? `cto hygiene apply: ${applyResult.applied_count} event(s) appended for ${applyResult.applicable_count} actionable row(s)\n`
+        : `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
     );
   }
 

--- a/packages/remote/cto/events.mjs
+++ b/packages/remote/cto/events.mjs
@@ -22,6 +22,7 @@ export const CTO_EVENT_TYPES = Object.freeze([
   "pr_merged_or_closed",
   "worktree_created",
   "worktree_removed",
+  "hygiene_applied",
 ]);
 
 export const CTO_HYGIENE_STATUSES = Object.freeze([
@@ -144,6 +145,10 @@ export function normalizeCtoEvent(input = {}) {
   putString(ref, "branch", input.branch);
   putString(ref, "last_seen_at", input.last_seen_at);
   putString(ref, "stale_reason", input.stale_reason);
+  putString(ref, "hygiene_key", input.hygiene_key);
+  putString(ref, "hygiene_kind", input.hygiene_kind);
+  putString(ref, "hygiene_id", input.hygiene_id);
+  putString(ref, "hygiene_action", input.hygiene_action);
   if (status) ref.status = status;
 
   const projectRoot = maybeString(input.project_root);

--- a/packages/remote/cto/hygiene.mjs
+++ b/packages/remote/cto/hygiene.mjs
@@ -1,7 +1,18 @@
-import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
+import { appendCtoEvent } from "./events.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const COUNT_KEYS = [
@@ -15,6 +26,10 @@ const COUNT_KEYS = [
 
 function hasFlag(args, flag) {
   return Array.isArray(args) && args.includes(flag);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function writeJson(stdout, payload) {
@@ -127,7 +142,9 @@ function eventTime(entry) {
 }
 
 function eventRef(entry) {
-  return entry?.ref && typeof entry.ref === "object" && !Array.isArray(entry.ref)
+  return entry?.ref &&
+    typeof entry.ref === "object" &&
+    !Array.isArray(entry.ref)
     ? entry.ref
     : {};
 }
@@ -164,6 +181,14 @@ function rowFrom(kind, id, status, entry, ref, action) {
   return row;
 }
 
+function rowKey(kind, id) {
+  return `${kind}:${id}`;
+}
+
+function hygieneKeyForRow(row) {
+  return rowKey(row.kind, row.id);
+}
+
 function upsertLatest(map, key, value) {
   const existing = map.get(key);
   if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
@@ -175,12 +200,34 @@ function emptyCounts() {
   return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
 }
 
+function countsFromRows(rows) {
+  const counts = emptyCounts();
+  for (const row of rows) {
+    if (row.kind === "task") {
+      if (row.status === "completed") counts.completed_tasks += 1;
+      else counts.active_tasks += 1;
+    } else if (row.kind === "session" && row.status === "stale") {
+      counts.stale_sessions += 1;
+    } else if (row.kind === "worktree" && row.status === "orphaned") {
+      counts.orphan_worktrees += 1;
+    } else if (row.kind === "checkpoint" && row.status === "superseded") {
+      counts.superseded_checkpoints += 1;
+    }
+  }
+  counts.unknown_owner = rows.filter((row) => row.owner === "unknown").length;
+  return counts;
+}
+
 export function compactHygieneCounts(projection) {
   const counts = projection?.counts || {};
   return Object.fromEntries(COUNT_KEYS.map((key) => [key, counts[key] || 0]));
 }
 
-export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } = {}) {
+export function projectCtoHygiene({
+  current = {},
+  ledger = null,
+  overlay = {},
+} = {}) {
   const events = Array.isArray(ledger)
     ? ledger
     : Array.isArray(current?.ledger_tail)
@@ -191,10 +238,20 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
   const worktrees = new Map();
   const checkpointsBySession = new Map();
   const explicitSupersededCheckpoints = new Map();
+  const appliedByKey = new Map();
 
   for (const entry of events) {
     const ref = eventRef(entry);
     switch (entry?.event) {
+      case "hygiene_applied": {
+        const key =
+          typeof ref.hygiene_key === "string" && ref.hygiene_key.trim()
+            ? ref.hygiene_key.trim()
+            : null;
+        if (!key) break;
+        upsertLatest(appliedByKey, key, { entry, ref });
+        break;
+      }
       case "task_claimed":
       case "task_completed": {
         const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
@@ -203,7 +260,8 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
         break;
       }
       case "session_stale": {
-        const sessionId = typeof ref.session_id === "string" ? ref.session_id : null;
+        const sessionId =
+          typeof ref.session_id === "string" ? ref.session_id : null;
         if (!sessionId) break;
         upsertLatest(staleSessions, sessionId, { entry, ref });
         break;
@@ -211,7 +269,8 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
       case "worktree_created":
       case "worktree_removed": {
         const key =
-          (typeof ref.worktree_path_hash === "string" && ref.worktree_path_hash) ||
+          (typeof ref.worktree_path_hash === "string" &&
+            ref.worktree_path_hash) ||
           (typeof ref.worktree_label === "string" && ref.worktree_label) ||
           null;
         if (!key) break;
@@ -224,14 +283,19 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
           typeof ref.checkpoint_id === "string" ? ref.checkpoint_id : null;
         if (!checkpointId) break;
         if (ref.status === "superseded") {
-          upsertLatest(explicitSupersededCheckpoints, checkpointId, { entry, ref });
+          upsertLatest(explicitSupersededCheckpoints, checkpointId, {
+            entry,
+            ref,
+          });
         }
         const sessionId =
           (typeof ref.session_id === "string" && ref.session_id) ||
-          (typeof ref.restored_from_session_id === "string" && ref.restored_from_session_id) ||
+          (typeof ref.restored_from_session_id === "string" &&
+            ref.restored_from_session_id) ||
           null;
         if (!sessionId) break;
-        if (!checkpointsBySession.has(sessionId)) checkpointsBySession.set(sessionId, []);
+        if (!checkpointsBySession.has(sessionId))
+          checkpointsBySession.set(sessionId, []);
         checkpointsBySession.get(sessionId).push({ entry, ref, checkpointId });
         break;
       }
@@ -241,12 +305,10 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
   }
 
   const rows = [];
-  const counts = emptyCounts();
 
   for (const [taskId, item] of tasks) {
     const completed = item.entry?.event === "task_completed";
     const status = statusOf(item.ref, completed ? "completed" : "active");
-    counts[completed || status === "completed" ? "completed_tasks" : "active_tasks"] += 1;
     rows.push(
       rowFrom(
         "task",
@@ -254,24 +316,33 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
         completed || status === "completed" ? "completed" : status,
         item.entry,
         item.ref,
-        completed || status === "completed" ? null : "complete_or_reassign_task",
+        completed || status === "completed"
+          ? null
+          : "complete_or_reassign_task",
       ),
     );
   }
 
   for (const [sessionId, item] of staleSessions) {
-    counts.stale_sessions += 1;
     rows.push(
-      rowFrom("session", sessionId, "stale", item.entry, item.ref, "archive_or_resume_session"),
+      rowFrom(
+        "session",
+        sessionId,
+        "stale",
+        item.entry,
+        item.ref,
+        "archive_or_resume_session",
+      ),
     );
   }
 
   for (const session of overlay?.live_sessions || []) {
     const phase = String(session?.phase || session?.status || "").toLowerCase();
     if (phase !== "stale") continue;
-    const sessionId = String(session?.sessionId || session?.session_id || "").trim();
+    const sessionId = String(
+      session?.sessionId || session?.session_id || "",
+    ).trim();
     if (!sessionId || staleSessions.has(sessionId)) continue;
-    counts.stale_sessions += 1;
     rows.push({
       kind: "session",
       id: sessionId,
@@ -286,7 +357,6 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
     if (item.entry?.event === "worktree_removed") continue;
     const status = statusOf(item.ref, "active");
     if (status !== "orphaned") continue;
-    counts.orphan_worktrees += 1;
     rows.push(
       rowFrom(
         "worktree",
@@ -311,7 +381,6 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
     }
   }
   for (const [checkpointId, item] of superseded) {
-    counts.superseded_checkpoints += 1;
     rows.push(
       rowFrom(
         "checkpoint",
@@ -324,14 +393,20 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
     );
   }
 
-  const sortedRows = rows.map((row) => {
-    if (row.owner === undefined) {
-      const { owner: _owner, ...rest } = row;
-      return rest;
-    }
-    return row;
-  });
-  counts.unknown_owner = sortedRows.filter((row) => row.owner === "unknown").length;
+  const sortedRows = rows
+    .filter((row) => {
+      const applied = appliedByKey.get(hygieneKeyForRow(row));
+      if (!applied) return true;
+      return eventTime(applied.entry) < String(row.last_event_at || "");
+    })
+    .map((row) => {
+      if (row.owner === undefined) {
+        const { owner: _owner, ...rest } = row;
+        return rest;
+      }
+      return row;
+    });
+  const counts = countsFromRows(sortedRows);
 
   return {
     schema_version: "cto-hygiene.v1",
@@ -341,30 +416,212 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
   };
 }
 
+function safeLabel(value) {
+  return (
+    String(value || "project")
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/gu, "-")
+      .replace(/^-+|-+$/gu, "")
+      .slice(0, 40) || "project"
+  );
+}
+
+function rootHash(rootDir) {
+  return createHash("sha256")
+    .update(String(rootDir || ""))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function ctoHygieneStewardLockPath(rootDir, lakeRoot) {
+  const label = safeLabel(basename(rootDir || "project"));
+  return join(lakeRoot, "stewards", `${label}-${rootHash(rootDir)}.apply.lock`);
+}
+
+export async function acquireCtoHygieneStewardLock(
+  rootDir,
+  lakeRoot,
+  opts = {},
+) {
+  const lockPath =
+    opts.lockPath || ctoHygieneStewardLockPath(rootDir, lakeRoot);
+  const timeoutMs = Math.max(0, Number(opts.timeoutMs) || 3000);
+  const retryMs = Math.max(1, Number(opts.retryMs) || 50);
+  const staleMs = Math.max(1000, Number(opts.staleMs) || 10 * 60_000);
+  const start = Date.now();
+
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  while (true) {
+    let fd = null;
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      writeFileSync(
+        fd,
+        `${JSON.stringify(
+          {
+            pid: process.pid,
+            project_root: rootDir,
+            project_root_hash: rootHash(rootDir),
+            created_at: new Date().toISOString(),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      return {
+        path: lockPath,
+        project_root: rootDir,
+        project_root_hash: rootHash(rootDir),
+        release() {
+          try {
+            closeSync(fd);
+          } catch {}
+          try {
+            unlinkSync(lockPath);
+          } catch {}
+        },
+      };
+    } catch (error) {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleMs) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch {}
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(`cto hygiene steward lock busy: ${lockPath}`);
+      }
+      await sleep(retryMs);
+    }
+  }
+}
+
+const APPLICABLE_STATUSES = new Set([
+  "active",
+  "stale",
+  "superseded",
+  "orphaned",
+  "hidden",
+  "completed",
+]);
+
+function isApplicableRow(row) {
+  return Boolean(row?.action) || APPLICABLE_STATUSES.has(row?.status);
+}
+
+async function applyHygieneRows({
+  rootDir,
+  lakeRoot,
+  projection,
+  steward,
+  opts,
+}) {
+  const rows = projection.rows.filter(isApplicableRow);
+  const appended = [];
+  const now = opts.now || new Date().toISOString();
+  for (const row of rows) {
+    const result = await appendCtoEvent(
+      lakeRoot,
+      {
+        event: "hygiene_applied",
+        now,
+        source: "tfx_cto_hygiene_apply",
+        project_root: rootDir,
+        status: row.status,
+        hygiene_key: hygieneKeyForRow(row),
+        hygiene_kind: row.kind,
+        hygiene_id: row.id,
+        hygiene_action: row.action || `acknowledge_${row.status}`,
+        summary: `hygiene apply ${row.kind}:${row.id} ${row.status}`,
+        actor: { cli: "tfx cto hygiene --apply" },
+      },
+      {
+        stderr: opts.stderr,
+        lockRetries: opts.ledgerLockRetries,
+        lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+      },
+    );
+    if (result.appended) appended.push(result.event);
+  }
+  return {
+    steward: {
+      lock_path: steward.path,
+      project_root: steward.project_root,
+      project_root_hash: steward.project_root_hash,
+    },
+    applicable_count: rows.length,
+    applied_count: appended.length,
+    events: appended,
+  };
+}
+
 export async function runHygiene(args = [], opts = {}) {
   const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");
   const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
-  if (!dryRun) {
-    throw new Error("tfx cto hygiene only supports --dry-run");
+  const apply = opts.apply === true || hasFlag(args, "--apply");
+  if (dryRun && apply) {
+    throw new Error("tfx cto hygiene accepts only one of --dry-run or --apply");
+  }
+  if (!dryRun && !apply) {
+    throw new Error("tfx cto hygiene requires --dry-run or --apply");
   }
 
-  const currentPath = join(lakeRoot, "current.json");
-  const current = existsSync(currentPath) ? readJson(currentPath) : {};
-  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
-  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
-  const projection = projectCtoHygiene({
-    current,
-    ledger: ledger.length > 0 ? ledger : null,
-    overlay,
-  });
+  const buildProjection = async () => {
+    const currentPath = join(lakeRoot, "current.json");
+    const current = existsSync(currentPath) ? readJson(currentPath) : {};
+    const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+    const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+    return projectCtoHygiene({
+      current,
+      ledger: ledger.length > 0 ? ledger : null,
+      overlay,
+    });
+  };
+
+  let steward = null;
+  let projection;
+  let applyResult = null;
+  if (apply) {
+    steward = await acquireCtoHygieneStewardLock(rootDir, lakeRoot, {
+      timeoutMs: opts.stewardLockTimeoutMs,
+      retryMs: opts.stewardLockRetryMs,
+      staleMs: opts.stewardLockStaleMs,
+      lockPath: opts.stewardLockPath,
+    });
+    try {
+      projection = await buildProjection();
+      applyResult = await applyHygieneRows({
+        rootDir,
+        lakeRoot,
+        projection,
+        steward,
+        opts,
+      });
+      projection = { ...projection, dry_run: false, apply: applyResult };
+    } finally {
+      steward.release();
+    }
+  } else {
+    projection = await buildProjection();
+  }
 
   if (jsonOut) writeJson(stdout, projection);
   else {
     stdout.write(
-      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+      apply
+        ? `cto hygiene apply: ${applyResult.applied_count} event(s) appended for ${applyResult.applicable_count} actionable row(s)\n`
+        : `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
     );
   }
 

--- a/packages/triflux/cto/events.mjs
+++ b/packages/triflux/cto/events.mjs
@@ -22,6 +22,7 @@ export const CTO_EVENT_TYPES = Object.freeze([
   "pr_merged_or_closed",
   "worktree_created",
   "worktree_removed",
+  "hygiene_applied",
 ]);
 
 export const CTO_HYGIENE_STATUSES = Object.freeze([
@@ -144,6 +145,10 @@ export function normalizeCtoEvent(input = {}) {
   putString(ref, "branch", input.branch);
   putString(ref, "last_seen_at", input.last_seen_at);
   putString(ref, "stale_reason", input.stale_reason);
+  putString(ref, "hygiene_key", input.hygiene_key);
+  putString(ref, "hygiene_kind", input.hygiene_kind);
+  putString(ref, "hygiene_id", input.hygiene_id);
+  putString(ref, "hygiene_action", input.hygiene_action);
   if (status) ref.status = status;
 
   const projectRoot = maybeString(input.project_root);

--- a/packages/triflux/cto/hygiene.mjs
+++ b/packages/triflux/cto/hygiene.mjs
@@ -1,7 +1,18 @@
-import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
+import { appendCtoEvent } from "./events.mjs";
 import { resolveLakeRootDir } from "./lake-root.mjs";
 
 const COUNT_KEYS = [
@@ -15,6 +26,10 @@ const COUNT_KEYS = [
 
 function hasFlag(args, flag) {
   return Array.isArray(args) && args.includes(flag);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function writeJson(stdout, payload) {
@@ -166,6 +181,14 @@ function rowFrom(kind, id, status, entry, ref, action) {
   return row;
 }
 
+function rowKey(kind, id) {
+  return `${kind}:${id}`;
+}
+
+function hygieneKeyForRow(row) {
+  return rowKey(row.kind, row.id);
+}
+
 function upsertLatest(map, key, value) {
   const existing = map.get(key);
   if (!existing || eventTime(value.entry) >= eventTime(existing.entry)) {
@@ -175,6 +198,24 @@ function upsertLatest(map, key, value) {
 
 function emptyCounts() {
   return Object.fromEntries(COUNT_KEYS.map((key) => [key, 0]));
+}
+
+function countsFromRows(rows) {
+  const counts = emptyCounts();
+  for (const row of rows) {
+    if (row.kind === "task") {
+      if (row.status === "completed") counts.completed_tasks += 1;
+      else counts.active_tasks += 1;
+    } else if (row.kind === "session" && row.status === "stale") {
+      counts.stale_sessions += 1;
+    } else if (row.kind === "worktree" && row.status === "orphaned") {
+      counts.orphan_worktrees += 1;
+    } else if (row.kind === "checkpoint" && row.status === "superseded") {
+      counts.superseded_checkpoints += 1;
+    }
+  }
+  counts.unknown_owner = rows.filter((row) => row.owner === "unknown").length;
+  return counts;
 }
 
 export function compactHygieneCounts(projection) {
@@ -197,10 +238,20 @@ export function projectCtoHygiene({
   const worktrees = new Map();
   const checkpointsBySession = new Map();
   const explicitSupersededCheckpoints = new Map();
+  const appliedByKey = new Map();
 
   for (const entry of events) {
     const ref = eventRef(entry);
     switch (entry?.event) {
+      case "hygiene_applied": {
+        const key =
+          typeof ref.hygiene_key === "string" && ref.hygiene_key.trim()
+            ? ref.hygiene_key.trim()
+            : null;
+        if (!key) break;
+        upsertLatest(appliedByKey, key, { entry, ref });
+        break;
+      }
       case "task_claimed":
       case "task_completed": {
         const taskId = typeof ref.task_id === "string" ? ref.task_id : null;
@@ -254,14 +305,10 @@ export function projectCtoHygiene({
   }
 
   const rows = [];
-  const counts = emptyCounts();
 
   for (const [taskId, item] of tasks) {
     const completed = item.entry?.event === "task_completed";
     const status = statusOf(item.ref, completed ? "completed" : "active");
-    counts[
-      completed || status === "completed" ? "completed_tasks" : "active_tasks"
-    ] += 1;
     rows.push(
       rowFrom(
         "task",
@@ -277,7 +324,6 @@ export function projectCtoHygiene({
   }
 
   for (const [sessionId, item] of staleSessions) {
-    counts.stale_sessions += 1;
     rows.push(
       rowFrom(
         "session",
@@ -297,7 +343,6 @@ export function projectCtoHygiene({
       session?.sessionId || session?.session_id || "",
     ).trim();
     if (!sessionId || staleSessions.has(sessionId)) continue;
-    counts.stale_sessions += 1;
     rows.push({
       kind: "session",
       id: sessionId,
@@ -312,7 +357,6 @@ export function projectCtoHygiene({
     if (item.entry?.event === "worktree_removed") continue;
     const status = statusOf(item.ref, "active");
     if (status !== "orphaned") continue;
-    counts.orphan_worktrees += 1;
     rows.push(
       rowFrom(
         "worktree",
@@ -337,7 +381,6 @@ export function projectCtoHygiene({
     }
   }
   for (const [checkpointId, item] of superseded) {
-    counts.superseded_checkpoints += 1;
     rows.push(
       rowFrom(
         "checkpoint",
@@ -350,16 +393,20 @@ export function projectCtoHygiene({
     );
   }
 
-  const sortedRows = rows.map((row) => {
-    if (row.owner === undefined) {
-      const { owner: _owner, ...rest } = row;
-      return rest;
-    }
-    return row;
-  });
-  counts.unknown_owner = sortedRows.filter(
-    (row) => row.owner === "unknown",
-  ).length;
+  const sortedRows = rows
+    .filter((row) => {
+      const applied = appliedByKey.get(hygieneKeyForRow(row));
+      if (!applied) return true;
+      return eventTime(applied.entry) < String(row.last_event_at || "");
+    })
+    .map((row) => {
+      if (row.owner === undefined) {
+        const { owner: _owner, ...rest } = row;
+        return rest;
+      }
+      return row;
+    });
+  const counts = countsFromRows(sortedRows);
 
   return {
     schema_version: "cto-hygiene.v1",
@@ -369,30 +416,212 @@ export function projectCtoHygiene({
   };
 }
 
+function safeLabel(value) {
+  return (
+    String(value || "project")
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/gu, "-")
+      .replace(/^-+|-+$/gu, "")
+      .slice(0, 40) || "project"
+  );
+}
+
+function rootHash(rootDir) {
+  return createHash("sha256")
+    .update(String(rootDir || ""))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function ctoHygieneStewardLockPath(rootDir, lakeRoot) {
+  const label = safeLabel(basename(rootDir || "project"));
+  return join(lakeRoot, "stewards", `${label}-${rootHash(rootDir)}.apply.lock`);
+}
+
+export async function acquireCtoHygieneStewardLock(
+  rootDir,
+  lakeRoot,
+  opts = {},
+) {
+  const lockPath =
+    opts.lockPath || ctoHygieneStewardLockPath(rootDir, lakeRoot);
+  const timeoutMs = Math.max(0, Number(opts.timeoutMs) || 3000);
+  const retryMs = Math.max(1, Number(opts.retryMs) || 50);
+  const staleMs = Math.max(1000, Number(opts.staleMs) || 10 * 60_000);
+  const start = Date.now();
+
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  while (true) {
+    let fd = null;
+    try {
+      fd = openSync(lockPath, "wx", 0o600);
+      writeFileSync(
+        fd,
+        `${JSON.stringify(
+          {
+            pid: process.pid,
+            project_root: rootDir,
+            project_root_hash: rootHash(rootDir),
+            created_at: new Date().toISOString(),
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      return {
+        path: lockPath,
+        project_root: rootDir,
+        project_root_hash: rootHash(rootDir),
+        release() {
+          try {
+            closeSync(fd);
+          } catch {}
+          try {
+            unlinkSync(lockPath);
+          } catch {}
+        },
+      };
+    } catch (error) {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleMs) {
+          unlinkSync(lockPath);
+          continue;
+        }
+      } catch {}
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(`cto hygiene steward lock busy: ${lockPath}`);
+      }
+      await sleep(retryMs);
+    }
+  }
+}
+
+const APPLICABLE_STATUSES = new Set([
+  "active",
+  "stale",
+  "superseded",
+  "orphaned",
+  "hidden",
+  "completed",
+]);
+
+function isApplicableRow(row) {
+  return Boolean(row?.action) || APPLICABLE_STATUSES.has(row?.status);
+}
+
+async function applyHygieneRows({
+  rootDir,
+  lakeRoot,
+  projection,
+  steward,
+  opts,
+}) {
+  const rows = projection.rows.filter(isApplicableRow);
+  const appended = [];
+  const now = opts.now || new Date().toISOString();
+  for (const row of rows) {
+    const result = await appendCtoEvent(
+      lakeRoot,
+      {
+        event: "hygiene_applied",
+        now,
+        source: "tfx_cto_hygiene_apply",
+        project_root: rootDir,
+        status: row.status,
+        hygiene_key: hygieneKeyForRow(row),
+        hygiene_kind: row.kind,
+        hygiene_id: row.id,
+        hygiene_action: row.action || `acknowledge_${row.status}`,
+        summary: `hygiene apply ${row.kind}:${row.id} ${row.status}`,
+        actor: { cli: "tfx cto hygiene --apply" },
+      },
+      {
+        stderr: opts.stderr,
+        lockRetries: opts.ledgerLockRetries,
+        lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+      },
+    );
+    if (result.appended) appended.push(result.event);
+  }
+  return {
+    steward: {
+      lock_path: steward.path,
+      project_root: steward.project_root,
+      project_root_hash: steward.project_root_hash,
+    },
+    applicable_count: rows.length,
+    applied_count: appended.length,
+    events: appended,
+  };
+}
+
 export async function runHygiene(args = [], opts = {}) {
   const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
   const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
   const stdout = opts.stdout || process.stdout;
   const jsonOut = opts.json === true || hasFlag(args, "--json");
   const dryRun = opts.dryRun === true || hasFlag(args, "--dry-run");
-  if (!dryRun) {
-    throw new Error("tfx cto hygiene only supports --dry-run");
+  const apply = opts.apply === true || hasFlag(args, "--apply");
+  if (dryRun && apply) {
+    throw new Error("tfx cto hygiene accepts only one of --dry-run or --apply");
+  }
+  if (!dryRun && !apply) {
+    throw new Error("tfx cto hygiene requires --dry-run or --apply");
   }
 
-  const currentPath = join(lakeRoot, "current.json");
-  const current = existsSync(currentPath) ? readJson(currentPath) : {};
-  const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
-  const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
-  const projection = projectCtoHygiene({
-    current,
-    ledger: ledger.length > 0 ? ledger : null,
-    overlay,
-  });
+  const buildProjection = async () => {
+    const currentPath = join(lakeRoot, "current.json");
+    const current = existsSync(currentPath) ? readJson(currentPath) : {};
+    const ledger = readJsonLines(join(lakeRoot, "ledger.jsonl"));
+    const overlay = await readLiveOverlay({ ...opts, rootDir, lakeRoot });
+    return projectCtoHygiene({
+      current,
+      ledger: ledger.length > 0 ? ledger : null,
+      overlay,
+    });
+  };
+
+  let steward = null;
+  let projection;
+  let applyResult = null;
+  if (apply) {
+    steward = await acquireCtoHygieneStewardLock(rootDir, lakeRoot, {
+      timeoutMs: opts.stewardLockTimeoutMs,
+      retryMs: opts.stewardLockRetryMs,
+      staleMs: opts.stewardLockStaleMs,
+      lockPath: opts.stewardLockPath,
+    });
+    try {
+      projection = await buildProjection();
+      applyResult = await applyHygieneRows({
+        rootDir,
+        lakeRoot,
+        projection,
+        steward,
+        opts,
+      });
+      projection = { ...projection, dry_run: false, apply: applyResult };
+    } finally {
+      steward.release();
+    }
+  } else {
+    projection = await buildProjection();
+  }
 
   if (jsonOut) writeJson(stdout, projection);
   else {
     stdout.write(
-      `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
+      apply
+        ? `cto hygiene apply: ${applyResult.applied_count} event(s) appended for ${applyResult.applicable_count} actionable row(s)\n`
+        : `cto hygiene dry-run: ${projection.counts.active_tasks} active tasks, ${projection.counts.stale_sessions} stale sessions, ${projection.counts.orphan_worktrees} orphan worktrees\n`,
     );
   }
 

--- a/tests/cto/hygiene.test.mjs
+++ b/tests/cto/hygiene.test.mjs
@@ -1,7 +1,21 @@
 import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 
-import { projectCtoHygiene } from "../../cto/hygiene.mjs";
+import {
+  ctoHygieneStewardLockPath,
+  projectCtoHygiene,
+  runHygiene,
+} from "../../cto/hygiene.mjs";
 
 const baseCurrent = {
   ledger_tail: [],
@@ -10,6 +24,33 @@ const baseCurrent = {
 
 function event(ts, name, ref = {}, summary = name) {
   return { ts, event: name, source: "test", summary, ref };
+}
+
+function tempRoot() {
+  return mkdtempSync(join(tmpdir(), "tfx-cto-hygiene-"));
+}
+
+function readJsonl(filePath) {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf8")
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function stdoutSink() {
+  let text = "";
+  return {
+    write(chunk) {
+      text += chunk;
+    },
+    json() {
+      return JSON.parse(text);
+    },
+    text() {
+      return text;
+    },
+  };
 }
 
 describe("projectCtoHygiene", () => {
@@ -70,5 +111,125 @@ describe("projectCtoHygiene", () => {
         ["checkpoint", "cp-old", "superseded"],
       ],
     );
+  });
+
+  it("apply is a locked no-op with evidence when dry-run has no actionable rows", async () => {
+    const root = tempRoot();
+    const lakeRoot = join(root, ".triflux", "lake");
+    const stdout = stdoutSink();
+    try {
+      const result = await runHygiene(["--apply", "--json"], {
+        rootDir: root,
+        lakeRoot,
+        stdout,
+        overlay: { live_sessions: [] },
+        now: "2026-06-17T01:00:00.000Z",
+      });
+
+      assert.equal(result.dry_run, false);
+      assert.equal(result.apply.applicable_count, 0);
+      assert.equal(result.apply.applied_count, 0);
+      assert.deepEqual(result.apply.events, []);
+      assert.equal(existsSync(join(lakeRoot, "ledger.jsonl")), false);
+      assert.equal(
+        existsSync(ctoHygieneStewardLockPath(root, lakeRoot)),
+        false,
+      );
+      assert.equal(stdout.json().apply.applied_count, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("apply appends deterministic hygiene events for actionable sample data", async () => {
+    const root = tempRoot();
+    const lakeRoot = join(root, ".triflux", "lake");
+    const ledgerPath = join(lakeRoot, "ledger.jsonl");
+    const stdout = stdoutSink();
+    try {
+      mkdirSync(lakeRoot, { recursive: true });
+      writeFileSync(
+        ledgerPath,
+        `${JSON.stringify(
+          event("2026-06-17T00:00:00.000Z", "task_claimed", {
+            task_id: "task-active",
+            actor: { agent_id: "agent-a" },
+          }),
+        )}\n`,
+        "utf8",
+      );
+
+      const result = await runHygiene(["--apply", "--json"], {
+        rootDir: root,
+        lakeRoot,
+        stdout,
+        overlay: { live_sessions: [] },
+        now: "2026-06-17T01:00:00.000Z",
+      });
+
+      assert.equal(result.apply.applicable_count, 1);
+      assert.equal(result.apply.applied_count, 1);
+      assert.equal(result.apply.events[0].event, "hygiene_applied");
+      assert.equal(result.apply.events[0].ts, "2026-06-17T01:00:00.000Z");
+      assert.equal(result.apply.events[0].ref.hygiene_key, "task:task-active");
+      assert.equal(result.apply.events[0].ref.hygiene_kind, "task");
+      assert.equal(result.apply.events[0].ref.hygiene_id, "task-active");
+      assert.equal(
+        result.apply.events[0].ref.hygiene_action,
+        "complete_or_reassign_task",
+      );
+
+      const rows = readJsonl(ledgerPath);
+      assert.equal(rows.length, 2);
+      assert.equal(rows[1].event, "hygiene_applied");
+
+      const after = projectCtoHygiene({
+        current: baseCurrent,
+        ledger: rows,
+        overlay: { live_sessions: [] },
+      });
+      assert.equal(after.counts.active_tasks, 0);
+      assert.deepEqual(after.rows, []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("apply refuses to overlap when the project steward lock already exists", async () => {
+    const root = tempRoot();
+    const lakeRoot = join(root, ".triflux", "lake");
+    const ledgerPath = join(lakeRoot, "ledger.jsonl");
+    const lockPath = ctoHygieneStewardLockPath(root, lakeRoot);
+    try {
+      mkdirSync(lakeRoot, { recursive: true });
+      writeFileSync(
+        ledgerPath,
+        `${JSON.stringify(
+          event("2026-06-17T00:00:00.000Z", "session_stale", {
+            session_id: "session-old",
+          }),
+        )}\n`,
+        "utf8",
+      );
+      mkdirSync(dirname(lockPath), { recursive: true });
+      writeFileSync(lockPath, "held\n", "utf8");
+
+      await assert.rejects(
+        () =>
+          runHygiene(["--apply", "--json"], {
+            rootDir: root,
+            lakeRoot,
+            stdout: stdoutSink(),
+            overlay: { live_sessions: [] },
+            stewardLockTimeoutMs: 1,
+            stewardLockRetryMs: 1,
+            stewardLockStaleMs: 60_000,
+          }),
+        /steward lock busy/i,
+      );
+      assert.equal(readJsonl(ledgerPath).length, 1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add `tfx cto hygiene --apply` with a project-root keyed steward lock under the CTO lake (`.triflux/lake/stewards/...`) using an O_EXCL file lock to prevent overlapping apply stewards.
- Add deterministic `hygiene_applied` CTO ledger events through `appendCtoEvent`, keyed by dry-run row kind/id, so applied rows are suppressed from subsequent hygiene projections.
- Keep `--dry-run` read-only and return no-op apply evidence when there are no actionable rows.
- Mirror changed CTO files into `packages/triflux` and `packages/remote`.

## Notes
- Small additive G002 API change: `runHygiene` now accepts exactly one of `--dry-run` or `--apply`; `projectCtoHygiene` recognizes `hygiene_applied` ledger rows as apply acknowledgements.

## Tests
- `node --test tests/cto/hygiene.test.mjs tests/cto/events.test.mjs`
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `git diff --check`
- `npx biome check cto/events.mjs cto/hygiene.mjs tests/cto/hygiene.test.mjs`

Refs #422
