### PR TITLE
fix(codex): select effort profile via -c overrides in hub codex exec (no --profile/[profiles.X] conflict)

### DIFF
--- a/hub/cli-adapter-base.mjs
+++ b/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -172,7 +173,12 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } = opts;
 
   const parts = ["codex"];
-  if (profile) parts.push("--profile", profile);
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`. codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (and codex re-injects such
+  // tables when it rewrites config.toml), so the `-c model=.. -c
+  // model_reasoning_effort=..` form is immune and mutates no config.
+  const profileOverrides = profile ? codexProfileConfigOverrides(profile) : [];
 
   if (FEATURES.execSubcommand) {
     parts.push("exec");
@@ -182,6 +188,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
       parts.push("--output-last-message", resultFile);
     }
     if (FEATURES.colorNever) parts.push("--color", "never");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
     // NOTE: `codex exec`는 --cwd 플래그를 지원하지 않는다. Node spawn의 cwd
     // 옵션으로 child process의 working directory를 제어한다 (conductor.mjs 참조).
     // opts.cwd는 기록용으로만 받아두고 CLI command에는 반영하지 않는다.
@@ -194,6 +202,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } else {
     parts.push("--dangerously-bypass-approvals-and-sandbox");
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
   }
 
   const useStdin = resolveStdinPromptMode(stdinPrompt);

--- a/hub/codex-adapter.mjs
+++ b/hub/codex-adapter.mjs
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import {
   buildExecCommand,
   createResult,
@@ -72,14 +73,21 @@ function buildAttempts(opts, preflight) {
 // ── Launch script ───────────────────────────────────────────────
 
 function createLaunchScriptText(opts) {
-  const parts = ["codex"];
-  if (opts.profile) parts.push("--profile", shellQuote(opts.profile));
-  parts.push(
+  const parts = [
+    "codex",
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
     "--skip-git-repo-check",
-    '$(cat "$PROMPT_FILE")',
-  );
+  ];
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>` (see buildExecCommand): codex 0.134+ rejects `--profile
+  // X` whenever config.toml still contains an inline [profiles.X] table.
+  if (opts.profile) {
+    for (const override of codexProfileConfigOverrides(opts.profile)) {
+      parts.push("-c", shellQuote(override));
+    }
+  }
+  parts.push('$(cat "$PROMPT_FILE")');
   return [
     "#!/usr/bin/env bash",
     "set -euo pipefail",

--- a/hub/team/execution-mode.mjs
+++ b/hub/team/execution-mode.mjs
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve as pathResolve } from "node:path";
 
+import { codexProfileConfigOverrides } from "../../scripts/lib/codex-profile-config.mjs";
 import { whichCommand } from "../platform.mjs";
 
 const WIN32_EXT_PRECEDENCE = [".cmd", ".exe", ".bat", ".ps1"];
@@ -147,7 +148,6 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
   }
 
   const args = [];
-  pushFlag(args, "--profile", opts.profile);
   args.push(
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
@@ -155,6 +155,14 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "--color",
     "never",
   );
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`: codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (which codex re-injects on
+  // config rewrite). These go straight to spawn argv (shell: false), so push
+  // the raw TOML-scalar overrides without shell-quoting.
+  for (const override of codexProfileConfigOverrides(opts.profile)) {
+    args.push("-c", override);
+  }
   if (Array.isArray(opts.mcpServers)) {
     const excludedMcpServers = new Set(
       (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])

--- a/packages/core/hub/cli-adapter-base.mjs
+++ b/packages/core/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -172,7 +173,12 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } = opts;
 
   const parts = ["codex"];
-  if (profile) parts.push("--profile", profile);
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`. codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (and codex re-injects such
+  // tables when it rewrites config.toml), so the `-c model=.. -c
+  // model_reasoning_effort=..` form is immune and mutates no config.
+  const profileOverrides = profile ? codexProfileConfigOverrides(profile) : [];
 
   if (FEATURES.execSubcommand) {
     parts.push("exec");
@@ -182,6 +188,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
       parts.push("--output-last-message", resultFile);
     }
     if (FEATURES.colorNever) parts.push("--color", "never");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
     // NOTE: `codex exec`는 --cwd 플래그를 지원하지 않는다. Node spawn의 cwd
     // 옵션으로 child process의 working directory를 제어한다 (conductor.mjs 참조).
     // opts.cwd는 기록용으로만 받아두고 CLI command에는 반영하지 않는다.
@@ -194,6 +202,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } else {
     parts.push("--dangerously-bypass-approvals-and-sandbox");
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
   }
 
   const useStdin = resolveStdinPromptMode(stdinPrompt);

--- a/packages/core/hub/codex-adapter.mjs
+++ b/packages/core/hub/codex-adapter.mjs
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import {
   buildExecCommand,
   createResult,
@@ -72,14 +73,21 @@ function buildAttempts(opts, preflight) {
 // ── Launch script ───────────────────────────────────────────────
 
 function createLaunchScriptText(opts) {
-  const parts = ["codex"];
-  if (opts.profile) parts.push("--profile", shellQuote(opts.profile));
-  parts.push(
+  const parts = [
+    "codex",
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
     "--skip-git-repo-check",
-    '$(cat "$PROMPT_FILE")',
-  );
+  ];
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>` (see buildExecCommand): codex 0.134+ rejects `--profile
+  // X` whenever config.toml still contains an inline [profiles.X] table.
+  if (opts.profile) {
+    for (const override of codexProfileConfigOverrides(opts.profile)) {
+      parts.push("-c", shellQuote(override));
+    }
+  }
+  parts.push('$(cat "$PROMPT_FILE")');
   return [
     "#!/usr/bin/env bash",
     "set -euo pipefail",

--- a/packages/core/scripts/lib/codex-profile-config.mjs
+++ b/packages/core/scripts/lib/codex-profile-config.mjs
@@ -1,5 +1,76 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+const EFFORT_BY_SUFFIX = {
+  xhigh: "xhigh",
+  high: "high",
+  med: "medium",
+  medium: "medium",
+  low: "low",
+};
+
+function readProfileScalar(raw, key) {
+  const match = String(raw).match(
+    new RegExp(
+      `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+      "m",
+    ),
+  );
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to the `-c key=value`
+ * config overrides that `codex exec` accepts, so the headless CLI lanes can
+ * select a profile WITHOUT `codex exec --profile <name>`. codex 0.134+ rejects
+ * `--profile X` whenever config.toml still contains an inline `[profiles.X]`
+ * table (which codex itself re-injects when it rewrites config.toml), so the
+ * `-c` form is immune and needs no config mutation / sanitize race.
+ *
+ * SSOT = the per-profile file `~/.codex/<name>.config.toml` written by
+ * `tfx setup`; falls back to deriving the effort from the `<...>_<effort>`
+ * naming convention when the file is absent. Returns the keys that resolve, in
+ * `key="value"` TOML-scalar form ready to be shell-quoted by the caller.
+ *
+ * NOTE: the Codex MCP transport does the structured-arg equivalent in
+ * hub/workers/codex-mcp.mjs (resolveCodexProfileConfig → model + config object);
+ * this returns the CLI `-c` string form for the same per-profile file.
+ *
+ * @param {string} profileName
+ * @param {{ codexHome?: string }} [opts]
+ * @returns {string[]} e.g. ['model="gpt-5.5"', 'model_reasoning_effort="high"']
+ */
+export function codexProfileConfigOverrides(profileName, opts = {}) {
+  if (typeof profileName !== "string" || !profileName) return [];
+  const codexHome =
+    opts.codexHome || process.env.CODEX_HOME || join(homedir(), ".codex");
+  let model = null;
+  let effort = null;
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    model = readProfileScalar(raw, "model");
+    effort = readProfileScalar(raw, "model_reasoning_effort");
+  } catch {
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) effort = EFFORT_BY_SUFFIX[suffix[1]] || null;
+  }
+  const overrides = [];
+  if (model) overrides.push(`model="${model}"`);
+  if (effort) overrides.push(`model_reasoning_effort="${effort}"`);
+  return overrides;
+}
 
 const PROFILE_SECTION_PREFIX = "profiles.";
 const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
@@ -137,6 +208,16 @@ export function sanitizeCodexProfileConfigFile(
   const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
   if (!sanitized.changed) return sanitized;
   writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
-  writeFileSync(configPath, sanitized.toml, "utf8");
+  // Atomic replace. config.toml is shared global state: a codex session may be
+  // reading it while another entry point (tfx-route, the codex session hook, or
+  // a parallel swarm worker) sanitizes it. Write the sanitized content to a
+  // unique temp file in the same directory, then rename — rename is atomic on
+  // the same filesystem, so no reader ever observes a torn/half-written config.
+  // Concurrent sanitizers each rename their own complete temp; last writer wins
+  // without corruption (the content is identical anyway since the migration is
+  // deterministic). The pid keeps temp names unique across separate processes.
+  const tmpPath = `${configPath}.tmp-${process.pid}-${stamp(now)}`;
+  writeFileSync(tmpPath, sanitized.toml, "utf8");
+  renameSync(tmpPath, configPath);
   return sanitized;
 }

--- a/packages/remote/hub/team/execution-mode.mjs
+++ b/packages/remote/hub/team/execution-mode.mjs
@@ -3,6 +3,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve as pathResolve } from "node:path";
 
+// scripts/lib is bundled into @triflux/remote itself (package.json files), so
+// import the local mirror relatively rather than via @triflux/core. The core
+// peer range (^10.0.0-alpha.1) could resolve to a build that predates this
+// export, which would fail at import time; the bundled copy is version-skew
+// safe and always carries the matching codexProfileConfigOverrides.
+import { codexProfileConfigOverrides } from "../../scripts/lib/codex-profile-config.mjs";
 import { whichCommand } from "@triflux/core/hub/platform.mjs";
 
 const WIN32_EXT_PRECEDENCE = [".cmd", ".exe", ".bat", ".ps1"];
@@ -147,7 +153,6 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
   }
 
   const args = [];
-  pushFlag(args, "--profile", opts.profile);
   args.push(
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
@@ -155,6 +160,14 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "--color",
     "never",
   );
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`: codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (which codex re-injects on
+  // config rewrite). These go straight to spawn argv (shell: false), so push
+  // the raw TOML-scalar overrides without shell-quoting.
+  for (const override of codexProfileConfigOverrides(opts.profile)) {
+    args.push("-c", override);
+  }
   if (Array.isArray(opts.mcpServers)) {
     const excludedMcpServers = new Set(
       (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])

--- a/packages/remote/scripts/lib/codex-profile-config.mjs
+++ b/packages/remote/scripts/lib/codex-profile-config.mjs
@@ -1,5 +1,76 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+const EFFORT_BY_SUFFIX = {
+  xhigh: "xhigh",
+  high: "high",
+  med: "medium",
+  medium: "medium",
+  low: "low",
+};
+
+function readProfileScalar(raw, key) {
+  const match = String(raw).match(
+    new RegExp(
+      `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+      "m",
+    ),
+  );
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to the `-c key=value`
+ * config overrides that `codex exec` accepts, so the headless CLI lanes can
+ * select a profile WITHOUT `codex exec --profile <name>`. codex 0.134+ rejects
+ * `--profile X` whenever config.toml still contains an inline `[profiles.X]`
+ * table (which codex itself re-injects when it rewrites config.toml), so the
+ * `-c` form is immune and needs no config mutation / sanitize race.
+ *
+ * SSOT = the per-profile file `~/.codex/<name>.config.toml` written by
+ * `tfx setup`; falls back to deriving the effort from the `<...>_<effort>`
+ * naming convention when the file is absent. Returns the keys that resolve, in
+ * `key="value"` TOML-scalar form ready to be shell-quoted by the caller.
+ *
+ * NOTE: the Codex MCP transport does the structured-arg equivalent in
+ * hub/workers/codex-mcp.mjs (resolveCodexProfileConfig → model + config object);
+ * this returns the CLI `-c` string form for the same per-profile file.
+ *
+ * @param {string} profileName
+ * @param {{ codexHome?: string }} [opts]
+ * @returns {string[]} e.g. ['model="gpt-5.5"', 'model_reasoning_effort="high"']
+ */
+export function codexProfileConfigOverrides(profileName, opts = {}) {
+  if (typeof profileName !== "string" || !profileName) return [];
+  const codexHome =
+    opts.codexHome || process.env.CODEX_HOME || join(homedir(), ".codex");
+  let model = null;
+  let effort = null;
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    model = readProfileScalar(raw, "model");
+    effort = readProfileScalar(raw, "model_reasoning_effort");
+  } catch {
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) effort = EFFORT_BY_SUFFIX[suffix[1]] || null;
+  }
+  const overrides = [];
+  if (model) overrides.push(`model="${model}"`);
+  if (effort) overrides.push(`model_reasoning_effort="${effort}"`);
+  return overrides;
+}
 
 const PROFILE_SECTION_PREFIX = "profiles.";
 const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
@@ -137,6 +208,16 @@ export function sanitizeCodexProfileConfigFile(
   const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
   if (!sanitized.changed) return sanitized;
   writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
-  writeFileSync(configPath, sanitized.toml, "utf8");
+  // Atomic replace. config.toml is shared global state: a codex session may be
+  // reading it while another entry point (tfx-route, the codex session hook, or
+  // a parallel swarm worker) sanitizes it. Write the sanitized content to a
+  // unique temp file in the same directory, then rename — rename is atomic on
+  // the same filesystem, so no reader ever observes a torn/half-written config.
+  // Concurrent sanitizers each rename their own complete temp; last writer wins
+  // without corruption (the content is identical anyway since the migration is
+  // deterministic). The pid keeps temp names unique across separate processes.
+  const tmpPath = `${configPath}.tmp-${process.pid}-${stamp(now)}`;
+  writeFileSync(tmpPath, sanitized.toml, "utf8");
+  renameSync(tmpPath, configPath);
   return sanitized;
 }

--- a/packages/triflux/hub/cli-adapter-base.mjs
+++ b/packages/triflux/hub/cli-adapter-base.mjs
@@ -4,6 +4,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import { writePromptToTmpFile } from "./lib/prompt-tmp.mjs";
 import { IS_WINDOWS, killProcess } from "./platform.mjs";
 
@@ -172,7 +173,12 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } = opts;
 
   const parts = ["codex"];
-  if (profile) parts.push("--profile", profile);
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`. codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (and codex re-injects such
+  // tables when it rewrites config.toml), so the `-c model=.. -c
+  // model_reasoning_effort=..` form is immune and mutates no config.
+  const profileOverrides = profile ? codexProfileConfigOverrides(profile) : [];
 
   if (FEATURES.execSubcommand) {
     parts.push("exec");
@@ -182,6 +188,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
       parts.push("--output-last-message", resultFile);
     }
     if (FEATURES.colorNever) parts.push("--color", "never");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
     // NOTE: `codex exec`는 --cwd 플래그를 지원하지 않는다. Node spawn의 cwd
     // 옵션으로 child process의 working directory를 제어한다 (conductor.mjs 참조).
     // opts.cwd는 기록용으로만 받아두고 CLI command에는 반영하지 않는다.
@@ -194,6 +202,8 @@ export function buildExecCommand(prompt, resultFile = null, opts = {}) {
   } else {
     parts.push("--dangerously-bypass-approvals-and-sandbox");
     if (skipGitRepoCheck) parts.push("--skip-git-repo-check");
+    for (const override of profileOverrides)
+      parts.push("-c", shellQuote(override));
   }
 
   const useStdin = resolveStdinPromptMode(stdinPrompt);

--- a/packages/triflux/hub/codex-adapter.mjs
+++ b/packages/triflux/hub/codex-adapter.mjs
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
+import { codexProfileConfigOverrides } from "../scripts/lib/codex-profile-config.mjs";
 import {
   buildExecCommand,
   createResult,
@@ -72,14 +73,21 @@ function buildAttempts(opts, preflight) {
 // ── Launch script ───────────────────────────────────────────────
 
 function createLaunchScriptText(opts) {
-  const parts = ["codex"];
-  if (opts.profile) parts.push("--profile", shellQuote(opts.profile));
-  parts.push(
+  const parts = [
+    "codex",
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
     "--skip-git-repo-check",
-    '$(cat "$PROMPT_FILE")',
-  );
+  ];
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>` (see buildExecCommand): codex 0.134+ rejects `--profile
+  // X` whenever config.toml still contains an inline [profiles.X] table.
+  if (opts.profile) {
+    for (const override of codexProfileConfigOverrides(opts.profile)) {
+      parts.push("-c", shellQuote(override));
+    }
+  }
+  parts.push('$(cat "$PROMPT_FILE")');
   return [
     "#!/usr/bin/env bash",
     "set -euo pipefail",

--- a/packages/triflux/hub/team/execution-mode.mjs
+++ b/packages/triflux/hub/team/execution-mode.mjs
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve as pathResolve } from "node:path";
 
+import { codexProfileConfigOverrides } from "../../scripts/lib/codex-profile-config.mjs";
 import { whichCommand } from "../platform.mjs";
 
 const WIN32_EXT_PRECEDENCE = [".cmd", ".exe", ".bat", ".ps1"];
@@ -147,7 +148,6 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
   }
 
   const args = [];
-  pushFlag(args, "--profile", opts.profile);
   args.push(
     "exec",
     "--dangerously-bypass-approvals-and-sandbox",
@@ -155,6 +155,14 @@ export function buildSpawnSpecForMode(mode, opts = {}) {
     "--color",
     "never",
   );
+  // Select the effort profile via `-c` config overrides instead of
+  // `--profile <name>`: codex 0.134+ rejects `--profile X` whenever config.toml
+  // still contains an inline [profiles.X] table (which codex re-injects on
+  // config rewrite). These go straight to spawn argv (shell: false), so push
+  // the raw TOML-scalar overrides without shell-quoting.
+  for (const override of codexProfileConfigOverrides(opts.profile)) {
+    args.push("-c", override);
+  }
   if (Array.isArray(opts.mcpServers)) {
     const excludedMcpServers = new Set(
       (Array.isArray(opts.excludeMcpServers) ? opts.excludeMcpServers : [])

--- a/packages/triflux/scripts/lib/codex-profile-config.mjs
+++ b/packages/triflux/scripts/lib/codex-profile-config.mjs
@@ -1,5 +1,76 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+const EFFORT_BY_SUFFIX = {
+  xhigh: "xhigh",
+  high: "high",
+  med: "medium",
+  medium: "medium",
+  low: "low",
+};
+
+function readProfileScalar(raw, key) {
+  const match = String(raw).match(
+    new RegExp(
+      `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+      "m",
+    ),
+  );
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to the `-c key=value`
+ * config overrides that `codex exec` accepts, so the headless CLI lanes can
+ * select a profile WITHOUT `codex exec --profile <name>`. codex 0.134+ rejects
+ * `--profile X` whenever config.toml still contains an inline `[profiles.X]`
+ * table (which codex itself re-injects when it rewrites config.toml), so the
+ * `-c` form is immune and needs no config mutation / sanitize race.
+ *
+ * SSOT = the per-profile file `~/.codex/<name>.config.toml` written by
+ * `tfx setup`; falls back to deriving the effort from the `<...>_<effort>`
+ * naming convention when the file is absent. Returns the keys that resolve, in
+ * `key="value"` TOML-scalar form ready to be shell-quoted by the caller.
+ *
+ * NOTE: the Codex MCP transport does the structured-arg equivalent in
+ * hub/workers/codex-mcp.mjs (resolveCodexProfileConfig → model + config object);
+ * this returns the CLI `-c` string form for the same per-profile file.
+ *
+ * @param {string} profileName
+ * @param {{ codexHome?: string }} [opts]
+ * @returns {string[]} e.g. ['model="gpt-5.5"', 'model_reasoning_effort="high"']
+ */
+export function codexProfileConfigOverrides(profileName, opts = {}) {
+  if (typeof profileName !== "string" || !profileName) return [];
+  const codexHome =
+    opts.codexHome || process.env.CODEX_HOME || join(homedir(), ".codex");
+  let model = null;
+  let effort = null;
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    model = readProfileScalar(raw, "model");
+    effort = readProfileScalar(raw, "model_reasoning_effort");
+  } catch {
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) effort = EFFORT_BY_SUFFIX[suffix[1]] || null;
+  }
+  const overrides = [];
+  if (model) overrides.push(`model="${model}"`);
+  if (effort) overrides.push(`model_reasoning_effort="${effort}"`);
+  return overrides;
+}
 
 const PROFILE_SECTION_PREFIX = "profiles.";
 const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
@@ -137,6 +208,16 @@ export function sanitizeCodexProfileConfigFile(
   const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
   if (!sanitized.changed) return sanitized;
   writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
-  writeFileSync(configPath, sanitized.toml, "utf8");
+  // Atomic replace. config.toml is shared global state: a codex session may be
+  // reading it while another entry point (tfx-route, the codex session hook, or
+  // a parallel swarm worker) sanitizes it. Write the sanitized content to a
+  // unique temp file in the same directory, then rename — rename is atomic on
+  // the same filesystem, so no reader ever observes a torn/half-written config.
+  // Concurrent sanitizers each rename their own complete temp; last writer wins
+  // without corruption (the content is identical anyway since the migration is
+  // deterministic). The pid keeps temp names unique across separate processes.
+  const tmpPath = `${configPath}.tmp-${process.pid}-${stamp(now)}`;
+  writeFileSync(tmpPath, sanitized.toml, "utf8");
+  renameSync(tmpPath, configPath);
   return sanitized;
 }

--- a/scripts/lib/codex-profile-config.mjs
+++ b/scripts/lib/codex-profile-config.mjs
@@ -1,5 +1,76 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+const EFFORT_BY_SUFFIX = {
+  xhigh: "xhigh",
+  high: "high",
+  med: "medium",
+  medium: "medium",
+  low: "low",
+};
+
+function readProfileScalar(raw, key) {
+  const match = String(raw).match(
+    new RegExp(
+      `^\\s*${key}\\s*=\\s*(?:"([^"\\n]*)"|'([^'\\n]*)'|([^#\\n]*?))\\s*(?:#.*)?$`,
+      "m",
+    ),
+  );
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+  return value || null;
+}
+
+/**
+ * Resolve a Codex effort profile name (e.g. "gpt55_high") to the `-c key=value`
+ * config overrides that `codex exec` accepts, so the headless CLI lanes can
+ * select a profile WITHOUT `codex exec --profile <name>`. codex 0.134+ rejects
+ * `--profile X` whenever config.toml still contains an inline `[profiles.X]`
+ * table (which codex itself re-injects when it rewrites config.toml), so the
+ * `-c` form is immune and needs no config mutation / sanitize race.
+ *
+ * SSOT = the per-profile file `~/.codex/<name>.config.toml` written by
+ * `tfx setup`; falls back to deriving the effort from the `<...>_<effort>`
+ * naming convention when the file is absent. Returns the keys that resolve, in
+ * `key="value"` TOML-scalar form ready to be shell-quoted by the caller.
+ *
+ * NOTE: the Codex MCP transport does the structured-arg equivalent in
+ * hub/workers/codex-mcp.mjs (resolveCodexProfileConfig → model + config object);
+ * this returns the CLI `-c` string form for the same per-profile file.
+ *
+ * @param {string} profileName
+ * @param {{ codexHome?: string }} [opts]
+ * @returns {string[]} e.g. ['model="gpt-5.5"', 'model_reasoning_effort="high"']
+ */
+export function codexProfileConfigOverrides(profileName, opts = {}) {
+  if (typeof profileName !== "string" || !profileName) return [];
+  const codexHome =
+    opts.codexHome || process.env.CODEX_HOME || join(homedir(), ".codex");
+  let model = null;
+  let effort = null;
+  try {
+    const raw = readFileSync(
+      join(codexHome, `${profileName}.config.toml`),
+      "utf8",
+    );
+    model = readProfileScalar(raw, "model");
+    effort = readProfileScalar(raw, "model_reasoning_effort");
+  } catch {
+    const suffix = /_(xhigh|high|med|medium|low)$/.exec(profileName);
+    if (suffix) effort = EFFORT_BY_SUFFIX[suffix[1]] || null;
+  }
+  const overrides = [];
+  if (model) overrides.push(`model="${model}"`);
+  if (effort) overrides.push(`model_reasoning_effort="${effort}"`);
+  return overrides;
+}
 
 const PROFILE_SECTION_PREFIX = "profiles.";
 const SAFE_PROFILE_FILE_RE = /^[A-Za-z0-9_.-]+$/;
@@ -137,6 +208,16 @@ export function sanitizeCodexProfileConfigFile(
   const sanitized = sanitizeCodexProfileConfig(source, { codexHome });
   if (!sanitized.changed) return sanitized;
   writeFileSync(`${configPath}.${backupPrefix}-${stamp(now)}`, source, "utf8");
-  writeFileSync(configPath, sanitized.toml, "utf8");
+  // Atomic replace. config.toml is shared global state: a codex session may be
+  // reading it while another entry point (tfx-route, the codex session hook, or
+  // a parallel swarm worker) sanitizes it. Write the sanitized content to a
+  // unique temp file in the same directory, then rename — rename is atomic on
+  // the same filesystem, so no reader ever observes a torn/half-written config.
+  // Concurrent sanitizers each rename their own complete temp; last writer wins
+  // without corruption (the content is identical anyway since the migration is
+  // deterministic). The pid keeps temp names unique across separate processes.
+  const tmpPath = `${configPath}.tmp-${process.pid}-${stamp(now)}`;
+  writeFileSync(tmpPath, sanitized.toml, "utf8");
+  renameSync(tmpPath, configPath);
   return sanitized;
 }

--- a/tests/unit/cli-adapter-base.test.mjs
+++ b/tests/unit/cli-adapter-base.test.mjs
@@ -145,7 +145,14 @@ test("cli-adapter-base exports the shared codex exec builder and codex-compat re
       }),
       command,
     );
-    assert.match(command, /^codex --profile codex53_high exec /);
+    // Profile is now selected via `-c` config overrides, not `--profile`
+    // (codex 0.134+ rejects --profile X against an inline [profiles.X]).
+    assert.doesNotMatch(command, /--profile/);
+    assert.match(command, /^codex exec /);
+    assert.ok(
+      command.includes('-c "model_reasoning_effort=\\"high\\""'),
+      `expected -c effort override, got: ${command}`,
+    );
     assert.match(command, /--dangerously-bypass-approvals-and-sandbox/);
     assert.match(command, /--skip-git-repo-check/);
     assert.match(command, /--output-last-message \/tmp\/result\.txt/);

--- a/tests/unit/codex-adapter.test.mjs
+++ b/tests/unit/codex-adapter.test.mjs
@@ -166,7 +166,13 @@ test("buildLaunchScript emits headless codex exec wrapper", async () => {
   assert.match(script, /--dangerously-bypass-approvals-and-sandbox/);
   assert.match(script, /--skip-git-repo-check/);
   assert.match(script, /\$\(cat "\$PROMPT_FILE"\)/);
-  assert.match(script, /--profile "codex53_high"/);
+  // Profile selected via `-c` overrides, not `--profile` (codex 0.134+ rejects
+  // --profile X against an inline [profiles.X] in config.toml).
+  assert.doesNotMatch(script, /--profile/);
+  assert.ok(
+    script.includes('-c "model_reasoning_effort=\\"high\\""'),
+    `expected -c effort override, got: ${script}`,
+  );
 });
 
 test("execute returns stdout for successful codex exec", async () => {

--- a/tests/unit/codex-profile-config.test.mjs
+++ b/tests/unit/codex-profile-config.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -11,6 +12,7 @@ import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
 
 import {
+  codexProfileConfigOverrides,
   listLegacyCodexProfileSections,
   sanitizeCodexProfileConfig,
   sanitizeCodexProfileConfigFile,
@@ -125,5 +127,41 @@ describe("codex legacy profile config sanitizer", () => {
       false,
     );
     assert.doesNotMatch(readFileSync(configPath, "utf8"), /^\[profiles\./m);
+    // Atomic write must not leave behind a `.tmp-*` staging file; rename
+    // consumes it. A leftover temp would mean a torn/aborted write.
+    assert.equal(
+      readdirSync(codexHome).some((name) => name.includes(".tmp-")),
+      false,
+      "atomic sanitize should leave no .tmp- staging file",
+    );
+  });
+});
+
+describe("codexProfileConfigOverrides", () => {
+  it("reads model + reasoning effort from the per-profile file", () => {
+    const codexHome = makeHome();
+    writeFileSync(
+      join(codexHome, "gpt55_high.config.toml"),
+      'model = "gpt-5.5"\nmodel_reasoning_effort = "high"\n',
+    );
+    assert.deepEqual(codexProfileConfigOverrides("gpt55_high", { codexHome }), [
+      'model="gpt-5.5"',
+      'model_reasoning_effort="high"',
+    ]);
+  });
+
+  it("falls back to the _<effort> naming convention when the file is absent", () => {
+    const codexHome = makeHome();
+    // no gpt55_xhigh.config.toml written → derive effort only, leave model unset
+    assert.deepEqual(
+      codexProfileConfigOverrides("gpt55_xhigh", { codexHome }),
+      ['model_reasoning_effort="xhigh"'],
+    );
+  });
+
+  it("returns [] for an unknown profile with no file and no effort suffix", () => {
+    const codexHome = makeHome();
+    assert.deepEqual(codexProfileConfigOverrides("auto", { codexHome }), []);
+    assert.deepEqual(codexProfileConfigOverrides("", { codexHome }), []);
   });
 });


### PR DESCRIPTION
## 문제

codex 0.134+의 Config Profile V2에서 `codex exec --profile X` 는 `~/.codex/config.toml` 에 inline `[profiles.X]` 테이블이 같이 있으면 거부한다. 그리고 codex 자신이 config.toml 을 재작성(projects/hooks/skills state)할 때 그 inline 테이블을 다시 주입하므로, config 재생성기가 이 실패를 계속 재발시킨다. tfx-route(bash) 레인은 이미 커밋된 pre-exec sanitizer 가 커버하지만, hub headless codex exec 경로(conductor/swarm)는 미커버였다.

triflux 의 별도파일 + `--profile` 방식 자체는 codex 공식("Config Profile V2", `resolve_profile_v2_config_path` → `~/.codex/<name>.config.toml`)과 일치한다 — 발산이 아니다. 폐기된 건 옛 inline 방식이고, 그걸 되살리는 재생성기가 충돌의 원인이다.

## 해결 (hub headless 경로 = `-c` 주입)

공유 config 의 sanitize race 와 싸우는 대신, hub headless codex exec 가 `--profile <name>` 대신 `-c model=.. -c model_reasoning_effort=..` config override 를 쓰도록 전환했다. config 를 전혀 변경하지 않으므로 inline 충돌과 swarm 워커 write race 양쪽에 면역이다. Codex MCP transport 가 0.137 부터 쓰는 방식(`resolveCodexProfileConfig`)과 동일하다.

- **`scripts/lib/codex-profile-config.mjs`**: 신규 `codexProfileConfigOverrides(name)` — `~/.codex/<name>.config.toml`(또는 `_<effort>` naming convention)을 `-c` TOML-scalar override 로 해석. `sanitizeCodexProfileConfigFile` 은 atomic write(temp + rename)로 강화 → 여전히 `--profile` 을 쓰는 tfx-route 레인 및 동시 reader 가 torn config.toml 을 절대 보지 않는다.
- **`hub/team/execution-mode.mjs` `buildSpawnSpecForMode`**: conductor/swarm 이 실제로 spawn 하는 active headless spawn spec(`conductor.mjs` 가 `spawnSpec.args` 를 `shell:false` 로 직접 spawn). raw spawn argv 이므로 shell-quoting 없이 `-c` override 를 push. (codex-adapter 의 buildLauncher 출력은 `legacyCommand` 로 로깅만 됨 — 실제 실패 경로는 이쪽이었다.)
- **`hub/cli-adapter-base.mjs` `buildExecCommand` + `hub/codex-adapter.mjs` `createLaunchScriptText`**: shell-string 빌더는 shellQuote 된 `-c` override 를 emit, `--profile` 제거.

## 미러

`packages/{core,remote,triflux}` byte-identical. remote 의 `execution-mode` 미러는 `@triflux/core` 대신 **자체 번들 `scripts/lib` 상대 import** 를 쓴다 — core peer-version skew 가 import-time 에 깨뜨리지 못하도록.

## 교차검증 (Codex)

3회 교차리뷰로 적발·수정:
1. 1차 시도(codex-session-hook sanitize)는 codex 가 config-load 단계에서 죽으면 훅이 발화되지 않아 `--profile` 실패를 구제 못함 → `-c` 주입으로 전환.
2. 진짜 active 경로는 `codex-adapter` 가 아니라 `execution-mode` `buildSpawnSpecForMode` → 포함.
3. remote 가 `@triflux/core` import 시 peer skew 로 import-time SyntaxError → 자체 번들 상대 import 로 회피.

## 검증

- 전체 테스트 스위트 **4401 pass / 0 fail / 17 skip**
- `check-packages-mirror` Mirror OK
- biome clean
- remote `execution-mode` 로드 확인(상대 import 해결)

## 의도적 잔여 (별도 follow-up)

여전히 `--profile` 을 쓰지만 이번 범위 밖:
- `tfx-route.sh` CLI_ARGS — 이미 커밋된 pre-exec sanitizer 가 커버
- bridge retry-state-machine argv
- 인터랙티브 tmux/wt codex 런처
