### PR TITLE
fix(tfx-live): dismiss claude welcome/tour startup screen

### DIFF
--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -740,6 +740,17 @@ function isClaudeExternalImportsPrompt(text) {
   );
 }
 
+function isClaudeTourPrompt(text) {
+  // Claude's post-update welcome/tour screen ("Take the tour" / "Skip for now").
+  // Claude has no codex-style "Update available / Skip until next version" menu
+  // (its update is a non-blocking background auto-updater), so the recurring
+  // startup screen that needs a "skip" is this tour prompt. Require both labels
+  // so a stray "Skip for now" elsewhere cannot false-match.
+  return (
+    /Take the tour/i.test(String(text)) && /Skip for now/i.test(String(text))
+  );
+}
+
 function selectedLine(text) {
   // Menu selector glyphs only (exclude ASCII '>' which appears in codex's
   // "> You are in ..." trust-prompt header and would mis-target navigation).
@@ -870,6 +881,30 @@ async function dismissClaudeExternalImportsPrompt(remote, session) {
   return { dismissed: true, raw };
 }
 
+async function dismissClaudeTourPrompt(remote, session) {
+  let raw = await captureVisible(remote, session);
+  if (!isClaudeTourPrompt(raw)) {
+    return { dismissed: false, raw };
+  }
+
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    if (/Skip for now/.test(selectedLine(raw))) {
+      await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+      return { dismissed: true, raw };
+    }
+
+    await runTmux(remote, ["send-keys", "-t", session, "Down"]);
+    await sleep(200);
+    raw = await captureVisible(remote, session);
+  }
+
+  // Fallback: Escape cancels the welcome/tour dialog (equivalent to "Skip for
+  // now"). Never blind-Enter here — the default selection may be "Take the
+  // tour", and Enter would launch the tour instead of skipping it.
+  await runTmux(remote, ["send-keys", "-t", session, "Escape"]);
+  return { dismissed: true, raw };
+}
+
 const ADAPTERS = {
   codex: {
     cli: "codex",
@@ -948,6 +983,11 @@ const ADAPTERS = {
         name: "external-imports",
         isPresent: isClaudeExternalImportsPrompt,
         dismiss: dismissClaudeExternalImportsPrompt,
+      },
+      {
+        name: "tour",
+        isPresent: isClaudeTourPrompt,
+        dismiss: dismissClaudeTourPrompt,
       },
     ],
   },

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -740,6 +740,17 @@ function isClaudeExternalImportsPrompt(text) {
   );
 }
 
+function isClaudeTourPrompt(text) {
+  // Claude's post-update welcome/tour screen ("Take the tour" / "Skip for now").
+  // Claude has no codex-style "Update available / Skip until next version" menu
+  // (its update is a non-blocking background auto-updater), so the recurring
+  // startup screen that needs a "skip" is this tour prompt. Require both labels
+  // so a stray "Skip for now" elsewhere cannot false-match.
+  return (
+    /Take the tour/i.test(String(text)) && /Skip for now/i.test(String(text))
+  );
+}
+
 function selectedLine(text) {
   // Menu selector glyphs only (exclude ASCII '>' which appears in codex's
   // "> You are in ..." trust-prompt header and would mis-target navigation).
@@ -870,6 +881,30 @@ async function dismissClaudeExternalImportsPrompt(remote, session) {
   return { dismissed: true, raw };
 }
 
+async function dismissClaudeTourPrompt(remote, session) {
+  let raw = await captureVisible(remote, session);
+  if (!isClaudeTourPrompt(raw)) {
+    return { dismissed: false, raw };
+  }
+
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    if (/Skip for now/.test(selectedLine(raw))) {
+      await runTmux(remote, ["send-keys", "-t", session, "Enter"]);
+      return { dismissed: true, raw };
+    }
+
+    await runTmux(remote, ["send-keys", "-t", session, "Down"]);
+    await sleep(200);
+    raw = await captureVisible(remote, session);
+  }
+
+  // Fallback: Escape cancels the welcome/tour dialog (equivalent to "Skip for
+  // now"). Never blind-Enter here — the default selection may be "Take the
+  // tour", and Enter would launch the tour instead of skipping it.
+  await runTmux(remote, ["send-keys", "-t", session, "Escape"]);
+  return { dismissed: true, raw };
+}
+
 const ADAPTERS = {
   codex: {
     cli: "codex",
@@ -948,6 +983,11 @@ const ADAPTERS = {
         name: "external-imports",
         isPresent: isClaudeExternalImportsPrompt,
         dismiss: dismissClaudeExternalImportsPrompt,
+      },
+      {
+        name: "tour",
+        isPresent: isClaudeTourPrompt,
+        dismiss: dismissClaudeTourPrompt,
       },
     ],
   },

--- a/tests/unit/tfx-live-transport.test.mjs
+++ b/tests/unit/tfx-live-transport.test.mjs
@@ -317,3 +317,43 @@ test("external-imports startup screen detects the claude import prompt", () => {
   );
   assert.equal(screen.isPresent("ready for input"), false);
 });
+
+test("claude adapter registers a tour startup screen after external-imports", () => {
+  const names = ADAPTERS.claude.startupScreens.map((screen) => screen.name);
+  assert.ok(
+    names.includes("tour"),
+    "claude startupScreens must include a tour entry",
+  );
+  assert.ok(
+    names.indexOf("tour") > names.indexOf("external-imports"),
+    "tour must be registered after the external-imports screen",
+  );
+});
+
+test("tour startup screen detects the claude welcome/tour prompt", () => {
+  const screen = ADAPTERS.claude.startupScreens.find(
+    (entry) => entry.name === "tour",
+  );
+  assert.ok(screen, "tour startup screen must exist");
+
+  // Real claude welcome screen renders both the confirm and cancel labels.
+  assert.equal(
+    screen.isPresent(
+      "Welcome to Claude Code\n  ❯ Take the tour\n    Skip for now",
+    ),
+    true,
+  );
+  // Requires BOTH labels — a stray "Skip for now" alone must not match.
+  assert.equal(screen.isPresent("Skip for now"), false);
+  assert.equal(screen.isPresent("Take the tour"), false);
+  // Must not collide with the other claude startup screens or the ready state.
+  assert.equal(
+    screen.isPresent("Allow external CLAUDE.md file imports?"),
+    false,
+  );
+  assert.equal(
+    screen.isPresent("Quick safety check: trust this folder?"),
+    false,
+  );
+  assert.equal(screen.isPresent("ready for input"), false);
+});


### PR DESCRIPTION
## What

tfx-live dismisses CLI startup screens before treating a session as ready. The claude adapter handled `trust` and `external-imports` (the latter from #438) but had no handler for the post-update welcome/tour screen. Adds a claude-specific `tour` startup-screen handler.

## Why this is NOT a codex-style "update" handler

The prior checkpoint planned to reuse codex's `isUpdatePrompt` (`/Update available/ && /Skip until next version/`). Investigation of the installed **claude 2.1.181** binary disproved that premise:

- claude has **no codex-style interactive update menu**. Its "Update available" strings are all non-blocking warnings (`Update available! Run:`, `restart to update`); updates are handled by a background auto-updater.
- claude has **no "Skip until next version" string at all** — so reusing the codex detector would be dead code that never fires.
- The only claude startup screen with a skip action is the post-update welcome/tour prompt: `confirmLabel:"Take the tour"`, `cancelLabel:"Skip for now"`.

So the correct fix is a claude-specific tour handler matching `Take the tour` + `Skip for now`, dismissed by selecting **Skip for now**.

## How

- `isClaudeTourPrompt` — requires BOTH labels so a stray "Skip for now" can't false-match.
- `dismissClaudeTourPrompt` — presses Down until the selected line is "Skip for now", then Enter. Fallback is **Escape** (cancel), never a blind Enter that could launch the tour.
- Registered as a `tour` entry in `ADAPTERS.claude.startupScreens` after `external-imports`.
- Root + `packages/triflux` mirror byte-identical; tests in `tests/unit` (mirror-excluded per policy).

## Verification

- `npm test`: 4398 pass / 0 fail; `lint:skills` PASS; `biome check` clean.
- 2 new unit tests (registration + detector specificity/non-collision).
- Cross-review: Codex APPROVE (independent, per repo no-self-approve policy).

Authored by Claude, cross-reviewed by Codex.