### PR TITLE
fix(tfx-live): dismiss claude external-imports startup screen

### DIFF
--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -734,6 +734,12 @@ function isClaudeTrustPrompt(text) {
   return /Quick safety check|trust this folder/i.test(String(text));
 }
 
+function isClaudeExternalImportsPrompt(text) {
+  return /Allow external CLAUDE\.md file imports|allow external imports/i.test(
+    String(text),
+  );
+}
+
 function selectedLine(text) {
   // Menu selector glyphs only (exclude ASCII '>' which appears in codex's
   // "> You are in ..." trust-prompt header and would mis-target navigation).
@@ -843,6 +849,27 @@ async function dismissClaudeTrustPrompt(remote, session) {
   return { dismissed: false, raw };
 }
 
+async function dismissClaudeExternalImportsPrompt(remote, session) {
+  let raw = await captureVisible(remote, session);
+  if (!isClaudeExternalImportsPrompt(raw)) {
+    return { dismissed: false, raw };
+  }
+
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    if (/Yes, allow external imports/.test(selectedLine(raw))) {
+      await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+      return { dismissed: true, raw };
+    }
+
+    await runTmux(remote, ["send-keys", "-t", session, "Up"]);
+    await sleep(200);
+    raw = await captureVisible(remote, session);
+  }
+
+  await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+  return { dismissed: true, raw };
+}
+
 const ADAPTERS = {
   codex: {
     cli: "codex",
@@ -916,6 +943,11 @@ const ADAPTERS = {
         name: "trust",
         isPresent: isClaudeTrustPrompt,
         dismiss: dismissClaudeTrustPrompt,
+      },
+      {
+        name: "external-imports",
+        isPresent: isClaudeExternalImportsPrompt,
+        dismiss: dismissClaudeExternalImportsPrompt,
       },
     ],
   },

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -734,6 +734,12 @@ function isClaudeTrustPrompt(text) {
   return /Quick safety check|trust this folder/i.test(String(text));
 }
 
+function isClaudeExternalImportsPrompt(text) {
+  return /Allow external CLAUDE\.md file imports|allow external imports/i.test(
+    String(text),
+  );
+}
+
 function selectedLine(text) {
   // Menu selector glyphs only (exclude ASCII '>' which appears in codex's
   // "> You are in ..." trust-prompt header and would mis-target navigation).
@@ -843,6 +849,27 @@ async function dismissClaudeTrustPrompt(remote, session) {
   return { dismissed: false, raw };
 }
 
+async function dismissClaudeExternalImportsPrompt(remote, session) {
+  let raw = await captureVisible(remote, session);
+  if (!isClaudeExternalImportsPrompt(raw)) {
+    return { dismissed: false, raw };
+  }
+
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    if (/Yes, allow external imports/.test(selectedLine(raw))) {
+      await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+      return { dismissed: true, raw };
+    }
+
+    await runTmux(remote, ["send-keys", "-t", session, "Up"]);
+    await sleep(200);
+    raw = await captureVisible(remote, session);
+  }
+
+  await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+  return { dismissed: true, raw };
+}
+
 const ADAPTERS = {
   codex: {
     cli: "codex",
@@ -916,6 +943,11 @@ const ADAPTERS = {
         name: "trust",
         isPresent: isClaudeTrustPrompt,
         dismiss: dismissClaudeTrustPrompt,
+      },
+      {
+        name: "external-imports",
+        isPresent: isClaudeExternalImportsPrompt,
+        dismiss: dismissClaudeExternalImportsPrompt,
       },
     ],
   },

--- a/tests/unit/tfx-live-transport.test.mjs
+++ b/tests/unit/tfx-live-transport.test.mjs
@@ -282,3 +282,38 @@ test("callRemoteLive uses injected remote env probe and ssh exec", async () => {
   assert.match(calls[1].args[1], /'\\''--transport'\\'' '\\''uds'\\''/);
   assert.doesNotMatch(calls[1].args[1], /'\\''--json'\\''/);
 });
+
+test("claude adapter registers an external-imports startup screen after trust", () => {
+  const names = ADAPTERS.claude.startupScreens.map((screen) => screen.name);
+  assert.ok(
+    names.includes("external-imports"),
+    "claude startupScreens must include an external-imports entry",
+  );
+  assert.ok(
+    names.indexOf("external-imports") > names.indexOf("trust"),
+    "external-imports must be registered after the trust screen",
+  );
+});
+
+test("external-imports startup screen detects the claude import prompt", () => {
+  const screen = ADAPTERS.claude.startupScreens.find(
+    (entry) => entry.name === "external-imports",
+  );
+  assert.ok(screen, "external-imports startup screen must exist");
+
+  assert.equal(
+    screen.isPresent(
+      "Allow external CLAUDE.md file imports?\n  Yes, allow external imports\n  No",
+    ),
+    true,
+  );
+  assert.equal(
+    screen.isPresent("allow external imports for this session"),
+    true,
+  );
+  assert.equal(
+    screen.isPresent("Quick safety check: trust this folder?"),
+    false,
+  );
+  assert.equal(screen.isPresent("ready for input"), false);
+});


### PR DESCRIPTION
**Authored by Codex (via `tfx-route.sh --cli codex`), reviewed by Claude.**

## Problem
`tfx-live` (`bin/tfx-live.mjs`) claude tmux launch path **hangs with a silent timeout** (`(no text; status=timeout)`) when launching `claude` in environments whose global `~/.claude/CLAUDE.md` `@imports` external files. Claude shows a startup screen **"Allow external CLAUDE.md file imports?"** that `tfx-live` never dismisses, so `waitForReady` never observes the ready signal and the launch times out.

## Root cause
`ADAPTERS.claude.startupScreens` only handled the `trust` prompt (codex handles `trust` + `update`). `dismissStartupScreens()` therefore left the external-imports prompt on screen, and the session never reached the ready state.

## Fix
- Add `isClaudeExternalImportsPrompt(text)` detection near `isClaudeTrustPrompt`.
- Add `dismissClaudeExternalImportsPrompt(remote, session)` near `dismissClaudeTrustPrompt`, matching the existing `(remote, session)` dismiss signature (`runTmux` / `captureVisible` / `selectedLine` / `sleep`). It selects **"Yes, allow external imports"** (option 1/top) by navigating `Up` then `Enter`, with an `Enter` fallback after 4 iterations.
- Register a new `external-imports` entry in `ADAPTERS.claude.startupScreens`, **after** the `trust` entry. The codex adapter is untouched.

## Authoring / review
- **Authored by Codex** — the `bin/tfx-live.mjs` edit was written by Codex, dispatched through `bash scripts/tfx-route.sh --cli codex` (headless-guard requires routing through `tfx-route.sh`; direct `codex exec` is blocked). Codex exit 0, `node --check` clean.
- **Reviewed by Claude** — cross-reviewed the Codex diff against the spec: all three edits correct, `(remote, session)` signature honored, external-imports registered after trust, codex adapter left alone. No reviewer corrections were required.

## Mirror
Per `.claude/rules/tfx-mirror-policy.md`, `bin/*` mirrors to `packages/triflux/bin/` only (core/remote do not mirror `bin`). `packages/triflux/bin/tfx-live.mjs` is kept **byte-identical**:
```
$ diff -q bin/tfx-live.mjs packages/triflux/bin/tfx-live.mjs  # exit 0
```

## Tests
- `node --check` passes on both `bin/tfx-live.mjs` and `packages/triflux/bin/tfx-live.mjs`.
- `npm run lint` (biome check = lint+format) passes — 804 files, no fixes.
- Extended `tests/unit/tfx-live-transport.test.mjs` (mirror-excluded per policy) with two cases: the claude adapter registers an `external-imports` startup screen **after** `trust`, and that screen's `isPresent` detects the prompt text (both phrasings) while rejecting the trust prompt and ready text. `node --test` across the three tfx-live test files → **29/29 pass**.

## Follow-up (out of scope)
`ADAPTERS.claude` still lacks an `update` startup-screen handler (codex has `trust` + `update`; claude now has `trust` + `external-imports`). Tracking separately.