### PR TITLE
fix: add CTO wrapper event emission surface

### DIFF
--- a/bin/triflux.mjs
+++ b/bin/triflux.mjs
@@ -499,13 +499,15 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     },
   },
   cto: {
-    usage: "tfx cto <collect|status|dashboard|hygiene> [options]",
+    usage: "tfx cto <collect|status|dashboard|hygiene|event> [options]",
     description: "repo-local authority layer console",
     subcommands: {
       collect: "refresh .triflux/lake/current.json from authority sources",
       status: "print the current authority summary",
       dashboard: "render the CTO console dashboard, optionally with --watch",
       hygiene: "project CTO hygiene counts and actionable dry-run rows",
+      event:
+        "append wrapper lineage events: context-save, context-restore, pr-created, pr-merged-or-closed",
     },
   },
   multi: {

--- a/cto/events.mjs
+++ b/cto/events.mjs
@@ -6,6 +6,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
 export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
@@ -40,6 +41,98 @@ export const CTO_HYGIENE_STATUSES = Object.freeze([
 
 const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
 const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+const EVENT_PRESETS = Object.freeze({
+  "context-save": {
+    event: "checkpoint_saved",
+    source: "gstack_context_save",
+    actor: { cli: "gstack context-save" },
+    ownerSurface: "gstack context-save -> tfx cto event context-save",
+  },
+  "checkpoint-saved": {
+    event: "checkpoint_saved",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-saved",
+  },
+  "context-restore": {
+    event: "checkpoint_restored",
+    source: "gstack_context_restore",
+    actor: { cli: "gstack context-restore" },
+    ownerSurface: "gstack context-restore -> tfx cto event context-restore",
+  },
+  "checkpoint-restored": {
+    event: "checkpoint_restored",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-restored",
+  },
+  "pr-created": {
+    event: "pr_created",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr create" },
+    ownerSurface: "gh pr create/merge/close -> tfx cto event pr-created",
+  },
+  "pr-merged": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr merge" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-merged-or-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr merge/close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+});
+
+const OPTION_KEYS = Object.freeze({
+  event: "event",
+  "event-type": "event",
+  source: "source",
+  summary: "summary",
+  now: "now",
+  ts: "ts",
+  status: "status",
+  "session-id": "session_id",
+  "parent-session-id": "parent_session_id",
+  "restored-from-session-id": "restored_from_session_id",
+  "checkpoint-id": "checkpoint_id",
+  "artifact-path": "artifact_path",
+  artifact: "artifact_path",
+  "task-id": "task_id",
+  branch: "branch",
+  "last-seen-at": "last_seen_at",
+  "stale-reason": "stale_reason",
+  "hygiene-key": "hygiene_key",
+  "hygiene-kind": "hygiene_kind",
+  "hygiene-id": "hygiene_id",
+  "hygiene-action": "hygiene_action",
+  "project-root": "project_root",
+  "worktree-path": "worktree_path",
+  worktree: "worktree_path",
+  issue: "issue_refs",
+  "issue-ref": "issue_refs",
+  "issue-refs": "issue_refs",
+  pr: "pr_refs",
+  "pr-ref": "pr_refs",
+  "pr-refs": "pr_refs",
+  "actor-cli": "actor.cli",
+  "actor-session-id": "actor.session_id",
+  "actor-agent-id": "actor.agent_id",
+  "actor-host": "actor.host",
+  "owner-surface": "owner_surface",
+});
+
+const COLLECTION_KEYS = new Set(["issue_refs", "pr_refs"]);
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -105,6 +198,124 @@ function normalizeActor(actor) {
     if (value) normalized[key] = value;
   }
   return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function optionName(raw) {
+  return String(raw || "")
+    .replace(/^--?/u, "")
+    .trim();
+}
+
+function appendCollection(target, key, value) {
+  const values = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (values.length === 0) return;
+  if (!Array.isArray(target[key])) target[key] = [];
+  target[key].push(...values);
+}
+
+function putPathValue(target, keyPath, value) {
+  if (keyPath.startsWith("actor.")) {
+    const key = keyPath.slice("actor.".length);
+    target.actor ||= {};
+    target.actor[key] = value;
+    return;
+  }
+  if (COLLECTION_KEYS.has(keyPath)) {
+    appendCollection(target, keyPath, value);
+    return;
+  }
+  target[keyPath] = value;
+}
+
+function parseEventArgs(args = []) {
+  const fields = {};
+  const positional = [];
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!arg?.startsWith?.("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const eqIndex = arg.indexOf("=");
+    const rawName = eqIndex >= 0 ? arg.slice(0, eqIndex) : arg;
+    const name = optionName(rawName);
+    const mapped = OPTION_KEYS[name];
+    if (!mapped) {
+      throw new Error(`unknown tfx cto event option: --${name}`);
+    }
+
+    let value = eqIndex >= 0 ? arg.slice(eqIndex + 1) : null;
+    if (value === null) {
+      const next = args[i + 1];
+      if (typeof next === "string" && !next.startsWith("--")) {
+        value = next;
+        i += 1;
+      } else {
+        value = "true";
+      }
+    }
+    putPathValue(fields, mapped, value);
+  }
+
+  return {
+    presetName: positional[0] || null,
+    extraPositionals: positional.slice(1),
+    fields,
+    json,
+  };
+}
+
+function mergeActor(defaultActor, overrideActor) {
+  const actor = { ...(defaultActor || {}), ...(overrideActor || {}) };
+  return Object.keys(actor).length > 0 ? actor : undefined;
+}
+
+function defaultEventSummary(input) {
+  if (input.event === "checkpoint_saved") {
+    return `context-save checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "checkpoint_restored") {
+    return `context-restore checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "pr_created") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} created` : "PR created";
+  }
+  if (input.event === "pr_merged_or_closed") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} merged or closed` : "PR merged or closed";
+  }
+  return undefined;
+}
+
+function validateRunEventInput(input) {
+  if (!input.event) {
+    throw new Error("tfx cto event requires a preset or --event <event_type>");
+  }
+
+  if (
+    ["checkpoint_saved", "checkpoint_restored"].includes(input.event) &&
+    !maybeString(input.checkpoint_id)
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --checkpoint-id`);
+  }
+
+  if (
+    ["pr_created", "pr_merged_or_closed"].includes(input.event) &&
+    normalizeNumericRefs(input.pr_refs).length === 0
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --pr`);
+  }
 }
 
 function putString(target, key, value) {
@@ -219,4 +430,60 @@ export async function appendCtoEvent(lakeRoot, input, opts = {}) {
       unlinkSync(lockPath);
     } catch {}
   }
+}
+
+export async function runEvent(args = [], opts = {}) {
+  const parsed = parseEventArgs(args);
+  if (parsed.extraPositionals.length > 0) {
+    throw new Error(
+      `unexpected tfx cto event argument: ${parsed.extraPositionals[0]}`,
+    );
+  }
+  const preset = parsed.presetName ? EVENT_PRESETS[parsed.presetName] : null;
+  if (parsed.presetName && !preset && !parsed.fields.event) {
+    throw new Error(`unknown tfx cto event preset: ${parsed.presetName}`);
+  }
+
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || parsed.json;
+  const ownerSurface =
+    parsed.fields.owner_surface ||
+    preset?.ownerSurface ||
+    "external wrapper -> tfx cto event --event";
+
+  const input = {
+    ...(preset || {}),
+    ...parsed.fields,
+    actor: mergeActor(preset?.actor, parsed.fields.actor),
+  };
+  delete input.ownerSurface;
+  delete input.owner_surface;
+  if (!input.project_root) input.project_root = rootDir;
+  if (!input.summary) input.summary = defaultEventSummary(input);
+
+  validateRunEventInput(input);
+
+  const result = await appendCtoEvent(lakeRoot, input, {
+    stderr: opts.stderr,
+    lockRetries: opts.ledgerLockRetries,
+    lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+  });
+  const payload = {
+    appended: result.appended,
+    owner_surface: ownerSurface,
+    event: result.event,
+  };
+
+  if (jsonOut) {
+    stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const status = result.appended ? "appended" : "skipped";
+    stdout.write(
+      `[tfx cto event] ${status} ${result.event.event} via ${ownerSurface}\n`,
+    );
+  }
+
+  return payload;
 }

--- a/cto/index.mjs
+++ b/cto/index.mjs
@@ -1,4 +1,4 @@
-const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene"];
+const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene", "event"];
 
 function printUsage(subcommand) {
   if (subcommand) {
@@ -6,13 +6,14 @@ function printUsage(subcommand) {
   }
   console.log(`
 Usage
-  tfx cto <collect|status|dashboard|hygiene> [options]
+  tfx cto <collect|status|dashboard|hygiene|event> [options]
 
 Subcommands
   collect     Refresh .triflux/lake/current.json from repo-local authority sources
   status      Print the current authority summary
   dashboard   Render the CTO console dashboard, optionally with --watch
   hygiene     Project CTO hygiene counts and actionable dry-run rows
+  event       Append normalized wrapper lifecycle events to the CTO ledger
 `);
 }
 
@@ -35,6 +36,10 @@ export async function cmdCto(cmdArgs, opts = {}) {
     case "hygiene": {
       const { runHygiene } = await import("./hygiene.mjs");
       return runHygiene(rest, opts);
+    }
+    case "event": {
+      const { runEvent } = await import("./events.mjs");
+      return runEvent(rest, opts);
     }
     case undefined:
     case "":

--- a/packages/remote/cto/events.mjs
+++ b/packages/remote/cto/events.mjs
@@ -6,6 +6,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
 export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
@@ -40,6 +41,98 @@ export const CTO_HYGIENE_STATUSES = Object.freeze([
 
 const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
 const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+const EVENT_PRESETS = Object.freeze({
+  "context-save": {
+    event: "checkpoint_saved",
+    source: "gstack_context_save",
+    actor: { cli: "gstack context-save" },
+    ownerSurface: "gstack context-save -> tfx cto event context-save",
+  },
+  "checkpoint-saved": {
+    event: "checkpoint_saved",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-saved",
+  },
+  "context-restore": {
+    event: "checkpoint_restored",
+    source: "gstack_context_restore",
+    actor: { cli: "gstack context-restore" },
+    ownerSurface: "gstack context-restore -> tfx cto event context-restore",
+  },
+  "checkpoint-restored": {
+    event: "checkpoint_restored",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-restored",
+  },
+  "pr-created": {
+    event: "pr_created",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr create" },
+    ownerSurface: "gh pr create/merge/close -> tfx cto event pr-created",
+  },
+  "pr-merged": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr merge" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-merged-or-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr merge/close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+});
+
+const OPTION_KEYS = Object.freeze({
+  event: "event",
+  "event-type": "event",
+  source: "source",
+  summary: "summary",
+  now: "now",
+  ts: "ts",
+  status: "status",
+  "session-id": "session_id",
+  "parent-session-id": "parent_session_id",
+  "restored-from-session-id": "restored_from_session_id",
+  "checkpoint-id": "checkpoint_id",
+  "artifact-path": "artifact_path",
+  artifact: "artifact_path",
+  "task-id": "task_id",
+  branch: "branch",
+  "last-seen-at": "last_seen_at",
+  "stale-reason": "stale_reason",
+  "hygiene-key": "hygiene_key",
+  "hygiene-kind": "hygiene_kind",
+  "hygiene-id": "hygiene_id",
+  "hygiene-action": "hygiene_action",
+  "project-root": "project_root",
+  "worktree-path": "worktree_path",
+  worktree: "worktree_path",
+  issue: "issue_refs",
+  "issue-ref": "issue_refs",
+  "issue-refs": "issue_refs",
+  pr: "pr_refs",
+  "pr-ref": "pr_refs",
+  "pr-refs": "pr_refs",
+  "actor-cli": "actor.cli",
+  "actor-session-id": "actor.session_id",
+  "actor-agent-id": "actor.agent_id",
+  "actor-host": "actor.host",
+  "owner-surface": "owner_surface",
+});
+
+const COLLECTION_KEYS = new Set(["issue_refs", "pr_refs"]);
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -105,6 +198,124 @@ function normalizeActor(actor) {
     if (value) normalized[key] = value;
   }
   return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function optionName(raw) {
+  return String(raw || "")
+    .replace(/^--?/u, "")
+    .trim();
+}
+
+function appendCollection(target, key, value) {
+  const values = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (values.length === 0) return;
+  if (!Array.isArray(target[key])) target[key] = [];
+  target[key].push(...values);
+}
+
+function putPathValue(target, keyPath, value) {
+  if (keyPath.startsWith("actor.")) {
+    const key = keyPath.slice("actor.".length);
+    target.actor ||= {};
+    target.actor[key] = value;
+    return;
+  }
+  if (COLLECTION_KEYS.has(keyPath)) {
+    appendCollection(target, keyPath, value);
+    return;
+  }
+  target[keyPath] = value;
+}
+
+function parseEventArgs(args = []) {
+  const fields = {};
+  const positional = [];
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!arg?.startsWith?.("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const eqIndex = arg.indexOf("=");
+    const rawName = eqIndex >= 0 ? arg.slice(0, eqIndex) : arg;
+    const name = optionName(rawName);
+    const mapped = OPTION_KEYS[name];
+    if (!mapped) {
+      throw new Error(`unknown tfx cto event option: --${name}`);
+    }
+
+    let value = eqIndex >= 0 ? arg.slice(eqIndex + 1) : null;
+    if (value === null) {
+      const next = args[i + 1];
+      if (typeof next === "string" && !next.startsWith("--")) {
+        value = next;
+        i += 1;
+      } else {
+        value = "true";
+      }
+    }
+    putPathValue(fields, mapped, value);
+  }
+
+  return {
+    presetName: positional[0] || null,
+    extraPositionals: positional.slice(1),
+    fields,
+    json,
+  };
+}
+
+function mergeActor(defaultActor, overrideActor) {
+  const actor = { ...(defaultActor || {}), ...(overrideActor || {}) };
+  return Object.keys(actor).length > 0 ? actor : undefined;
+}
+
+function defaultEventSummary(input) {
+  if (input.event === "checkpoint_saved") {
+    return `context-save checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "checkpoint_restored") {
+    return `context-restore checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "pr_created") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} created` : "PR created";
+  }
+  if (input.event === "pr_merged_or_closed") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} merged or closed` : "PR merged or closed";
+  }
+  return undefined;
+}
+
+function validateRunEventInput(input) {
+  if (!input.event) {
+    throw new Error("tfx cto event requires a preset or --event <event_type>");
+  }
+
+  if (
+    ["checkpoint_saved", "checkpoint_restored"].includes(input.event) &&
+    !maybeString(input.checkpoint_id)
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --checkpoint-id`);
+  }
+
+  if (
+    ["pr_created", "pr_merged_or_closed"].includes(input.event) &&
+    normalizeNumericRefs(input.pr_refs).length === 0
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --pr`);
+  }
 }
 
 function putString(target, key, value) {
@@ -219,4 +430,60 @@ export async function appendCtoEvent(lakeRoot, input, opts = {}) {
       unlinkSync(lockPath);
     } catch {}
   }
+}
+
+export async function runEvent(args = [], opts = {}) {
+  const parsed = parseEventArgs(args);
+  if (parsed.extraPositionals.length > 0) {
+    throw new Error(
+      `unexpected tfx cto event argument: ${parsed.extraPositionals[0]}`,
+    );
+  }
+  const preset = parsed.presetName ? EVENT_PRESETS[parsed.presetName] : null;
+  if (parsed.presetName && !preset && !parsed.fields.event) {
+    throw new Error(`unknown tfx cto event preset: ${parsed.presetName}`);
+  }
+
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || parsed.json;
+  const ownerSurface =
+    parsed.fields.owner_surface ||
+    preset?.ownerSurface ||
+    "external wrapper -> tfx cto event --event";
+
+  const input = {
+    ...(preset || {}),
+    ...parsed.fields,
+    actor: mergeActor(preset?.actor, parsed.fields.actor),
+  };
+  delete input.ownerSurface;
+  delete input.owner_surface;
+  if (!input.project_root) input.project_root = rootDir;
+  if (!input.summary) input.summary = defaultEventSummary(input);
+
+  validateRunEventInput(input);
+
+  const result = await appendCtoEvent(lakeRoot, input, {
+    stderr: opts.stderr,
+    lockRetries: opts.ledgerLockRetries,
+    lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+  });
+  const payload = {
+    appended: result.appended,
+    owner_surface: ownerSurface,
+    event: result.event,
+  };
+
+  if (jsonOut) {
+    stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const status = result.appended ? "appended" : "skipped";
+    stdout.write(
+      `[tfx cto event] ${status} ${result.event.event} via ${ownerSurface}\n`,
+    );
+  }
+
+  return payload;
 }

--- a/packages/triflux/bin/triflux.mjs
+++ b/packages/triflux/bin/triflux.mjs
@@ -499,13 +499,15 @@ const CLI_COMMAND_SCHEMAS = Object.freeze({
     },
   },
   cto: {
-    usage: "tfx cto <collect|status|dashboard|hygiene> [options]",
+    usage: "tfx cto <collect|status|dashboard|hygiene|event> [options]",
     description: "repo-local authority layer console",
     subcommands: {
       collect: "refresh .triflux/lake/current.json from authority sources",
       status: "print the current authority summary",
       dashboard: "render the CTO console dashboard, optionally with --watch",
       hygiene: "project CTO hygiene counts and actionable dry-run rows",
+      event:
+        "append wrapper lineage events: context-save, context-restore, pr-created, pr-merged-or-closed",
     },
   },
   multi: {

--- a/packages/triflux/cto/events.mjs
+++ b/packages/triflux/cto/events.mjs
@@ -6,6 +6,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import { resolveLakeRootDir } from "./lake-root.mjs";
 
 export const CTO_EVENT_SCHEMA_VERSION = "cto-event.v1";
 export const DEFAULT_CTO_EVENT_SOURCE = "tfx_cto_event";
@@ -40,6 +41,98 @@ export const CTO_HYGIENE_STATUSES = Object.freeze([
 
 const EVENT_TYPE_SET = new Set(CTO_EVENT_TYPES);
 const STATUS_SET = new Set(CTO_HYGIENE_STATUSES);
+
+const EVENT_PRESETS = Object.freeze({
+  "context-save": {
+    event: "checkpoint_saved",
+    source: "gstack_context_save",
+    actor: { cli: "gstack context-save" },
+    ownerSurface: "gstack context-save -> tfx cto event context-save",
+  },
+  "checkpoint-saved": {
+    event: "checkpoint_saved",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-saved",
+  },
+  "context-restore": {
+    event: "checkpoint_restored",
+    source: "gstack_context_restore",
+    actor: { cli: "gstack context-restore" },
+    ownerSurface: "gstack context-restore -> tfx cto event context-restore",
+  },
+  "checkpoint-restored": {
+    event: "checkpoint_restored",
+    ownerSurface: "checkpoint wrapper -> tfx cto event checkpoint-restored",
+  },
+  "pr-created": {
+    event: "pr_created",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr create" },
+    ownerSurface: "gh pr create/merge/close -> tfx cto event pr-created",
+  },
+  "pr-merged": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr merge" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    status: "completed",
+    actor: { cli: "gh pr close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+  "pr-merged-or-closed": {
+    event: "pr_merged_or_closed",
+    source: "tfx_pr_lifecycle",
+    actor: { cli: "gh pr merge/close" },
+    ownerSurface:
+      "gh pr create/merge/close -> tfx cto event pr-merged-or-closed",
+  },
+});
+
+const OPTION_KEYS = Object.freeze({
+  event: "event",
+  "event-type": "event",
+  source: "source",
+  summary: "summary",
+  now: "now",
+  ts: "ts",
+  status: "status",
+  "session-id": "session_id",
+  "parent-session-id": "parent_session_id",
+  "restored-from-session-id": "restored_from_session_id",
+  "checkpoint-id": "checkpoint_id",
+  "artifact-path": "artifact_path",
+  artifact: "artifact_path",
+  "task-id": "task_id",
+  branch: "branch",
+  "last-seen-at": "last_seen_at",
+  "stale-reason": "stale_reason",
+  "hygiene-key": "hygiene_key",
+  "hygiene-kind": "hygiene_kind",
+  "hygiene-id": "hygiene_id",
+  "hygiene-action": "hygiene_action",
+  "project-root": "project_root",
+  "worktree-path": "worktree_path",
+  worktree: "worktree_path",
+  issue: "issue_refs",
+  "issue-ref": "issue_refs",
+  "issue-refs": "issue_refs",
+  pr: "pr_refs",
+  "pr-ref": "pr_refs",
+  "pr-refs": "pr_refs",
+  "actor-cli": "actor.cli",
+  "actor-session-id": "actor.session_id",
+  "actor-agent-id": "actor.agent_id",
+  "actor-host": "actor.host",
+  "owner-surface": "owner_surface",
+});
+
+const COLLECTION_KEYS = new Set(["issue_refs", "pr_refs"]);
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -105,6 +198,124 @@ function normalizeActor(actor) {
     if (value) normalized[key] = value;
   }
   return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function optionName(raw) {
+  return String(raw || "")
+    .replace(/^--?/u, "")
+    .trim();
+}
+
+function appendCollection(target, key, value) {
+  const values = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (values.length === 0) return;
+  if (!Array.isArray(target[key])) target[key] = [];
+  target[key].push(...values);
+}
+
+function putPathValue(target, keyPath, value) {
+  if (keyPath.startsWith("actor.")) {
+    const key = keyPath.slice("actor.".length);
+    target.actor ||= {};
+    target.actor[key] = value;
+    return;
+  }
+  if (COLLECTION_KEYS.has(keyPath)) {
+    appendCollection(target, keyPath, value);
+    return;
+  }
+  target[keyPath] = value;
+}
+
+function parseEventArgs(args = []) {
+  const fields = {};
+  const positional = [];
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!arg?.startsWith?.("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const eqIndex = arg.indexOf("=");
+    const rawName = eqIndex >= 0 ? arg.slice(0, eqIndex) : arg;
+    const name = optionName(rawName);
+    const mapped = OPTION_KEYS[name];
+    if (!mapped) {
+      throw new Error(`unknown tfx cto event option: --${name}`);
+    }
+
+    let value = eqIndex >= 0 ? arg.slice(eqIndex + 1) : null;
+    if (value === null) {
+      const next = args[i + 1];
+      if (typeof next === "string" && !next.startsWith("--")) {
+        value = next;
+        i += 1;
+      } else {
+        value = "true";
+      }
+    }
+    putPathValue(fields, mapped, value);
+  }
+
+  return {
+    presetName: positional[0] || null,
+    extraPositionals: positional.slice(1),
+    fields,
+    json,
+  };
+}
+
+function mergeActor(defaultActor, overrideActor) {
+  const actor = { ...(defaultActor || {}), ...(overrideActor || {}) };
+  return Object.keys(actor).length > 0 ? actor : undefined;
+}
+
+function defaultEventSummary(input) {
+  if (input.event === "checkpoint_saved") {
+    return `context-save checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "checkpoint_restored") {
+    return `context-restore checkpoint ${input.checkpoint_id}`;
+  }
+  if (input.event === "pr_created") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} created` : "PR created";
+  }
+  if (input.event === "pr_merged_or_closed") {
+    const [pr] = normalizeNumericRefs(input.pr_refs);
+    return pr ? `PR #${pr} merged or closed` : "PR merged or closed";
+  }
+  return undefined;
+}
+
+function validateRunEventInput(input) {
+  if (!input.event) {
+    throw new Error("tfx cto event requires a preset or --event <event_type>");
+  }
+
+  if (
+    ["checkpoint_saved", "checkpoint_restored"].includes(input.event) &&
+    !maybeString(input.checkpoint_id)
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --checkpoint-id`);
+  }
+
+  if (
+    ["pr_created", "pr_merged_or_closed"].includes(input.event) &&
+    normalizeNumericRefs(input.pr_refs).length === 0
+  ) {
+    throw new Error(`tfx cto event ${input.event} requires --pr`);
+  }
 }
 
 function putString(target, key, value) {
@@ -219,4 +430,60 @@ export async function appendCtoEvent(lakeRoot, input, opts = {}) {
       unlinkSync(lockPath);
     } catch {}
   }
+}
+
+export async function runEvent(args = [], opts = {}) {
+  const parsed = parseEventArgs(args);
+  if (parsed.extraPositionals.length > 0) {
+    throw new Error(
+      `unexpected tfx cto event argument: ${parsed.extraPositionals[0]}`,
+    );
+  }
+  const preset = parsed.presetName ? EVENT_PRESETS[parsed.presetName] : null;
+  if (parsed.presetName && !preset && !parsed.fields.event) {
+    throw new Error(`unknown tfx cto event preset: ${parsed.presetName}`);
+  }
+
+  const rootDir = opts.rootDir || resolveLakeRootDir(process.cwd());
+  const lakeRoot = opts.lakeRoot || join(rootDir, ".triflux", "lake");
+  const stdout = opts.stdout || process.stdout;
+  const jsonOut = opts.json === true || parsed.json;
+  const ownerSurface =
+    parsed.fields.owner_surface ||
+    preset?.ownerSurface ||
+    "external wrapper -> tfx cto event --event";
+
+  const input = {
+    ...(preset || {}),
+    ...parsed.fields,
+    actor: mergeActor(preset?.actor, parsed.fields.actor),
+  };
+  delete input.ownerSurface;
+  delete input.owner_surface;
+  if (!input.project_root) input.project_root = rootDir;
+  if (!input.summary) input.summary = defaultEventSummary(input);
+
+  validateRunEventInput(input);
+
+  const result = await appendCtoEvent(lakeRoot, input, {
+    stderr: opts.stderr,
+    lockRetries: opts.ledgerLockRetries,
+    lockRetryDelayMs: opts.ledgerLockRetryDelayMs,
+  });
+  const payload = {
+    appended: result.appended,
+    owner_surface: ownerSurface,
+    event: result.event,
+  };
+
+  if (jsonOut) {
+    stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const status = result.appended ? "appended" : "skipped";
+    stdout.write(
+      `[tfx cto event] ${status} ${result.event.event} via ${ownerSurface}\n`,
+    );
+  }
+
+  return payload;
 }

--- a/packages/triflux/cto/index.mjs
+++ b/packages/triflux/cto/index.mjs
@@ -1,4 +1,4 @@
-const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene"];
+const SUBCOMMANDS = ["collect", "status", "dashboard", "hygiene", "event"];
 
 function printUsage(subcommand) {
   if (subcommand) {
@@ -6,13 +6,14 @@ function printUsage(subcommand) {
   }
   console.log(`
 Usage
-  tfx cto <collect|status|dashboard|hygiene> [options]
+  tfx cto <collect|status|dashboard|hygiene|event> [options]
 
 Subcommands
   collect     Refresh .triflux/lake/current.json from repo-local authority sources
   status      Print the current authority summary
   dashboard   Render the CTO console dashboard, optionally with --watch
   hygiene     Project CTO hygiene counts and actionable dry-run rows
+  event       Append normalized wrapper lifecycle events to the CTO ledger
 `);
 }
 
@@ -35,6 +36,10 @@ export async function cmdCto(cmdArgs, opts = {}) {
     case "hygiene": {
       const { runHygiene } = await import("./hygiene.mjs");
       return runHygiene(rest, opts);
+    }
+    case "event": {
+      const { runEvent } = await import("./events.mjs");
+      return runEvent(rest, opts);
     }
     case undefined:
     case "":

--- a/tests/cto/router.test.mjs
+++ b/tests/cto/router.test.mjs
@@ -22,11 +22,15 @@ describe("cmdCto", () => {
     const output = await captureStdout(() => cmdCto([]));
 
     assert.match(output, /Usage/u);
-    assert.match(output, /tfx cto <collect\|status\|dashboard\|hygiene>/u);
+    assert.match(
+      output,
+      /tfx cto <collect\|status\|dashboard\|hygiene\|event>/u,
+    );
     assert.match(output, /collect/u);
     assert.match(output, /status/u);
     assert.match(output, /dashboard/u);
     assert.match(output, /hygiene/u);
+    assert.match(output, /event/u);
   });
 
   it("prints usage for an unknown subcommand without throwing", async () => {
@@ -75,6 +79,120 @@ describe("cmdCto", () => {
         readFileSync(ledgerPath, "utf8").split(/\r?\n/u).filter(Boolean).length,
         1,
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("routes context-save wrapper lineage events into the CTO ledger", async () => {
+    const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const root = mkdtempSync(join(tmpdir(), "tfx-cto-router-event-"));
+    const lakeRoot = join(root, ".triflux", "lake");
+    let output = "";
+    try {
+      const result = await cmdCto(
+        [
+          "event",
+          "context-save",
+          "--checkpoint-id",
+          "cp-434",
+          "--session-id",
+          "session-434",
+          "--artifact-path",
+          "/tmp/cp-434.md",
+          "--issue",
+          "434",
+          "--json",
+        ],
+        {
+          rootDir: root,
+          lakeRoot,
+          stdout: {
+            write: (chunk) => {
+              output += String(chunk);
+            },
+          },
+        },
+      );
+
+      assert.equal(result.appended, true);
+      assert.equal(
+        result.owner_surface,
+        "gstack context-save -> tfx cto event context-save",
+      );
+      const printed = JSON.parse(output);
+      assert.equal(printed.appended, true);
+      assert.equal(printed.event.event, "checkpoint_saved");
+      assert.equal(printed.event.source, "gstack_context_save");
+      assert.equal(printed.event.ref.checkpoint_id, "cp-434");
+      assert.equal(printed.event.ref.session_id, "session-434");
+      assert.deepEqual(printed.event.ref.issue_refs, [434]);
+      assert.deepEqual(printed.event.ref.actor, { cli: "gstack context-save" });
+
+      const ledgerRows = readFileSync(join(lakeRoot, "ledger.jsonl"), "utf8")
+        .split(/\r?\n/u)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+      assert.equal(ledgerRows.length, 1);
+      assert.equal(ledgerRows[0].event, "checkpoint_saved");
+      assert.equal(ledgerRows[0].ref.checkpoint_id, "cp-434");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("routes PR lifecycle wrapper events into the CTO ledger", async () => {
+    const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const root = mkdtempSync(join(tmpdir(), "tfx-cto-router-pr-event-"));
+    const lakeRoot = join(root, ".triflux", "lake");
+    let output = "";
+    try {
+      const result = await cmdCto(
+        [
+          "event",
+          "pr-created",
+          "--pr",
+          "#434",
+          "--branch",
+          "fix/cto-wrapper-lineage-events",
+          "--summary",
+          "PR #434 created",
+          "--json",
+        ],
+        {
+          rootDir: root,
+          lakeRoot,
+          stdout: {
+            write: (chunk) => {
+              output += String(chunk);
+            },
+          },
+        },
+      );
+
+      assert.equal(result.appended, true);
+      assert.equal(
+        result.owner_surface,
+        "gh pr create/merge/close -> tfx cto event pr-created",
+      );
+      const printed = JSON.parse(output);
+      assert.equal(printed.event.event, "pr_created");
+      assert.equal(printed.event.source, "tfx_pr_lifecycle");
+      assert.deepEqual(printed.event.ref.pr_refs, [434]);
+      assert.equal(printed.event.ref.branch, "fix/cto-wrapper-lineage-events");
+      assert.deepEqual(printed.event.ref.actor, { cli: "gh pr create" });
+
+      const ledgerRows = readFileSync(join(lakeRoot, "ledger.jsonl"), "utf8")
+        .split(/\r?\n/u)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+      assert.equal(ledgerRows.length, 1);
+      assert.equal(ledgerRows[0].event, "pr_created");
+      assert.deepEqual(ledgerRows[0].ref.pr_refs, [434]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Add `tfx cto event` as the repo-owned narrow integration point for wrapper lineage emission.
- Provide wrapper presets for `context-save`, `context-restore`, `pr-created`, and PR merged/closed lifecycle events.
- Sync package mirrors and add router tests proving checkpoint and PR lifecycle events append normalized CTO ledger rows.

Closes #434

## Verification
- `node --test tests/cto/router.test.mjs tests/cto/events.test.mjs tests/cto/hygiene.test.mjs` → 13 pass, 0 fail
- `npm run lint` → 804 files checked, 0 errors
- `npm run release:check-sync` → Version sync OK (10.37.0)
- `npm run release:check-mirror` → Mirror OK
- `git diff --check` → no whitespace errors
- `npm test` → 4408 tests, 4391 pass, 0 fail, 17 skipped
