### PR TITLE
feat(cto): surface hygiene in tray

### DIFF
--- a/cto/dashboard.mjs
+++ b/cto/dashboard.mjs
@@ -196,6 +196,65 @@ function renderLedger(entries) {
   `;
 }
 
+const HYGIENE_METRICS = Object.freeze([
+  ["active_tasks", "Active tasks"],
+  ["stale_sessions", "Stale sessions"],
+  ["orphan_worktrees", "Orphan worktrees"],
+  ["superseded_checkpoints", "Superseded checkpoints"],
+  ["unknown_owner", "Unknown owners"],
+]);
+
+function hygieneCount(hygiene, key) {
+  const value = Number(hygiene?.[key] || 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function renderHygiene(hygiene) {
+  if (!hygiene || typeof hygiene !== "object") return "";
+  const actions = Array.isArray(hygiene.actions)
+    ? hygiene.actions.slice(0, 5)
+    : [];
+  const actionCount = hygieneCount(hygiene, "action_count") || actions.length;
+  return `
+    <section class="panel">
+      <h2>Hygiene</h2>
+      <table>
+        <tbody>
+          ${HYGIENE_METRICS.map(
+            ([key, label]) => `
+              <tr>
+                <th>${escapeHtml(label)}</th>
+                <td>${hygieneCount(hygiene, key)}</td>
+              </tr>
+            `,
+          ).join("")}
+          <tr>
+            <th>Actions</th>
+            <td>${actionCount}</td>
+          </tr>
+        </tbody>
+      </table>
+      ${
+        actions.length
+          ? `<ul class="items">
+              ${actions
+                .map(
+                  (action) => `
+                    <li>
+                      <strong>${escapeHtml(formatValue(action?.id || action?.kind, "item"))}</strong>
+                      <span>${escapeHtml(formatValue(action?.action || action?.kind, "review"))}</span>
+                      <em>${escapeHtml(formatValue(action?.status, "action"))}</em>
+                    </li>
+                  `,
+                )
+                .join("")}
+            </ul>`
+          : `<p class="empty">No hygiene actions reported.</p>`
+      }
+    </section>
+  `;
+}
+
 function pageShell(title, body) {
   return `<!doctype html>
 <html lang="en">
@@ -326,6 +385,7 @@ function renderCurrentHtml(current) {
           <h2>Swarm Shards</h2>
           ${renderShards(shards)}
         </section>
+        ${renderHygiene(current.hygiene || current.summary?.hygiene)}
         <section class="panel">
           <h2>Recent Ledger</h2>
           ${renderLedger(Array.isArray(current.ledger_tail) ? current.ledger_tail : [])}

--- a/hub/public/tray.html
+++ b/hub/public/tray.html
@@ -224,6 +224,41 @@
       `).join('')}</div>`;
     }
 
+    function hygieneCount(hygiene, key) {
+      const value = Number(hygiene?.[key] || 0);
+      return Number.isFinite(value) && value > 0 ? value : 0;
+    }
+
+    function renderCtoHygiene(hygiene) {
+      if (!hygiene || typeof hygiene !== 'object') return '';
+      const actions = Array.isArray(hygiene.actions) ? hygiene.actions.slice(0, 2) : [];
+      const actionCount = hygieneCount(hygiene, 'action_count') || actions.length;
+      const actionHtml = actions.length > 0
+        ? `<div class="models-list">${actions.map(action => `
+            <div class="mini-card">
+              <div class="mini-head">
+                <div class="mini-title">${escapeHtml(action.id || action.kind || 'hygiene item')}</div>
+                <div class="value-pill status-text partial">${escapeHtml(action.status || 'action')}</div>
+              </div>
+              <div class="path-text">${escapeHtml(action.action || action.kind || '')}</div>
+            </div>
+          `).join('')}</div>`
+        : '<div class="mini-card muted">No hygiene actions reported</div>';
+      return `
+        <div class="section">
+          <div class="section-title">CTO Hygiene</div>
+          <div class="stats-grid">
+            <div class="stat-box"><div class="stat-label">Active tasks</div><div class="stat-value">${hygieneCount(hygiene, 'active_tasks')}<span class="stat-unit">open</span></div></div>
+            <div class="stat-box"><div class="stat-label">Stale sessions</div><div class="stat-value">${hygieneCount(hygiene, 'stale_sessions')}<span class="stat-unit">stale</span></div></div>
+            <div class="stat-box"><div class="stat-label">Orphan worktrees</div><div class="stat-value">${hygieneCount(hygiene, 'orphan_worktrees')}<span class="stat-unit">orphan</span></div></div>
+            <div class="stat-box"><div class="stat-label">Actions</div><div class="stat-value">${actionCount}<span class="stat-unit">dry-run</span></div></div>
+          </div>
+          <div class="path-text">${hygieneCount(hygiene, 'superseded_checkpoints')} superseded checkpoints · ${hygieneCount(hygiene, 'unknown_owner')} unknown owners</div>
+          ${actionHtml}
+        </div>
+      `;
+    }
+
     function liveFallbackRows(live) {
       return live.map(session => ({
         sessionId: session.sessionId,
@@ -499,6 +534,7 @@
           <div class="section-title">Agent Mix</div>
           <div class="models-list">${renderRuntimeClients(runtime)}</div>
         </div>
+        ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/hub/tray-state.mjs
+++ b/hub/tray-state.mjs
@@ -387,6 +387,58 @@ function normalizeLiveSession(session = {}) {
   };
 }
 
+const CTO_HYGIENE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function compactNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function normalizeHygieneAction(action = {}) {
+  return {
+    kind: String(action.kind || ""),
+    id: String(action.id || ""),
+    status: String(action.status || ""),
+    action: String(action.action || ""),
+  };
+}
+
+function normalizeCtoHygiene(ctoStatus = {}) {
+  const hygiene =
+    ctoStatus?.hygiene && typeof ctoStatus.hygiene === "object"
+      ? ctoStatus.hygiene
+      : null;
+  if (!hygiene) return null;
+
+  const actionsSource = Array.isArray(hygiene.actions)
+    ? hygiene.actions
+    : Array.isArray(hygiene.rows)
+      ? hygiene.rows
+      : Array.isArray(ctoStatus?.hygiene_actions)
+        ? ctoStatus.hygiene_actions
+        : [];
+  const actions = actionsSource
+    .map(normalizeHygieneAction)
+    .filter(
+      (action) => action.kind || action.id || action.status || action.action,
+    );
+
+  return {
+    ...Object.fromEntries(
+      CTO_HYGIENE_COUNT_KEYS.map((key) => [key, compactNumber(hygiene[key])]),
+    ),
+    action_count: compactNumber(hygiene.action_count ?? actions.length),
+    actions: actions.slice(0, 2),
+  };
+}
+
 function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const explicitLive = Array.isArray(ctoStatus?.live_sessions)
     ? ctoStatus.live_sessions
@@ -407,11 +459,13 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const activeShards = Array.isArray(ctoStatus?.active_shards)
     ? ctoStatus.active_shards
     : [];
+  const hygiene = normalizeCtoHygiene(ctoStatus);
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,
       active_shard_count: activeShards.length,

--- a/packages/remote/cto/hygiene.mjs
+++ b/packages/remote/cto/hygiene.mjs
@@ -127,7 +127,9 @@ function eventTime(entry) {
 }
 
 function eventRef(entry) {
-  return entry?.ref && typeof entry.ref === "object" && !Array.isArray(entry.ref)
+  return entry?.ref &&
+    typeof entry.ref === "object" &&
+    !Array.isArray(entry.ref)
     ? entry.ref
     : {};
 }
@@ -180,7 +182,11 @@ export function compactHygieneCounts(projection) {
   return Object.fromEntries(COUNT_KEYS.map((key) => [key, counts[key] || 0]));
 }
 
-export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } = {}) {
+export function projectCtoHygiene({
+  current = {},
+  ledger = null,
+  overlay = {},
+} = {}) {
   const events = Array.isArray(ledger)
     ? ledger
     : Array.isArray(current?.ledger_tail)
@@ -203,7 +209,8 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
         break;
       }
       case "session_stale": {
-        const sessionId = typeof ref.session_id === "string" ? ref.session_id : null;
+        const sessionId =
+          typeof ref.session_id === "string" ? ref.session_id : null;
         if (!sessionId) break;
         upsertLatest(staleSessions, sessionId, { entry, ref });
         break;
@@ -211,7 +218,8 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
       case "worktree_created":
       case "worktree_removed": {
         const key =
-          (typeof ref.worktree_path_hash === "string" && ref.worktree_path_hash) ||
+          (typeof ref.worktree_path_hash === "string" &&
+            ref.worktree_path_hash) ||
           (typeof ref.worktree_label === "string" && ref.worktree_label) ||
           null;
         if (!key) break;
@@ -224,14 +232,19 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
           typeof ref.checkpoint_id === "string" ? ref.checkpoint_id : null;
         if (!checkpointId) break;
         if (ref.status === "superseded") {
-          upsertLatest(explicitSupersededCheckpoints, checkpointId, { entry, ref });
+          upsertLatest(explicitSupersededCheckpoints, checkpointId, {
+            entry,
+            ref,
+          });
         }
         const sessionId =
           (typeof ref.session_id === "string" && ref.session_id) ||
-          (typeof ref.restored_from_session_id === "string" && ref.restored_from_session_id) ||
+          (typeof ref.restored_from_session_id === "string" &&
+            ref.restored_from_session_id) ||
           null;
         if (!sessionId) break;
-        if (!checkpointsBySession.has(sessionId)) checkpointsBySession.set(sessionId, []);
+        if (!checkpointsBySession.has(sessionId))
+          checkpointsBySession.set(sessionId, []);
         checkpointsBySession.get(sessionId).push({ entry, ref, checkpointId });
         break;
       }
@@ -246,7 +259,9 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
   for (const [taskId, item] of tasks) {
     const completed = item.entry?.event === "task_completed";
     const status = statusOf(item.ref, completed ? "completed" : "active");
-    counts[completed || status === "completed" ? "completed_tasks" : "active_tasks"] += 1;
+    counts[
+      completed || status === "completed" ? "completed_tasks" : "active_tasks"
+    ] += 1;
     rows.push(
       rowFrom(
         "task",
@@ -254,7 +269,9 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
         completed || status === "completed" ? "completed" : status,
         item.entry,
         item.ref,
-        completed || status === "completed" ? null : "complete_or_reassign_task",
+        completed || status === "completed"
+          ? null
+          : "complete_or_reassign_task",
       ),
     );
   }
@@ -262,14 +279,23 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
   for (const [sessionId, item] of staleSessions) {
     counts.stale_sessions += 1;
     rows.push(
-      rowFrom("session", sessionId, "stale", item.entry, item.ref, "archive_or_resume_session"),
+      rowFrom(
+        "session",
+        sessionId,
+        "stale",
+        item.entry,
+        item.ref,
+        "archive_or_resume_session",
+      ),
     );
   }
 
   for (const session of overlay?.live_sessions || []) {
     const phase = String(session?.phase || session?.status || "").toLowerCase();
     if (phase !== "stale") continue;
-    const sessionId = String(session?.sessionId || session?.session_id || "").trim();
+    const sessionId = String(
+      session?.sessionId || session?.session_id || "",
+    ).trim();
     if (!sessionId || staleSessions.has(sessionId)) continue;
     counts.stale_sessions += 1;
     rows.push({
@@ -331,7 +357,9 @@ export function projectCtoHygiene({ current = {}, ledger = null, overlay = {} } 
     }
     return row;
   });
-  counts.unknown_owner = sortedRows.filter((row) => row.owner === "unknown").length;
+  counts.unknown_owner = sortedRows.filter(
+    (row) => row.owner === "unknown",
+  ).length;
 
   return {
     schema_version: "cto-hygiene.v1",

--- a/packages/remote/hub/public/tray.html
+++ b/packages/remote/hub/public/tray.html
@@ -224,6 +224,41 @@
       `).join('')}</div>`;
     }
 
+    function hygieneCount(hygiene, key) {
+      const value = Number(hygiene?.[key] || 0);
+      return Number.isFinite(value) && value > 0 ? value : 0;
+    }
+
+    function renderCtoHygiene(hygiene) {
+      if (!hygiene || typeof hygiene !== 'object') return '';
+      const actions = Array.isArray(hygiene.actions) ? hygiene.actions.slice(0, 2) : [];
+      const actionCount = hygieneCount(hygiene, 'action_count') || actions.length;
+      const actionHtml = actions.length > 0
+        ? `<div class="models-list">${actions.map(action => `
+            <div class="mini-card">
+              <div class="mini-head">
+                <div class="mini-title">${escapeHtml(action.id || action.kind || 'hygiene item')}</div>
+                <div class="value-pill status-text partial">${escapeHtml(action.status || 'action')}</div>
+              </div>
+              <div class="path-text">${escapeHtml(action.action || action.kind || '')}</div>
+            </div>
+          `).join('')}</div>`
+        : '<div class="mini-card muted">No hygiene actions reported</div>';
+      return `
+        <div class="section">
+          <div class="section-title">CTO Hygiene</div>
+          <div class="stats-grid">
+            <div class="stat-box"><div class="stat-label">Active tasks</div><div class="stat-value">${hygieneCount(hygiene, 'active_tasks')}<span class="stat-unit">open</span></div></div>
+            <div class="stat-box"><div class="stat-label">Stale sessions</div><div class="stat-value">${hygieneCount(hygiene, 'stale_sessions')}<span class="stat-unit">stale</span></div></div>
+            <div class="stat-box"><div class="stat-label">Orphan worktrees</div><div class="stat-value">${hygieneCount(hygiene, 'orphan_worktrees')}<span class="stat-unit">orphan</span></div></div>
+            <div class="stat-box"><div class="stat-label">Actions</div><div class="stat-value">${actionCount}<span class="stat-unit">dry-run</span></div></div>
+          </div>
+          <div class="path-text">${hygieneCount(hygiene, 'superseded_checkpoints')} superseded checkpoints · ${hygieneCount(hygiene, 'unknown_owner')} unknown owners</div>
+          ${actionHtml}
+        </div>
+      `;
+    }
+
     function liveFallbackRows(live) {
       return live.map(session => ({
         sessionId: session.sessionId,
@@ -499,6 +534,7 @@
           <div class="section-title">Agent Mix</div>
           <div class="models-list">${renderRuntimeClients(runtime)}</div>
         </div>
+        ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/packages/remote/hub/tray-state.mjs
+++ b/packages/remote/hub/tray-state.mjs
@@ -387,6 +387,58 @@ function normalizeLiveSession(session = {}) {
   };
 }
 
+const CTO_HYGIENE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function compactNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function normalizeHygieneAction(action = {}) {
+  return {
+    kind: String(action.kind || ""),
+    id: String(action.id || ""),
+    status: String(action.status || ""),
+    action: String(action.action || ""),
+  };
+}
+
+function normalizeCtoHygiene(ctoStatus = {}) {
+  const hygiene =
+    ctoStatus?.hygiene && typeof ctoStatus.hygiene === "object"
+      ? ctoStatus.hygiene
+      : null;
+  if (!hygiene) return null;
+
+  const actionsSource = Array.isArray(hygiene.actions)
+    ? hygiene.actions
+    : Array.isArray(hygiene.rows)
+      ? hygiene.rows
+      : Array.isArray(ctoStatus?.hygiene_actions)
+        ? ctoStatus.hygiene_actions
+        : [];
+  const actions = actionsSource
+    .map(normalizeHygieneAction)
+    .filter(
+      (action) => action.kind || action.id || action.status || action.action,
+    );
+
+  return {
+    ...Object.fromEntries(
+      CTO_HYGIENE_COUNT_KEYS.map((key) => [key, compactNumber(hygiene[key])]),
+    ),
+    action_count: compactNumber(hygiene.action_count ?? actions.length),
+    actions: actions.slice(0, 2),
+  };
+}
+
 function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const explicitLive = Array.isArray(ctoStatus?.live_sessions)
     ? ctoStatus.live_sessions
@@ -407,11 +459,13 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const activeShards = Array.isArray(ctoStatus?.active_shards)
     ? ctoStatus.active_shards
     : [];
+  const hygiene = normalizeCtoHygiene(ctoStatus);
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,
       active_shard_count: activeShards.length,

--- a/packages/triflux/cto/dashboard.mjs
+++ b/packages/triflux/cto/dashboard.mjs
@@ -196,6 +196,65 @@ function renderLedger(entries) {
   `;
 }
 
+const HYGIENE_METRICS = Object.freeze([
+  ["active_tasks", "Active tasks"],
+  ["stale_sessions", "Stale sessions"],
+  ["orphan_worktrees", "Orphan worktrees"],
+  ["superseded_checkpoints", "Superseded checkpoints"],
+  ["unknown_owner", "Unknown owners"],
+]);
+
+function hygieneCount(hygiene, key) {
+  const value = Number(hygiene?.[key] || 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function renderHygiene(hygiene) {
+  if (!hygiene || typeof hygiene !== "object") return "";
+  const actions = Array.isArray(hygiene.actions)
+    ? hygiene.actions.slice(0, 5)
+    : [];
+  const actionCount = hygieneCount(hygiene, "action_count") || actions.length;
+  return `
+    <section class="panel">
+      <h2>Hygiene</h2>
+      <table>
+        <tbody>
+          ${HYGIENE_METRICS.map(
+            ([key, label]) => `
+              <tr>
+                <th>${escapeHtml(label)}</th>
+                <td>${hygieneCount(hygiene, key)}</td>
+              </tr>
+            `,
+          ).join("")}
+          <tr>
+            <th>Actions</th>
+            <td>${actionCount}</td>
+          </tr>
+        </tbody>
+      </table>
+      ${
+        actions.length
+          ? `<ul class="items">
+              ${actions
+                .map(
+                  (action) => `
+                    <li>
+                      <strong>${escapeHtml(formatValue(action?.id || action?.kind, "item"))}</strong>
+                      <span>${escapeHtml(formatValue(action?.action || action?.kind, "review"))}</span>
+                      <em>${escapeHtml(formatValue(action?.status, "action"))}</em>
+                    </li>
+                  `,
+                )
+                .join("")}
+            </ul>`
+          : `<p class="empty">No hygiene actions reported.</p>`
+      }
+    </section>
+  `;
+}
+
 function pageShell(title, body) {
   return `<!doctype html>
 <html lang="en">
@@ -326,6 +385,7 @@ function renderCurrentHtml(current) {
           <h2>Swarm Shards</h2>
           ${renderShards(shards)}
         </section>
+        ${renderHygiene(current.hygiene || current.summary?.hygiene)}
         <section class="panel">
           <h2>Recent Ledger</h2>
           ${renderLedger(Array.isArray(current.ledger_tail) ? current.ledger_tail : [])}

--- a/packages/triflux/hub/public/tray.html
+++ b/packages/triflux/hub/public/tray.html
@@ -224,6 +224,41 @@
       `).join('')}</div>`;
     }
 
+    function hygieneCount(hygiene, key) {
+      const value = Number(hygiene?.[key] || 0);
+      return Number.isFinite(value) && value > 0 ? value : 0;
+    }
+
+    function renderCtoHygiene(hygiene) {
+      if (!hygiene || typeof hygiene !== 'object') return '';
+      const actions = Array.isArray(hygiene.actions) ? hygiene.actions.slice(0, 2) : [];
+      const actionCount = hygieneCount(hygiene, 'action_count') || actions.length;
+      const actionHtml = actions.length > 0
+        ? `<div class="models-list">${actions.map(action => `
+            <div class="mini-card">
+              <div class="mini-head">
+                <div class="mini-title">${escapeHtml(action.id || action.kind || 'hygiene item')}</div>
+                <div class="value-pill status-text partial">${escapeHtml(action.status || 'action')}</div>
+              </div>
+              <div class="path-text">${escapeHtml(action.action || action.kind || '')}</div>
+            </div>
+          `).join('')}</div>`
+        : '<div class="mini-card muted">No hygiene actions reported</div>';
+      return `
+        <div class="section">
+          <div class="section-title">CTO Hygiene</div>
+          <div class="stats-grid">
+            <div class="stat-box"><div class="stat-label">Active tasks</div><div class="stat-value">${hygieneCount(hygiene, 'active_tasks')}<span class="stat-unit">open</span></div></div>
+            <div class="stat-box"><div class="stat-label">Stale sessions</div><div class="stat-value">${hygieneCount(hygiene, 'stale_sessions')}<span class="stat-unit">stale</span></div></div>
+            <div class="stat-box"><div class="stat-label">Orphan worktrees</div><div class="stat-value">${hygieneCount(hygiene, 'orphan_worktrees')}<span class="stat-unit">orphan</span></div></div>
+            <div class="stat-box"><div class="stat-label">Actions</div><div class="stat-value">${actionCount}<span class="stat-unit">dry-run</span></div></div>
+          </div>
+          <div class="path-text">${hygieneCount(hygiene, 'superseded_checkpoints')} superseded checkpoints · ${hygieneCount(hygiene, 'unknown_owner')} unknown owners</div>
+          ${actionHtml}
+        </div>
+      `;
+    }
+
     function liveFallbackRows(live) {
       return live.map(session => ({
         sessionId: session.sessionId,
@@ -499,6 +534,7 @@
           <div class="section-title">Agent Mix</div>
           <div class="models-list">${renderRuntimeClients(runtime)}</div>
         </div>
+        ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/packages/triflux/hub/tray-state.mjs
+++ b/packages/triflux/hub/tray-state.mjs
@@ -387,6 +387,58 @@ function normalizeLiveSession(session = {}) {
   };
 }
 
+const CTO_HYGIENE_COUNT_KEYS = Object.freeze([
+  "active_tasks",
+  "completed_tasks",
+  "stale_sessions",
+  "orphan_worktrees",
+  "superseded_checkpoints",
+  "unknown_owner",
+]);
+
+function compactNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function normalizeHygieneAction(action = {}) {
+  return {
+    kind: String(action.kind || ""),
+    id: String(action.id || ""),
+    status: String(action.status || ""),
+    action: String(action.action || ""),
+  };
+}
+
+function normalizeCtoHygiene(ctoStatus = {}) {
+  const hygiene =
+    ctoStatus?.hygiene && typeof ctoStatus.hygiene === "object"
+      ? ctoStatus.hygiene
+      : null;
+  if (!hygiene) return null;
+
+  const actionsSource = Array.isArray(hygiene.actions)
+    ? hygiene.actions
+    : Array.isArray(hygiene.rows)
+      ? hygiene.rows
+      : Array.isArray(ctoStatus?.hygiene_actions)
+        ? ctoStatus.hygiene_actions
+        : [];
+  const actions = actionsSource
+    .map(normalizeHygieneAction)
+    .filter(
+      (action) => action.kind || action.id || action.status || action.action,
+    );
+
+  return {
+    ...Object.fromEntries(
+      CTO_HYGIENE_COUNT_KEYS.map((key) => [key, compactNumber(hygiene[key])]),
+    ),
+    action_count: compactNumber(hygiene.action_count ?? actions.length),
+    actions: actions.slice(0, 2),
+  };
+}
+
 function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const explicitLive = Array.isArray(ctoStatus?.live_sessions)
     ? ctoStatus.live_sessions
@@ -407,11 +459,13 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
   const activeShards = Array.isArray(ctoStatus?.active_shards)
     ? ctoStatus.active_shards
     : [];
+  const hygiene = normalizeCtoHygiene(ctoStatus);
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,
       active_shard_count: activeShards.length,

--- a/packages/triflux/scripts/pack.mjs
+++ b/packages/triflux/scripts/pack.mjs
@@ -86,6 +86,8 @@ const REMOTE_FILES = [
   "hub/tray-state.mjs",
   "cto/brief.mjs",
   "cto/collect.mjs",
+  "cto/hygiene.mjs",
+  "cto/lake-root.mjs",
   "cto/status.mjs",
   "cto/current.schema.json",
 ];

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -86,6 +86,8 @@ const REMOTE_FILES = [
   "hub/tray-state.mjs",
   "cto/brief.mjs",
   "cto/collect.mjs",
+  "cto/hygiene.mjs",
+  "cto/lake-root.mjs",
   "cto/status.mjs",
   "cto/current.schema.json",
 ];

--- a/tests/cto/dashboard.test.mjs
+++ b/tests/cto/dashboard.test.mjs
@@ -159,6 +159,50 @@ describe("runDashboard", () => {
     }
   });
 
+  it("renders a Hygiene section from current status summary when available", async () => {
+    const rootDir = makeTempDir();
+    const lakeRoot = join(rootDir, ".test-lake");
+    try {
+      writeJson(
+        join(lakeRoot, "current.json"),
+        fixtureCurrent({
+          hygiene: {
+            active_tasks: 2,
+            completed_tasks: 1,
+            stale_sessions: 1,
+            orphan_worktrees: 1,
+            superseded_checkpoints: 3,
+            unknown_owner: 2,
+            action_count: 2,
+            actions: [
+              {
+                kind: "session",
+                id: "stale-session",
+                status: "stale",
+                action: "review_or_archive_session",
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await runDashboard([], {
+        lakeRoot,
+        stdout: { write() {} },
+      });
+
+      const html = readFileSync(result.path, "utf8");
+      assert.match(html, /<h2>Hygiene<\/h2>/u);
+      assert.match(html, /Active tasks/u);
+      assert.match(html, /Stale sessions/u);
+      assert.match(html, /stale-session/u);
+      assert.match(html, /review_or_archive_session/u);
+      assert.doesNotMatch(html, /Apply/u);
+    } finally {
+      cleanup(rootDir);
+    }
+  });
+
   it("renders graceful minimal HTML when current.json is missing", async () => {
     const rootDir = makeTempDir();
     const lakeRoot = join(rootDir, ".test-lake");

--- a/tests/unit/tray-html.test.mjs
+++ b/tests/unit/tray-html.test.mjs
@@ -137,6 +137,48 @@ describe("tray Sessions frontend", () => {
     assert.match(tabSessions.innerHTML, /data-agent-id="antigravity"/u);
   });
 
+  it("renders compact CTO Hygiene from the provided tray payload", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: { id: "hub-abcdef", projectRoot: "/repo" },
+      sessions: [],
+      cto: {
+        live_sessions: [],
+        active_shards: [],
+        hygiene: {
+          active_tasks: 2,
+          stale_sessions: 1,
+          orphan_worktrees: 1,
+          superseded_checkpoints: 3,
+          unknown_owner: 2,
+          action_count: 2,
+          actions: [
+            {
+              kind: "session",
+              id: "stale-session",
+              status: "stale",
+              action: "review_or_archive_session",
+            },
+          ],
+        },
+      },
+      runtime: { summary: { total: 0, clients: [] } },
+    });
+
+    assert.match(tabSessions.innerHTML, /CTO Hygiene/u);
+    assert.match(tabSessions.innerHTML, /Active tasks/u);
+    assert.match(
+      tabSessions.innerHTML,
+      />2<span class="stat-unit">open<\/span>/u,
+    );
+    assert.match(tabSessions.innerHTML, /Stale sessions/u);
+    assert.match(tabSessions.innerHTML, /stale-session/u);
+    assert.match(tabSessions.innerHTML, /review_or_archive_session/u);
+    assert.doesNotMatch(tabSessions.innerHTML, /apply/i);
+    assert.equal(context.__requests.length, 0);
+  });
+
   it("renders session detail as a single-column prompt and agents stream with C/X/A badges", () => {
     const { context, tabSessions } = loadTrayRenderer();
 

--- a/tests/unit/tray-state.test.mjs
+++ b/tests/unit/tray-state.test.mjs
@@ -50,6 +50,67 @@ describe("tray-state contract", () => {
     );
   });
 
+  it("passes compact CTO hygiene counts and actions through to the tray payload", () => {
+    const payload = buildTrayStatePayload({
+      ctoStatus: {
+        schema_version: "cto-lake.v1",
+        hygiene: {
+          active_tasks: 2,
+          completed_tasks: 1,
+          stale_sessions: 1,
+          orphan_worktrees: 1,
+          superseded_checkpoints: 3,
+          unknown_owner: 2,
+        },
+        hygiene_actions: [
+          {
+            kind: "session",
+            id: "stale-session",
+            status: "stale",
+            action: "review_or_archive_session",
+          },
+          {
+            kind: "worktree",
+            id: "wt-old",
+            status: "orphaned",
+            action: "remove_or_reassign_worktree",
+          },
+          {
+            kind: "ignored",
+            id: "too-many",
+            status: "ignored",
+            action: "ignored",
+          },
+        ],
+      },
+    });
+
+    assert.deepEqual(payload.cto.hygiene, {
+      active_tasks: 2,
+      completed_tasks: 1,
+      stale_sessions: 1,
+      orphan_worktrees: 1,
+      superseded_checkpoints: 3,
+      unknown_owner: 2,
+      action_count: 3,
+      actions: [
+        {
+          kind: "session",
+          id: "stale-session",
+          status: "stale",
+          action: "review_or_archive_session",
+        },
+        {
+          kind: "worktree",
+          id: "wt-old",
+          status: "orphaned",
+          action: "remove_or_reassign_worktree",
+        },
+      ],
+    });
+    assert.equal(payload.cto.summary.live_session_count, 0);
+  });
+
   it("includes CTO overlay and MCP rows in one tray payload", () => {
     const payload = buildTrayStatePayload({
       hub: { id: "hub-123456", pid: 123456, port: 27888 },


### PR DESCRIPTION
## Summary
- pass compact CTO hygiene counts/actions through the tray state payload
- render compact CTO Hygiene cards in tray Sessions and CTO dashboard from provided status/current payloads
- refresh package mirrors/remote pack support for CTO hygiene dependencies

## Tests
- node --test tests/unit/tray-state.test.mjs tests/unit/tray-html.test.mjs tests/cto/dashboard.test.mjs
- npm run release:check-mirror
- npm run release:check-sync
- git diff --check
- npx biome check cto/dashboard.mjs hub/tray-state.mjs hub/public/tray.html scripts/pack.mjs packages/triflux/cto/dashboard.mjs packages/triflux/hub/tray-state.mjs packages/triflux/hub/public/tray.html packages/triflux/scripts/pack.mjs packages/remote/hub/public/tray.html packages/remote/hub/tray-state.mjs packages/remote/cto/hygiene.mjs tests/unit/tray-state.test.mjs tests/unit/tray-html.test.mjs tests/cto/dashboard.test.mjs

Refs #422