### PR TITLE
fix: agy lane profile-based --model + effort tiers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "triflux",
       "description": "Tri-CLI orchestrator for Claude Code. Routes tasks across Claude + Codex + Antigravity with consensus intelligence, natural language routing, 34 skills, and cross-model review.",
-      "version": "10.38.0",
+      "version": "10.39.0",
       "author": {
         "name": "tellang"
       },
@@ -30,5 +30,5 @@
       ]
     }
   ],
-  "version": "10.38.0"
+  "version": "10.39.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "triflux",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "description": "CLI-first multi-model orchestrator for Claude Code — route tasks to Codex, Antigravity, and Claude",
   "author": {
     "name": "tellang"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to triflux will be documented in this file.
 
+## [10.39.0] - 2026-06-18
+
+### Added
+- agy: Antigravity 레인 effort tier 프로필 풀셋(3.5 Flash Low/Medium/High, 3.1 Pro Low/High) + agent 별 모델 매핑(designer→3.5 Flash High, writer·직접 alias→Medium). 우선순위 `TFX_GEMINI_PROFILE`(env) > agent 기본 > flash35. `agy models` 실측 라인업 반영.
+
+### Fixed
+- agy: 레인이 `--model` 을 지정하지 않아 Antigravity 계정 기본 모델이 의도와 무관하게 사용되던 회귀 수정. `run_antigravity_exec` 가 프로필 기반 모델(display name)을 `agy_args` 배열에 주입하고, 호출처가 0이던 `resolve_gemini_profile` 을 실배선. deprecated 2.5 프로필(pro25/flash25/lite25) 제거 + 기존 사용자 설정 1회 마이그레이션(백업 동반).
+
+### Tests
+- gemini-profiles 마이그레이션 회귀 커버리지 추가(2.5 prune, 옛 ID→display name, 멱등).
+
 ## [10.38.0] - 2026-06-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "triflux",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "triflux",
-      "version": "10.38.0",
+      "version": "10.39.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triflux",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "description": "CLI-first multi-model orchestrator for Claude Code — route tasks to Codex, Antigravity, and Claude",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triflux/core",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "description": "triflux core — CLI routing, pipeline, adapters. Zero native dependencies.",
   "type": "module",
   "main": "hub/index.mjs",

--- a/packages/core/scripts/lib/gemini-profiles.mjs
+++ b/packages/core/scripts/lib/gemini-profiles.mjs
@@ -8,22 +8,40 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+// 모델명 SSOT. 값은 agy 1.0.x `agy models` 가 출력하는 display name 형식이다
+// (`--model` 인자가 이 문자열을 받는다). 옛 `gemini-*-preview` ID 형식이 아님.
 const DEFAULT_GEMINI_PROFILES = {
-  model: "gemini-3.1-pro-preview",
+  model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35: {
+      model: "Gemini 3.5 Flash (Medium)",
+      hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
+    },
+    flash35_high: {
+      model: "Gemini 3.5 Flash (High)",
+      hint: "3.5 Flash (High) — 코드/추론 강화",
+    },
     pro31: {
-      model: "gemini-3.1-pro-preview",
-      hint: "3.1 Pro — 플래그십 (1M ctx, 멀티모달)",
+      model: "Gemini 3.1 Pro (High)",
+      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
-      model: "gemini-3-flash-preview",
-      hint: "3.0 Flash — 빠른 응답, 비용 효율",
+      model: "Gemini 3 Flash",
+      hint: "3.0 Flash — 레거시 호환",
     },
-    pro25: { model: "gemini-2.5-pro", hint: "2.5 Pro — 안정 (추론 강화)" },
-    flash25: { model: "gemini-2.5-flash", hint: "2.5 Flash — 경량 범용" },
-    lite25: { model: "gemini-2.5-flash-lite", hint: "2.5 Flash Lite — 최경량" },
   },
 };
+
+// 1회 마이그레이션 테이블: 옛 ID 형식 모델값 → agy display name.
+// null = deprecated(2.5 계열) → 해당 프로필 제거 대상.
+const LEGACY_MODEL_MIGRATION = {
+  "gemini-3.1-pro-preview": "Gemini 3.1 Pro (High)",
+  "gemini-3-flash-preview": "Gemini 3 Flash",
+  "gemini-2.5-pro": null,
+  "gemini-2.5-flash": null,
+  "gemini-2.5-flash-lite": null,
+};
+const LEGACY_PROFILE_NAMES = ["pro25", "flash25", "lite25"];
 
 const DEFAULT_PROFILE_COUNT = Object.keys(
   DEFAULT_GEMINI_PROFILES.profiles,
@@ -80,6 +98,39 @@ function ensureGeminiProfiles({
     )
       cfg.profiles = {};
 
+    // ── 1회 마이그레이션: deprecated 2.5 프로필 prune + 옛 ID 형식 → display name ──
+    // merge-only 로직만으로는 기존 사용자 파일에 남은 stale 프로필/옛 모델 ID 가
+    // 정리되지 않으므로, 신규 default 를 채우기 전에 마이그레이션을 먼저 적용한다.
+    let migrated = false;
+    for (const legacy of LEGACY_PROFILE_NAMES) {
+      if (cfg.profiles[legacy]) {
+        delete cfg.profiles[legacy];
+        migrated = true;
+      }
+    }
+    for (const [pname, pval] of Object.entries(cfg.profiles)) {
+      const mid = typeof pval === "string" ? pval : pval?.model;
+      if (mid && Object.hasOwn(LEGACY_MODEL_MIGRATION, mid)) {
+        const repl = LEGACY_MODEL_MIGRATION[mid];
+        if (repl === null) {
+          delete cfg.profiles[pname];
+        } else if (typeof pval === "string") {
+          cfg.profiles[pname] = repl;
+        } else {
+          cfg.profiles[pname].model = repl;
+        }
+        migrated = true;
+      }
+    }
+    if (
+      typeof cfg.model === "string" &&
+      Object.hasOwn(LEGACY_MODEL_MIGRATION, cfg.model)
+    ) {
+      // 옛 ID 형식 기본값은 구버전 자동 생성값이므로 새 기본(DEFAULT)으로 정규화한다.
+      cfg.model = DEFAULT_GEMINI_PROFILES.model;
+      migrated = true;
+    }
+
     let added = 0;
     for (const [name, value] of Object.entries(
       DEFAULT_GEMINI_PROFILES.profiles,
@@ -91,7 +142,12 @@ function ensureGeminiProfiles({
     }
     if (!cfg.model) cfg.model = DEFAULT_GEMINI_PROFILES.model;
 
-    if (added > 0) {
+    if (added > 0 || migrated) {
+      if (migrated) {
+        try {
+          copyFileSync(profilesPath, profilesPath + `.bak.${Date.now()}`);
+        } catch {}
+      }
       writeFileSync(profilesPath, JSON.stringify(cfg, null, 2) + "\n", {
         encoding: "utf8",
         mode: 0o600,

--- a/packages/core/scripts/lib/gemini-profiles.mjs
+++ b/packages/core/scripts/lib/gemini-profiles.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 const DEFAULT_GEMINI_PROFILES = {
   model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35_low: {
+      model: "Gemini 3.5 Flash (Low)",
+      hint: "3.5 Flash (Low) — 경량·저비용",
+    },
     flash35: {
       model: "Gemini 3.5 Flash (Medium)",
       hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
@@ -21,9 +25,13 @@ const DEFAULT_GEMINI_PROFILES = {
       model: "Gemini 3.5 Flash (High)",
       hint: "3.5 Flash (High) — 코드/추론 강화",
     },
+    pro31_low: {
+      model: "Gemini 3.1 Pro (Low)",
+      hint: "3.1 Pro (Low) — 플래그십 경량",
+    },
     pro31: {
       model: "Gemini 3.1 Pro (High)",
-      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
+      hint: "3.1 Pro (High) — 플래그십 최고 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
       model: "Gemini 3 Flash",

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triflux/remote",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "description": "triflux remote — team mode, psmux, MCP workers, SQLite store.",
   "type": "module",
   "main": "hub/index.mjs",

--- a/packages/remote/scripts/lib/gemini-profiles.mjs
+++ b/packages/remote/scripts/lib/gemini-profiles.mjs
@@ -8,22 +8,40 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+// 모델명 SSOT. 값은 agy 1.0.x `agy models` 가 출력하는 display name 형식이다
+// (`--model` 인자가 이 문자열을 받는다). 옛 `gemini-*-preview` ID 형식이 아님.
 const DEFAULT_GEMINI_PROFILES = {
-  model: "gemini-3.1-pro-preview",
+  model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35: {
+      model: "Gemini 3.5 Flash (Medium)",
+      hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
+    },
+    flash35_high: {
+      model: "Gemini 3.5 Flash (High)",
+      hint: "3.5 Flash (High) — 코드/추론 강화",
+    },
     pro31: {
-      model: "gemini-3.1-pro-preview",
-      hint: "3.1 Pro — 플래그십 (1M ctx, 멀티모달)",
+      model: "Gemini 3.1 Pro (High)",
+      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
-      model: "gemini-3-flash-preview",
-      hint: "3.0 Flash — 빠른 응답, 비용 효율",
+      model: "Gemini 3 Flash",
+      hint: "3.0 Flash — 레거시 호환",
     },
-    pro25: { model: "gemini-2.5-pro", hint: "2.5 Pro — 안정 (추론 강화)" },
-    flash25: { model: "gemini-2.5-flash", hint: "2.5 Flash — 경량 범용" },
-    lite25: { model: "gemini-2.5-flash-lite", hint: "2.5 Flash Lite — 최경량" },
   },
 };
+
+// 1회 마이그레이션 테이블: 옛 ID 형식 모델값 → agy display name.
+// null = deprecated(2.5 계열) → 해당 프로필 제거 대상.
+const LEGACY_MODEL_MIGRATION = {
+  "gemini-3.1-pro-preview": "Gemini 3.1 Pro (High)",
+  "gemini-3-flash-preview": "Gemini 3 Flash",
+  "gemini-2.5-pro": null,
+  "gemini-2.5-flash": null,
+  "gemini-2.5-flash-lite": null,
+};
+const LEGACY_PROFILE_NAMES = ["pro25", "flash25", "lite25"];
 
 const DEFAULT_PROFILE_COUNT = Object.keys(
   DEFAULT_GEMINI_PROFILES.profiles,
@@ -80,6 +98,39 @@ function ensureGeminiProfiles({
     )
       cfg.profiles = {};
 
+    // ── 1회 마이그레이션: deprecated 2.5 프로필 prune + 옛 ID 형식 → display name ──
+    // merge-only 로직만으로는 기존 사용자 파일에 남은 stale 프로필/옛 모델 ID 가
+    // 정리되지 않으므로, 신규 default 를 채우기 전에 마이그레이션을 먼저 적용한다.
+    let migrated = false;
+    for (const legacy of LEGACY_PROFILE_NAMES) {
+      if (cfg.profiles[legacy]) {
+        delete cfg.profiles[legacy];
+        migrated = true;
+      }
+    }
+    for (const [pname, pval] of Object.entries(cfg.profiles)) {
+      const mid = typeof pval === "string" ? pval : pval?.model;
+      if (mid && Object.hasOwn(LEGACY_MODEL_MIGRATION, mid)) {
+        const repl = LEGACY_MODEL_MIGRATION[mid];
+        if (repl === null) {
+          delete cfg.profiles[pname];
+        } else if (typeof pval === "string") {
+          cfg.profiles[pname] = repl;
+        } else {
+          cfg.profiles[pname].model = repl;
+        }
+        migrated = true;
+      }
+    }
+    if (
+      typeof cfg.model === "string" &&
+      Object.hasOwn(LEGACY_MODEL_MIGRATION, cfg.model)
+    ) {
+      // 옛 ID 형식 기본값은 구버전 자동 생성값이므로 새 기본(DEFAULT)으로 정규화한다.
+      cfg.model = DEFAULT_GEMINI_PROFILES.model;
+      migrated = true;
+    }
+
     let added = 0;
     for (const [name, value] of Object.entries(
       DEFAULT_GEMINI_PROFILES.profiles,
@@ -91,7 +142,12 @@ function ensureGeminiProfiles({
     }
     if (!cfg.model) cfg.model = DEFAULT_GEMINI_PROFILES.model;
 
-    if (added > 0) {
+    if (added > 0 || migrated) {
+      if (migrated) {
+        try {
+          copyFileSync(profilesPath, profilesPath + `.bak.${Date.now()}`);
+        } catch {}
+      }
       writeFileSync(profilesPath, JSON.stringify(cfg, null, 2) + "\n", {
         encoding: "utf8",
         mode: 0o600,

--- a/packages/remote/scripts/lib/gemini-profiles.mjs
+++ b/packages/remote/scripts/lib/gemini-profiles.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 const DEFAULT_GEMINI_PROFILES = {
   model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35_low: {
+      model: "Gemini 3.5 Flash (Low)",
+      hint: "3.5 Flash (Low) — 경량·저비용",
+    },
     flash35: {
       model: "Gemini 3.5 Flash (Medium)",
       hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
@@ -21,9 +25,13 @@ const DEFAULT_GEMINI_PROFILES = {
       model: "Gemini 3.5 Flash (High)",
       hint: "3.5 Flash (High) — 코드/추론 강화",
     },
+    pro31_low: {
+      model: "Gemini 3.1 Pro (Low)",
+      hint: "3.1 Pro (Low) — 플래그십 경량",
+    },
     pro31: {
       model: "Gemini 3.1 Pro (High)",
-      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
+      hint: "3.1 Pro (High) — 플래그십 최고 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
       model: "Gemini 3 Flash",

--- a/packages/triflux/package.json
+++ b/packages/triflux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triflux",
-  "version": "10.38.0",
+  "version": "10.39.0",
   "description": "CLI-first multi-model orchestrator for Claude Code — route tasks to Codex, Antigravity, and Claude",
   "type": "module",
   "bin": {

--- a/packages/triflux/scripts/lib/gemini-profiles.mjs
+++ b/packages/triflux/scripts/lib/gemini-profiles.mjs
@@ -8,22 +8,40 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+// 모델명 SSOT. 값은 agy 1.0.x `agy models` 가 출력하는 display name 형식이다
+// (`--model` 인자가 이 문자열을 받는다). 옛 `gemini-*-preview` ID 형식이 아님.
 const DEFAULT_GEMINI_PROFILES = {
-  model: "gemini-3.1-pro-preview",
+  model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35: {
+      model: "Gemini 3.5 Flash (Medium)",
+      hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
+    },
+    flash35_high: {
+      model: "Gemini 3.5 Flash (High)",
+      hint: "3.5 Flash (High) — 코드/추론 강화",
+    },
     pro31: {
-      model: "gemini-3.1-pro-preview",
-      hint: "3.1 Pro — 플래그십 (1M ctx, 멀티모달)",
+      model: "Gemini 3.1 Pro (High)",
+      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
-      model: "gemini-3-flash-preview",
-      hint: "3.0 Flash — 빠른 응답, 비용 효율",
+      model: "Gemini 3 Flash",
+      hint: "3.0 Flash — 레거시 호환",
     },
-    pro25: { model: "gemini-2.5-pro", hint: "2.5 Pro — 안정 (추론 강화)" },
-    flash25: { model: "gemini-2.5-flash", hint: "2.5 Flash — 경량 범용" },
-    lite25: { model: "gemini-2.5-flash-lite", hint: "2.5 Flash Lite — 최경량" },
   },
 };
+
+// 1회 마이그레이션 테이블: 옛 ID 형식 모델값 → agy display name.
+// null = deprecated(2.5 계열) → 해당 프로필 제거 대상.
+const LEGACY_MODEL_MIGRATION = {
+  "gemini-3.1-pro-preview": "Gemini 3.1 Pro (High)",
+  "gemini-3-flash-preview": "Gemini 3 Flash",
+  "gemini-2.5-pro": null,
+  "gemini-2.5-flash": null,
+  "gemini-2.5-flash-lite": null,
+};
+const LEGACY_PROFILE_NAMES = ["pro25", "flash25", "lite25"];
 
 const DEFAULT_PROFILE_COUNT = Object.keys(
   DEFAULT_GEMINI_PROFILES.profiles,
@@ -80,6 +98,39 @@ function ensureGeminiProfiles({
     )
       cfg.profiles = {};
 
+    // ── 1회 마이그레이션: deprecated 2.5 프로필 prune + 옛 ID 형식 → display name ──
+    // merge-only 로직만으로는 기존 사용자 파일에 남은 stale 프로필/옛 모델 ID 가
+    // 정리되지 않으므로, 신규 default 를 채우기 전에 마이그레이션을 먼저 적용한다.
+    let migrated = false;
+    for (const legacy of LEGACY_PROFILE_NAMES) {
+      if (cfg.profiles[legacy]) {
+        delete cfg.profiles[legacy];
+        migrated = true;
+      }
+    }
+    for (const [pname, pval] of Object.entries(cfg.profiles)) {
+      const mid = typeof pval === "string" ? pval : pval?.model;
+      if (mid && Object.hasOwn(LEGACY_MODEL_MIGRATION, mid)) {
+        const repl = LEGACY_MODEL_MIGRATION[mid];
+        if (repl === null) {
+          delete cfg.profiles[pname];
+        } else if (typeof pval === "string") {
+          cfg.profiles[pname] = repl;
+        } else {
+          cfg.profiles[pname].model = repl;
+        }
+        migrated = true;
+      }
+    }
+    if (
+      typeof cfg.model === "string" &&
+      Object.hasOwn(LEGACY_MODEL_MIGRATION, cfg.model)
+    ) {
+      // 옛 ID 형식 기본값은 구버전 자동 생성값이므로 새 기본(DEFAULT)으로 정규화한다.
+      cfg.model = DEFAULT_GEMINI_PROFILES.model;
+      migrated = true;
+    }
+
     let added = 0;
     for (const [name, value] of Object.entries(
       DEFAULT_GEMINI_PROFILES.profiles,
@@ -91,7 +142,12 @@ function ensureGeminiProfiles({
     }
     if (!cfg.model) cfg.model = DEFAULT_GEMINI_PROFILES.model;
 
-    if (added > 0) {
+    if (added > 0 || migrated) {
+      if (migrated) {
+        try {
+          copyFileSync(profilesPath, profilesPath + `.bak.${Date.now()}`);
+        } catch {}
+      }
       writeFileSync(profilesPath, JSON.stringify(cfg, null, 2) + "\n", {
         encoding: "utf8",
         mode: 0o600,

--- a/packages/triflux/scripts/lib/gemini-profiles.mjs
+++ b/packages/triflux/scripts/lib/gemini-profiles.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 const DEFAULT_GEMINI_PROFILES = {
   model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35_low: {
+      model: "Gemini 3.5 Flash (Low)",
+      hint: "3.5 Flash (Low) — 경량·저비용",
+    },
     flash35: {
       model: "Gemini 3.5 Flash (Medium)",
       hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
@@ -21,9 +25,13 @@ const DEFAULT_GEMINI_PROFILES = {
       model: "Gemini 3.5 Flash (High)",
       hint: "3.5 Flash (High) — 코드/추론 강화",
     },
+    pro31_low: {
+      model: "Gemini 3.1 Pro (Low)",
+      hint: "3.1 Pro (Low) — 플래그십 경량",
+    },
     pro31: {
       model: "Gemini 3.1 Pro (High)",
-      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
+      hint: "3.1 Pro (High) — 플래그십 최고 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
       model: "Gemini 3 Flash",

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1121,8 +1121,10 @@ resolve_gemini_profile() {
     const primaryRaw = process.argv[2] || '{}';
     const settingsRaw = process.argv[3] || '{}';
     const defaults = {
+      flash35_low: 'Gemini 3.5 Flash (Low)',
       flash35: 'Gemini 3.5 Flash (Medium)',
       flash35_high: 'Gemini 3.5 Flash (High)',
+      pro31_low: 'Gemini 3.1 Pro (Low)',
       pro31: 'Gemini 3.1 Pro (High)',
       flash3: 'Gemini 3 Flash'
     };
@@ -1288,15 +1290,28 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델은 run_antigravity_exec() 가 resolve_gemini_profile(TFX_GEMINI_PROFILE,
-    # 기본 flash35)로 해석해 `--model "<display name>"`을 agy_args 에 주입한다.
+    # effort 차등: agent 별 GEMINI_PROFILE 을 설정하면 run_antigravity_exec() 가
+    # resolve_gemini_profile 로 해석해 `--model "<display name>"`을 agy_args 에
+    # 주입한다. 우선순위는 TFX_GEMINI_PROFILE(env) > GEMINI_PROFILE(agent) > flash35.
     # CLI_ARGS 는 read -a 로 word-split 되므로 공백 포함 모델명을 여기 넣지 않는다.
     # #310: upstream callers are normalized through agent-map.json, but this
     # direct route entrypoint intentionally keeps agy as a compatibility alias.
-    designer|writer|gemini|antigravity|agy)
+    designer)
+      # 디자인 = 시각/UX 추론 → 3.5 Flash (High)
+      CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35_high"
+      CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+    writer)
+      # 문서 작성 = 균형 → 3.5 Flash (Medium)
+      CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35"
+      CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+    gemini|antigravity|agy)
+      # 직접 호출 alias — 기본 flash35. TFX_GEMINI_PROFILE 로 override 가능.
       # agy --print + --dangerously-skip-permissions 조합은 positional prompt에서
       # timeout이 재현되므로 wrapper 호출은 stdin pipe로 고정한다.
       CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35"
       CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── 탐색 (Claude-native: Glob/Grep/Read 직접 접근) ───
@@ -1489,6 +1504,12 @@ apply_cli_mode() {
         CLI_TYPE="antigravity"
         CLI_CMD="agy"
         CLI_ARGS="--print --dangerously-skip-permissions"
+        # 주 라우팅(route_agent)과 동일하게 designer 만 effort 상향. 나머지는
+        # run_antigravity_exec 폴백(flash35) 또는 TFX_GEMINI_PROFILE override.
+        case "$AGENT_TYPE" in
+          designer) GEMINI_PROFILE="flash35_high" ;;
+          *)        GEMINI_PROFILE="flash35" ;;
+        esac
         CLI_EFFORT="agy_v1"
         DEFAULT_TIMEOUT=900
         echo "[tfx-route] TFX_CLI_MODE=antigravity: $AGENT_TYPE → antigravity($CLI_EFFORT)로 리매핑" >&2
@@ -2187,7 +2208,7 @@ run_antigravity_exec() {
   # "${agy_args[@]}" expand 시 단일 인자로 보존된다. 모델 SSOT 는 프로필 설정이다.
   if [[ -z "${TFX_GEMINI_NO_MODEL:-}" ]]; then
     local _agy_model
-    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-flash35}")"
+    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-${GEMINI_PROFILE:-flash35}}")"
     if [[ -n "$_agy_model" ]]; then
       agy_args+=("--model" "$_agy_model")
     fi

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1121,11 +1121,10 @@ resolve_gemini_profile() {
     const primaryRaw = process.argv[2] || '{}';
     const settingsRaw = process.argv[3] || '{}';
     const defaults = {
-      pro31: 'gemini-3.1-pro-preview',
-      flash3: 'gemini-3-flash-preview',
-      pro25: 'gemini-2.5-pro',
-      flash25: 'gemini-2.5-flash',
-      lite25: 'gemini-2.5-flash-lite'
+      flash35: 'Gemini 3.5 Flash (Medium)',
+      flash35_high: 'Gemini 3.5 Flash (High)',
+      pro31: 'Gemini 3.1 Pro (High)',
+      flash3: 'Gemini 3 Flash'
     };
 
     if (typeof name === 'string' && name.startsWith('gemini-')) {
@@ -1193,9 +1192,9 @@ resolve_gemini_profile() {
       }
     }
 
-    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.pro25);
+    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.flash35);
   " "$profile" "$_GEMINI_PROFILE_CACHE" "$settings_cache" 2>/dev/null)
-  echo "${result:-gemini-2.5-pro}"
+  echo "${result:-Gemini 3.5 Flash (Medium)}"
 }
 
 # ── 라우팅 테이블 ──
@@ -1289,7 +1288,9 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic.
+    # 모델은 run_antigravity_exec() 가 resolve_gemini_profile(TFX_GEMINI_PROFILE,
+    # 기본 flash35)로 해석해 `--model "<display name>"`을 agy_args 에 주입한다.
+    # CLI_ARGS 는 read -a 로 word-split 되므로 공백 포함 모델명을 여기 넣지 않는다.
     # #310: upstream callers are normalized through agent-map.json, but this
     # direct route entrypoint intentionally keeps agy as a compatibility alias.
     designer|writer|gemini|antigravity|agy)
@@ -2179,6 +2180,18 @@ run_antigravity_exec() {
   local worker_pid
   local -a agy_args=()
   read -r -a agy_args <<< "$CLI_ARGS"
+
+  # ── 프로필 기반 모델 주입 ──
+  # display name 에 공백/괄호가 있으므로(예: "Gemini 3.5 Flash (Medium)") CLI_ARGS
+  # 문자열이 아니라 agy_args 배열에 두 원소(--model, <display name>)로 append 해야
+  # "${agy_args[@]}" expand 시 단일 인자로 보존된다. 모델 SSOT 는 프로필 설정이다.
+  if [[ -z "${TFX_GEMINI_NO_MODEL:-}" ]]; then
+    local _agy_model
+    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-flash35}")"
+    if [[ -n "$_agy_model" ]]; then
+      agy_args+=("--model" "$_agy_model")
+    fi
+  fi
 
   if ! agy_supports_headless "$CLI_CMD"; then
     echo "[tfx-route] Antigravity CLI headless flags unsupported or missing: $CLI_CMD" >"$STDERR_LOG"

--- a/scripts/lib/gemini-profiles.mjs
+++ b/scripts/lib/gemini-profiles.mjs
@@ -8,22 +8,40 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+// 모델명 SSOT. 값은 agy 1.0.x `agy models` 가 출력하는 display name 형식이다
+// (`--model` 인자가 이 문자열을 받는다). 옛 `gemini-*-preview` ID 형식이 아님.
 const DEFAULT_GEMINI_PROFILES = {
-  model: "gemini-3.1-pro-preview",
+  model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35: {
+      model: "Gemini 3.5 Flash (Medium)",
+      hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
+    },
+    flash35_high: {
+      model: "Gemini 3.5 Flash (High)",
+      hint: "3.5 Flash (High) — 코드/추론 강화",
+    },
     pro31: {
-      model: "gemini-3.1-pro-preview",
-      hint: "3.1 Pro — 플래그십 (1M ctx, 멀티모달)",
+      model: "Gemini 3.1 Pro (High)",
+      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
-      model: "gemini-3-flash-preview",
-      hint: "3.0 Flash — 빠른 응답, 비용 효율",
+      model: "Gemini 3 Flash",
+      hint: "3.0 Flash — 레거시 호환",
     },
-    pro25: { model: "gemini-2.5-pro", hint: "2.5 Pro — 안정 (추론 강화)" },
-    flash25: { model: "gemini-2.5-flash", hint: "2.5 Flash — 경량 범용" },
-    lite25: { model: "gemini-2.5-flash-lite", hint: "2.5 Flash Lite — 최경량" },
   },
 };
+
+// 1회 마이그레이션 테이블: 옛 ID 형식 모델값 → agy display name.
+// null = deprecated(2.5 계열) → 해당 프로필 제거 대상.
+const LEGACY_MODEL_MIGRATION = {
+  "gemini-3.1-pro-preview": "Gemini 3.1 Pro (High)",
+  "gemini-3-flash-preview": "Gemini 3 Flash",
+  "gemini-2.5-pro": null,
+  "gemini-2.5-flash": null,
+  "gemini-2.5-flash-lite": null,
+};
+const LEGACY_PROFILE_NAMES = ["pro25", "flash25", "lite25"];
 
 const DEFAULT_PROFILE_COUNT = Object.keys(
   DEFAULT_GEMINI_PROFILES.profiles,
@@ -80,6 +98,39 @@ function ensureGeminiProfiles({
     )
       cfg.profiles = {};
 
+    // ── 1회 마이그레이션: deprecated 2.5 프로필 prune + 옛 ID 형식 → display name ──
+    // merge-only 로직만으로는 기존 사용자 파일에 남은 stale 프로필/옛 모델 ID 가
+    // 정리되지 않으므로, 신규 default 를 채우기 전에 마이그레이션을 먼저 적용한다.
+    let migrated = false;
+    for (const legacy of LEGACY_PROFILE_NAMES) {
+      if (cfg.profiles[legacy]) {
+        delete cfg.profiles[legacy];
+        migrated = true;
+      }
+    }
+    for (const [pname, pval] of Object.entries(cfg.profiles)) {
+      const mid = typeof pval === "string" ? pval : pval?.model;
+      if (mid && Object.hasOwn(LEGACY_MODEL_MIGRATION, mid)) {
+        const repl = LEGACY_MODEL_MIGRATION[mid];
+        if (repl === null) {
+          delete cfg.profiles[pname];
+        } else if (typeof pval === "string") {
+          cfg.profiles[pname] = repl;
+        } else {
+          cfg.profiles[pname].model = repl;
+        }
+        migrated = true;
+      }
+    }
+    if (
+      typeof cfg.model === "string" &&
+      Object.hasOwn(LEGACY_MODEL_MIGRATION, cfg.model)
+    ) {
+      // 옛 ID 형식 기본값은 구버전 자동 생성값이므로 새 기본(DEFAULT)으로 정규화한다.
+      cfg.model = DEFAULT_GEMINI_PROFILES.model;
+      migrated = true;
+    }
+
     let added = 0;
     for (const [name, value] of Object.entries(
       DEFAULT_GEMINI_PROFILES.profiles,
@@ -91,7 +142,12 @@ function ensureGeminiProfiles({
     }
     if (!cfg.model) cfg.model = DEFAULT_GEMINI_PROFILES.model;
 
-    if (added > 0) {
+    if (added > 0 || migrated) {
+      if (migrated) {
+        try {
+          copyFileSync(profilesPath, profilesPath + `.bak.${Date.now()}`);
+        } catch {}
+      }
       writeFileSync(profilesPath, JSON.stringify(cfg, null, 2) + "\n", {
         encoding: "utf8",
         mode: 0o600,

--- a/scripts/lib/gemini-profiles.mjs
+++ b/scripts/lib/gemini-profiles.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 const DEFAULT_GEMINI_PROFILES = {
   model: "Gemini 3.5 Flash (Medium)",
   profiles: {
+    flash35_low: {
+      model: "Gemini 3.5 Flash (Low)",
+      hint: "3.5 Flash (Low) — 경량·저비용",
+    },
     flash35: {
       model: "Gemini 3.5 Flash (Medium)",
       hint: "3.5 Flash (Medium) — 기본, 비용·속도 균형",
@@ -21,9 +25,13 @@ const DEFAULT_GEMINI_PROFILES = {
       model: "Gemini 3.5 Flash (High)",
       hint: "3.5 Flash (High) — 코드/추론 강화",
     },
+    pro31_low: {
+      model: "Gemini 3.1 Pro (Low)",
+      hint: "3.1 Pro (Low) — 플래그십 경량",
+    },
     pro31: {
       model: "Gemini 3.1 Pro (High)",
-      hint: "3.1 Pro (High) — 플래그십 (긴 컨텍스트/복잡 추론)",
+      hint: "3.1 Pro (High) — 플래그십 최고 (긴 컨텍스트/복잡 추론)",
     },
     flash3: {
       model: "Gemini 3 Flash",

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1121,8 +1121,10 @@ resolve_gemini_profile() {
     const primaryRaw = process.argv[2] || '{}';
     const settingsRaw = process.argv[3] || '{}';
     const defaults = {
+      flash35_low: 'Gemini 3.5 Flash (Low)',
       flash35: 'Gemini 3.5 Flash (Medium)',
       flash35_high: 'Gemini 3.5 Flash (High)',
+      pro31_low: 'Gemini 3.1 Pro (Low)',
       pro31: 'Gemini 3.1 Pro (High)',
       flash3: 'Gemini 3 Flash'
     };
@@ -1288,15 +1290,28 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델은 run_antigravity_exec() 가 resolve_gemini_profile(TFX_GEMINI_PROFILE,
-    # 기본 flash35)로 해석해 `--model "<display name>"`을 agy_args 에 주입한다.
+    # effort 차등: agent 별 GEMINI_PROFILE 을 설정하면 run_antigravity_exec() 가
+    # resolve_gemini_profile 로 해석해 `--model "<display name>"`을 agy_args 에
+    # 주입한다. 우선순위는 TFX_GEMINI_PROFILE(env) > GEMINI_PROFILE(agent) > flash35.
     # CLI_ARGS 는 read -a 로 word-split 되므로 공백 포함 모델명을 여기 넣지 않는다.
     # #310: upstream callers are normalized through agent-map.json, but this
     # direct route entrypoint intentionally keeps agy as a compatibility alias.
-    designer|writer|gemini|antigravity|agy)
+    designer)
+      # 디자인 = 시각/UX 추론 → 3.5 Flash (High)
+      CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35_high"
+      CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+    writer)
+      # 문서 작성 = 균형 → 3.5 Flash (Medium)
+      CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35"
+      CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
+    gemini|antigravity|agy)
+      # 직접 호출 alias — 기본 flash35. TFX_GEMINI_PROFILE 로 override 가능.
       # agy --print + --dangerously-skip-permissions 조합은 positional prompt에서
       # timeout이 재현되므로 wrapper 호출은 stdin pipe로 고정한다.
       CLI_ARGS="--print --dangerously-skip-permissions"
+      GEMINI_PROFILE="flash35"
       CLI_EFFORT="agy_v1"; DEFAULT_TIMEOUT=900; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── 탐색 (Claude-native: Glob/Grep/Read 직접 접근) ───
@@ -1489,6 +1504,12 @@ apply_cli_mode() {
         CLI_TYPE="antigravity"
         CLI_CMD="agy"
         CLI_ARGS="--print --dangerously-skip-permissions"
+        # 주 라우팅(route_agent)과 동일하게 designer 만 effort 상향. 나머지는
+        # run_antigravity_exec 폴백(flash35) 또는 TFX_GEMINI_PROFILE override.
+        case "$AGENT_TYPE" in
+          designer) GEMINI_PROFILE="flash35_high" ;;
+          *)        GEMINI_PROFILE="flash35" ;;
+        esac
         CLI_EFFORT="agy_v1"
         DEFAULT_TIMEOUT=900
         echo "[tfx-route] TFX_CLI_MODE=antigravity: $AGENT_TYPE → antigravity($CLI_EFFORT)로 리매핑" >&2
@@ -2187,7 +2208,7 @@ run_antigravity_exec() {
   # "${agy_args[@]}" expand 시 단일 인자로 보존된다. 모델 SSOT 는 프로필 설정이다.
   if [[ -z "${TFX_GEMINI_NO_MODEL:-}" ]]; then
     local _agy_model
-    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-flash35}")"
+    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-${GEMINI_PROFILE:-flash35}}")"
     if [[ -n "$_agy_model" ]]; then
       agy_args+=("--model" "$_agy_model")
     fi

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1121,11 +1121,10 @@ resolve_gemini_profile() {
     const primaryRaw = process.argv[2] || '{}';
     const settingsRaw = process.argv[3] || '{}';
     const defaults = {
-      pro31: 'gemini-3.1-pro-preview',
-      flash3: 'gemini-3-flash-preview',
-      pro25: 'gemini-2.5-pro',
-      flash25: 'gemini-2.5-flash',
-      lite25: 'gemini-2.5-flash-lite'
+      flash35: 'Gemini 3.5 Flash (Medium)',
+      flash35_high: 'Gemini 3.5 Flash (High)',
+      pro31: 'Gemini 3.1 Pro (High)',
+      flash3: 'Gemini 3 Flash'
     };
 
     if (typeof name === 'string' && name.startsWith('gemini-')) {
@@ -1193,9 +1192,9 @@ resolve_gemini_profile() {
       }
     }
 
-    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.pro25);
+    process.stdout.write(defaults[name] || defaults[process.env.TFX_GEMINI_DEFAULT_PROFILE] || defaults.flash35);
   " "$profile" "$_GEMINI_PROFILE_CACHE" "$settings_cache" 2>/dev/null)
-  echo "${result:-gemini-2.5-pro}"
+  echo "${result:-Gemini 3.5 Flash (Medium)}"
 }
 
 # ── 라우팅 테이블 ──
@@ -1289,7 +1288,9 @@ route_agent() {
       CLI_EFFORT="gpt55_xhigh"; DEFAULT_TIMEOUT=3600; RUN_MODE="bg"; OPUS_OVERSIGHT="false" ;;
 
     # ─── Antigravity CLI 레인 (Gemini CLI 후속) ───
-    # 모델 선택 옵션 부재 (top-level), Antigravity 측 settings.json 으로 endemic.
+    # 모델은 run_antigravity_exec() 가 resolve_gemini_profile(TFX_GEMINI_PROFILE,
+    # 기본 flash35)로 해석해 `--model "<display name>"`을 agy_args 에 주입한다.
+    # CLI_ARGS 는 read -a 로 word-split 되므로 공백 포함 모델명을 여기 넣지 않는다.
     # #310: upstream callers are normalized through agent-map.json, but this
     # direct route entrypoint intentionally keeps agy as a compatibility alias.
     designer|writer|gemini|antigravity|agy)
@@ -2179,6 +2180,18 @@ run_antigravity_exec() {
   local worker_pid
   local -a agy_args=()
   read -r -a agy_args <<< "$CLI_ARGS"
+
+  # ── 프로필 기반 모델 주입 ──
+  # display name 에 공백/괄호가 있으므로(예: "Gemini 3.5 Flash (Medium)") CLI_ARGS
+  # 문자열이 아니라 agy_args 배열에 두 원소(--model, <display name>)로 append 해야
+  # "${agy_args[@]}" expand 시 단일 인자로 보존된다. 모델 SSOT 는 프로필 설정이다.
+  if [[ -z "${TFX_GEMINI_NO_MODEL:-}" ]]; then
+    local _agy_model
+    _agy_model="$(resolve_gemini_profile "${TFX_GEMINI_PROFILE:-flash35}")"
+    if [[ -n "$_agy_model" ]]; then
+      agy_args+=("--model" "$_agy_model")
+    fi
+  fi
 
   if ! agy_supports_headless "$CLI_CMD"; then
     echo "[tfx-route] Antigravity CLI headless flags unsupported or missing: $CLI_CMD" >"$STDERR_LOG"

--- a/tests/unit/gemini-profiles.test.mjs
+++ b/tests/unit/gemini-profiles.test.mjs
@@ -109,3 +109,70 @@ describe("ensureGeminiProfiles()", () => {
     );
   });
 });
+
+describe("ensureGeminiProfiles() 마이그레이션", () => {
+  it("deprecated 2.5 프로필을 제거하고 옛 ID 형식을 display name 으로 갱신한다", () => {
+    const { geminiDir, profilesPath } = makeTempPaths();
+    writeFileSync(
+      profilesPath,
+      JSON.stringify({
+        model: "gemini-3.1-pro-preview",
+        profiles: {
+          pro31: { model: "gemini-3.1-pro-preview", hint: "old" },
+          flash3: { model: "gemini-3-flash-preview", hint: "old" },
+          pro25: { model: "gemini-2.5-pro" },
+          flash25: { model: "gemini-2.5-flash" },
+          lite25: { model: "gemini-2.5-flash-lite" },
+        },
+      }),
+    );
+
+    const result = ensureGeminiProfiles({ geminiDir, profilesPath });
+    const saved = JSON.parse(readFileSync(profilesPath, "utf8"));
+
+    assert.equal(result.ok, true);
+    assert.equal(saved.profiles.pro25, undefined);
+    assert.equal(saved.profiles.flash25, undefined);
+    assert.equal(saved.profiles.lite25, undefined);
+    assert.equal(saved.profiles.pro31.model, "Gemini 3.1 Pro (High)");
+    assert.equal(saved.profiles.flash3.model, "Gemini 3 Flash");
+    // 모델 값만 교체, 나머지 필드(hint)는 보존
+    assert.equal(saved.profiles.pro31.hint, "old");
+    // 신규 default 프로필이 함께 채워짐
+    assert.ok(saved.profiles.flash35);
+    const baks = readdirSync(geminiDir).filter((name) =>
+      name.startsWith("triflux-profiles.json.bak."),
+    );
+    assert.equal(baks.length, 1);
+  });
+
+  it("옛 ID 형식 기본 model 을 새 기본으로 정규화한다", () => {
+    const { geminiDir, profilesPath } = makeTempPaths();
+    writeFileSync(
+      profilesPath,
+      JSON.stringify({
+        model: "gemini-3.1-pro-preview",
+        profiles: { pro31: { model: "gemini-3.1-pro-preview" } },
+      }),
+    );
+
+    ensureGeminiProfiles({ geminiDir, profilesPath });
+    const saved = JSON.parse(readFileSync(profilesPath, "utf8"));
+
+    assert.equal(saved.model, DEFAULT_GEMINI_PROFILES.model);
+    assert.equal(saved.model, "Gemini 3.5 Flash (Medium)");
+  });
+
+  it("이미 새 형식이면 마이그레이션/백업하지 않는다 (멱등)", () => {
+    const { geminiDir, profilesPath } = makeTempPaths();
+    writeFileSync(profilesPath, JSON.stringify(DEFAULT_GEMINI_PROFILES));
+
+    const result = ensureGeminiProfiles({ geminiDir, profilesPath });
+    const baks = readdirSync(geminiDir).filter((name) =>
+      name.startsWith("triflux-profiles.json.bak."),
+    );
+
+    assert.equal(result.added, 0);
+    assert.equal(baks.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
agy(Antigravity) 레인이 `--model` 을 지정하지 않아 계정 기본 모델이 의도와 무관하게 사용되던 회귀를 수정하고, effort tier 프로필 풀셋 + agent 별 모델 매핑을 추가한다.

## Fixed
- agy lane `--model` 미지정 회귀: `run_antigravity_exec` 가 프로필 기반 모델(display name)을 `agy_args` **배열**에 주입(공백/괄호 보존). 호출처가 0이던 `resolve_gemini_profile` 을 실배선.
- deprecated 2.5 프로필(pro25/flash25/lite25) 제거 + merge-only `ensureGeminiProfiles` 에 1회 마이그레이션(stale prune + 옛 ID→display name, 백업 동반).

## Added
- effort tier 풀셋: `flash35_low / flash35 / flash35_high / pro31_low / pro31 / flash3` (`agy models` 실측 라인업 반영).
- agy lane agent 매핑: designer→flash35_high, writer→flash35, 직접 alias→flash35.
- 우선순위: `TFX_GEMINI_PROFILE`(env) > `GEMINI_PROFILE`(agent) > flash35. `TFX_GEMINI_NO_MODEL` 안전밸브.

## 검증
- `resolve_gemini_profile` 실호출(6 프로필 전부 정확) + agy 레인 실호출(`=== OUTPUT === SHIPOK` → `--model` display name 실증).
- gemini-profiles 테스트 6/6, tfx-route 영향 테스트 20/20 pass.
- `bash -n`, 전체 `npm run lint` 804파일 clean, 미러 byte-identical 4곳 + `pack check-mirror`.
- 실제 `~/.gemini/triflux-profiles.json` 마이그레이션 적용 확인(2.5 제거, display name 전환, 백업 생성).

## 미러
- `scripts/tfx-route.sh` → `packages/triflux`
- `scripts/lib/gemini-profiles.mjs` → `packages/{core,triflux,remote}` (dep-free byte-identical)

## 주의
- agy `--model` 이 display name 을 받는다는 건 실호출(SHIPOK)로 실증됨. 형식 문제 시 프로필 값(SSOT)만 조정하거나 `TFX_GEMINI_NO_MODEL=1` 로 회피 가능.
