### PR TITLE
test: harden codex config hermeticity (synapse flaky + home isolation)

### DIFF
--- a/tests/integration/tfx-route-smoke.test.mjs
+++ b/tests/integration/tfx-route-smoke.test.mjs
@@ -12,7 +12,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -58,31 +58,41 @@ function createRouteHome() {
 
 // bash 실행 헬퍼 — stdout + stderr 합산 반환
 function runBash(command, extraEnv = {}) {
-  return spawnSync(BASH_EXE, ["-c", command], {
-    cwd: PROJECT_ROOT,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      TFX_TEAM_NAME: "",
-      TFX_TEAM_TASK_ID: "",
-      TFX_TEAM_AGENT_NAME: "",
-      TFX_TEAM_LEAD_NAME: "",
-      TFX_HUB_URL: "",
-      TMUX: "",
-      TFX_CLI_MODE: "auto",
-      TFX_NO_CLAUDE_NATIVE: "0",
-      TFX_CODEX_TRANSPORT: "exec",
-      TFX_WORKER_INDEX: "",
-      TFX_SEARCH_TOOL: "",
-      // #148: 테스트 환경에서는 실제 MCP probe 가 모두 dead 로 나와 early-fail 발생.
-      // 라우팅/트랜스포트 검증이 목적이므로 preflight 자체를 스킵.
-      TFX_MCP_HEALTH_CHECK: "0",
-      // Fixture config is intentionally tiny but valid. Production keeps the
-      // small-config corruption guard unless a caller opts in explicitly.
-      TFX_ALLOW_SMALL_CODEX_CONFIG: "1",
-      ...extraEnv,
-    },
-  });
+  const fallbackHome = extraEnv.HOME ? null : createRouteHome();
+  const home = extraEnv.HOME ?? fallbackHome;
+
+  try {
+    return spawnSync(BASH_EXE, ["-c", command], {
+      cwd: PROJECT_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        TRIFLUX_TEST_HOME: home,
+        TFX_TEAM_NAME: "",
+        TFX_TEAM_TASK_ID: "",
+        TFX_TEAM_AGENT_NAME: "",
+        TFX_TEAM_LEAD_NAME: "",
+        TFX_HUB_URL: "",
+        TMUX: "",
+        TFX_CLI_MODE: "auto",
+        TFX_NO_CLAUDE_NATIVE: "0",
+        TFX_CODEX_TRANSPORT: "exec",
+        TFX_WORKER_INDEX: "",
+        TFX_SEARCH_TOOL: "",
+        // #148: 테스트 환경에서는 실제 MCP probe 가 모두 dead 로 나와 early-fail 발생.
+        // 라우팅/트랜스포트 검증이 목적이므로 preflight 자체를 스킵.
+        TFX_MCP_HEALTH_CHECK: "0",
+        // Fixture config is intentionally tiny but valid. Production keeps the
+        // small-config corruption guard unless a caller opts in explicitly.
+        TFX_ALLOW_SMALL_CODEX_CONFIG: "1",
+        ...extraEnv,
+      },
+    });
+  } finally {
+    if (fallbackHome) rmSync(fallbackHome, { recursive: true, force: true });
+  }
 }
 
 // stdout + stderr 합산 문자열
@@ -107,6 +117,7 @@ function fixtureEnv(extraEnv = {}) {
     PATH: `${FIXTURE_BIN}:${process.env.PATH || ""}`,
     HOME: home,
     USERPROFILE: home,
+    TRIFLUX_TEST_HOME: home,
   };
 }
 

--- a/tests/unit/setup-sync.test.mjs
+++ b/tests/unit/setup-sync.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 import { execFileSync } from "child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -24,6 +32,19 @@ const {
 // ── helpers ──
 
 const TMP_DIR = join(PROJECT_ROOT, "tests", ".tmp-setup-sync");
+const SETUP_TEST_HOME = mkdtempSync(join(tmpdir(), "tfx-setup-sync-"));
+const SETUP_TEST_ENV = {
+  ...process.env,
+  TRIFLUX_TEST_HOME: SETUP_TEST_HOME,
+  HOME: SETUP_TEST_HOME,
+  USERPROFILE: SETUP_TEST_HOME,
+};
+
+mkdirSync(join(SETUP_TEST_HOME, ".codex"), { recursive: true });
+
+after(() => {
+  rmSync(SETUP_TEST_HOME, { recursive: true, force: true });
+});
 
 function ensureTmpDir() {
   if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
@@ -73,6 +94,7 @@ describe("setup-sync: --sync 플래그 파싱", () => {
       {
         timeout: 15000,
         encoding: "utf8",
+        env: SETUP_TEST_ENV,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -89,6 +111,7 @@ describe("setup-sync: --sync 플래그 파싱", () => {
       {
         timeout: 15000,
         encoding: "utf8",
+        env: SETUP_TEST_ENV,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -316,6 +339,7 @@ describe("setup-sync: dry-run 실행", () => {
       {
         timeout: 15000,
         encoding: "utf8",
+        env: SETUP_TEST_ENV,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -330,6 +354,7 @@ describe("setup-sync: dry-run 실행", () => {
       {
         timeout: 15000,
         encoding: "utf8",
+        env: SETUP_TEST_ENV,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );

--- a/tests/unit/synapse-http.test.mjs
+++ b/tests/unit/synapse-http.test.mjs
@@ -16,6 +16,65 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+async function withDeadline(promise, timeoutMs, message) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function closeServer(server) {
+  await withDeadline(
+    new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+    1000,
+    "test server did not close within 1000ms",
+  );
+}
+
+async function waitForChildExit(cp, timeoutMs) {
+  let timeout;
+  let exited = false;
+  const exitPromise = new Promise((resolve, reject) => {
+    cp.once("error", reject);
+    cp.once("exit", (code, signal) => {
+      exited = true;
+      if (code === 0) resolve();
+      else reject(new Error(`child exited ${code ?? `signal ${signal}`}`));
+    });
+  });
+
+  try {
+    await Promise.race([
+      exitPromise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`child did not exit within ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+    if (!exited) {
+      cp.kill("SIGTERM");
+      await Promise.race([
+        new Promise((resolve) => cp.once("exit", resolve)),
+        new Promise((resolve) => setTimeout(resolve, 500)),
+      ]);
+      if (!exited) cp.kill("SIGKILL");
+    }
+  }
+}
+
 describe("synapse-http helpers", () => {
   it("task summary를 앞 100자로 자른다", () => {
     const prompt = "a".repeat(120);
@@ -243,7 +302,11 @@ describe("drainPendingSynapse (flush before process.exit)", () => {
         { sessionId: "drain-real", host: "local" },
         { token: false },
       );
-      await drainPendingSynapse(2000);
+      await withDeadline(
+        drainPendingSynapse(2000),
+        3000,
+        "drainPendingSynapse did not flush loopback POST within 3000ms",
+      );
       assert.equal(received.length, 1);
       assert.equal(received[0].method, "POST");
       assert.equal(received[0].url, "/synapse/register");
@@ -251,7 +314,7 @@ describe("drainPendingSynapse (flush before process.exit)", () => {
     } finally {
       if (prevUrl === undefined) delete process.env.TFX_HUB_URL;
       else process.env.TFX_HUB_URL = prevUrl;
-      await new Promise((resolve) => server.close(resolve));
+      await closeServer(server);
     }
   });
 
@@ -267,12 +330,24 @@ describe("drainPendingSynapse (flush before process.exit)", () => {
       { token: false, fetchImpl: () => blocked },
     );
     const t0 = performance.now();
-    await drainPendingSynapse(60);
-    const elapsed = performance.now() - t0;
-    assert.ok(elapsed < 1000, `drain should be bounded, took ${elapsed}ms`);
-    // Release so the tracked promise leaves the in-flight set (no cross-test leak).
-    release({ ok: true });
-    await new Promise((resolve) => setImmediate(resolve));
+    try {
+      await withDeadline(
+        drainPendingSynapse(60),
+        1000,
+        "drainPendingSynapse did not resolve stalled fetch within test deadline",
+      );
+      const elapsed = performance.now() - t0;
+      assert.ok(elapsed < 1000, `drain should be bounded, took ${elapsed}ms`);
+    } finally {
+      // Release and await the tracked promise so the module-global in-flight set
+      // cannot leak into later subtests when --test-force-exit is active.
+      release({ ok: true });
+      await withDeadline(
+        drainPendingSynapse(0),
+        1000,
+        "released stalled Synapse request did not settle within 1000ms",
+      );
+    }
   });
 
   it("register POST가 drain 후 실제 process.exit(0) 경계를 넘어 도달한다", async () => {
@@ -298,21 +373,16 @@ describe("drainPendingSynapse (flush before process.exit)", () => {
     // reaches the server before the child process dies.
     const childCode = `import(${JSON.stringify(moduleUrl)}).then(async (m) => { m.registerSynapseSession({ sessionId: "exit-boundary" }, { token: false }); await m.drainPendingSynapse(2000); process.exit(0); }).catch((e) => { console.error(e); process.exit(1); });`;
     try {
-      await new Promise((resolve, reject) => {
-        const cp = spawn(process.execPath, ["-e", childCode], {
-          env: { ...process.env, TFX_HUB_URL: `http://127.0.0.1:${port}` },
-          stdio: "ignore",
-        });
-        cp.on("error", reject);
-        cp.on("exit", (code) =>
-          code === 0 ? resolve() : reject(new Error(`child exited ${code}`)),
-        );
+      const cp = spawn(process.execPath, ["-e", childCode], {
+        env: { ...process.env, TFX_HUB_URL: `http://127.0.0.1:${port}` },
+        stdio: "ignore",
       });
+      await waitForChildExit(cp, 4000);
       assert.equal(received.length, 1);
       assert.equal(received[0].url, "/synapse/register");
       assert.equal(JSON.parse(received[0].body).sessionId, "exit-boundary");
     } finally {
-      await new Promise((resolve) => server.close(resolve));
+      await closeServer(server);
     }
   });
 });


### PR DESCRIPTION
## Summary
테스트가 실제 런타임 상태(`~/.codex` config, 실-subprocess pending)를 건드려 풀 스위트/릴리즈에서만 터지는 회귀를 차단하는 hermetic 하드닝.

- `tests/unit/synapse-http.test.mjs`: drainPendingSynapse 실-subprocess 테스트의 force-exit pending 제거 — CI flaky 원인 해소.
- `tests/unit/setup-sync.test.mjs`, `tests/integration/tfx-route-smoke.test.mjs`: HOME 격리로 실제 codex config leak 차단 (테스트가 사용자 `~/.codex`를 오염시키던 경로 제거).

## Scope
- 테스트 파일 3개만 변경 (151/-45). 런타임/배포 코드 변경 없음 → 미러 영향 없음.

## Test Plan
- `npm test` (CI)
