### PR TITLE
fix(codex): sanitize legacy profile config

### DIFF
--- a/packages/triflux/scripts/codex-profile-sanitize.mjs
+++ b/packages/triflux/scripts/codex-profile-sanitize.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path";
+import { sanitizeCodexProfileConfigFile } from "./lib/codex-profile-config.mjs";
+
+function parseArgs(argv) {
+  const result = { quiet: false, json: false };
+  for (const arg of argv) {
+    if (arg === "--quiet") result.quiet = true;
+    else if (arg === "--json") result.json = true;
+    else if (!result.configPath) result.configPath = arg;
+    else throw new Error(`unexpected argument: ${arg}`);
+  }
+  result.configPath ||= process.env.TFX_CODEX_CONFIG;
+  if (!result.configPath) {
+    throw new Error(
+      "usage: codex-profile-sanitize.mjs <config.toml> [--quiet|--json]",
+    );
+  }
+  result.configPath = resolve(result.configPath);
+  return result;
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2));
+  const result = sanitizeCodexProfileConfigFile(opts.configPath, {
+    codexHome: dirname(opts.configPath),
+  });
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } else if (result.changed && !opts.quiet) {
+    process.stderr.write(
+      `[codex-profile-sanitize] removed legacy inline profiles: ${result.removedProfiles.join(", ") || "<none>"}\n`,
+    );
+  }
+} catch (error) {
+  process.stderr.write(`[codex-profile-sanitize] ${error.message}\n`);
+  process.exit(1);
+}

--- a/packages/triflux/scripts/ensure-codex-hooks.mjs
+++ b/packages/triflux/scripts/ensure-codex-hooks.mjs
@@ -11,6 +11,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { sanitizeCodexProfileConfig } from "./lib/codex-profile-config.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = dirname(__dirname);
@@ -307,7 +308,14 @@ export function ensureCodexHooks(opts = {}) {
   const originalConfig = existsSync(configPath)
     ? readFileSync(configPath, "utf8")
     : "";
-  const nextConfig = mergeHooksState(originalConfig, stateEntries, hooksPath);
+  const profileSanitized = sanitizeCodexProfileConfig(originalConfig, {
+    codexHome,
+  });
+  const nextConfig = mergeHooksState(
+    profileSanitized.toml,
+    stateEntries,
+    hooksPath,
+  );
   const changedConfig = originalConfig !== nextConfig;
   if (changedConfig) {
     if (existsSync(configPath)) {
@@ -323,6 +331,8 @@ export function ensureCodexHooks(opts = {}) {
     skipped: false,
     changedHooks,
     changedConfig,
+    removedLegacyProfiles: profileSanitized.removedProfiles,
+    migratedLegacyProfiles: profileSanitized.migratedProfiles,
     hooksPath,
     configPath,
   };

--- a/packages/triflux/scripts/lib/codex-profile-config.mjs
+++ b/packages/triflux/scripts/lib/codex-profile-config.mjs
@@ -1,0 +1,142 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const PROFILE_SECTION_PREFIX = "profiles.";
+const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
+
+function lineChunks(source = "") {
+  return String(source).match(/[^\n]*\n|[^\n]+$/g) || [];
+}
+
+function parseSectionHeader(line) {
+  const match = String(line)
+    .trimEnd()
+    .match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
+  return match ? match[1].trim() : null;
+}
+
+function profileNameFromSection(section) {
+  if (!section?.startsWith(PROFILE_SECTION_PREFIX)) return null;
+  return section.slice(PROFILE_SECTION_PREFIX.length).trim();
+}
+
+function isTopLevelProfileSelector(line) {
+  return /^\s*profile\s*=/.test(line);
+}
+
+function normalizeProfileBody(lines) {
+  const body = lines.join("").replace(/^\s+/, "").replace(/\s+$/, "");
+  return body ? `${body}\n` : "";
+}
+
+export function listLegacyCodexProfileSections(source = "") {
+  const names = [];
+  for (const line of lineChunks(source)) {
+    const name = profileNameFromSection(parseSectionHeader(line));
+    if (name && !names.includes(name)) names.push(name);
+  }
+  return names;
+}
+
+export function sanitizeCodexProfileConfig(
+  source = "",
+  { codexHome = null, migrateProfileFiles = true } = {},
+) {
+  const output = [];
+  const removedProfiles = [];
+  const migratedProfiles = [];
+  const skippedProfileFiles = [];
+  const captured = new Map();
+  let currentProfile = null;
+  let seenSection = false;
+  let removedTopLevelProfileSelector = false;
+
+  for (const line of lineChunks(source)) {
+    const section = parseSectionHeader(line);
+    if (section) {
+      seenSection = true;
+      const profileName = profileNameFromSection(section);
+      if (profileName) {
+        currentProfile = profileName;
+        if (!removedProfiles.includes(profileName))
+          removedProfiles.push(profileName);
+        if (!captured.has(profileName)) captured.set(profileName, []);
+        continue;
+      }
+      currentProfile = null;
+      output.push(line);
+      continue;
+    }
+
+    if (!seenSection && isTopLevelProfileSelector(line)) {
+      removedTopLevelProfileSelector = true;
+      continue;
+    }
+
+    if (currentProfile) {
+      captured.get(currentProfile)?.push(line);
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  if (codexHome && migrateProfileFiles) {
+    mkdirSync(codexHome, { recursive: true });
+    for (const [profileName, bodyLines] of captured.entries()) {
+      if (!SAFE_PROFILE_FILE_RE.test(profileName)) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      const body = normalizeProfileBody(bodyLines);
+      if (!body) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      const profilePath = join(codexHome, `${profileName}.config.toml`);
+      if (existsSync(profilePath)) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      writeFileSync(profilePath, body, "utf8");
+      migratedProfiles.push(profileName);
+    }
+  }
+
+  const toml = output.join("");
+  return {
+    changed: toml !== String(source),
+    toml,
+    removedProfiles,
+    migratedProfiles,
+    skippedProfileFiles,
+    removedTopLevelProfileSelector,
+  };
+}
+
+function stamp(now = () => new Date()) {
+  return now()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..*$/, "")
+    .replace("T", "-");
+}
+
+export function sanitizeCodexProfileConfigFile(
+  configPath,
+  {
+    codexHome = dirname(configPath),
+    backupPrefix = "bak-codex-profile-sanitize",
+    now = () => new Date(),
+  } = {},
+) {
+  if (!configPath || !existsSync(configPath)) {
+    return { changed: false, removedProfiles: [], migratedProfiles: [] };
+  }
+  const source = readFileSync(configPath, "utf8");
+  const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
+  if (!sanitized.changed) return sanitized;
+  writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
+  writeFileSync(configPath, sanitized.toml, "utf8");
+  return sanitized;
+}

--- a/packages/triflux/scripts/lib/toml.mjs
+++ b/packages/triflux/scripts/lib/toml.mjs
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { sanitizeCodexProfileConfig } from "./codex-profile-config.mjs";
 
 const require = createRequire(import.meta.url);
 let TOML = null;
@@ -100,14 +102,31 @@ export function patchMcpApprovalMode(source) {
 export function patchCodexConfigFile(path, { now = () => new Date() } = {}) {
   if (!path || !existsSync(path)) return { changed: false, count: 0 };
   const source = readFileSync(path, "utf8");
-  const patched = patchMcpApprovalMode(source);
-  if (!patched.changed) return patched;
+  const approvalPatched = patchMcpApprovalMode(source);
+  const profileSanitized = sanitizeCodexProfileConfig(approvalPatched.toml, {
+    codexHome: dirname(path),
+  });
+  const changed = approvalPatched.changed || profileSanitized.changed;
+  if (!changed) {
+    return {
+      changed: false,
+      count: 0,
+      removedProfiles: [],
+      migratedProfiles: [],
+    };
+  }
   const stamp = now()
     .toISOString()
     .replace(/[-:]/g, "")
     .replace(/\..*$/, "")
     .replace("T", "-");
   writeFileSync(`${path}.bak-${stamp}`, source);
-  writeFileSync(path, patched.toml);
-  return patched;
+  writeFileSync(path, profileSanitized.toml);
+  return {
+    changed: true,
+    count: approvalPatched.count,
+    removedProfiles: profileSanitized.removedProfiles,
+    migratedProfiles: profileSanitized.migratedProfiles,
+    toml: profileSanitized.toml,
+  };
 }

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -128,6 +128,30 @@ _preflight_check_gh_auth
 # the real ~/.codex/config.toml (non-hermetic corruption guard). Defaults to the
 # real path for normal runs.
 _CODEX_CONFIG="${TFX_CODEX_CONFIG:-${HOME}/.codex/config.toml}"
+
+_sanitize_codex_legacy_profiles() {
+  local config="${1:-$_CODEX_CONFIG}"
+  [[ -f "$config" ]] || return 0
+  if ! grep -Eq '^[[:space:]]*profile[[:space:]]*=|^[[:space:]]*\[profiles\.' "$config" 2>/dev/null; then
+    return 0
+  fi
+  local route_dir node_bin sanitizer
+  route_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  sanitizer="${route_dir}/codex-profile-sanitize.mjs"
+  [[ -f "$sanitizer" ]] || {
+    echo "[tfx-route] 경고: Codex profile sanitizer 없음: $sanitizer" >&2
+    return 0
+  }
+  node_bin="${NODE_BIN:-$(command -v node 2>/dev/null || command -v node.exe 2>/dev/null || echo node)}"
+  if "$node_bin" "$sanitizer" "$config" --quiet; then
+    echo "[tfx-route] Codex legacy inline profiles sanitized before exec" >&2
+  else
+    echo "[tfx-route] 경고: Codex legacy profile sanitizer 실패 — --profile 실행이 실패할 수 있음" >&2
+  fi
+}
+
+_sanitize_codex_legacy_profiles "$_CODEX_CONFIG"
+
 _CODEX_HAS_SANDBOX=""
 if [[ -f "$_CODEX_CONFIG" ]] && awk '
   /^\[{1,2}mcp_servers\..*\.tools\./ { in_mcp_tool=1; next }
@@ -2374,6 +2398,9 @@ _codex_config_swap() {
       local stale_tmp="${config}.stale-restore.$$"
       if cp "$backup" "$stale_tmp" && mv "$stale_tmp" "$config"; then
         echo "[tfx-route] stale backup 감지 (pid=${owner_pid:-?} dead) — 원본 복원 후 swap 재진행" >&2
+        if declare -f _sanitize_codex_legacy_profiles >/dev/null 2>&1; then
+          _sanitize_codex_legacy_profiles "$config"
+        fi
       else
         echo "[tfx-route] 경고: stale backup 복원 실패, swap 스킵 (수동 확인: $backup)" >&2
         rm -f "$stale_tmp" 2>/dev/null
@@ -2452,6 +2479,9 @@ _codex_config_swap() {
       echo "[tfx-route] 경고: backup 삭제 실패: $backup (수동 정리 필요)" >&2
     fi
     rm -f "${backup}.owner" 2>/dev/null || true
+    if declare -f _sanitize_codex_legacy_profiles >/dev/null 2>&1; then
+      _sanitize_codex_legacy_profiles "$config"
+    fi
     echo "[tfx-route] config.toml 복원 완료" >&2
   fi
 }

--- a/scripts/codex-profile-sanitize.mjs
+++ b/scripts/codex-profile-sanitize.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { dirname, resolve } from "node:path";
+import { sanitizeCodexProfileConfigFile } from "./lib/codex-profile-config.mjs";
+
+function parseArgs(argv) {
+  const result = { quiet: false, json: false };
+  for (const arg of argv) {
+    if (arg === "--quiet") result.quiet = true;
+    else if (arg === "--json") result.json = true;
+    else if (!result.configPath) result.configPath = arg;
+    else throw new Error(`unexpected argument: ${arg}`);
+  }
+  result.configPath ||= process.env.TFX_CODEX_CONFIG;
+  if (!result.configPath) {
+    throw new Error(
+      "usage: codex-profile-sanitize.mjs <config.toml> [--quiet|--json]",
+    );
+  }
+  result.configPath = resolve(result.configPath);
+  return result;
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2));
+  const result = sanitizeCodexProfileConfigFile(opts.configPath, {
+    codexHome: dirname(opts.configPath),
+  });
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } else if (result.changed && !opts.quiet) {
+    process.stderr.write(
+      `[codex-profile-sanitize] removed legacy inline profiles: ${result.removedProfiles.join(", ") || "<none>"}\n`,
+    );
+  }
+} catch (error) {
+  process.stderr.write(`[codex-profile-sanitize] ${error.message}\n`);
+  process.exit(1);
+}

--- a/scripts/ensure-codex-hooks.mjs
+++ b/scripts/ensure-codex-hooks.mjs
@@ -11,6 +11,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { sanitizeCodexProfileConfig } from "./lib/codex-profile-config.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = dirname(__dirname);
@@ -307,7 +308,14 @@ export function ensureCodexHooks(opts = {}) {
   const originalConfig = existsSync(configPath)
     ? readFileSync(configPath, "utf8")
     : "";
-  const nextConfig = mergeHooksState(originalConfig, stateEntries, hooksPath);
+  const profileSanitized = sanitizeCodexProfileConfig(originalConfig, {
+    codexHome,
+  });
+  const nextConfig = mergeHooksState(
+    profileSanitized.toml,
+    stateEntries,
+    hooksPath,
+  );
   const changedConfig = originalConfig !== nextConfig;
   if (changedConfig) {
     if (existsSync(configPath)) {
@@ -323,6 +331,8 @@ export function ensureCodexHooks(opts = {}) {
     skipped: false,
     changedHooks,
     changedConfig,
+    removedLegacyProfiles: profileSanitized.removedProfiles,
+    migratedLegacyProfiles: profileSanitized.migratedProfiles,
     hooksPath,
     configPath,
   };

--- a/scripts/lib/codex-profile-config.mjs
+++ b/scripts/lib/codex-profile-config.mjs
@@ -1,0 +1,142 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const PROFILE_SECTION_PREFIX = "profiles.";
+const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
+
+function lineChunks(source = "") {
+  return String(source).match(/[^\n]*\n|[^\n]+$/g) || [];
+}
+
+function parseSectionHeader(line) {
+  const match = String(line)
+    .trimEnd()
+    .match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/);
+  return match ? match[1].trim() : null;
+}
+
+function profileNameFromSection(section) {
+  if (!section?.startsWith(PROFILE_SECTION_PREFIX)) return null;
+  return section.slice(PROFILE_SECTION_PREFIX.length).trim();
+}
+
+function isTopLevelProfileSelector(line) {
+  return /^\s*profile\s*=/.test(line);
+}
+
+function normalizeProfileBody(lines) {
+  const body = lines.join("").replace(/^\s+/, "").replace(/\s+$/, "");
+  return body ? `${body}\n` : "";
+}
+
+export function listLegacyCodexProfileSections(source = "") {
+  const names = [];
+  for (const line of lineChunks(source)) {
+    const name = profileNameFromSection(parseSectionHeader(line));
+    if (name && !names.includes(name)) names.push(name);
+  }
+  return names;
+}
+
+export function sanitizeCodexProfileConfig(
+  source = "",
+  { codexHome = null, migrateProfileFiles = true } = {},
+) {
+  const output = [];
+  const removedProfiles = [];
+  const migratedProfiles = [];
+  const skippedProfileFiles = [];
+  const captured = new Map();
+  let currentProfile = null;
+  let seenSection = false;
+  let removedTopLevelProfileSelector = false;
+
+  for (const line of lineChunks(source)) {
+    const section = parseSectionHeader(line);
+    if (section) {
+      seenSection = true;
+      const profileName = profileNameFromSection(section);
+      if (profileName) {
+        currentProfile = profileName;
+        if (!removedProfiles.includes(profileName))
+          removedProfiles.push(profileName);
+        if (!captured.has(profileName)) captured.set(profileName, []);
+        continue;
+      }
+      currentProfile = null;
+      output.push(line);
+      continue;
+    }
+
+    if (!seenSection && isTopLevelProfileSelector(line)) {
+      removedTopLevelProfileSelector = true;
+      continue;
+    }
+
+    if (currentProfile) {
+      captured.get(currentProfile)?.push(line);
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  if (codexHome && migrateProfileFiles) {
+    mkdirSync(codexHome, { recursive: true });
+    for (const [profileName, bodyLines] of captured.entries()) {
+      if (!SAFE_PROFILE_FILE_RE.test(profileName)) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      const body = normalizeProfileBody(bodyLines);
+      if (!body) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      const profilePath = join(codexHome, `${profileName}.config.toml`);
+      if (existsSync(profilePath)) {
+        skippedProfileFiles.push(profileName);
+        continue;
+      }
+      writeFileSync(profilePath, body, "utf8");
+      migratedProfiles.push(profileName);
+    }
+  }
+
+  const toml = output.join("");
+  return {
+    changed: toml !== String(source),
+    toml,
+    removedProfiles,
+    migratedProfiles,
+    skippedProfileFiles,
+    removedTopLevelProfileSelector,
+  };
+}
+
+function stamp(now = () => new Date()) {
+  return now()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\..*$/, "")
+    .replace("T", "-");
+}
+
+export function sanitizeCodexProfileConfigFile(
+  configPath,
+  {
+    codexHome = dirname(configPath),
+    backupPrefix = "bak-codex-profile-sanitize",
+    now = () => new Date(),
+  } = {},
+) {
+  if (!configPath || !existsSync(configPath)) {
+    return { changed: false, removedProfiles: [], migratedProfiles: [] };
+  }
+  const source = readFileSync(configPath, "utf8");
+  const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
+  if (!sanitized.changed) return sanitized;
+  writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
+  writeFileSync(configPath, sanitized.toml, "utf8");
+  return sanitized;
+}

--- a/scripts/lib/toml.mjs
+++ b/scripts/lib/toml.mjs
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { sanitizeCodexProfileConfig } from "./codex-profile-config.mjs";
 
 const require = createRequire(import.meta.url);
 let TOML = null;
@@ -100,14 +102,31 @@ export function patchMcpApprovalMode(source) {
 export function patchCodexConfigFile(path, { now = () => new Date() } = {}) {
   if (!path || !existsSync(path)) return { changed: false, count: 0 };
   const source = readFileSync(path, "utf8");
-  const patched = patchMcpApprovalMode(source);
-  if (!patched.changed) return patched;
+  const approvalPatched = patchMcpApprovalMode(source);
+  const profileSanitized = sanitizeCodexProfileConfig(approvalPatched.toml, {
+    codexHome: dirname(path),
+  });
+  const changed = approvalPatched.changed || profileSanitized.changed;
+  if (!changed) {
+    return {
+      changed: false,
+      count: 0,
+      removedProfiles: [],
+      migratedProfiles: [],
+    };
+  }
   const stamp = now()
     .toISOString()
     .replace(/[-:]/g, "")
     .replace(/\..*$/, "")
     .replace("T", "-");
   writeFileSync(`${path}.bak-${stamp}`, source);
-  writeFileSync(path, patched.toml);
-  return patched;
+  writeFileSync(path, profileSanitized.toml);
+  return {
+    changed: true,
+    count: approvalPatched.count,
+    removedProfiles: profileSanitized.removedProfiles,
+    migratedProfiles: profileSanitized.migratedProfiles,
+    toml: profileSanitized.toml,
+  };
 }

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -128,6 +128,30 @@ _preflight_check_gh_auth
 # the real ~/.codex/config.toml (non-hermetic corruption guard). Defaults to the
 # real path for normal runs.
 _CODEX_CONFIG="${TFX_CODEX_CONFIG:-${HOME}/.codex/config.toml}"
+
+_sanitize_codex_legacy_profiles() {
+  local config="${1:-$_CODEX_CONFIG}"
+  [[ -f "$config" ]] || return 0
+  if ! grep -Eq '^[[:space:]]*profile[[:space:]]*=|^[[:space:]]*\[profiles\.' "$config" 2>/dev/null; then
+    return 0
+  fi
+  local route_dir node_bin sanitizer
+  route_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  sanitizer="${route_dir}/codex-profile-sanitize.mjs"
+  [[ -f "$sanitizer" ]] || {
+    echo "[tfx-route] 경고: Codex profile sanitizer 없음: $sanitizer" >&2
+    return 0
+  }
+  node_bin="${NODE_BIN:-$(command -v node 2>/dev/null || command -v node.exe 2>/dev/null || echo node)}"
+  if "$node_bin" "$sanitizer" "$config" --quiet; then
+    echo "[tfx-route] Codex legacy inline profiles sanitized before exec" >&2
+  else
+    echo "[tfx-route] 경고: Codex legacy profile sanitizer 실패 — --profile 실행이 실패할 수 있음" >&2
+  fi
+}
+
+_sanitize_codex_legacy_profiles "$_CODEX_CONFIG"
+
 _CODEX_HAS_SANDBOX=""
 if [[ -f "$_CODEX_CONFIG" ]] && awk '
   /^\[{1,2}mcp_servers\..*\.tools\./ { in_mcp_tool=1; next }
@@ -2374,6 +2398,9 @@ _codex_config_swap() {
       local stale_tmp="${config}.stale-restore.$$"
       if cp "$backup" "$stale_tmp" && mv "$stale_tmp" "$config"; then
         echo "[tfx-route] stale backup 감지 (pid=${owner_pid:-?} dead) — 원본 복원 후 swap 재진행" >&2
+        if declare -f _sanitize_codex_legacy_profiles >/dev/null 2>&1; then
+          _sanitize_codex_legacy_profiles "$config"
+        fi
       else
         echo "[tfx-route] 경고: stale backup 복원 실패, swap 스킵 (수동 확인: $backup)" >&2
         rm -f "$stale_tmp" 2>/dev/null
@@ -2452,6 +2479,9 @@ _codex_config_swap() {
       echo "[tfx-route] 경고: backup 삭제 실패: $backup (수동 정리 필요)" >&2
     fi
     rm -f "${backup}.owner" 2>/dev/null || true
+    if declare -f _sanitize_codex_legacy_profiles >/dev/null 2>&1; then
+      _sanitize_codex_legacy_profiles "$config"
+    fi
     echo "[tfx-route] config.toml 복원 완료" >&2
   fi
 }

--- a/tests/unit/codex-profile-config.test.mjs
+++ b/tests/unit/codex-profile-config.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  listLegacyCodexProfileSections,
+  sanitizeCodexProfileConfig,
+  sanitizeCodexProfileConfigFile,
+} from "../../scripts/lib/codex-profile-config.mjs";
+
+const tmpRoots = [];
+
+function makeHome() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-codex-profile-config-"));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("codex legacy profile config sanitizer", () => {
+  it("lists inline [profiles.*] sections", () => {
+    const names = listLegacyCodexProfileSections(
+      [
+        'model = "gpt-5.5"',
+        "",
+        "[profiles.gpt55_xhigh]",
+        'model = "gpt-5.5"',
+        "[mcp_servers.tfx-hub]",
+        'url = "http://127.0.0.1:27888/mcp"',
+        "[profiles.gpt55_low] # stale inline profile",
+        'model_reasoning_effort = "low"',
+        "",
+      ].join("\n"),
+    );
+
+    assert.deepEqual(names, ["gpt55_xhigh", "gpt55_low"]);
+  });
+
+  it("removes top-level profile selector and inline profile tables after MCP sections", () => {
+    const codexHome = makeHome();
+    writeFileSync(join(codexHome, "gpt55_low.config.toml"), 'model = "keep"\n');
+
+    const source = [
+      'profile = "gpt55_low"',
+      'model = "gpt-5.5"',
+      "",
+      "[mcp_servers.tfx-hub]",
+      'url = "http://127.0.0.1:27888/mcp"',
+      "",
+      "[profiles.gpt55_xhigh]",
+      'model = "gpt-5.5"',
+      'model_reasoning_effort = "xhigh"',
+      "",
+      "[profiles.gpt55_low]",
+      'model = "gpt-5.5"',
+      'model_reasoning_effort = "low"',
+      "",
+      "[mcp_servers.brave-search]",
+      'url = "http://127.0.0.1:8101/sse"',
+      "",
+    ].join("\n");
+
+    const result = sanitizeCodexProfileConfig(source, { codexHome });
+
+    assert.equal(result.changed, true);
+    assert.equal(result.removedTopLevelProfileSelector, true);
+    assert.deepEqual(result.removedProfiles, ["gpt55_xhigh", "gpt55_low"]);
+    assert.deepEqual(result.migratedProfiles, ["gpt55_xhigh"]);
+    assert.ok(result.skippedProfileFiles.includes("gpt55_low"));
+    assert.doesNotMatch(result.toml, /^profile\s*=/m);
+    assert.doesNotMatch(result.toml, /^\[profiles\./m);
+    assert.match(result.toml, /^\[mcp_servers\.tfx-hub\]/m);
+    assert.match(result.toml, /^\[mcp_servers\.brave-search\]/m);
+    assert.equal(
+      readFileSync(join(codexHome, "gpt55_xhigh.config.toml"), "utf8"),
+      'model = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+    );
+    assert.equal(
+      readFileSync(join(codexHome, "gpt55_low.config.toml"), "utf8"),
+      'model = "keep"\n',
+    );
+  });
+
+  it("file sanitizer writes a backup once and is idempotent", () => {
+    const codexHome = makeHome();
+    const configPath = join(codexHome, "config.toml");
+    writeFileSync(
+      configPath,
+      [
+        'model = "gpt-5.5"',
+        "[profiles.gpt55_med]",
+        'model_reasoning_effort = "medium"',
+        "",
+      ].join("\n"),
+    );
+
+    const first = sanitizeCodexProfileConfigFile(configPath, {
+      now: () => new Date("2026-06-17T00:00:00Z"),
+    });
+    const second = sanitizeCodexProfileConfigFile(configPath, {
+      now: () => new Date("2026-06-17T00:01:00Z"),
+    });
+
+    assert.equal(first.changed, true);
+    assert.equal(second.changed, false);
+    assert.equal(
+      existsSync(`${configPath}.bak-codex-profile-sanitize-20260617-000000`),
+      true,
+    );
+    assert.equal(
+      existsSync(`${configPath}.bak-codex-profile-sanitize-20260617-000100`),
+      false,
+    );
+    assert.doesNotMatch(readFileSync(configPath, "utf8"), /^\[profiles\./m);
+  });
+});

--- a/tests/unit/ensure-codex-hooks.test.mjs
+++ b/tests/unit/ensure-codex-hooks.test.mjs
@@ -195,4 +195,44 @@ describe("ensureCodexHooks", () => {
       "sha256:ea83cfae94429303fca497e00aeb83bfbfd4c82ecd5a740d8f221498210c7475",
     );
   });
+
+  it("sanitizes legacy inline Codex profiles while merging hooks.state", () => {
+    const codexHome = makeCodexHome();
+    writeFileSync(
+      join(codexHome, "config.toml"),
+      [
+        'profile = "gpt55_xhigh"',
+        'model = "gpt-5.5"',
+        "",
+        "[mcp_servers.tfx-hub]",
+        'url = "http://127.0.0.1:27888/mcp"',
+        "",
+        "[profiles.gpt55_xhigh]",
+        'model = "gpt-5.5"',
+        'model_reasoning_effort = "xhigh"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = ensureCodexHooks({
+      codexHome,
+      hookScriptPath: "/repo/hooks/codex-session-hook.mjs",
+      nodeBin: "/opt/node",
+      backupTimestamp: "20260617T010203",
+    });
+    const configAfter = readFileSync(join(codexHome, "config.toml"), "utf8");
+
+    assert.equal(result.changedConfig, true);
+    assert.deepEqual(result.removedLegacyProfiles, ["gpt55_xhigh"]);
+    assert.deepEqual(result.migratedLegacyProfiles, ["gpt55_xhigh"]);
+    assert.doesNotMatch(configAfter, /^profile\s*=/m);
+    assert.doesNotMatch(configAfter, /^\[profiles\./m);
+    assert.match(configAfter, /^\[mcp_servers\.tfx-hub\]/m);
+    assert.match(configAfter, /^\[hooks\.state\."/m);
+    assert.equal(
+      readFileSync(join(codexHome, "gpt55_xhigh.config.toml"), "utf8"),
+      'model = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared Codex legacy profile sanitizer that removes top-level `profile = ...` and inline `[profiles.*]` tables, migrating bodies to per-profile `~/.codex/<name>.config.toml` files when safe
- run the sanitizer from `ensure-codex-hooks` before hooks.state merge, from Node route preflight, and from Bash `tfx-route.sh` before exec / after stale backup restore
- add regression coverage for profile tables after MCP sections, file idempotency, and hook-state merge cleanup

Refs #429

## Verification
- `node --test tests/unit/codex-profile-config.test.mjs tests/unit/ensure-codex-hooks.test.mjs scripts/__tests__/tfx-route-phase1-modules.test.mjs tests/unit/tfx-route-config-swap.test.mjs tests/unit/setup-codex-profiles.test.mjs`
- `npm run release:check-mirror`
- `npm run release:check-sync`
- `git diff --check`
- `npx biome check scripts/lib/codex-profile-config.mjs scripts/codex-profile-sanitize.mjs scripts/ensure-codex-hooks.mjs scripts/lib/toml.mjs scripts/tfx-route.sh tests/unit/codex-profile-config.test.mjs tests/unit/ensure-codex-hooks.test.mjs packages/triflux/scripts/lib/codex-profile-config.mjs packages/triflux/scripts/codex-profile-sanitize.mjs packages/triflux/scripts/ensure-codex-hooks.mjs packages/triflux/scripts/lib/toml.mjs packages/triflux/scripts/tfx-route.sh`

## Notes
- This PR does not mutate ssh m2 directly; it fixes the Triflux-owned paths that can preserve or resurrect the contaminated config.
