### PR TITLE
fix: keep AGY session hook stdout JSON-only

### DIFF
--- a/hooks/agy-session-hook.mjs
+++ b/hooks/agy-session-hook.mjs
@@ -67,6 +67,33 @@ export function normalizeMode(argvMode, payload) {
   return "register";
 }
 
+function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
+  const done =
+    typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+  if (typeof done === "function") done();
+  return true;
+}
+
+async function runHookSideEffectsWithStdoutSuppressed(fn) {
+  const originalStdoutWrite = stdout.write;
+  const originalConsoleDebug = console.debug;
+  const originalConsoleInfo = console.info;
+  const originalConsoleLog = console.log;
+
+  stdout.write = swallowStdoutWrite;
+  console.debug = () => {};
+  console.info = () => {};
+  console.log = () => {};
+  try {
+    return await fn();
+  } finally {
+    stdout.write = originalStdoutWrite;
+    console.debug = originalConsoleDebug;
+    console.info = originalConsoleInfo;
+    console.log = originalConsoleLog;
+  }
+}
+
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);
@@ -93,24 +120,26 @@ export async function runAgySessionHook(stdinData, opts = {}) {
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
 
   try {
-    if (mode === "register") {
-      try {
-        await hubEnsureRun(sessionPayload);
-      } catch {}
-      try {
-        await Promise.resolve(registerInteractiveSession(sessionPayload));
-      } catch {}
-      try {
-        await drainPendingSynapse(1000);
-      } catch {}
-    } else if (mode === "heartbeat") {
-      try {
-        heartbeatInteractiveSession(sessionPayload);
-      } catch {}
-      try {
-        await drainPendingSynapse(500);
-      } catch {}
-    }
+    await runHookSideEffectsWithStdoutSuppressed(async () => {
+      if (mode === "register") {
+        try {
+          await hubEnsureRun(sessionPayload);
+        } catch {}
+        try {
+          await Promise.resolve(registerInteractiveSession(sessionPayload));
+        } catch {}
+        try {
+          await drainPendingSynapse(1000);
+        } catch {}
+      } else if (mode === "heartbeat") {
+        try {
+          heartbeatInteractiveSession(sessionPayload);
+        } catch {}
+        try {
+          await drainPendingSynapse(500);
+        } catch {}
+      }
+    });
   } catch {
     // agy session hooks are observational and must never block the session.
   }

--- a/packages/core/hooks/agy-session-hook.mjs
+++ b/packages/core/hooks/agy-session-hook.mjs
@@ -67,6 +67,33 @@ export function normalizeMode(argvMode, payload) {
   return "register";
 }
 
+function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
+  const done =
+    typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+  if (typeof done === "function") done();
+  return true;
+}
+
+async function runHookSideEffectsWithStdoutSuppressed(fn) {
+  const originalStdoutWrite = stdout.write;
+  const originalConsoleDebug = console.debug;
+  const originalConsoleInfo = console.info;
+  const originalConsoleLog = console.log;
+
+  stdout.write = swallowStdoutWrite;
+  console.debug = () => {};
+  console.info = () => {};
+  console.log = () => {};
+  try {
+    return await fn();
+  } finally {
+    stdout.write = originalStdoutWrite;
+    console.debug = originalConsoleDebug;
+    console.info = originalConsoleInfo;
+    console.log = originalConsoleLog;
+  }
+}
+
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);
@@ -93,24 +120,26 @@ export async function runAgySessionHook(stdinData, opts = {}) {
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
 
   try {
-    if (mode === "register") {
-      try {
-        await hubEnsureRun(sessionPayload);
-      } catch {}
-      try {
-        await Promise.resolve(registerInteractiveSession(sessionPayload));
-      } catch {}
-      try {
-        await drainPendingSynapse(1000);
-      } catch {}
-    } else if (mode === "heartbeat") {
-      try {
-        heartbeatInteractiveSession(sessionPayload);
-      } catch {}
-      try {
-        await drainPendingSynapse(500);
-      } catch {}
-    }
+    await runHookSideEffectsWithStdoutSuppressed(async () => {
+      if (mode === "register") {
+        try {
+          await hubEnsureRun(sessionPayload);
+        } catch {}
+        try {
+          await Promise.resolve(registerInteractiveSession(sessionPayload));
+        } catch {}
+        try {
+          await drainPendingSynapse(1000);
+        } catch {}
+      } else if (mode === "heartbeat") {
+        try {
+          heartbeatInteractiveSession(sessionPayload);
+        } catch {}
+        try {
+          await drainPendingSynapse(500);
+        } catch {}
+      }
+    });
   } catch {
     // agy session hooks are observational and must never block the session.
   }

--- a/packages/triflux/hooks/agy-session-hook.mjs
+++ b/packages/triflux/hooks/agy-session-hook.mjs
@@ -67,6 +67,33 @@ export function normalizeMode(argvMode, payload) {
   return "register";
 }
 
+function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
+  const done =
+    typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+  if (typeof done === "function") done();
+  return true;
+}
+
+async function runHookSideEffectsWithStdoutSuppressed(fn) {
+  const originalStdoutWrite = stdout.write;
+  const originalConsoleDebug = console.debug;
+  const originalConsoleInfo = console.info;
+  const originalConsoleLog = console.log;
+
+  stdout.write = swallowStdoutWrite;
+  console.debug = () => {};
+  console.info = () => {};
+  console.log = () => {};
+  try {
+    return await fn();
+  } finally {
+    stdout.write = originalStdoutWrite;
+    console.debug = originalConsoleDebug;
+    console.info = originalConsoleInfo;
+    console.log = originalConsoleLog;
+  }
+}
+
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);
@@ -93,24 +120,26 @@ export async function runAgySessionHook(stdinData, opts = {}) {
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
 
   try {
-    if (mode === "register") {
-      try {
-        await hubEnsureRun(sessionPayload);
-      } catch {}
-      try {
-        await Promise.resolve(registerInteractiveSession(sessionPayload));
-      } catch {}
-      try {
-        await drainPendingSynapse(1000);
-      } catch {}
-    } else if (mode === "heartbeat") {
-      try {
-        heartbeatInteractiveSession(sessionPayload);
-      } catch {}
-      try {
-        await drainPendingSynapse(500);
-      } catch {}
-    }
+    await runHookSideEffectsWithStdoutSuppressed(async () => {
+      if (mode === "register") {
+        try {
+          await hubEnsureRun(sessionPayload);
+        } catch {}
+        try {
+          await Promise.resolve(registerInteractiveSession(sessionPayload));
+        } catch {}
+        try {
+          await drainPendingSynapse(1000);
+        } catch {}
+      } else if (mode === "heartbeat") {
+        try {
+          heartbeatInteractiveSession(sessionPayload);
+        } catch {}
+        try {
+          await drainPendingSynapse(500);
+        } catch {}
+      }
+    });
   } catch {
     // agy session hooks are observational and must never block the session.
   }

--- a/tests/unit/agy-session-hook.test.mjs
+++ b/tests/unit/agy-session-hook.test.mjs
@@ -76,6 +76,37 @@ describe("agy-session-hook adapter", () => {
     ]);
   });
 
+  it("suppresses side-effect stdout while preserving the final JSON hook result", async () => {
+    let captured = "";
+    const originalWrite = process.stdout.write;
+    process.stdout.write = (chunk, encodingOrCallback, callback) => {
+      captured += String(chunk);
+      const done =
+        typeof encodingOrCallback === "function"
+          ? encodingOrCallback
+          : callback;
+      if (typeof done === "function") done();
+      return true;
+    };
+    try {
+      const result = await runAgySessionHook(agyPayload({ invocationNum: 1 }), {
+        hubEnsureRun: async () => {
+          process.stdout.write("[mcp-sync] skipped: noisy side effect\n");
+          console.log("noisy console log");
+        },
+        registerInteractiveSession: () => {
+          process.stdout.write("[register] noisy side effect\n");
+        },
+        drainPendingSynapse: async () => {},
+      });
+
+      assert.equal(result, "{}\n");
+      assert.equal(captured, "{}\n");
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  });
+
   it("heartbeat mode heartbeats the mapped payload and drains without hub ensure", async () => {
     const calls = [];
     const result = await runAgySessionHook(agyPayload({ invocationNum: 4 }), {


### PR DESCRIPTION
## Summary
- Suppress stdout/console noise from AGY session-hook side effects while preserving the final `{}` hook response.
- Mirror the fix into `packages/core` and `packages/triflux` hook copies.
- Add a regression test that noisy side effects do not corrupt AGY hook stdout.

## Test Plan
- `node --test tests/unit/agy-session-hook.test.mjs`
- `npm run release:check-mirror`
- `git diff --check -- hooks/agy-session-hook.mjs packages/core/hooks/agy-session-hook.mjs packages/triflux/hooks/agy-session-hook.mjs tests/unit/agy-session-hook.test.mjs`
- Direct probe: `node hooks/agy-session-hook.mjs` with AGY payload emits exactly `'{}\n'`
