### PR TITLE
feat(cto): notify actionable hygiene

### DIFF
--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -5,6 +5,9 @@ import { homedir, tmpdir } from "node:os";
 import { join as pathJoin, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { runHygiene } from "../cto/hygiene.mjs";
+import { notifyCtoHygieneOnce } from "../cto/hygiene-notify.mjs";
+import { createNotifier } from "../hub/team/notify.mjs";
 import {
   escapePwshSingleQuoted as escapeRemotePwshSingleQuoted,
   probeRemoteEnv as probeRemoteHostEnv,
@@ -51,6 +54,8 @@ function usage() {
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
     "  tfx-live orchestrate --task TEXT [--mode peer|codex-led|claude-led] [--codex-transport exec|app-server-uds] [--cwd DIR] [--timeout 120]",
     "    Runs the Claude(UDS)+Codex orchestration engine. --codex-transport app-server-uds drives a real `codex app-server` over WebSocket-over-UDS (experimental); default exec keeps the codex stdio one-shot path.",
+    "  tfx-live cto-hygiene-notify --root DIR --state-file PATH [--json]",
+    "    One-shot CTO hygiene dry-run notification: sends only when actionable hygiene state changes; no polling or apply/steward lock.",
   ].join("\n");
 }
 
@@ -2207,6 +2212,45 @@ function printJson(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
+async function ctoHygieneNotify(flags) {
+  const rootDir = flags.root ? pathResolve(flags.root) : process.cwd();
+  const stateFile = flags["state-file"]
+    ? pathResolve(flags["state-file"])
+    : pathJoin(rootDir, ".triflux", "cto-hygiene-notify-state.json");
+
+  const projection = await runHygiene(["--dry-run", "--json"], {
+    rootDir,
+    dryRun: true,
+    json: false,
+    stdout: {
+      write() {
+        return true;
+      },
+    },
+  });
+
+  const notifier = createNotifier({ stdout: process.stderr });
+  const result = await notifyCtoHygieneOnce(projection, {
+    notifier,
+    stateFile,
+  });
+  const payload = {
+    ok: true,
+    stateFile,
+    counts: projection.counts,
+    ...result,
+  };
+
+  if (flags.json) {
+    printJson(payload);
+    return;
+  }
+
+  process.stdout.write(
+    `cto hygiene notify: ${payload.reason} (${payload.hash})\n`,
+  );
+}
+
 async function main() {
   const { command, flags } = parseCli(process.argv.slice(2));
 
@@ -2233,6 +2277,8 @@ async function main() {
     await peer(flags);
   } else if (command === "orchestrate") {
     await orchestrate(flags);
+  } else if (command === "cto-hygiene-notify") {
+    await ctoHygieneNotify(flags);
   } else {
     throw new Error(`Unknown subcommand: ${command}\n${usage()}`);
   }
@@ -2242,6 +2288,7 @@ export {
   ADAPTERS,
   buildRemoteLiveCommand,
   callRemoteLive,
+  ctoHygieneNotify,
   extractAssistantResponse,
   extractClaudeCompletedTaskListResponse,
   hasClaudeCompletedTaskListResponse,

--- a/cto/hygiene-notify.mjs
+++ b/cto/hygiene-notify.mjs
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const ACTIONABLE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return JSON.stringify(stableValue(value));
+}
+
+function normalizeCount(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function actionableCounts(projection = {}) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(
+    ACTIONABLE_COUNT_KEYS.map((key) => [key, normalizeCount(counts[key])]),
+  );
+}
+
+function normalizeRows(rows) {
+  return (Array.isArray(rows) ? rows : [])
+    .map((row) => ({
+      kind: String(row?.kind || ""),
+      id: String(row?.id || ""),
+      status: String(row?.status || ""),
+      action: row?.action == null ? "" : String(row.action),
+      owner: row?.owner == null ? "" : String(row.owner),
+    }))
+    .sort((a, b) =>
+      [a.kind, a.id, a.status, a.action, a.owner]
+        .join("\u0000")
+        .localeCompare(
+          [b.kind, b.id, b.status, b.action, b.owner].join("\u0000"),
+        ),
+    );
+}
+
+export function ctoHygieneStateHash(projection = {}) {
+  const canonical = {
+    counts: actionableCounts(projection),
+    rows: normalizeRows(projection.rows),
+  };
+  return createHash("sha256").update(stableJson(canonical)).digest("hex");
+}
+
+function plural(count, singular, pluralWord = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : pluralWord}`;
+}
+
+function summarizeCounts(counts) {
+  const parts = [];
+  if (counts.active_tasks)
+    parts.push(plural(counts.active_tasks, "active task"));
+  if (counts.stale_sessions)
+    parts.push(plural(counts.stale_sessions, "stale session"));
+  if (counts.orphan_worktrees)
+    parts.push(plural(counts.orphan_worktrees, "orphan worktree"));
+  if (counts.superseded_checkpoints)
+    parts.push(plural(counts.superseded_checkpoints, "superseded checkpoint"));
+  if (counts.unknown_owner)
+    parts.push(plural(counts.unknown_owner, "unknown owner"));
+  return parts;
+}
+
+export function buildCtoHygieneNotification(projection = {}, opts = {}) {
+  const counts = actionableCounts(projection);
+  const actionable = ACTIONABLE_COUNT_KEYS.some((key) => counts[key] > 0);
+  const hash = ctoHygieneStateHash(projection);
+  if (!actionable) {
+    return { actionable, hash, event: null, counts };
+  }
+
+  const summary = `CTO hygiene needs action: ${summarizeCounts(counts).join(", ")}`;
+  return {
+    actionable,
+    hash,
+    counts,
+    event: {
+      type: "ctoHygiene",
+      sessionId: opts.sessionId || "cto-hygiene",
+      summary,
+      timestamp:
+        typeof opts.now === "function"
+          ? opts.now()
+          : (opts.timestamp ?? new Date().toISOString()),
+    },
+  };
+}
+
+async function readState(stateFile) {
+  if (!stateFile) return null;
+  try {
+    return JSON.parse(await readFile(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(stateFile, state) {
+  if (!stateFile) return;
+  await mkdir(dirname(stateFile), { recursive: true });
+  await writeFile(stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+export async function notifyCtoHygieneOnce(projection = {}, opts = {}) {
+  const notification = buildCtoHygieneNotification(projection, opts);
+  const previous = await readState(opts.stateFile);
+  const unchanged = previous?.hash === notification.hash;
+  const checkedAt =
+    typeof opts.now === "function" ? opts.now() : new Date().toISOString();
+
+  if (!notification.actionable) {
+    await writeState(opts.stateFile, {
+      hash: notification.hash,
+      actionable: false,
+      checkedAt,
+    });
+    return {
+      actionable: false,
+      notified: false,
+      reason: "not-actionable",
+      hash: notification.hash,
+    };
+  }
+
+  if (unchanged) {
+    return {
+      actionable: true,
+      notified: false,
+      reason: "unchanged-state",
+      hash: notification.hash,
+    };
+  }
+
+  const notifierResult = await opts.notifier.notify(notification.event);
+  await writeState(opts.stateFile, {
+    hash: notification.hash,
+    actionable: true,
+    notifiedAt: notification.event.timestamp,
+  });
+
+  return {
+    actionable: true,
+    notified: true,
+    reason: "changed-actionable-state",
+    hash: notification.hash,
+    event: notification.event,
+    notify: notifierResult,
+  };
+}

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -1246,7 +1246,7 @@ export function attachClaudeDaemonSession({
         cancelCompletionTimer();
       }
     });
-    socket.on("close", () => {
+    const finishClosed = () => {
       if (!settled) {
         if (pendingCompletion) {
           finish(pendingCompletion);
@@ -1254,7 +1254,9 @@ export function attachClaudeDaemonSession({
         }
         finish({ timedOut: false, matchedCompletion: false, closed: true });
       }
-    });
+    };
+    socket.on("end", finishClosed);
+    socket.on("close", finishClosed);
   });
 }
 

--- a/hub/team/notify.mjs
+++ b/hub/team/notify.mjs
@@ -7,6 +7,7 @@ export const NOTIFY_EVENT_TYPES = Object.freeze([
   "completed",
   "failed",
   "inputWait",
+  "ctoHygiene",
 ]);
 export const NOTIFY_CHANNELS = Object.freeze(["bell", "toast", "webhook"]);
 
@@ -137,6 +138,8 @@ function formatEventTitle(event) {
       return "Triflux failed";
     case "inputWait":
       return "Triflux waiting for input";
+    case "ctoHygiene":
+      return "Triflux CTO hygiene needs action";
     default:
       return "Triflux notification";
   }

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -1246,7 +1246,7 @@ export function attachClaudeDaemonSession({
         cancelCompletionTimer();
       }
     });
-    socket.on("close", () => {
+    const finishClosed = () => {
       if (!settled) {
         if (pendingCompletion) {
           finish(pendingCompletion);
@@ -1254,7 +1254,9 @@ export function attachClaudeDaemonSession({
         }
         finish({ timedOut: false, matchedCompletion: false, closed: true });
       }
-    });
+    };
+    socket.on("end", finishClosed);
+    socket.on("close", finishClosed);
   });
 }
 

--- a/packages/remote/cto/hygiene-notify.mjs
+++ b/packages/remote/cto/hygiene-notify.mjs
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const ACTIONABLE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return JSON.stringify(stableValue(value));
+}
+
+function normalizeCount(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function actionableCounts(projection = {}) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(
+    ACTIONABLE_COUNT_KEYS.map((key) => [key, normalizeCount(counts[key])]),
+  );
+}
+
+function normalizeRows(rows) {
+  return (Array.isArray(rows) ? rows : [])
+    .map((row) => ({
+      kind: String(row?.kind || ""),
+      id: String(row?.id || ""),
+      status: String(row?.status || ""),
+      action: row?.action == null ? "" : String(row.action),
+      owner: row?.owner == null ? "" : String(row.owner),
+    }))
+    .sort((a, b) =>
+      [a.kind, a.id, a.status, a.action, a.owner]
+        .join("\u0000")
+        .localeCompare([b.kind, b.id, b.status, b.action, b.owner].join("\u0000")),
+    );
+}
+
+export function ctoHygieneStateHash(projection = {}) {
+  const canonical = {
+    counts: actionableCounts(projection),
+    rows: normalizeRows(projection.rows),
+  };
+  return createHash("sha256").update(stableJson(canonical)).digest("hex");
+}
+
+function plural(count, singular, pluralWord = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : pluralWord}`;
+}
+
+function summarizeCounts(counts) {
+  const parts = [];
+  if (counts.active_tasks)
+    parts.push(plural(counts.active_tasks, "active task"));
+  if (counts.stale_sessions)
+    parts.push(plural(counts.stale_sessions, "stale session"));
+  if (counts.orphan_worktrees)
+    parts.push(plural(counts.orphan_worktrees, "orphan worktree"));
+  if (counts.superseded_checkpoints)
+    parts.push(plural(counts.superseded_checkpoints, "superseded checkpoint"));
+  if (counts.unknown_owner)
+    parts.push(plural(counts.unknown_owner, "unknown owner"));
+  return parts;
+}
+
+export function buildCtoHygieneNotification(projection = {}, opts = {}) {
+  const counts = actionableCounts(projection);
+  const actionable = ACTIONABLE_COUNT_KEYS.some((key) => counts[key] > 0);
+  const hash = ctoHygieneStateHash(projection);
+  if (!actionable) {
+    return { actionable, hash, event: null, counts };
+  }
+
+  const summary = `CTO hygiene needs action: ${summarizeCounts(counts).join(", ")}`;
+  return {
+    actionable,
+    hash,
+    counts,
+    event: {
+      type: "ctoHygiene",
+      sessionId: opts.sessionId || "cto-hygiene",
+      summary,
+      timestamp:
+        typeof opts.now === "function"
+          ? opts.now()
+          : (opts.timestamp ?? new Date().toISOString()),
+    },
+  };
+}
+
+async function readState(stateFile) {
+  if (!stateFile) return null;
+  try {
+    return JSON.parse(await readFile(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(stateFile, state) {
+  if (!stateFile) return;
+  await mkdir(dirname(stateFile), { recursive: true });
+  await writeFile(stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+export async function notifyCtoHygieneOnce(projection = {}, opts = {}) {
+  const notification = buildCtoHygieneNotification(projection, opts);
+  const previous = await readState(opts.stateFile);
+  const unchanged = previous?.hash === notification.hash;
+  const checkedAt =
+    typeof opts.now === "function" ? opts.now() : new Date().toISOString();
+
+  if (!notification.actionable) {
+    await writeState(opts.stateFile, {
+      hash: notification.hash,
+      actionable: false,
+      checkedAt,
+    });
+    return {
+      actionable: false,
+      notified: false,
+      reason: "not-actionable",
+      hash: notification.hash,
+    };
+  }
+
+  if (unchanged) {
+    return {
+      actionable: true,
+      notified: false,
+      reason: "unchanged-state",
+      hash: notification.hash,
+    };
+  }
+
+  const notifierResult = await opts.notifier.notify(notification.event);
+  await writeState(opts.stateFile, {
+    hash: notification.hash,
+    actionable: true,
+    notifiedAt: notification.event.timestamp,
+  });
+
+  return {
+    actionable: true,
+    notified: true,
+    reason: "changed-actionable-state",
+    hash: notification.hash,
+    event: notification.event,
+    notify: notifierResult,
+  };
+}

--- a/packages/remote/hub/team/notify.mjs
+++ b/packages/remote/hub/team/notify.mjs
@@ -7,6 +7,7 @@ export const NOTIFY_EVENT_TYPES = Object.freeze([
   "completed",
   "failed",
   "inputWait",
+  "ctoHygiene",
 ]);
 export const NOTIFY_CHANNELS = Object.freeze(["bell", "toast", "webhook"]);
 
@@ -137,6 +138,8 @@ function formatEventTitle(event) {
       return "Triflux failed";
     case "inputWait":
       return "Triflux waiting for input";
+    case "ctoHygiene":
+      return "Triflux CTO hygiene needs action";
     default:
       return "Triflux notification";
   }

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -5,6 +5,9 @@ import { homedir, tmpdir } from "node:os";
 import { join as pathJoin, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { runHygiene } from "../cto/hygiene.mjs";
+import { notifyCtoHygieneOnce } from "../cto/hygiene-notify.mjs";
+import { createNotifier } from "../hub/team/notify.mjs";
 import {
   escapePwshSingleQuoted as escapeRemotePwshSingleQuoted,
   probeRemoteEnv as probeRemoteHostEnv,
@@ -51,6 +54,8 @@ function usage() {
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
     "  tfx-live orchestrate --task TEXT [--mode peer|codex-led|claude-led] [--codex-transport exec|app-server-uds] [--cwd DIR] [--timeout 120]",
     "    Runs the Claude(UDS)+Codex orchestration engine. --codex-transport app-server-uds drives a real `codex app-server` over WebSocket-over-UDS (experimental); default exec keeps the codex stdio one-shot path.",
+    "  tfx-live cto-hygiene-notify --root DIR --state-file PATH [--json]",
+    "    One-shot CTO hygiene dry-run notification: sends only when actionable hygiene state changes; no polling or apply/steward lock.",
   ].join("\n");
 }
 
@@ -2207,6 +2212,45 @@ function printJson(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
+async function ctoHygieneNotify(flags) {
+  const rootDir = flags.root ? pathResolve(flags.root) : process.cwd();
+  const stateFile = flags["state-file"]
+    ? pathResolve(flags["state-file"])
+    : pathJoin(rootDir, ".triflux", "cto-hygiene-notify-state.json");
+
+  const projection = await runHygiene(["--dry-run", "--json"], {
+    rootDir,
+    dryRun: true,
+    json: false,
+    stdout: {
+      write() {
+        return true;
+      },
+    },
+  });
+
+  const notifier = createNotifier({ stdout: process.stderr });
+  const result = await notifyCtoHygieneOnce(projection, {
+    notifier,
+    stateFile,
+  });
+  const payload = {
+    ok: true,
+    stateFile,
+    counts: projection.counts,
+    ...result,
+  };
+
+  if (flags.json) {
+    printJson(payload);
+    return;
+  }
+
+  process.stdout.write(
+    `cto hygiene notify: ${payload.reason} (${payload.hash})\n`,
+  );
+}
+
 async function main() {
   const { command, flags } = parseCli(process.argv.slice(2));
 
@@ -2233,6 +2277,8 @@ async function main() {
     await peer(flags);
   } else if (command === "orchestrate") {
     await orchestrate(flags);
+  } else if (command === "cto-hygiene-notify") {
+    await ctoHygieneNotify(flags);
   } else {
     throw new Error(`Unknown subcommand: ${command}\n${usage()}`);
   }
@@ -2242,6 +2288,7 @@ export {
   ADAPTERS,
   buildRemoteLiveCommand,
   callRemoteLive,
+  ctoHygieneNotify,
   extractAssistantResponse,
   extractClaudeCompletedTaskListResponse,
   hasClaudeCompletedTaskListResponse,

--- a/packages/triflux/cto/hygiene-notify.mjs
+++ b/packages/triflux/cto/hygiene-notify.mjs
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const ACTIONABLE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return JSON.stringify(stableValue(value));
+}
+
+function normalizeCount(value) {
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function actionableCounts(projection = {}) {
+  const counts = projection?.counts || {};
+  return Object.fromEntries(
+    ACTIONABLE_COUNT_KEYS.map((key) => [key, normalizeCount(counts[key])]),
+  );
+}
+
+function normalizeRows(rows) {
+  return (Array.isArray(rows) ? rows : [])
+    .map((row) => ({
+      kind: String(row?.kind || ""),
+      id: String(row?.id || ""),
+      status: String(row?.status || ""),
+      action: row?.action == null ? "" : String(row.action),
+      owner: row?.owner == null ? "" : String(row.owner),
+    }))
+    .sort((a, b) =>
+      [a.kind, a.id, a.status, a.action, a.owner]
+        .join("\u0000")
+        .localeCompare(
+          [b.kind, b.id, b.status, b.action, b.owner].join("\u0000"),
+        ),
+    );
+}
+
+export function ctoHygieneStateHash(projection = {}) {
+  const canonical = {
+    counts: actionableCounts(projection),
+    rows: normalizeRows(projection.rows),
+  };
+  return createHash("sha256").update(stableJson(canonical)).digest("hex");
+}
+
+function plural(count, singular, pluralWord = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : pluralWord}`;
+}
+
+function summarizeCounts(counts) {
+  const parts = [];
+  if (counts.active_tasks)
+    parts.push(plural(counts.active_tasks, "active task"));
+  if (counts.stale_sessions)
+    parts.push(plural(counts.stale_sessions, "stale session"));
+  if (counts.orphan_worktrees)
+    parts.push(plural(counts.orphan_worktrees, "orphan worktree"));
+  if (counts.superseded_checkpoints)
+    parts.push(plural(counts.superseded_checkpoints, "superseded checkpoint"));
+  if (counts.unknown_owner)
+    parts.push(plural(counts.unknown_owner, "unknown owner"));
+  return parts;
+}
+
+export function buildCtoHygieneNotification(projection = {}, opts = {}) {
+  const counts = actionableCounts(projection);
+  const actionable = ACTIONABLE_COUNT_KEYS.some((key) => counts[key] > 0);
+  const hash = ctoHygieneStateHash(projection);
+  if (!actionable) {
+    return { actionable, hash, event: null, counts };
+  }
+
+  const summary = `CTO hygiene needs action: ${summarizeCounts(counts).join(", ")}`;
+  return {
+    actionable,
+    hash,
+    counts,
+    event: {
+      type: "ctoHygiene",
+      sessionId: opts.sessionId || "cto-hygiene",
+      summary,
+      timestamp:
+        typeof opts.now === "function"
+          ? opts.now()
+          : (opts.timestamp ?? new Date().toISOString()),
+    },
+  };
+}
+
+async function readState(stateFile) {
+  if (!stateFile) return null;
+  try {
+    return JSON.parse(await readFile(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(stateFile, state) {
+  if (!stateFile) return;
+  await mkdir(dirname(stateFile), { recursive: true });
+  await writeFile(stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+export async function notifyCtoHygieneOnce(projection = {}, opts = {}) {
+  const notification = buildCtoHygieneNotification(projection, opts);
+  const previous = await readState(opts.stateFile);
+  const unchanged = previous?.hash === notification.hash;
+  const checkedAt =
+    typeof opts.now === "function" ? opts.now() : new Date().toISOString();
+
+  if (!notification.actionable) {
+    await writeState(opts.stateFile, {
+      hash: notification.hash,
+      actionable: false,
+      checkedAt,
+    });
+    return {
+      actionable: false,
+      notified: false,
+      reason: "not-actionable",
+      hash: notification.hash,
+    };
+  }
+
+  if (unchanged) {
+    return {
+      actionable: true,
+      notified: false,
+      reason: "unchanged-state",
+      hash: notification.hash,
+    };
+  }
+
+  const notifierResult = await opts.notifier.notify(notification.event);
+  await writeState(opts.stateFile, {
+    hash: notification.hash,
+    actionable: true,
+    notifiedAt: notification.event.timestamp,
+  });
+
+  return {
+    actionable: true,
+    notified: true,
+    reason: "changed-actionable-state",
+    hash: notification.hash,
+    event: notification.event,
+    notify: notifierResult,
+  };
+}

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -1246,7 +1246,7 @@ export function attachClaudeDaemonSession({
         cancelCompletionTimer();
       }
     });
-    socket.on("close", () => {
+    const finishClosed = () => {
       if (!settled) {
         if (pendingCompletion) {
           finish(pendingCompletion);
@@ -1254,7 +1254,9 @@ export function attachClaudeDaemonSession({
         }
         finish({ timedOut: false, matchedCompletion: false, closed: true });
       }
-    });
+    };
+    socket.on("end", finishClosed);
+    socket.on("close", finishClosed);
   });
 }
 

--- a/packages/triflux/hub/team/notify.mjs
+++ b/packages/triflux/hub/team/notify.mjs
@@ -7,6 +7,7 @@ export const NOTIFY_EVENT_TYPES = Object.freeze([
   "completed",
   "failed",
   "inputWait",
+  "ctoHygiene",
 ]);
 export const NOTIFY_CHANNELS = Object.freeze(["bell", "toast", "webhook"]);
 
@@ -137,6 +138,8 @@ function formatEventTitle(event) {
       return "Triflux failed";
     case "inputWait":
       return "Triflux waiting for input";
+    case "ctoHygiene":
+      return "Triflux CTO hygiene needs action";
     default:
       return "Triflux notification";
   }

--- a/tests/notify.test.mjs
+++ b/tests/notify.test.mjs
@@ -184,4 +184,51 @@ describe("createNotifier", () => {
       timestamp: "2026-04-04T00:00:03.000Z",
     });
   });
+  it("normalizes and formats CTO hygiene notification events", async () => {
+    const requests = [];
+    const toastCalls = [];
+    const fetch = async (url, init) => {
+      requests.push({ url, init });
+      return { ok: true, status: 202 };
+    };
+    const execFile = (command, args, options, callback) => {
+      toastCalls.push({ command, args, options });
+      callback(null, "", "");
+    };
+
+    const notifier = createNotifier({
+      stdout: {
+        write() {
+          return true;
+        },
+      },
+      platform: "win32",
+      env: { TRIFLUX_NOTIFY_WEBHOOK: "https://example.test/cto" },
+      deps: { execFile, fetch },
+      hostname: "cto-host",
+    }).setChannel("bell", false);
+
+    const result = await notifier.notify({
+      type: "ctoHygiene",
+      sessionId: "cto-hygiene",
+      summary: "CTO hygiene needs action: 1 active task",
+      timestamp: "2026-06-17T00:00:00.000Z",
+    });
+
+    assert.equal(result.results.toast.status, "sent");
+    assert.match(toastCalls[0].args[3], /Triflux CTO hygiene needs action/u);
+    assert.match(
+      toastCalls[0].args[3],
+      /CTO hygiene needs action: 1 active task/u,
+    );
+    assert.equal(result.results.webhook.status, "sent");
+    assert.equal(requests.length, 1);
+    assert.deepEqual(JSON.parse(requests[0].init.body), {
+      type: "ctoHygiene",
+      sessionId: "cto-hygiene",
+      host: "cto-host",
+      summary: "CTO hygiene needs action: 1 active task",
+      timestamp: "2026-06-17T00:00:00.000Z",
+    });
+  });
 });

--- a/tests/unit/cto-hygiene-notify.test.mjs
+++ b/tests/unit/cto-hygiene-notify.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildCtoHygieneNotification,
+  ctoHygieneStateHash,
+  notifyCtoHygieneOnce,
+} from "../../cto/hygiene-notify.mjs";
+
+test("CTO hygiene notification helper treats only actionable counts as notify-worthy", () => {
+  const quiet = buildCtoHygieneNotification({
+    counts: {
+      active_tasks: 0,
+      stale_sessions: 0,
+      orphan_worktrees: 0,
+      superseded_checkpoints: 0,
+      unknown_owner: 0,
+    },
+    rows: [],
+  });
+
+  assert.equal(quiet.actionable, false);
+  assert.equal(quiet.event, null);
+
+  const actionable = buildCtoHygieneNotification({
+    counts: {
+      active_tasks: 1,
+      stale_sessions: 1,
+      orphan_worktrees: 0,
+      superseded_checkpoints: 0,
+      unknown_owner: 1,
+    },
+    rows: [
+      { kind: "task", id: "T1", action: "complete_or_reassign_task" },
+      { kind: "session", id: "S1", action: "archive_or_resume_session" },
+    ],
+  });
+
+  assert.equal(actionable.actionable, true);
+  assert.equal(actionable.event.type, "ctoHygiene");
+  assert.equal(actionable.event.sessionId, "cto-hygiene");
+  assert.match(actionable.event.summary, /1 active task/u);
+  assert.match(actionable.event.summary, /1 stale session/u);
+  assert.match(actionable.event.summary, /1 unknown owner/u);
+});
+
+test("CTO hygiene state hash is stable across row order changes", () => {
+  const first = ctoHygieneStateHash({
+    counts: { active_tasks: 1 },
+    rows: [
+      { kind: "session", id: "S1", status: "stale" },
+      { kind: "task", id: "T1", status: "active" },
+    ],
+  });
+  const second = ctoHygieneStateHash({
+    counts: { active_tasks: 1 },
+    rows: [
+      { kind: "task", id: "T1", status: "active" },
+      { kind: "session", id: "S1", status: "stale" },
+    ],
+  });
+
+  assert.equal(first, second);
+});
+
+test("notifyCtoHygieneOnce sends once for changed actionable state and dedupes repeats", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "cto-hygiene-notify-"));
+  const stateFile = join(dir, "state.json");
+  const sent = [];
+  const notifier = {
+    async notify(event) {
+      sent.push(event);
+      return { event, results: { bell: { status: "sent" } } };
+    },
+  };
+  const projection = {
+    counts: { active_tasks: 1, stale_sessions: 0, orphan_worktrees: 0 },
+    rows: [{ kind: "task", id: "T1", status: "active" }],
+  };
+
+  try {
+    const first = await notifyCtoHygieneOnce(projection, {
+      notifier,
+      stateFile,
+      now: () => "2026-06-17T00:00:00.000Z",
+    });
+    const second = await notifyCtoHygieneOnce(projection, {
+      notifier,
+      stateFile,
+      now: () => "2026-06-17T00:01:00.000Z",
+    });
+
+    assert.equal(first.notified, true);
+    assert.equal(first.reason, "changed-actionable-state");
+    assert.equal(second.notified, false);
+    assert.equal(second.reason, "unchanged-state");
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "ctoHygiene");
+
+    const persisted = JSON.parse(await readFile(stateFile, "utf8"));
+    assert.equal(persisted.hash, first.hash);
+    assert.equal(persisted.actionable, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/tfx-live-cli.test.mjs
+++ b/tests/unit/tfx-live-cli.test.mjs
@@ -349,3 +349,55 @@ test("tfx-live interrupt returns the common abort contract through tmux Escape",
     await fs.rm(dir, { recursive: true, force: true });
   }
 });
+
+test("tfx-live cto-hygiene-notify notifies once for actionable unchanged hygiene state", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-live-cto-hygiene-"));
+  try {
+    const lakeDir = path.join(dir, ".triflux", "lake");
+    await fs.mkdir(lakeDir, { recursive: true });
+    await fs.writeFile(path.join(lakeDir, "current.json"), "{}", "utf8");
+    await fs.writeFile(
+      path.join(lakeDir, "ledger.jsonl"),
+      `${JSON.stringify({
+        ts: "2026-06-17T00:00:00.000Z",
+        event: "task_claimed",
+        summary: "Open item",
+        ref: { task_id: "G005", status: "active", actor: { cli: "codex" } },
+      })}\n`,
+      "utf8",
+    );
+    const stateFile = path.join(dir, "notify-state.json");
+
+    const first = JSON.parse(
+      await runTfxLive([
+        "cto-hygiene-notify",
+        "--root",
+        dir,
+        "--state-file",
+        stateFile,
+        "--json",
+      ]),
+    );
+    const second = JSON.parse(
+      await runTfxLive([
+        "cto-hygiene-notify",
+        "--root",
+        dir,
+        "--state-file",
+        stateFile,
+        "--json",
+      ]),
+    );
+
+    assert.equal(first.ok, true);
+    assert.equal(first.actionable, true);
+    assert.equal(first.notified, true);
+    assert.equal(first.reason, "changed-actionable-state");
+    assert.equal(second.ok, true);
+    assert.equal(second.actionable, true);
+    assert.equal(second.notified, false);
+    assert.equal(second.reason, "unchanged-state");
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add a strict `ctoHygiene` notifier event type with toast/webhook formatting coverage.
- Add pure CTO hygiene notification helpers for actionable-state hashing and state-file dedupe.
- Add explicit one-shot `tfx-live cto-hygiene-notify` wiring; no daemon polling, no apply/steward lock, and no tray UI changes.

## Tests
- node --test tests/notify.test.mjs tests/unit/cto-hygiene-notify.test.mjs tests/unit/tfx-live-cli.test.mjs
- npm run release:check-mirror
- npm run release:check-sync
- git diff --check
- npx biome check bin/tfx-live.mjs cto/hygiene-notify.mjs hub/team/notify.mjs packages/remote/cto/hygiene-notify.mjs packages/remote/hub/team/notify.mjs packages/triflux/bin/tfx-live.mjs packages/triflux/cto/hygiene-notify.mjs packages/triflux/hub/team/notify.mjs tests/notify.test.mjs tests/unit/cto-hygiene-notify.test.mjs tests/unit/tfx-live-cli.test.mjs

Refs #422