### PR TITLE
fix: harden remaining consensus follow-ups

### DIFF
--- a/hooks/agy-session-hook.mjs
+++ b/hooks/agy-session-hook.mjs
@@ -30,12 +30,18 @@ function parsePayload(stdinData) {
   }
 }
 
-// Antigravity hook payloads use camelCase system metadata (conversationId,
-// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
-// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
-// payload into that shape before delegating. conversationId is the stable
-// per-conversation UUID (== session identity); the first mounted workspace path
-// is the effective cwd.
+/**
+ * Convert an Antigravity hook payload into the Codex-shaped session payload
+ * consumed by the shared fast session registration helpers.
+ *
+ * Antigravity hook payloads use camelCase system metadata (`conversationId`,
+ * `workspacePaths`) rather than Codex's `session_id`/`cwd`. The
+ * `conversationId` is the stable per-conversation UUID; the first mounted
+ * workspace path is the effective cwd.
+ *
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {string} JSON string with `{ session_id, cwd, actor_cli }`.
+ */
 export function toSessionPayload(payload) {
   const sessionId = String(payload?.conversationId || "").trim();
   const workspacePaths = Array.isArray(payload?.workspacePaths)
@@ -48,10 +54,18 @@ export function toSessionPayload(payload) {
   return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
-// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
-// fires before every model call, so the per-conversation invocationNum gates
-// register (first call == session start) vs heartbeat (subsequent calls).
-// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+/**
+ * Decide whether a PreInvocation payload should register or heartbeat.
+ *
+ * agy has no distinct SessionStart/UserPromptSubmit events. PreInvocation fires
+ * before every model call, so per-conversation `invocationNum` gates register
+ * (first call) vs heartbeat (later calls). An explicit argv mode overrides this,
+ * mirroring the Codex hook.
+ *
+ * @param {string | null | undefined} argvMode
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {"register" | "heartbeat"}
+ */
 export function normalizeMode(argvMode, payload) {
   const direct = String(argvMode || "")
     .trim()
@@ -94,6 +108,23 @@ async function runHookSideEffectsWithStdoutSuppressed(fn) {
   }
 }
 
+/**
+ * Execute the observational Antigravity session hook.
+ *
+ * The hook always returns/writes an empty JSON object so hook stdout remains
+ * JSON-only and hook failures never block the user session.
+ *
+ * @param {string} stdinData
+ * @param {{
+ *   argvMode?: string,
+ *   writeStdout?: boolean,
+ *   hubEnsureRun?: (stdinData: string) => Promise<unknown> | unknown,
+ *   registerInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   heartbeatInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   drainPendingSynapse?: (timeoutMs?: number) => Promise<unknown> | unknown,
+ * }} [opts]
+ * @returns {Promise<string>}
+ */
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);

--- a/hooks/subagent-tracker.mjs
+++ b/hooks/subagent-tracker.mjs
@@ -16,7 +16,11 @@ import { dirname, join } from "node:path";
 const STATE_VERSION = 1;
 const DEFAULT_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_COMPLETED = 20;
-const DEFAULT_LOCK_TIMEOUT_MS = 750;
+// Lifecycle hooks are best-effort, but under CI/Linux process contention a
+// 30-way SubagentStart burst can legitimately take around a second to drain.
+// Keep this bounded so hooks do not hang indefinitely, while avoiding silent
+// lifecycle drops during normal high-concurrency fan-out.
+const DEFAULT_LOCK_TIMEOUT_MS = 3000;
 const LOCK_RETRY_MS = 20;
 
 function readStdin() {
@@ -94,6 +98,16 @@ function withStateLock(statePath, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
       sleepSync(LOCK_RETRY_MS);
     }
   }
+}
+
+function lockTimeoutMsFromOptions(opts = {}) {
+  if (Number.isFinite(opts.lockTimeoutMs)) return opts.lockTimeoutMs;
+  const raw = opts.env?.TRIFLUX_SUBAGENT_LOCK_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_LOCK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.trunc(parsed)
+    : DEFAULT_LOCK_TIMEOUT_MS;
 }
 
 function lifecycleKey(input) {
@@ -241,7 +255,7 @@ export function recordLifecycle(input, opts = {}) {
       writeState(statePath, state);
       return output;
     },
-    opts.lockTimeoutMs,
+    lockTimeoutMsFromOptions(opts),
   );
 }
 

--- a/hub/team/claude-daemon-control.mjs
+++ b/hub/team/claude-daemon-control.mjs
@@ -468,21 +468,29 @@ export function sendClaudeControlRequest(
 // 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
 export async function readDaemonControlKey(
   configDir = resolveClaudeConfigDir(),
+  { diagnostics } = {},
 ) {
+  if (!configDir) return undefined;
+  const keyPath = path.join(configDir, "daemon", "control.key");
   try {
-    const key = await fs.readFile(
-      path.join(configDir, "daemon", "control.key"),
-      "utf8",
-    );
+    const key = await fs.readFile(keyPath, "utf8");
     return key.trim() || undefined;
-  } catch {
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    if (Array.isArray(diagnostics)) {
+      diagnostics.push({
+        code: error?.code || "UNKNOWN",
+        path: keyPath,
+        message: error?.message || String(error),
+      });
+    }
     return undefined;
   }
 }
 
-export async function buildDaemonControlAuth(configDir) {
+export async function buildDaemonControlAuth(configDir, opts = {}) {
   if (!configDir) return {};
-  const auth = await readDaemonControlKey(configDir);
+  const auth = await readDaemonControlKey(configDir, opts);
   return auth ? { auth } : {};
 }
 

--- a/hub/team/notify.mjs
+++ b/hub/team/notify.mjs
@@ -54,12 +54,17 @@ function normalizeEvent(event, defaults = {}) {
   });
 }
 
-function defaultChannelConfig(name, env) {
+function defaultChannelConfig(name, env, platform = process.platform) {
   switch (name) {
     case "bell":
-      return { enabled: true };
+      return { enabled: envFlag(env?.TRIFLUX_NOTIFY_BELL, true) };
     case "toast":
-      return { enabled: true };
+      return {
+        // macOS `osascript display notification` can surface Script Editor
+        // authorization/UI prompts. Keep it opt-in there; Windows keeps the
+        // historical toast default, and other platforms skip as unsupported.
+        enabled: envFlag(env?.TRIFLUX_NOTIFY_TOAST, platform !== "darwin"),
+      };
     case "webhook": {
       const url = String(env?.TRIFLUX_NOTIFY_WEBHOOK || "");
       return { enabled: Boolean(url), url };
@@ -69,8 +74,13 @@ function defaultChannelConfig(name, env) {
   }
 }
 
-function normalizeChannelConfig(name, value, env) {
-  const base = defaultChannelConfig(name, env);
+function envFlag(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  return !["0", "false", "no", "off"].includes(String(value).toLowerCase());
+}
+
+function normalizeChannelConfig(name, value, env, platform) {
+  const base = defaultChannelConfig(name, env, platform);
   const patch =
     typeof value === "boolean"
       ? { enabled: value }
@@ -103,16 +113,21 @@ function normalizeChannelConfig(name, value, env) {
   return freezeRecord(next);
 }
 
-function normalizeChannels(channels, env) {
+function normalizeChannels(channels, env, platform) {
   const source = channels && typeof channels === "object" ? channels : {};
   const normalized = {};
   for (const name of NOTIFY_CHANNELS) {
-    normalized[name] = normalizeChannelConfig(name, source[name], env);
+    normalized[name] = normalizeChannelConfig(
+      name,
+      source[name],
+      env,
+      platform,
+    );
   }
   return Object.freeze(normalized);
 }
 
-function updateChannelConfig(channels, channel, config, env) {
+function updateChannelConfig(channels, channel, config, env, platform) {
   if (!NOTIFY_CHANNELS.includes(channel)) {
     throw new TypeError(`Unknown notify channel: ${channel}`);
   }
@@ -126,6 +141,7 @@ function updateChannelConfig(channels, channel, config, env) {
         ...(typeof config === "boolean" ? { enabled: config } : config || {}),
       },
       env,
+      platform,
     ),
   });
 }
@@ -322,7 +338,7 @@ function createNotifierInstance(channels, deps) {
 
   function setChannel(channel, config) {
     return createNotifierInstance(
-      updateChannelConfig(channels, channel, config, deps.env),
+      updateChannelConfig(channels, channel, config, deps.env, deps.platform),
       deps,
     );
   }
@@ -349,17 +365,21 @@ function createNotifierInstance(channels, deps) {
  */
 export function createNotifier(opts = {}) {
   const env = opts.env || process.env;
+  const platform = opts.platform || process.platform;
   const deps = Object.freeze({
     env,
     stdout: opts.stdout || process.stdout,
     execFile: opts.deps?.execFile || execFile,
     fetch: opts.deps?.fetch || globalThis.fetch?.bind(globalThis),
-    platform: opts.platform || process.platform,
+    platform,
     hostname: opts.hostname || os.hostname(),
     powerShellCandidates: Object.freeze(
       opts.deps?.powerShellCandidates || ["pwsh", "powershell.exe"],
     ),
   });
 
-  return createNotifierInstance(normalizeChannels(opts.channels, env), deps);
+  return createNotifierInstance(
+    normalizeChannels(opts.channels, env, platform),
+    deps,
+  );
 }

--- a/hud/providers/gemini.mjs
+++ b/hud/providers/gemini.mjs
@@ -197,6 +197,8 @@ export function deriveGeminiFamilyBucket(buckets) {
 
 export function buildGeminiAuthContext(accountId) {
   let oauth = readJson(GEMINI_OAUTH_PATH, null);
+  let authSource = oauth?.access_token ? "gemini-file" : "none";
+  let expiryMissing = oauth?.access_token ? oauth.expiry_date == null : false;
   const fileExpired =
     oauth?.expiry_date != null && oauth.expiry_date < Date.now();
   // Preserve a valid Gemini file token; agy Keychain is only a missing/expired fallback.
@@ -209,13 +211,15 @@ export function buildGeminiAuthContext(accountId) {
         ...fileRest
       } = oauth || {};
       oauth = { ...fileRest, ...keychainOAuth };
+      authSource = "antigravity-keychain";
+      expiryMissing = keychainOAuth.expiry_date == null;
     }
   }
   const tokenSource =
     oauth?.refresh_token || oauth?.id_token || oauth?.access_token || "";
   const tokenFingerprint = tokenSource ? makeHash(tokenSource) : "none";
   const cacheKey = `${accountId || "gemini-main"}::${tokenFingerprint}`;
-  return { oauth, tokenFingerprint, cacheKey };
+  return { oauth, tokenFingerprint, cacheKey, authSource, expiryMissing };
 }
 
 function firstPresent(...values) {
@@ -305,12 +309,76 @@ function getAntigravityTokenFromKeychain() {
   }
 }
 
+export function classifyGeminiQuotaFailure(response, authContext = {}) {
+  if (!response) return "network";
+  const error = response?.error || {};
+  const code = Number(error.code ?? response.code ?? response.status);
+  const status = String(error.status || response.status || "").toUpperCase();
+  const message = String(
+    error.message || error.code || response.error || response.message || "",
+  );
+  if (
+    code === 401 ||
+    code === 403 ||
+    status === "UNAUTHENTICATED" ||
+    status === "PERMISSION_DENIED" ||
+    /(unauthorized|forbidden|invalid authentication|invalid credentials|oauth|token|credential|auth)/i.test(
+      message,
+    )
+  ) {
+    return "auth";
+  }
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true &&
+    /(expired|invalid|unauthenticated|permission denied)/i.test(message)
+  ) {
+    return "auth";
+  }
+  return "api";
+}
+
+function formatGeminiQuotaFailure(response, authContext = {}, stage = "quota") {
+  const error =
+    response?.error?.message ||
+    response?.error?.status ||
+    response?.error?.code ||
+    response?.error ||
+    response?.message ||
+    "no buckets in response";
+  const base = String(error);
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true
+  ) {
+    return `expiry-less Antigravity Keychain token failed bounded ${stage} freshness probe: ${base}`;
+  }
+  return base;
+}
+
+function writeGeminiQuotaErrorCache(cache, authContext, errorType, errorHint) {
+  const sameKey = cache?.cacheKey === authContext.cacheKey;
+  writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
+    ...(sameKey ? cache || {} : {}),
+    timestamp: sameKey && cache?.timestamp ? cache.timestamp : Date.now(),
+    cacheKey: authContext.cacheKey,
+    accountId: authContext.accountId || "gemini-main",
+    tokenFingerprint: authContext.tokenFingerprint,
+    authSource: authContext.authSource,
+    expiryMissing: authContext.expiryMissing === true,
+    error: true,
+    errorType,
+    errorHint,
+  });
+}
+
 // ============================================================================
 // Gemini 쿼터 API 호출 (5분 캐시)
 // ============================================================================
 export async function fetchGeminiQuota(accountId, options = {}) {
   const authContext = options.authContext || buildGeminiAuthContext(accountId);
   const { oauth, tokenFingerprint, cacheKey } = authContext;
+  authContext.accountId = accountId || "gemini-main";
   const forceRefresh = options.forceRefresh === true;
 
   // 1. 캐시 확인 (계정/토큰별)
@@ -330,35 +398,34 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!oauth?.access_token) {
     // access_token 없음: 에러 힌트를 캐시에 기록하고 stale 캐시 반환
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: "no access_token in oauth_creds.json",
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      "no access_token in oauth_creds.json",
+    );
     return cache;
   }
   if (oauth.expiry_date && oauth.expiry_date < Date.now()) {
     // OAuth 토큰 만료: 에러 힌트를 캐시에 기록 (refresh_token 갱신은 Gemini CLI 담당)
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
+    );
     return cache;
   }
 
   // 3. projectId (캐시 or API)
+  let loadCodeAssistResponse = null;
   const fetchProjectId = async () => {
-    const loadRes = await httpsPost(
+    loadCodeAssistResponse = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       { metadata: { pluginType: "GEMINI" } },
       oauth.access_token,
     );
-    const id = loadRes?.cloudaicompanionProject;
+    const id = loadCodeAssistResponse?.cloudaicompanionProject;
     if (id)
       writeJsonSafe(GEMINI_PROJECT_CACHE_PATH, {
         cacheKey,
@@ -376,7 +443,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   let projectId =
     projCache?.cacheKey === cacheKey ? projCache?.projectId : null;
   if (!projectId) projectId = await fetchProjectId();
-  if (!projectId) return cache;
+  if (!projectId) {
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+      formatGeminiQuotaFailure(
+        loadCodeAssistResponse,
+        authContext,
+        "loadCodeAssist",
+      ),
+    );
+    return cache;
+  }
 
   // 4. retrieveUserQuota 호출
   let quotaRes = await httpsPost(
@@ -388,7 +467,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   // projectId 캐시가 만료/변경된 경우 1회 재시도
   if (!quotaRes?.buckets && projCache?.projectId) {
     projectId = await fetchProjectId();
-    if (!projectId) return cache;
+    if (!projectId) {
+      writeGeminiQuotaErrorCache(
+        cache,
+        authContext,
+        classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+        formatGeminiQuotaFailure(
+          loadCodeAssistResponse,
+          authContext,
+          "loadCodeAssist",
+        ),
+      );
+      return cache;
+    }
     quotaRes = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
       { project: projectId },
@@ -398,18 +489,12 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!quotaRes?.buckets) {
     // API 응답에 buckets 없음: 에러 코드 또는 응답 내용을 캐시에 기록
-    const apiError =
-      quotaRes?.error?.message ||
-      quotaRes?.error?.code ||
-      quotaRes?.error ||
-      "no buckets in response";
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "api",
-      errorHint: String(apiError),
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(quotaRes, authContext),
+      formatGeminiQuotaFailure(quotaRes, authContext, "quota"),
+    );
     return cache;
   }
 

--- a/packages/core/hooks/agy-session-hook.mjs
+++ b/packages/core/hooks/agy-session-hook.mjs
@@ -30,12 +30,18 @@ function parsePayload(stdinData) {
   }
 }
 
-// Antigravity hook payloads use camelCase system metadata (conversationId,
-// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
-// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
-// payload into that shape before delegating. conversationId is the stable
-// per-conversation UUID (== session identity); the first mounted workspace path
-// is the effective cwd.
+/**
+ * Convert an Antigravity hook payload into the Codex-shaped session payload
+ * consumed by the shared fast session registration helpers.
+ *
+ * Antigravity hook payloads use camelCase system metadata (`conversationId`,
+ * `workspacePaths`) rather than Codex's `session_id`/`cwd`. The
+ * `conversationId` is the stable per-conversation UUID; the first mounted
+ * workspace path is the effective cwd.
+ *
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {string} JSON string with `{ session_id, cwd, actor_cli }`.
+ */
 export function toSessionPayload(payload) {
   const sessionId = String(payload?.conversationId || "").trim();
   const workspacePaths = Array.isArray(payload?.workspacePaths)
@@ -48,10 +54,18 @@ export function toSessionPayload(payload) {
   return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
-// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
-// fires before every model call, so the per-conversation invocationNum gates
-// register (first call == session start) vs heartbeat (subsequent calls).
-// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+/**
+ * Decide whether a PreInvocation payload should register or heartbeat.
+ *
+ * agy has no distinct SessionStart/UserPromptSubmit events. PreInvocation fires
+ * before every model call, so per-conversation `invocationNum` gates register
+ * (first call) vs heartbeat (later calls). An explicit argv mode overrides this,
+ * mirroring the Codex hook.
+ *
+ * @param {string | null | undefined} argvMode
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {"register" | "heartbeat"}
+ */
 export function normalizeMode(argvMode, payload) {
   const direct = String(argvMode || "")
     .trim()
@@ -94,6 +108,23 @@ async function runHookSideEffectsWithStdoutSuppressed(fn) {
   }
 }
 
+/**
+ * Execute the observational Antigravity session hook.
+ *
+ * The hook always returns/writes an empty JSON object so hook stdout remains
+ * JSON-only and hook failures never block the user session.
+ *
+ * @param {string} stdinData
+ * @param {{
+ *   argvMode?: string,
+ *   writeStdout?: boolean,
+ *   hubEnsureRun?: (stdinData: string) => Promise<unknown> | unknown,
+ *   registerInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   heartbeatInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   drainPendingSynapse?: (timeoutMs?: number) => Promise<unknown> | unknown,
+ * }} [opts]
+ * @returns {Promise<string>}
+ */
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);

--- a/packages/core/hooks/subagent-tracker.mjs
+++ b/packages/core/hooks/subagent-tracker.mjs
@@ -16,7 +16,11 @@ import { dirname, join } from "node:path";
 const STATE_VERSION = 1;
 const DEFAULT_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_COMPLETED = 20;
-const DEFAULT_LOCK_TIMEOUT_MS = 750;
+// Lifecycle hooks are best-effort, but under CI/Linux process contention a
+// 30-way SubagentStart burst can legitimately take around a second to drain.
+// Keep this bounded so hooks do not hang indefinitely, while avoiding silent
+// lifecycle drops during normal high-concurrency fan-out.
+const DEFAULT_LOCK_TIMEOUT_MS = 3000;
 const LOCK_RETRY_MS = 20;
 
 function readStdin() {
@@ -94,6 +98,16 @@ function withStateLock(statePath, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
       sleepSync(LOCK_RETRY_MS);
     }
   }
+}
+
+function lockTimeoutMsFromOptions(opts = {}) {
+  if (Number.isFinite(opts.lockTimeoutMs)) return opts.lockTimeoutMs;
+  const raw = opts.env?.TRIFLUX_SUBAGENT_LOCK_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_LOCK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.trunc(parsed)
+    : DEFAULT_LOCK_TIMEOUT_MS;
 }
 
 function lifecycleKey(input) {
@@ -241,7 +255,7 @@ export function recordLifecycle(input, opts = {}) {
       writeState(statePath, state);
       return output;
     },
-    opts.lockTimeoutMs,
+    lockTimeoutMsFromOptions(opts),
   );
 }
 

--- a/packages/core/hub/team/claude-daemon-control.mjs
+++ b/packages/core/hub/team/claude-daemon-control.mjs
@@ -468,21 +468,29 @@ export function sendClaudeControlRequest(
 // 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
 export async function readDaemonControlKey(
   configDir = resolveClaudeConfigDir(),
+  { diagnostics } = {},
 ) {
+  if (!configDir) return undefined;
+  const keyPath = path.join(configDir, "daemon", "control.key");
   try {
-    const key = await fs.readFile(
-      path.join(configDir, "daemon", "control.key"),
-      "utf8",
-    );
+    const key = await fs.readFile(keyPath, "utf8");
     return key.trim() || undefined;
-  } catch {
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    if (Array.isArray(diagnostics)) {
+      diagnostics.push({
+        code: error?.code || "UNKNOWN",
+        path: keyPath,
+        message: error?.message || String(error),
+      });
+    }
     return undefined;
   }
 }
 
-export async function buildDaemonControlAuth(configDir) {
+export async function buildDaemonControlAuth(configDir, opts = {}) {
   if (!configDir) return {};
-  const auth = await readDaemonControlKey(configDir);
+  const auth = await readDaemonControlKey(configDir, opts);
   return auth ? { auth } : {};
 }
 

--- a/packages/core/hud/providers/gemini.mjs
+++ b/packages/core/hud/providers/gemini.mjs
@@ -197,6 +197,8 @@ export function deriveGeminiFamilyBucket(buckets) {
 
 export function buildGeminiAuthContext(accountId) {
   let oauth = readJson(GEMINI_OAUTH_PATH, null);
+  let authSource = oauth?.access_token ? "gemini-file" : "none";
+  let expiryMissing = oauth?.access_token ? oauth.expiry_date == null : false;
   const fileExpired =
     oauth?.expiry_date != null && oauth.expiry_date < Date.now();
   // Preserve a valid Gemini file token; agy Keychain is only a missing/expired fallback.
@@ -209,13 +211,15 @@ export function buildGeminiAuthContext(accountId) {
         ...fileRest
       } = oauth || {};
       oauth = { ...fileRest, ...keychainOAuth };
+      authSource = "antigravity-keychain";
+      expiryMissing = keychainOAuth.expiry_date == null;
     }
   }
   const tokenSource =
     oauth?.refresh_token || oauth?.id_token || oauth?.access_token || "";
   const tokenFingerprint = tokenSource ? makeHash(tokenSource) : "none";
   const cacheKey = `${accountId || "gemini-main"}::${tokenFingerprint}`;
-  return { oauth, tokenFingerprint, cacheKey };
+  return { oauth, tokenFingerprint, cacheKey, authSource, expiryMissing };
 }
 
 function firstPresent(...values) {
@@ -305,12 +309,76 @@ function getAntigravityTokenFromKeychain() {
   }
 }
 
+export function classifyGeminiQuotaFailure(response, authContext = {}) {
+  if (!response) return "network";
+  const error = response?.error || {};
+  const code = Number(error.code ?? response.code ?? response.status);
+  const status = String(error.status || response.status || "").toUpperCase();
+  const message = String(
+    error.message || error.code || response.error || response.message || "",
+  );
+  if (
+    code === 401 ||
+    code === 403 ||
+    status === "UNAUTHENTICATED" ||
+    status === "PERMISSION_DENIED" ||
+    /(unauthorized|forbidden|invalid authentication|invalid credentials|oauth|token|credential|auth)/i.test(
+      message,
+    )
+  ) {
+    return "auth";
+  }
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true &&
+    /(expired|invalid|unauthenticated|permission denied)/i.test(message)
+  ) {
+    return "auth";
+  }
+  return "api";
+}
+
+function formatGeminiQuotaFailure(response, authContext = {}, stage = "quota") {
+  const error =
+    response?.error?.message ||
+    response?.error?.status ||
+    response?.error?.code ||
+    response?.error ||
+    response?.message ||
+    "no buckets in response";
+  const base = String(error);
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true
+  ) {
+    return `expiry-less Antigravity Keychain token failed bounded ${stage} freshness probe: ${base}`;
+  }
+  return base;
+}
+
+function writeGeminiQuotaErrorCache(cache, authContext, errorType, errorHint) {
+  const sameKey = cache?.cacheKey === authContext.cacheKey;
+  writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
+    ...(sameKey ? cache || {} : {}),
+    timestamp: sameKey && cache?.timestamp ? cache.timestamp : Date.now(),
+    cacheKey: authContext.cacheKey,
+    accountId: authContext.accountId || "gemini-main",
+    tokenFingerprint: authContext.tokenFingerprint,
+    authSource: authContext.authSource,
+    expiryMissing: authContext.expiryMissing === true,
+    error: true,
+    errorType,
+    errorHint,
+  });
+}
+
 // ============================================================================
 // Gemini 쿼터 API 호출 (5분 캐시)
 // ============================================================================
 export async function fetchGeminiQuota(accountId, options = {}) {
   const authContext = options.authContext || buildGeminiAuthContext(accountId);
   const { oauth, tokenFingerprint, cacheKey } = authContext;
+  authContext.accountId = accountId || "gemini-main";
   const forceRefresh = options.forceRefresh === true;
 
   // 1. 캐시 확인 (계정/토큰별)
@@ -330,35 +398,34 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!oauth?.access_token) {
     // access_token 없음: 에러 힌트를 캐시에 기록하고 stale 캐시 반환
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: "no access_token in oauth_creds.json",
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      "no access_token in oauth_creds.json",
+    );
     return cache;
   }
   if (oauth.expiry_date && oauth.expiry_date < Date.now()) {
     // OAuth 토큰 만료: 에러 힌트를 캐시에 기록 (refresh_token 갱신은 Gemini CLI 담당)
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
+    );
     return cache;
   }
 
   // 3. projectId (캐시 or API)
+  let loadCodeAssistResponse = null;
   const fetchProjectId = async () => {
-    const loadRes = await httpsPost(
+    loadCodeAssistResponse = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       { metadata: { pluginType: "GEMINI" } },
       oauth.access_token,
     );
-    const id = loadRes?.cloudaicompanionProject;
+    const id = loadCodeAssistResponse?.cloudaicompanionProject;
     if (id)
       writeJsonSafe(GEMINI_PROJECT_CACHE_PATH, {
         cacheKey,
@@ -376,7 +443,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   let projectId =
     projCache?.cacheKey === cacheKey ? projCache?.projectId : null;
   if (!projectId) projectId = await fetchProjectId();
-  if (!projectId) return cache;
+  if (!projectId) {
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+      formatGeminiQuotaFailure(
+        loadCodeAssistResponse,
+        authContext,
+        "loadCodeAssist",
+      ),
+    );
+    return cache;
+  }
 
   // 4. retrieveUserQuota 호출
   let quotaRes = await httpsPost(
@@ -388,7 +467,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   // projectId 캐시가 만료/변경된 경우 1회 재시도
   if (!quotaRes?.buckets && projCache?.projectId) {
     projectId = await fetchProjectId();
-    if (!projectId) return cache;
+    if (!projectId) {
+      writeGeminiQuotaErrorCache(
+        cache,
+        authContext,
+        classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+        formatGeminiQuotaFailure(
+          loadCodeAssistResponse,
+          authContext,
+          "loadCodeAssist",
+        ),
+      );
+      return cache;
+    }
     quotaRes = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
       { project: projectId },
@@ -398,18 +489,12 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!quotaRes?.buckets) {
     // API 응답에 buckets 없음: 에러 코드 또는 응답 내용을 캐시에 기록
-    const apiError =
-      quotaRes?.error?.message ||
-      quotaRes?.error?.code ||
-      quotaRes?.error ||
-      "no buckets in response";
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "api",
-      errorHint: String(apiError),
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(quotaRes, authContext),
+      formatGeminiQuotaFailure(quotaRes, authContext, "quota"),
+    );
     return cache;
   }
 

--- a/packages/triflux/hooks/agy-session-hook.mjs
+++ b/packages/triflux/hooks/agy-session-hook.mjs
@@ -30,12 +30,18 @@ function parsePayload(stdinData) {
   }
 }
 
-// Antigravity hook payloads use camelCase system metadata (conversationId,
-// workspacePaths) rather than Codex's session_id/cwd. registerInteractiveSession
-// and heartbeatInteractiveSession parse the Codex shape, so we adapt the agy
-// payload into that shape before delegating. conversationId is the stable
-// per-conversation UUID (== session identity); the first mounted workspace path
-// is the effective cwd.
+/**
+ * Convert an Antigravity hook payload into the Codex-shaped session payload
+ * consumed by the shared fast session registration helpers.
+ *
+ * Antigravity hook payloads use camelCase system metadata (`conversationId`,
+ * `workspacePaths`) rather than Codex's `session_id`/`cwd`. The
+ * `conversationId` is the stable per-conversation UUID; the first mounted
+ * workspace path is the effective cwd.
+ *
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {string} JSON string with `{ session_id, cwd, actor_cli }`.
+ */
 export function toSessionPayload(payload) {
   const sessionId = String(payload?.conversationId || "").trim();
   const workspacePaths = Array.isArray(payload?.workspacePaths)
@@ -48,10 +54,18 @@ export function toSessionPayload(payload) {
   return JSON.stringify({ session_id: sessionId, cwd, actor_cli: "agy" });
 }
 
-// agy has no distinct SessionStart / UserPromptSubmit events. PreInvocation
-// fires before every model call, so the per-conversation invocationNum gates
-// register (first call == session start) vs heartbeat (subsequent calls).
-// An explicit argv mode (register|heartbeat) overrides, mirroring the codex hook.
+/**
+ * Decide whether a PreInvocation payload should register or heartbeat.
+ *
+ * agy has no distinct SessionStart/UserPromptSubmit events. PreInvocation fires
+ * before every model call, so per-conversation `invocationNum` gates register
+ * (first call) vs heartbeat (later calls). An explicit argv mode overrides this,
+ * mirroring the Codex hook.
+ *
+ * @param {string | null | undefined} argvMode
+ * @param {Record<string, unknown> | null | undefined} payload
+ * @returns {"register" | "heartbeat"}
+ */
 export function normalizeMode(argvMode, payload) {
   const direct = String(argvMode || "")
     .trim()
@@ -94,6 +108,23 @@ async function runHookSideEffectsWithStdoutSuppressed(fn) {
   }
 }
 
+/**
+ * Execute the observational Antigravity session hook.
+ *
+ * The hook always returns/writes an empty JSON object so hook stdout remains
+ * JSON-only and hook failures never block the user session.
+ *
+ * @param {string} stdinData
+ * @param {{
+ *   argvMode?: string,
+ *   writeStdout?: boolean,
+ *   hubEnsureRun?: (stdinData: string) => Promise<unknown> | unknown,
+ *   registerInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   heartbeatInteractiveSession?: (stdinData: string) => Promise<unknown> | unknown,
+ *   drainPendingSynapse?: (timeoutMs?: number) => Promise<unknown> | unknown,
+ * }} [opts]
+ * @returns {Promise<string>}
+ */
 export async function runAgySessionHook(stdinData, opts = {}) {
   const output = "{}\n";
   const parsed = parsePayload(stdinData);

--- a/packages/triflux/hooks/subagent-tracker.mjs
+++ b/packages/triflux/hooks/subagent-tracker.mjs
@@ -16,7 +16,11 @@ import { dirname, join } from "node:path";
 const STATE_VERSION = 1;
 const DEFAULT_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_COMPLETED = 20;
-const DEFAULT_LOCK_TIMEOUT_MS = 750;
+// Lifecycle hooks are best-effort, but under CI/Linux process contention a
+// 30-way SubagentStart burst can legitimately take around a second to drain.
+// Keep this bounded so hooks do not hang indefinitely, while avoiding silent
+// lifecycle drops during normal high-concurrency fan-out.
+const DEFAULT_LOCK_TIMEOUT_MS = 3000;
 const LOCK_RETRY_MS = 20;
 
 function readStdin() {
@@ -94,6 +98,16 @@ function withStateLock(statePath, fn, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
       sleepSync(LOCK_RETRY_MS);
     }
   }
+}
+
+function lockTimeoutMsFromOptions(opts = {}) {
+  if (Number.isFinite(opts.lockTimeoutMs)) return opts.lockTimeoutMs;
+  const raw = opts.env?.TRIFLUX_SUBAGENT_LOCK_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_LOCK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.trunc(parsed)
+    : DEFAULT_LOCK_TIMEOUT_MS;
 }
 
 function lifecycleKey(input) {
@@ -241,7 +255,7 @@ export function recordLifecycle(input, opts = {}) {
       writeState(statePath, state);
       return output;
     },
-    opts.lockTimeoutMs,
+    lockTimeoutMsFromOptions(opts),
   );
 }
 

--- a/packages/triflux/hub/team/claude-daemon-control.mjs
+++ b/packages/triflux/hub/team/claude-daemon-control.mjs
@@ -468,21 +468,29 @@ export function sendClaudeControlRequest(
 // 인증 미강제 daemon 으로 보고 auth 필드를 생략한다 (fail-open — 구버전 호환).
 export async function readDaemonControlKey(
   configDir = resolveClaudeConfigDir(),
+  { diagnostics } = {},
 ) {
+  if (!configDir) return undefined;
+  const keyPath = path.join(configDir, "daemon", "control.key");
   try {
-    const key = await fs.readFile(
-      path.join(configDir, "daemon", "control.key"),
-      "utf8",
-    );
+    const key = await fs.readFile(keyPath, "utf8");
     return key.trim() || undefined;
-  } catch {
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    if (Array.isArray(diagnostics)) {
+      diagnostics.push({
+        code: error?.code || "UNKNOWN",
+        path: keyPath,
+        message: error?.message || String(error),
+      });
+    }
     return undefined;
   }
 }
 
-export async function buildDaemonControlAuth(configDir) {
+export async function buildDaemonControlAuth(configDir, opts = {}) {
   if (!configDir) return {};
-  const auth = await readDaemonControlKey(configDir);
+  const auth = await readDaemonControlKey(configDir, opts);
   return auth ? { auth } : {};
 }
 

--- a/packages/triflux/hub/team/notify.mjs
+++ b/packages/triflux/hub/team/notify.mjs
@@ -54,12 +54,17 @@ function normalizeEvent(event, defaults = {}) {
   });
 }
 
-function defaultChannelConfig(name, env) {
+function defaultChannelConfig(name, env, platform = process.platform) {
   switch (name) {
     case "bell":
-      return { enabled: true };
+      return { enabled: envFlag(env?.TRIFLUX_NOTIFY_BELL, true) };
     case "toast":
-      return { enabled: true };
+      return {
+        // macOS `osascript display notification` can surface Script Editor
+        // authorization/UI prompts. Keep it opt-in there; Windows keeps the
+        // historical toast default, and other platforms skip as unsupported.
+        enabled: envFlag(env?.TRIFLUX_NOTIFY_TOAST, platform !== "darwin"),
+      };
     case "webhook": {
       const url = String(env?.TRIFLUX_NOTIFY_WEBHOOK || "");
       return { enabled: Boolean(url), url };
@@ -69,8 +74,13 @@ function defaultChannelConfig(name, env) {
   }
 }
 
-function normalizeChannelConfig(name, value, env) {
-  const base = defaultChannelConfig(name, env);
+function envFlag(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  return !["0", "false", "no", "off"].includes(String(value).toLowerCase());
+}
+
+function normalizeChannelConfig(name, value, env, platform) {
+  const base = defaultChannelConfig(name, env, platform);
   const patch =
     typeof value === "boolean"
       ? { enabled: value }
@@ -103,16 +113,21 @@ function normalizeChannelConfig(name, value, env) {
   return freezeRecord(next);
 }
 
-function normalizeChannels(channels, env) {
+function normalizeChannels(channels, env, platform) {
   const source = channels && typeof channels === "object" ? channels : {};
   const normalized = {};
   for (const name of NOTIFY_CHANNELS) {
-    normalized[name] = normalizeChannelConfig(name, source[name], env);
+    normalized[name] = normalizeChannelConfig(
+      name,
+      source[name],
+      env,
+      platform,
+    );
   }
   return Object.freeze(normalized);
 }
 
-function updateChannelConfig(channels, channel, config, env) {
+function updateChannelConfig(channels, channel, config, env, platform) {
   if (!NOTIFY_CHANNELS.includes(channel)) {
     throw new TypeError(`Unknown notify channel: ${channel}`);
   }
@@ -126,6 +141,7 @@ function updateChannelConfig(channels, channel, config, env) {
         ...(typeof config === "boolean" ? { enabled: config } : config || {}),
       },
       env,
+      platform,
     ),
   });
 }
@@ -322,7 +338,7 @@ function createNotifierInstance(channels, deps) {
 
   function setChannel(channel, config) {
     return createNotifierInstance(
-      updateChannelConfig(channels, channel, config, deps.env),
+      updateChannelConfig(channels, channel, config, deps.env, deps.platform),
       deps,
     );
   }
@@ -349,17 +365,21 @@ function createNotifierInstance(channels, deps) {
  */
 export function createNotifier(opts = {}) {
   const env = opts.env || process.env;
+  const platform = opts.platform || process.platform;
   const deps = Object.freeze({
     env,
     stdout: opts.stdout || process.stdout,
     execFile: opts.deps?.execFile || execFile,
     fetch: opts.deps?.fetch || globalThis.fetch?.bind(globalThis),
-    platform: opts.platform || process.platform,
+    platform,
     hostname: opts.hostname || os.hostname(),
     powerShellCandidates: Object.freeze(
       opts.deps?.powerShellCandidates || ["pwsh", "powershell.exe"],
     ),
   });
 
-  return createNotifierInstance(normalizeChannels(opts.channels, env), deps);
+  return createNotifierInstance(
+    normalizeChannels(opts.channels, env, platform),
+    deps,
+  );
 }

--- a/packages/triflux/hud/providers/gemini.mjs
+++ b/packages/triflux/hud/providers/gemini.mjs
@@ -197,6 +197,8 @@ export function deriveGeminiFamilyBucket(buckets) {
 
 export function buildGeminiAuthContext(accountId) {
   let oauth = readJson(GEMINI_OAUTH_PATH, null);
+  let authSource = oauth?.access_token ? "gemini-file" : "none";
+  let expiryMissing = oauth?.access_token ? oauth.expiry_date == null : false;
   const fileExpired =
     oauth?.expiry_date != null && oauth.expiry_date < Date.now();
   // Preserve a valid Gemini file token; agy Keychain is only a missing/expired fallback.
@@ -209,13 +211,15 @@ export function buildGeminiAuthContext(accountId) {
         ...fileRest
       } = oauth || {};
       oauth = { ...fileRest, ...keychainOAuth };
+      authSource = "antigravity-keychain";
+      expiryMissing = keychainOAuth.expiry_date == null;
     }
   }
   const tokenSource =
     oauth?.refresh_token || oauth?.id_token || oauth?.access_token || "";
   const tokenFingerprint = tokenSource ? makeHash(tokenSource) : "none";
   const cacheKey = `${accountId || "gemini-main"}::${tokenFingerprint}`;
-  return { oauth, tokenFingerprint, cacheKey };
+  return { oauth, tokenFingerprint, cacheKey, authSource, expiryMissing };
 }
 
 function firstPresent(...values) {
@@ -305,12 +309,76 @@ function getAntigravityTokenFromKeychain() {
   }
 }
 
+export function classifyGeminiQuotaFailure(response, authContext = {}) {
+  if (!response) return "network";
+  const error = response?.error || {};
+  const code = Number(error.code ?? response.code ?? response.status);
+  const status = String(error.status || response.status || "").toUpperCase();
+  const message = String(
+    error.message || error.code || response.error || response.message || "",
+  );
+  if (
+    code === 401 ||
+    code === 403 ||
+    status === "UNAUTHENTICATED" ||
+    status === "PERMISSION_DENIED" ||
+    /(unauthorized|forbidden|invalid authentication|invalid credentials|oauth|token|credential|auth)/i.test(
+      message,
+    )
+  ) {
+    return "auth";
+  }
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true &&
+    /(expired|invalid|unauthenticated|permission denied)/i.test(message)
+  ) {
+    return "auth";
+  }
+  return "api";
+}
+
+function formatGeminiQuotaFailure(response, authContext = {}, stage = "quota") {
+  const error =
+    response?.error?.message ||
+    response?.error?.status ||
+    response?.error?.code ||
+    response?.error ||
+    response?.message ||
+    "no buckets in response";
+  const base = String(error);
+  if (
+    authContext.authSource === "antigravity-keychain" &&
+    authContext.expiryMissing === true
+  ) {
+    return `expiry-less Antigravity Keychain token failed bounded ${stage} freshness probe: ${base}`;
+  }
+  return base;
+}
+
+function writeGeminiQuotaErrorCache(cache, authContext, errorType, errorHint) {
+  const sameKey = cache?.cacheKey === authContext.cacheKey;
+  writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
+    ...(sameKey ? cache || {} : {}),
+    timestamp: sameKey && cache?.timestamp ? cache.timestamp : Date.now(),
+    cacheKey: authContext.cacheKey,
+    accountId: authContext.accountId || "gemini-main",
+    tokenFingerprint: authContext.tokenFingerprint,
+    authSource: authContext.authSource,
+    expiryMissing: authContext.expiryMissing === true,
+    error: true,
+    errorType,
+    errorHint,
+  });
+}
+
 // ============================================================================
 // Gemini 쿼터 API 호출 (5분 캐시)
 // ============================================================================
 export async function fetchGeminiQuota(accountId, options = {}) {
   const authContext = options.authContext || buildGeminiAuthContext(accountId);
   const { oauth, tokenFingerprint, cacheKey } = authContext;
+  authContext.accountId = accountId || "gemini-main";
   const forceRefresh = options.forceRefresh === true;
 
   // 1. 캐시 확인 (계정/토큰별)
@@ -330,35 +398,34 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!oauth?.access_token) {
     // access_token 없음: 에러 힌트를 캐시에 기록하고 stale 캐시 반환
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: "no access_token in oauth_creds.json",
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      "no access_token in oauth_creds.json",
+    );
     return cache;
   }
   if (oauth.expiry_date && oauth.expiry_date < Date.now()) {
     // OAuth 토큰 만료: 에러 힌트를 캐시에 기록 (refresh_token 갱신은 Gemini CLI 담당)
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "auth",
-      errorHint: `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      "auth",
+      `token expired at ${new Date(oauth.expiry_date).toISOString()}`,
+    );
     return cache;
   }
 
   // 3. projectId (캐시 or API)
+  let loadCodeAssistResponse = null;
   const fetchProjectId = async () => {
-    const loadRes = await httpsPost(
+    loadCodeAssistResponse = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
       { metadata: { pluginType: "GEMINI" } },
       oauth.access_token,
     );
-    const id = loadRes?.cloudaicompanionProject;
+    const id = loadCodeAssistResponse?.cloudaicompanionProject;
     if (id)
       writeJsonSafe(GEMINI_PROJECT_CACHE_PATH, {
         cacheKey,
@@ -376,7 +443,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   let projectId =
     projCache?.cacheKey === cacheKey ? projCache?.projectId : null;
   if (!projectId) projectId = await fetchProjectId();
-  if (!projectId) return cache;
+  if (!projectId) {
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+      formatGeminiQuotaFailure(
+        loadCodeAssistResponse,
+        authContext,
+        "loadCodeAssist",
+      ),
+    );
+    return cache;
+  }
 
   // 4. retrieveUserQuota 호출
   let quotaRes = await httpsPost(
@@ -388,7 +467,19 @@ export async function fetchGeminiQuota(accountId, options = {}) {
   // projectId 캐시가 만료/변경된 경우 1회 재시도
   if (!quotaRes?.buckets && projCache?.projectId) {
     projectId = await fetchProjectId();
-    if (!projectId) return cache;
+    if (!projectId) {
+      writeGeminiQuotaErrorCache(
+        cache,
+        authContext,
+        classifyGeminiQuotaFailure(loadCodeAssistResponse, authContext),
+        formatGeminiQuotaFailure(
+          loadCodeAssistResponse,
+          authContext,
+          "loadCodeAssist",
+        ),
+      );
+      return cache;
+    }
     quotaRes = await httpsPost(
       "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
       { project: projectId },
@@ -398,18 +489,12 @@ export async function fetchGeminiQuota(accountId, options = {}) {
 
   if (!quotaRes?.buckets) {
     // API 응답에 buckets 없음: 에러 코드 또는 응답 내용을 캐시에 기록
-    const apiError =
-      quotaRes?.error?.message ||
-      quotaRes?.error?.code ||
-      quotaRes?.error ||
-      "no buckets in response";
-    writeJsonSafe(GEMINI_QUOTA_CACHE_PATH, {
-      ...(cache || {}),
-      timestamp: cache?.timestamp || Date.now(),
-      error: true,
-      errorType: "api",
-      errorHint: String(apiError),
-    });
+    writeGeminiQuotaErrorCache(
+      cache,
+      authContext,
+      classifyGeminiQuotaFailure(quotaRes, authContext),
+      formatGeminiQuotaFailure(quotaRes, authContext, "quota"),
+    );
     return cache;
   }
 

--- a/packages/triflux/scripts/check-codex-config-stable.mjs
+++ b/packages/triflux/scripts/check-codex-config-stable.mjs
@@ -14,11 +14,15 @@
 //   사용자가 npm test 도중 다른 터미널에서 codex 를 활성 사용 중이면 이
 //   외부 mutation 이 false positive 로 잡힌다. 따라서 hooks.state-only
 //   churn 은 informational warning 으로 분류하고 exit 0 으로 통과시킨다.
+//   Codex plugin mode also auto-materializes OpenAI primary runtime plugin
+//   registry sections (for example pdf@openai-primary-runtime); those are
+//   likewise Codex-owned external churn, not triflux-owned MCP drift.
 //   triflux 자체 mutation (e.g. tfx-hub URL drift) 은 기존대로 exit 2.
 //
 // Exit codes:
 //   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0).
-//        hooks.state-only churn 도 여기 포함 (informational warning 만 출력).
+//        hooks.state/OpenAI runtime plugin churn 도 여기 포함
+//        (informational warning 만 출력).
 //   2  = triflux 가드가 잡아야 할 mutation 감지. wrap 한 명령의 exit code
 //        와 무관하게 강제 fail.
 //   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
@@ -32,6 +36,10 @@ import { join } from "node:path";
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const EXPECTED_TFX_HUB_URL = "http://127.0.0.1:27888/mcp";
 const HOOKS_STATE_PREFIX = "hooks.state.";
+const OPENAI_PRIMARY_RUNTIME_MARKETPLACE =
+  "marketplaces.openai-primary-runtime";
+const OPENAI_PRIMARY_RUNTIME_PLUGIN_RE =
+  /^plugins\."[^"]+@openai-primary-runtime"$/u;
 
 function readTfxHubUrl(raw) {
   const headerMatch =
@@ -79,11 +87,23 @@ export function splitTomlSections(raw) {
 
 // Classify which sections drifted between before / after payloads.
 // Returns:
-//   { hooksStateOnly: bool, changedSections: string[] }
+//   { hooksStateOnly: bool, externalChurnOnly: bool, changedSections: string[] }
 //
 // hooksStateOnly = true means every changed section header starts with
 // "hooks.state." (the oh-my-codex managed area). Empty diff returns
 // hooksStateOnly=false so callers don't accidentally whitelist "no change".
+//
+// externalChurnOnly additionally permits Codex-owned OpenAI primary runtime
+// plugin registry sections. It remains false for empty diffs and for any
+// triflux-owned or unknown section drift.
+function isExternalChurnSection(header) {
+  return (
+    header.startsWith(HOOKS_STATE_PREFIX) ||
+    header === OPENAI_PRIMARY_RUNTIME_MARKETPLACE ||
+    OPENAI_PRIMARY_RUNTIME_PLUGIN_RE.test(header)
+  );
+}
+
 export function classifySectionDiff(beforeRaw, afterRaw) {
   const beforeSections = splitTomlSections(beforeRaw);
   const afterSections = splitTomlSections(afterRaw);
@@ -109,7 +129,9 @@ export function classifySectionDiff(beforeRaw, afterRaw) {
   const hooksStateOnly =
     changedSections.length > 0 &&
     changedSections.every((h) => h.startsWith(HOOKS_STATE_PREFIX));
-  return { hooksStateOnly, changedSections };
+  const externalChurnOnly =
+    changedSections.length > 0 && changedSections.every(isExternalChurnSection);
+  return { hooksStateOnly, externalChurnOnly, changedSections };
 }
 
 function snapshotConfig() {
@@ -145,13 +167,12 @@ export function describeChange(before, after) {
   if (before.sha !== after.sha) {
     const beforeRaw = typeof before.raw === "string" ? before.raw : "";
     const afterRaw = typeof after.raw === "string" ? after.raw : "";
-    const { hooksStateOnly, changedSections } = classifySectionDiff(
-      beforeRaw,
-      afterRaw,
-    );
+    const { hooksStateOnly, externalChurnOnly, changedSections } =
+      classifySectionDiff(beforeRaw, afterRaw);
     return {
       kind: "sha-changed",
       hooksStateOnly,
+      externalChurnOnly,
       changedSections,
       message: `sha256 differs (size: ${before.size} → ${after.size})`,
     };
@@ -205,18 +226,24 @@ if (isMain) {
   const portDrift = describePortDrift(after);
   const hooksStateOnly =
     change?.kind === "sha-changed" && change.hooksStateOnly === true;
+  const externalChurnOnly =
+    change?.kind === "sha-changed" && change.externalChurnOnly === true;
 
-  // hooksStateOnly + port drift 없음 = informational warning + pass.
+  // External Codex-owned churn + port drift 없음 = informational warning + pass.
   // port drift 가 같이 잡혔으면 그건 triflux-owned section mutation 이라
   // 기존 fail path 를 탄다.
-  if (hooksStateOnly && !portDrift) {
+  if (externalChurnOnly && !portDrift) {
     process.stderr.write(
       [
         "",
-        "[check-codex-config-stable] hooks.state-only churn (whitelist)",
+        hooksStateOnly
+          ? "[check-codex-config-stable] hooks.state-only churn (whitelist)"
+          : "[check-codex-config-stable] Codex external plugin churn (whitelist)",
         `Path:     ${CODEX_CONFIG}`,
         `Sections: ${(change.changedSections || []).join(", ") || "(none)"}`,
-        "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신.",
+        hooksStateOnly
+          ? "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신."
+          : "Reason:   Codex plugin runtime 이 OpenAI primary runtime registry 를 자동 갱신.",
         "          triflux 외부 mutation 이므로 #193 가드의 false positive 다.",
         "Action:   informational only — pass-through.",
         "",

--- a/packages/triflux/scripts/test-lock.mjs
+++ b/packages/triflux/scripts/test-lock.mjs
@@ -321,27 +321,7 @@ export function main(argv = process.argv.slice(2)) {
   const timeoutMs = parseTimeoutMs();
   const lock = acquireLock(timeoutMs);
   const testHubPidDir = mkdtempSync(join(tmpdir(), "tfx-test-hub-pid-"));
-
-  // forward args after -- to node --test
-  const args = preserveForceExitFailures(expandTestArgs(argv));
-  // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
-  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
-  // to grand-child node --test, breaking ConPTY assumptions on Windows and
-  // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
-  // inherited so the grand-child still streams to whoever attached to us.
-  const child = spawn(process.execPath, args, {
-    stdio: ["pipe", "inherit", "inherit"],
-    env: {
-      ...process.env,
-      TEST_LOCK_PID: String(process.pid),
-      TFX_HUB_PID_DIR: process.env.TFX_HUB_PID_DIR || testHubPidDir,
-      TFX_HUB_STATE_DIR: process.env.TFX_HUB_STATE_DIR || testHubPidDir,
-    },
-  });
-  updateChildPid(lock, child.pid);
-  // Close stdin immediately so node --test never blocks waiting for input.
-  child.stdin?.end();
-
+  let child = null;
   let finished = false;
   let requestedExitCode = null;
   let timeoutTimer = null;
@@ -390,14 +370,6 @@ export function main(argv = process.argv.slice(2)) {
     finish(requestedExitCode);
   }
 
-  timeoutTimer = setTimeout(() => {
-    console.error(
-      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child.pid})\x1b[0m`,
-    );
-    requestShutdown("SIGTERM", 124);
-  }, timeoutMs);
-  timeoutTimer.unref?.();
-
   process.once("exit", () => {
     if (!finished) terminateChild(child, "SIGTERM");
     releaseLock();
@@ -406,6 +378,27 @@ export function main(argv = process.argv.slice(2)) {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.once(signal, () => requestShutdown(signal));
   }
+
+  // Install termination handlers before spawning/advertising child state. The
+  // child can become ready before this wrapper reaches later setup lines on
+  // fast Linux CI; without early handlers an external SIGTERM can terminate the
+  // wrapper by signal instead of the controlled 128+signal exit path.
+  // forward args after -- to node --test
+  const args = preserveForceExitFailures(expandTestArgs(argv));
+  // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
+  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
+  // to grand-child node --test, breaking ConPTY assumptions on Windows and
+  // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
+  // inherited so the grand-child still streams to whoever attached to us.
+  child = spawn(process.execPath, args, {
+    stdio: ["pipe", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      TEST_LOCK_PID: String(process.pid),
+      TFX_HUB_PID_DIR: process.env.TFX_HUB_PID_DIR || testHubPidDir,
+      TFX_HUB_STATE_DIR: process.env.TFX_HUB_STATE_DIR || testHubPidDir,
+    },
+  });
 
   child.on("error", (error) => {
     console.error(`test-lock failed to spawn child: ${error.message}`);
@@ -419,6 +412,18 @@ export function main(argv = process.argv.slice(2)) {
     }
     finish(code ?? signalToExitCode(signal));
   });
+
+  updateChildPid(lock, child.pid);
+  // Close stdin immediately so node --test never blocks waiting for input.
+  child.stdin?.end();
+
+  timeoutTimer = setTimeout(() => {
+    console.error(
+      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child?.pid ?? "unknown"})\x1b[0m`,
+    );
+    requestShutdown("SIGTERM", 124);
+  }, timeoutMs);
+  timeoutTimer.unref?.();
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {

--- a/scripts/check-codex-config-stable.mjs
+++ b/scripts/check-codex-config-stable.mjs
@@ -14,11 +14,15 @@
 //   사용자가 npm test 도중 다른 터미널에서 codex 를 활성 사용 중이면 이
 //   외부 mutation 이 false positive 로 잡힌다. 따라서 hooks.state-only
 //   churn 은 informational warning 으로 분류하고 exit 0 으로 통과시킨다.
+//   Codex plugin mode also auto-materializes OpenAI primary runtime plugin
+//   registry sections (for example pdf@openai-primary-runtime); those are
+//   likewise Codex-owned external churn, not triflux-owned MCP drift.
 //   triflux 자체 mutation (e.g. tfx-hub URL drift) 은 기존대로 exit 2.
 //
 // Exit codes:
 //   0  = config 안정. wrap 한 명령의 exit code 그대로 반환 (보통 0).
-//        hooks.state-only churn 도 여기 포함 (informational warning 만 출력).
+//        hooks.state/OpenAI runtime plugin churn 도 여기 포함
+//        (informational warning 만 출력).
 //   2  = triflux 가드가 잡아야 할 mutation 감지. wrap 한 명령의 exit code
 //        와 무관하게 강제 fail.
 //   N  = wrap 한 명령이 N 으로 끝남 (mutation 없음).
@@ -32,6 +36,10 @@ import { join } from "node:path";
 const CODEX_CONFIG = join(homedir(), ".codex", "config.toml");
 const EXPECTED_TFX_HUB_URL = "http://127.0.0.1:27888/mcp";
 const HOOKS_STATE_PREFIX = "hooks.state.";
+const OPENAI_PRIMARY_RUNTIME_MARKETPLACE =
+  "marketplaces.openai-primary-runtime";
+const OPENAI_PRIMARY_RUNTIME_PLUGIN_RE =
+  /^plugins\."[^"]+@openai-primary-runtime"$/u;
 
 function readTfxHubUrl(raw) {
   const headerMatch =
@@ -79,11 +87,23 @@ export function splitTomlSections(raw) {
 
 // Classify which sections drifted between before / after payloads.
 // Returns:
-//   { hooksStateOnly: bool, changedSections: string[] }
+//   { hooksStateOnly: bool, externalChurnOnly: bool, changedSections: string[] }
 //
 // hooksStateOnly = true means every changed section header starts with
 // "hooks.state." (the oh-my-codex managed area). Empty diff returns
 // hooksStateOnly=false so callers don't accidentally whitelist "no change".
+//
+// externalChurnOnly additionally permits Codex-owned OpenAI primary runtime
+// plugin registry sections. It remains false for empty diffs and for any
+// triflux-owned or unknown section drift.
+function isExternalChurnSection(header) {
+  return (
+    header.startsWith(HOOKS_STATE_PREFIX) ||
+    header === OPENAI_PRIMARY_RUNTIME_MARKETPLACE ||
+    OPENAI_PRIMARY_RUNTIME_PLUGIN_RE.test(header)
+  );
+}
+
 export function classifySectionDiff(beforeRaw, afterRaw) {
   const beforeSections = splitTomlSections(beforeRaw);
   const afterSections = splitTomlSections(afterRaw);
@@ -109,7 +129,9 @@ export function classifySectionDiff(beforeRaw, afterRaw) {
   const hooksStateOnly =
     changedSections.length > 0 &&
     changedSections.every((h) => h.startsWith(HOOKS_STATE_PREFIX));
-  return { hooksStateOnly, changedSections };
+  const externalChurnOnly =
+    changedSections.length > 0 && changedSections.every(isExternalChurnSection);
+  return { hooksStateOnly, externalChurnOnly, changedSections };
 }
 
 function snapshotConfig() {
@@ -145,13 +167,12 @@ export function describeChange(before, after) {
   if (before.sha !== after.sha) {
     const beforeRaw = typeof before.raw === "string" ? before.raw : "";
     const afterRaw = typeof after.raw === "string" ? after.raw : "";
-    const { hooksStateOnly, changedSections } = classifySectionDiff(
-      beforeRaw,
-      afterRaw,
-    );
+    const { hooksStateOnly, externalChurnOnly, changedSections } =
+      classifySectionDiff(beforeRaw, afterRaw);
     return {
       kind: "sha-changed",
       hooksStateOnly,
+      externalChurnOnly,
       changedSections,
       message: `sha256 differs (size: ${before.size} → ${after.size})`,
     };
@@ -205,18 +226,24 @@ if (isMain) {
   const portDrift = describePortDrift(after);
   const hooksStateOnly =
     change?.kind === "sha-changed" && change.hooksStateOnly === true;
+  const externalChurnOnly =
+    change?.kind === "sha-changed" && change.externalChurnOnly === true;
 
-  // hooksStateOnly + port drift 없음 = informational warning + pass.
+  // External Codex-owned churn + port drift 없음 = informational warning + pass.
   // port drift 가 같이 잡혔으면 그건 triflux-owned section mutation 이라
   // 기존 fail path 를 탄다.
-  if (hooksStateOnly && !portDrift) {
+  if (externalChurnOnly && !portDrift) {
     process.stderr.write(
       [
         "",
-        "[check-codex-config-stable] hooks.state-only churn (whitelist)",
+        hooksStateOnly
+          ? "[check-codex-config-stable] hooks.state-only churn (whitelist)"
+          : "[check-codex-config-stable] Codex external plugin churn (whitelist)",
         `Path:     ${CODEX_CONFIG}`,
         `Sections: ${(change.changedSections || []).join(", ") || "(none)"}`,
-        "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신.",
+        hooksStateOnly
+          ? "Reason:   oh-my-codex 가 codex CLI hook trust state 를 자동 갱신."
+          : "Reason:   Codex plugin runtime 이 OpenAI primary runtime registry 를 자동 갱신.",
         "          triflux 외부 mutation 이므로 #193 가드의 false positive 다.",
         "Action:   informational only — pass-through.",
         "",

--- a/scripts/test-lock.mjs
+++ b/scripts/test-lock.mjs
@@ -321,27 +321,7 @@ export function main(argv = process.argv.slice(2)) {
   const timeoutMs = parseTimeoutMs();
   const lock = acquireLock(timeoutMs);
   const testHubPidDir = mkdtempSync(join(tmpdir(), "tfx-test-hub-pid-"));
-
-  // forward args after -- to node --test
-  const args = preserveForceExitFailures(expandTestArgs(argv));
-  // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
-  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
-  // to grand-child node --test, breaking ConPTY assumptions on Windows and
-  // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
-  // inherited so the grand-child still streams to whoever attached to us.
-  const child = spawn(process.execPath, args, {
-    stdio: ["pipe", "inherit", "inherit"],
-    env: {
-      ...process.env,
-      TEST_LOCK_PID: String(process.pid),
-      TFX_HUB_PID_DIR: process.env.TFX_HUB_PID_DIR || testHubPidDir,
-      TFX_HUB_STATE_DIR: process.env.TFX_HUB_STATE_DIR || testHubPidDir,
-    },
-  });
-  updateChildPid(lock, child.pid);
-  // Close stdin immediately so node --test never blocks waiting for input.
-  child.stdin?.end();
-
+  let child = null;
   let finished = false;
   let requestedExitCode = null;
   let timeoutTimer = null;
@@ -390,14 +370,6 @@ export function main(argv = process.argv.slice(2)) {
     finish(requestedExitCode);
   }
 
-  timeoutTimer = setTimeout(() => {
-    console.error(
-      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child.pid})\x1b[0m`,
-    );
-    requestShutdown("SIGTERM", 124);
-  }, timeoutMs);
-  timeoutTimer.unref?.();
-
   process.once("exit", () => {
     if (!finished) terminateChild(child, "SIGTERM");
     releaseLock();
@@ -406,6 +378,27 @@ export function main(argv = process.argv.slice(2)) {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.once(signal, () => requestShutdown(signal));
   }
+
+  // Install termination handlers before spawning/advertising child state. The
+  // child can become ready before this wrapper reaches later setup lines on
+  // fast Linux CI; without early handlers an external SIGTERM can terminate the
+  // wrapper by signal instead of the controlled 128+signal exit path.
+  // forward args after -- to node --test
+  const args = preserveForceExitFailures(expandTestArgs(argv));
+  // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
+  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
+  // to grand-child node --test, breaking ConPTY assumptions on Windows and
+  // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
+  // inherited so the grand-child still streams to whoever attached to us.
+  child = spawn(process.execPath, args, {
+    stdio: ["pipe", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      TEST_LOCK_PID: String(process.pid),
+      TFX_HUB_PID_DIR: process.env.TFX_HUB_PID_DIR || testHubPidDir,
+      TFX_HUB_STATE_DIR: process.env.TFX_HUB_STATE_DIR || testHubPidDir,
+    },
+  });
 
   child.on("error", (error) => {
     console.error(`test-lock failed to spawn child: ${error.message}`);
@@ -419,6 +412,18 @@ export function main(argv = process.argv.slice(2)) {
     }
     finish(code ?? signalToExitCode(signal));
   });
+
+  updateChildPid(lock, child.pid);
+  // Close stdin immediately so node --test never blocks waiting for input.
+  child.stdin?.end();
+
+  timeoutTimer = setTimeout(() => {
+    console.error(
+      `\x1b[31m✗ test-lock child timed out after ${timeoutMs}ms (child PID ${child?.pid ?? "unknown"})\x1b[0m`,
+    );
+    requestShutdown("SIGTERM", 124);
+  }, timeoutMs);
+  timeoutTimer.unref?.();
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {

--- a/tests/integration/hub-start-codex-config.test.mjs
+++ b/tests/integration/hub-start-codex-config.test.mjs
@@ -8,6 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
@@ -31,6 +32,26 @@ function readJson(path) {
 
 function sleepMs(ms) {
   Atomics.wait(SLEEP_SAB, 0, 0, ms);
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" ? address?.port : null;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else if (Number.isFinite(port)) {
+          resolve(port);
+        } else {
+          reject(new Error("failed to allocate a free TCP port"));
+        }
+      });
+    });
+  });
 }
 
 function runHubStart(homeDir, port, { passPortArg = true } = {}) {
@@ -58,6 +79,24 @@ function runHubStart(homeDir, port, { passPortArg = true } = {}) {
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
+  );
+}
+
+function readConfigAfterHubStart(configPath, output) {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (existsSync(configPath)) {
+      return readJson(configPath);
+    }
+    sleepMs(50);
+  }
+
+  throw new Error(
+    [
+      `Codex config was not created: ${configPath}`,
+      "tfx hub start output:",
+      String(output || "").trim() || "<empty>",
+    ].join("\n"),
   );
 }
 
@@ -89,15 +128,15 @@ function stopHubFromPidFile(homeDir) {
 }
 
 describe("tfx hub start re-enables Codex MCP config", () => {
-  it("hub already running path should still flip tfx-hub back to enabled", () => {
+  it("hub already running path should still flip tfx-hub back to enabled", async () => {
     const homeDir = makeIsolatedHome("tfx-hub-codex-");
-    const port = 28180 + Math.floor(Math.random() * 50);
+    const port = await getFreePort();
     const configPath = join(homeDir, ".codex", "config.json");
 
     try {
-      runHubStart(homeDir, port);
+      let output = runHubStart(homeDir, port);
 
-      let config = readJson(configPath);
+      let config = readConfigAfterHubStart(configPath, output);
       assert.equal(config.mcpServers["tfx-hub"].enabled, true);
       assert.equal(
         config.mcpServers["tfx-hub"].url,
@@ -107,9 +146,9 @@ describe("tfx hub start re-enables Codex MCP config", () => {
       config.mcpServers["tfx-hub"].enabled = false;
       writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf8");
 
-      runHubStart(homeDir, port);
+      output = runHubStart(homeDir, port);
 
-      config = readJson(configPath);
+      config = readConfigAfterHubStart(configPath, output);
       assert.equal(config.mcpServers["tfx-hub"].enabled, true);
       assert.equal(
         config.mcpServers["tfx-hub"].url,
@@ -125,15 +164,15 @@ describe("tfx hub start re-enables Codex MCP config", () => {
     }
   });
 
-  it("hub start without --port should honor TFX_HUB_PORT", () => {
+  it("hub start without --port should honor TFX_HUB_PORT", async () => {
     const homeDir = makeIsolatedHome("tfx-hub-env-port-");
-    const port = 28230 + Math.floor(Math.random() * 50);
+    const port = await getFreePort();
     const configPath = join(homeDir, ".codex", "config.json");
 
     try {
-      runHubStart(homeDir, port, { passPortArg: false });
+      const output = runHubStart(homeDir, port, { passPortArg: false });
 
-      const config = readJson(configPath);
+      const config = readConfigAfterHubStart(configPath, output);
       assert.equal(config.mcpServers["tfx-hub"].enabled, true);
       assert.equal(
         config.mcpServers["tfx-hub"].url,

--- a/tests/notify.test.mjs
+++ b/tests/notify.test.mjs
@@ -97,49 +97,113 @@ describe("createNotifier", () => {
     assert.match(calls[0].args[3], /Triflux failed/u);
   });
 
+  it("honors env toggles that disable local bell and toast side effects", async () => {
+    const calls = [];
+    const writes = [];
+    const notifier = createNotifier({
+      stdout: {
+        write(chunk) {
+          writes.push(chunk);
+          return true;
+        },
+      },
+      platform: "darwin",
+      env: {
+        TRIFLUX_NOTIFY_BELL: "0",
+        TRIFLUX_NOTIFY_TOAST: "0",
+      },
+      deps: {
+        execFile(command, args, options, callback) {
+          calls.push({ command, args, options });
+          callback(null, "", "");
+        },
+      },
+      hostname: "muted-host",
+    });
+
+    const result = await notifier.notify({
+      type: "ctoHygiene",
+      sessionId: "cto-hygiene",
+      summary: "CTO hygiene needs action: 1 active task",
+      timestamp: "2026-06-17T00:00:00.000Z",
+    });
+
+    assert.equal(result.results.bell.status, "skipped");
+    assert.equal(result.results.bell.reason, "disabled");
+    assert.equal(result.results.toast.status, "skipped");
+    assert.equal(result.results.toast.reason, "disabled");
+    assert.deepEqual(writes, []);
+    assert.deepEqual(calls, []);
+  });
+
+  it("keeps macOS toast notifications opt-in to avoid Script Editor prompts", async () => {
+    const calls = [];
+    const notifier = createNotifier({
+      stdout: {
+        write() {
+          return true;
+        },
+      },
+      platform: "darwin",
+      env: {},
+      deps: {
+        execFile(command, args, options, callback) {
+          calls.push({ command, args, options });
+          callback(null, "", "");
+        },
+      },
+      hostname: "mac-host",
+    })
+      .setChannel("bell", false)
+      .setChannel("webhook", false);
+
+    const result = await notifier.notify({
+      type: "ctoHygiene",
+      sessionId: "cto-hygiene",
+      summary: "CTO hygiene needs action: 1 active task",
+      timestamp: "2026-06-17T00:00:00.000Z",
+    });
+
+    assert.equal(result.results.toast.status, "skipped");
+    assert.equal(result.results.toast.reason, "disabled");
+    assert.deepEqual(calls, []);
+  });
+
   it("escapes AppleScript notification strings on macOS", async () => {
     const calls = [];
     const execFile = (command, args, options, callback) => {
       calls.push({ command, args, options });
       callback(null, "", "");
     };
-    const platformDescriptor = Object.getOwnPropertyDescriptor(
-      process,
-      "platform",
-    );
 
-    Object.defineProperty(process, "platform", { value: "darwin" });
-    try {
-      const notifier = createNotifier({
-        stdout: {
-          write() {
-            return true;
-          },
+    const notifier = createNotifier({
+      stdout: {
+        write() {
+          return true;
         },
-        env: {},
-        deps: { execFile },
-        hostname: 'host "mac" \\ runtime',
-      })
-        .setChannel("bell", false)
-        .setChannel("webhook", false);
+      },
+      platform: "darwin",
+      env: { TRIFLUX_NOTIFY_TOAST: "1" },
+      deps: { execFile },
+      hostname: 'host "mac" \\ runtime',
+    })
+      .setChannel("bell", false)
+      .setChannel("webhook", false);
 
-      const result = await notifier.notify({
-        type: "completed",
-        sessionId: 'session "quoted" \\ path',
-        summary: 'summary "quoted" \\ path',
-        timestamp: "2026-04-04T00:00:04.000Z",
-      });
+    const result = await notifier.notify({
+      type: "completed",
+      sessionId: 'session "quoted" \\ path',
+      summary: 'summary "quoted" \\ path',
+      timestamp: "2026-04-04T00:00:04.000Z",
+    });
 
-      assert.equal(result.results.toast.status, "sent");
-      assert.equal(calls.length, 1);
-      assert.equal(calls[0].command, "osascript");
-      assert.match(
-        calls[0].args[1],
-        /display notification "summary \\"quoted\\" \\\\ path session session \\"quoted\\" \\\\ path · host host \\"mac\\" \\\\ runtime" with title "Triflux completed"/u,
-      );
-    } finally {
-      Object.defineProperty(process, "platform", platformDescriptor);
-    }
+    assert.equal(result.results.toast.status, "sent");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, "osascript");
+    assert.match(
+      calls[0].args[1],
+      /display notification "summary \\"quoted\\" \\\\ path session session \\"quoted\\" \\\\ path · host host \\"mac\\" \\\\ runtime" with title "Triflux completed"/u,
+    );
   });
 
   it("posts JSON payload to webhook when TRIFLUX_NOTIFY_WEBHOOK is configured", async () => {

--- a/tests/unit/check-codex-config-stable.test.mjs
+++ b/tests/unit/check-codex-config-stable.test.mjs
@@ -41,6 +41,22 @@ const PROFILE_BLOCK = `[profiles.codex53_low]
 model = "gpt-5.3-codex"
 `;
 
+const OPENAI_RUNTIME_PLUGIN_BLOCK = `[plugins."pdf@openai-primary-runtime"]
+enabled = true
+
+[marketplaces.openai-primary-runtime]
+source = "/Users/tellang/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
+`;
+
+const OPENAI_RUNTIME_PLUGIN_BLOCK_AFTER = `[plugins."pdf@openai-primary-runtime"]
+enabled = true
+version = "26.601.10930"
+
+[marketplaces.openai-primary-runtime]
+source = "/Users/tellang/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
+last_sync = "2026-06-18T00:00:00Z"
+`;
+
 function snapshot(raw) {
   return {
     exists: true,
@@ -83,10 +99,23 @@ describe("#193 classifySectionDiff", () => {
     const after = `${TFX_HUB_BLOCK}\n${HOOKS_STATE_BLOCK_AFTER}`;
     const result = classifySectionDiff(before, after);
     assert.equal(result.hooksStateOnly, true);
+    assert.equal(result.externalChurnOnly, true);
     assert.equal(result.changedSections.length, 2);
     for (const header of result.changedSections) {
       assert.match(header, /^hooks\.state\./);
     }
+  });
+
+  it("flags OpenAI primary runtime plugin churn as external-only", () => {
+    const before = `${TFX_HUB_BLOCK}\n${OPENAI_RUNTIME_PLUGIN_BLOCK}`;
+    const after = `${TFX_HUB_BLOCK}\n${OPENAI_RUNTIME_PLUGIN_BLOCK_AFTER}`;
+    const result = classifySectionDiff(before, after);
+    assert.equal(result.hooksStateOnly, false);
+    assert.equal(result.externalChurnOnly, true);
+    assert.deepEqual(result.changedSections.sort(), [
+      "marketplaces.openai-primary-runtime",
+      'plugins."pdf@openai-primary-runtime"',
+    ]);
   });
 
   it("rejects whitelist when tfx-hub also drifts", () => {
@@ -94,6 +123,7 @@ describe("#193 classifySectionDiff", () => {
     const after = `${TFX_HUB_BLOCK_DRIFTED}\n${HOOKS_STATE_BLOCK_AFTER}`;
     const result = classifySectionDiff(before, after);
     assert.equal(result.hooksStateOnly, false);
+    assert.equal(result.externalChurnOnly, false);
     assert.ok(
       result.changedSections.some((h) => h === "mcp_servers.tfx-hub"),
       `expected mcp_servers.tfx-hub in ${JSON.stringify(result.changedSections)}`,
@@ -105,6 +135,7 @@ describe("#193 classifySectionDiff", () => {
     const after = `${HOOKS_STATE_BLOCK_AFTER}\n${PROFILE_BLOCK}`;
     const result = classifySectionDiff(before, after);
     assert.equal(result.hooksStateOnly, false);
+    assert.equal(result.externalChurnOnly, false);
     assert.ok(result.changedSections.includes("profiles.codex53_low"));
   });
 });
@@ -124,7 +155,20 @@ describe("#193 describeChange", () => {
     assert.ok(change !== null, "expected change");
     assert.equal(change.kind, "sha-changed");
     assert.equal(change.hooksStateOnly, true);
+    assert.equal(change.externalChurnOnly, true);
     assert.ok(change.message.startsWith("sha256 differs"));
+  });
+
+  it("classifies OpenAI runtime plugin churn as externalChurnOnly=true", () => {
+    const before = snapshot(`${TFX_HUB_BLOCK}\n${OPENAI_RUNTIME_PLUGIN_BLOCK}`);
+    const after = snapshot(
+      `${TFX_HUB_BLOCK}\n${OPENAI_RUNTIME_PLUGIN_BLOCK_AFTER}`,
+    );
+    const change = describeChange(before, after);
+    assert.ok(change !== null, "expected change");
+    assert.equal(change.kind, "sha-changed");
+    assert.equal(change.hooksStateOnly, false);
+    assert.equal(change.externalChurnOnly, true);
   });
 
   it("classifies tfx-hub mutation as sha-changed + hooksStateOnly=false", () => {
@@ -136,6 +180,7 @@ describe("#193 describeChange", () => {
     assert.ok(change !== null, "expected change");
     assert.equal(change.kind, "sha-changed");
     assert.equal(change.hooksStateOnly, false);
+    assert.equal(change.externalChurnOnly, false);
   });
 
   it("rejects whitelist when hooks.state churn is mixed with other section drift", () => {

--- a/tests/unit/claude-daemon-control.test.mjs
+++ b/tests/unit/claude-daemon-control.test.mjs
@@ -15,6 +15,7 @@ import {
   extractClaudeDaemonAttachText,
   findDaemonJobByShort,
   interruptClaudeDaemonSession,
+  readDaemonControlKey,
   resolveDaemonBridgeSessionId,
   sendClaudeControlRequest,
   sendKillBySessionId,
@@ -979,6 +980,31 @@ test("buildDaemonControlAuth omits auth for explicit undefined configDir", async
     if (originalClaudeConfigDir === undefined) {
       delete process.env.CLAUDE_CONFIG_DIR;
     } else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    await fs.rm(configDir, { recursive: true, force: true });
+  }
+});
+
+test("readDaemonControlKey exposes diagnostics for unreadable non-ENOENT failures", async () => {
+  const configDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "tfx-daemon-auth-diagnostic-"),
+  );
+  await fs.mkdir(path.join(configDir, "daemon", "control.key"), {
+    recursive: true,
+  });
+  const diagnostics = [];
+  try {
+    assert.equal(
+      await readDaemonControlKey(configDir, { diagnostics }),
+      undefined,
+    );
+    assert.equal(diagnostics.length, 1);
+    assert.match(diagnostics[0].code, /EISDIR|EACCES|EPERM/);
+    assert.match(diagnostics[0].path, /control\.key$/);
+    assert.deepEqual(
+      await buildDaemonControlAuth(configDir, { diagnostics: [] }),
+      {},
+    );
+  } finally {
     await fs.rm(configDir, { recursive: true, force: true });
   }
 });

--- a/tests/unit/gemini-hud-keychain.test.mjs
+++ b/tests/unit/gemini-hud-keychain.test.mjs
@@ -93,6 +93,8 @@ describe("Gemini HUD Antigravity auth", () => {
 
       assert.equal(context.oauth.access_token, "keychain-access-token");
       assert.equal(context.oauth.expiry_date > Date.now(), true);
+      assert.equal(context.authSource, "antigravity-keychain");
+      assert.equal(context.expiryMissing, false);
       assert.notEqual(context.tokenFingerprint, "none");
       assert.match(context.cacheKey, /^agy-main::/);
     } finally {
@@ -114,6 +116,8 @@ describe("Gemini HUD Antigravity auth", () => {
       const context = buildGeminiAuthContextInChild("agy-main");
 
       assert.equal(context.oauth.access_token, "raw-keychain-token");
+      assert.equal(context.authSource, "antigravity-keychain");
+      assert.equal(context.expiryMissing, true);
       assert.notEqual(context.tokenFingerprint, "none");
     } finally {
       process.env.HOME = originalHome;
@@ -139,6 +143,8 @@ describe("Gemini HUD Antigravity auth", () => {
 
       assert.equal(context.oauth.access_token, "file-access-token");
       assert.equal(context.oauth.refresh_token, "file-refresh-token");
+      assert.equal(context.authSource, "gemini-file");
+      assert.equal(context.expiryMissing, true);
     } finally {
       process.env.HOME = originalHome;
       process.env.PATH = originalPath;
@@ -189,6 +195,8 @@ describe("Gemini HUD Antigravity auth", () => {
       const context = buildGeminiAuthContextInChild("gemini-main");
 
       assert.equal(context.oauth.access_token, "valid-file-token");
+      assert.equal(context.authSource, "gemini-file");
+      assert.equal(context.expiryMissing, false);
     } finally {
       process.env.HOME = originalHome;
       process.env.PATH = originalPath;
@@ -224,6 +232,25 @@ describe("Gemini HUD Antigravity auth", () => {
 });
 
 describe("Gemini HUD unlimited quota", () => {
+  it("classifies quota failures so expiry-less Keychain tokens produce auth-specific cache errors", async () => {
+    const { classifyGeminiQuotaFailure } = await importHudModule(
+      "hud/providers/gemini.mjs",
+    );
+
+    assert.equal(
+      classifyGeminiQuotaFailure(
+        { error: { code: 401, status: "UNAUTHENTICATED" } },
+        { authSource: "antigravity-keychain", expiryMissing: true },
+      ),
+      "auth",
+    );
+    assert.equal(classifyGeminiQuotaFailure(null), "network");
+    assert.equal(
+      classifyGeminiQuotaFailure({ error: { code: 500, message: "backend" } }),
+      "api",
+    );
+  });
+
   it("returns an unlimited sentinel instead of coercing Infinity into a percent", async () => {
     const { deriveGeminiLimits } = await importHudModule(
       "hud/providers/gemini.mjs",

--- a/tests/unit/tfx-live-cli.test.mjs
+++ b/tests/unit/tfx-live-cli.test.mjs
@@ -10,10 +10,17 @@ const execFileAsync = promisify(execFile);
 const CLI = path.resolve("bin/tfx-live.mjs");
 
 async function runTfxLive(args, options = {}) {
+  const { env: extraEnv, ...execOptions } = options;
   const result = await execFileAsync(process.execPath, [CLI, ...args], {
     timeout: 20_000,
     maxBuffer: 5 * 1024 * 1024,
-    ...options,
+    ...execOptions,
+    env: {
+      ...process.env,
+      TRIFLUX_NOTIFY_BELL: "0",
+      TRIFLUX_NOTIFY_TOAST: "0",
+      ...(extraEnv || {}),
+    },
   });
   return result.stdout;
 }
@@ -393,6 +400,8 @@ test("tfx-live cto-hygiene-notify notifies once for actionable unchanged hygiene
     assert.equal(first.actionable, true);
     assert.equal(first.notified, true);
     assert.equal(first.reason, "changed-actionable-state");
+    assert.equal(first.notify.results.bell.status, "skipped");
+    assert.equal(first.notify.results.toast.status, "skipped");
     assert.equal(second.ok, true);
     assert.equal(second.actionable, true);
     assert.equal(second.notified, false);


### PR DESCRIPTION
## Summary
- Harden daemon control-key auth lookup so explicit undefined config dirs never inherit host auth, while non-ENOENT key read failures can be surfaced through diagnostics.
- Make Gemini/Antigravity HUD quota refresh errors auth-specific for expiry-less Keychain tokens and avoid cross-token stale cache carryover.
- Add JSDoc types for exported Antigravity session hook helpers and mirror the runtime files into packages/core and packages/triflux.

Closes #411

## Test Plan
- `node --test tests/unit/claude-daemon-control.test.mjs tests/unit/native-bridge-immediate-cleanup.test.mjs tests/unit/ensure-agy-hooks.test.mjs tests/unit/gemini-hud-keychain.test.mjs tests/hud/hud-qos-status.test.mjs tests/unit/q-learning.test.mjs` (91/91 pass)
- `npm run release:check-mirror`
- `git diff --check`
- `npm run release:check-sync`
- `npm run lint`
- `npm test` (4402 tests, 4385 pass, 0 fail, 17 skipped; lint-skills PASS)
