### PR TITLE
feat(cto): role-based succession/failover for CTO coordinator

### DIFF
--- a/cto/status.mjs
+++ b/cto/status.mjs
@@ -55,6 +55,17 @@ export function deriveRepoRootFromCwd(cwd) {
   if (cwd.includes("\\") || /^[A-Za-z]:/u.test(cwd)) return cwd;
 
   const normalized = cwd.replace(/\/+$/u, "");
+  const gitWorktreeMarker = "/.worktrees/";
+  const gitWorktreeIndex = normalized.indexOf(gitWorktreeMarker);
+  if (gitWorktreeIndex > 0) {
+    const suffix = normalized.slice(
+      gitWorktreeIndex + gitWorktreeMarker.length,
+    );
+    if (/^[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, gitWorktreeIndex);
+    }
+  }
+
   const claudeMarker = "/.claude/worktrees/";
   const claudeIndex = normalized.indexOf(claudeMarker);
   if (claudeIndex > 0) {

--- a/hub/bridge.mjs
+++ b/hub/bridge.mjs
@@ -119,6 +119,11 @@ const HUB_OPERATIONS = Object.freeze({
     action: "publish",
     httpPath: "/bridge/publish",
   },
+  takeoverRole: {
+    transport: "command",
+    action: "takeover_role",
+    httpPath: "/bridge/takeover-role",
+  },
   sendInput: {
     transport: "command",
     action: "send_input",
@@ -365,6 +370,7 @@ export function parseArgs(argv) {
     args: argv,
     options: {
       agent: { type: "string" },
+      "agent-id": { type: "string" },
       cli: { type: "string" },
       timeout: { type: "string" },
       topics: { type: "string" },
@@ -387,6 +393,7 @@ export function parseArgs(argv) {
       claim: { type: "boolean" },
       actor: { type: "string" },
       command: { type: "string" },
+      role: { type: "string" },
       "session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
@@ -699,6 +706,19 @@ async function cmdPublish(args) {
     HUB_OPERATIONS.publish,
     buildPublishBody(from, to, type, payload),
   );
+  const result = outcome?.result;
+  return emitJson(result || unavailableResult());
+}
+
+async function cmdTakeoverRole(args) {
+  const role = args.role || args[1] || "cto";
+  const agentId = args.agent || args["agent-id"] || args[2];
+  const outcome = await requestHub(HUB_OPERATIONS.takeoverRole, {
+    role,
+    agent_id: agentId,
+    reason: args.reason || "manual",
+    requested_by: args["requested-by"] || "bridge",
+  });
   const result = outcome?.result;
   return emitJson(result || unavailableResult());
 }
@@ -1554,6 +1574,8 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdHandoff(args);
     case "publish":
       return await cmdPublish(args);
+    case "takeover-role":
+      return await cmdTakeoverRole(args);
     case "send-input":
       return await cmdSendInput(args);
     case "context":
@@ -1610,7 +1632,7 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdRetryStatus(args);
     default:
       console.error(
-        "사용법: bridge.mjs <register|result|control|handoff|publish|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
+        "사용법: bridge.mjs <register|result|control|handoff|publish|takeover-role|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
       );
       process.exit(1);
   }

--- a/hub/pipe.mjs
+++ b/hub/pipe.mjs
@@ -29,6 +29,17 @@ function normalizeTopics(topics) {
   return topics.map((topic) => String(topic || "").trim()).filter(Boolean);
 }
 
+function normalizeReplayTopics(topics) {
+  if (Array.isArray(topics)) return normalizeTopics(topics);
+  if (typeof topics === "string") {
+    return topics
+      .split(/[,\s]+/u)
+      .map((topic) => topic.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
 function getTeamBridgeMethod(methodName) {
   const method = getTeamBridge()?.[methodName];
   return typeof method === "function" ? method : null;
@@ -266,6 +277,12 @@ export function createPipeServer({
         return result;
       }
 
+      case "takeover_role": {
+        const result = router.takeoverRole(payload);
+        if (client) touchClient(client);
+        return result;
+      }
+
       case "handoff": {
         const result = router.handleHandoff(payload);
         if (client) touchClient(client);
@@ -454,13 +471,34 @@ export function createPipeServer({
       return pending.slice(0, maxMessages);
     }
 
+    const requestedTopics = normalizeReplayTopics(payload.topics);
+    const auditTopics = new Set(requestedTopics);
+    if (auditTopics.size === 0) {
+      const persistedTopics = store?.getAgent?.(agentId)?.topics || [];
+      for (const topic of persistedTopics) auditTopics.add(topic);
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        router.canReplayMessageForAgent(agentId, {
+          to_agent: "topic:cto",
+          topic: "cto",
+        })
+      ) {
+        auditTopics.add("cto");
+      }
+    }
+
     const audit = store.getAuditMessagesForAgent(agentId, {
       max_messages: maxMessages,
-      include_topics: payload.topics,
+      include_topics: Array.from(auditTopics),
     });
     const byId = new Map();
     for (const message of [...pending, ...audit]) {
       if (!message?.id || byId.has(message.id)) continue;
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        !router.canReplayMessageForAgent(agentId, message)
+      )
+        continue;
       byId.set(message.id, message);
     }
     return Array.from(byId.values())

--- a/hub/public/tray.html
+++ b/hub/public/tray.html
@@ -259,27 +259,31 @@
       `;
     }
 
-    function liveFallbackRows(live) {
-      return live.map(session => ({
-        sessionId: session.sessionId,
-        status: session.phase || 'active',
-        agent_id: session.agent_id || session.agent?.id || '',
-        agent: session.agent || null,
-        promptText: session.promptText || '',
-        prompt: session.prompt || '',
-        userPrompt: session.userPrompt || '',
-        handoffPrompt: session.handoffPrompt || '',
-        command: session.command || '',
+        function liveFallbackRows(live) {
+          return live.map(session => ({
+            sessionId: session.sessionId,
+            status: session.phase || 'active',
+            agent_id: session.agent_id || session.agent?.id || '',
+            agent: session.agent || null,
+            role: session.role || '',
+            roles: session.roles || [],
+            metadata: session.metadata || {},
+            promptText: session.promptText || '',
+            prompt: session.prompt || '',
+            userPrompt: session.userPrompt || '',
+            handoffPrompt: session.handoffPrompt || '',
+            command: session.command || '',
         source: session.source || '',
         conversationId: session.conversationId || '',
         focusable: session.focusable !== false,
-        taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
-        pid: session.pid || '',
-        cwd: session.cwd || session.host || 'local runtime',
-        elapsed: session.elapsed || '',
-        started_at: session.started_at || null,
-      }));
-    }
+            taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
+            pid: session.pid || '',
+            cwd: session.cwd || session.host || 'local runtime',
+            worktreePath: session.worktreePath || '',
+            elapsed: session.elapsed || '',
+            started_at: session.started_at || null,
+          }));
+        }
 
     function compactText(value, fallback = '') {
       const text = String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -293,12 +297,20 @@
       return path.replace(/^\/Users\/[^/]+/, '~');
     }
 
-    function normalizeProjectPath(value) {
-      const path = String(value || '').trim();
-      if (!path) return '';
-      if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
-      return path.replace(/[\\/]+$/u, '') || path;
-    }
+        function normalizeProjectPath(value) {
+          const path = String(value || '').trim();
+          if (!path) return '';
+          if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
+          return path.replace(/[\\/]+$/u, '') || path;
+        }
+
+        function worktreeFamilyRoot(path) {
+          const normalized = normalizeProjectPath(path);
+          const parts = normalized.split(/[\\/]/u);
+          const index = parts.lastIndexOf('.worktrees');
+          if (index <= 0) return '';
+          return parts.slice(0, index).join(normalized.includes('\\') ? '\\' : '/') || '';
+        }
 
     function projectName(value) {
       const path = normalizeProjectPath(value);
@@ -306,12 +318,14 @@
       return path.split(/[\\/]/u).filter(Boolean).pop() || path;
     }
 
-    function projectPathFor(row, hub, fallback = '') {
-      const cwd = String(row?.cwd || row?.worktreePath || '').trim();
-      if (cwd && cwd !== 'local' && cwd !== 'local runtime') return normalizeProjectPath(cwd);
-      const root = String(hub?.projectRoot || fallback || '').trim();
-      return normalizeProjectPath(root || cwd || 'local');
-    }
+        function projectPathFor(row, hub, fallback = '') {
+          const cwd = normalizeProjectPath(String(row?.cwd || row?.worktreePath || '').trim());
+          const rawRoot = normalizeProjectPath(String(hub?.projectRoot || fallback || '').trim());
+          const familyRoot = worktreeFamilyRoot(rawRoot) || rawRoot;
+          if (familyRoot && cwd && (cwd === familyRoot || cwd.startsWith(`${familyRoot}/.worktrees/`) || cwd.startsWith(`${familyRoot}/worktrees/`))) return familyRoot;
+          if (cwd && cwd !== 'local' && cwd !== 'local runtime') return worktreeFamilyRoot(cwd) || cwd;
+          return normalizeProjectPath(familyRoot || cwd || 'local');
+        }
 
     function getProjectGroup(groups, projectPath) {
       const key = normalizeProjectPath(projectPath) || 'local';
@@ -319,33 +333,86 @@
       return groups.get(key);
     }
 
-    function buildProjectGroups(activeSessions, liveRows, hub) {
-      const groups = new Map();
-      const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
-      for (const session of activeSessions) {
-        getProjectGroup(groups, projectPathFor(session, hub, fallbackProject)).ctos.push(session);
-      }
-
-      const ctoIds = new Set(activeSessions.map(session => session.sessionId).filter(Boolean));
-      for (const worker of liveRows) {
-        if (ctoIds.has(worker.sessionId)) continue;
-        getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject)).workers.push(worker);
-      }
-
-      if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
-      for (const group of groups.values()) {
-        if (group.ctos.length === 0 && group.workers.length > 0) {
-          group.ctos.push({
-            sessionId: `cto-${shortId(hub.id || group.projectPath)}`,
-            status: 'active',
-            cwd: group.projectPath,
-            taskSummary: 'CTO runtime overlay',
-            synthetic: true,
-          });
+        function ctoRoleFromPayload(cto) {
+          return cto?.roles?.cto || cto?.succession?.cto || null;
         }
-      }
-      return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+
+        function normalizedRoleValue(value) {
+          return String(value || '').trim().toLowerCase();
+        }
+
+    function rowHasCtoRole(row, ctoRole) {
+      const sid = String(row?.sessionId || '').trim();
+      const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+      const leader = String(ctoRole?.leader_agent_id || '').trim();
+      if (leader) return Boolean(agentId === leader || sid === leader || sid === `cto:${leader}`);
+      if (ctoRole) return false;
+      const role = normalizedRoleValue(row?.role || row?.metadata?.role || row?.sessionKind);
+      const roles = Array.isArray(row?.roles || row?.metadata?.roles)
+        ? (row.roles || row.metadata.roles).map(normalizedRoleValue)
+        : String(row?.roles || row?.metadata?.roles || '').split(/[,\s]+/u).map(normalizedRoleValue);
+      if (role === 'cto' || roles.includes('cto') || row?.metadata?.cto === true) return true;
+      if (agentId === 'cto') return true;
+      if (/^cto[:._-]/iu.test(sid)) return true;
+      return false;
     }
+
+        function ctoRoleRow(ctoRole, hub, fallbackProject) {
+          if (!ctoRole) return null;
+          const status = ctoRole.status === 'active' ? 'active' : 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'unassigned';
+          return {
+            sessionId: ctoRole.leader_agent_id ? `cto:${ctoRole.leader_agent_id}` : `cto:${shortId(hub.id || fallbackProject || 'role')}`,
+            status,
+            cwd: hub.projectRoot || fallbackProject || 'local',
+            taskSummary: status === 'active'
+              ? `CTO leader ${leader} · epoch ${ctoRole.leader_epoch || 0} · pending ${ctoRole.pending_count || 0}`
+              : `CTO offline · previous ${leader} · candidates ${ctoRole.live_candidate_count || 0}`,
+            synthetic: true,
+            roleStatus: ctoRole,
+          };
+        }
+
+        function buildProjectGroups(activeSessions, liveRows, hub, ctoRole = null) {
+          const groups = new Map();
+          const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
+          for (const session of activeSessions) {
+            const group = getProjectGroup(groups, projectPathFor(session, hub, fallbackProject));
+            if (rowHasCtoRole(session, ctoRole)) group.ctos.push(session);
+            else group.workers.push(session);
+          }
+
+          const activeSessionIds = new Set(
+            activeSessions
+              .map(session => session.sessionId)
+              .filter(Boolean)
+          );
+          for (const worker of liveRows) {
+            if (activeSessionIds.has(worker.sessionId)) continue;
+            const group = getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject));
+            if (rowHasCtoRole(worker, ctoRole)) group.ctos.push(worker);
+            else group.workers.push(worker);
+          }
+
+          if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
+          const roleRow = ctoRoleRow(ctoRole, hub, fallbackProject);
+          if (roleRow) {
+            const project = projectPathFor(roleRow, hub, fallbackProject);
+            const group = getProjectGroup(groups, project);
+            const leader = String(ctoRole?.leader_agent_id || '').trim();
+            const existing = group.ctos.find(row => {
+              const sid = String(row?.sessionId || '').trim();
+              const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+              return sid === roleRow.sessionId || (leader && (sid === leader || agentId === leader));
+            });
+            if (existing) {
+              existing.roleStatus = ctoRole;
+            } else {
+              group.ctos.unshift(roleRow);
+            }
+          }
+          return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+        }
 
     function explicitPromptText(row) {
       return String(row?.promptText || row?.prompt || row?.userPrompt || row?.handoffPrompt || '').trim();
@@ -443,20 +510,24 @@
       `;
     }
 
-    function renderCtoChat(ctoRow, workers) {
-      const status = ctoRow.status || ctoRow.phase || 'active';
-      const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
-      const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
-      const promptHtml = hasPromptText(ctoRow)
-        ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
-        : '';
-      const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
-      const agentsHtml = workers.length
-        ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
-        : '';
-      const emptyHtml = promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
-      return `
-        <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
+        function renderCtoChat(ctoRow, workers) {
+          const status = ctoRow.status || ctoRow.phase || 'active';
+          const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
+          const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
+          const role = ctoRow.roleStatus || null;
+          const roleHtml = role
+            ? `<div class="detail-section"><div class="detail-label">Succession</div><div class="path-text">leader ${escapeHtml(role.leader_agent_id || 'none')} · epoch ${escapeHtml(role.leader_epoch || 0)} · pending ${escapeHtml(role.pending_count || 0)} · candidates ${escapeHtml(role.live_candidate_count || 0)}/${escapeHtml(role.candidate_count || 0)}</div></div>`
+            : '';
+          const promptHtml = hasPromptText(ctoRow)
+            ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
+            : '';
+          const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+          const agentsHtml = workers.length
+            ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
+            : '';
+          const emptyHtml = roleHtml || promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
+          return `
+            <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
           <summary class="session-summary">
             <span class="agent-badge">T</span>
             <div style="min-width:0;">
@@ -465,10 +536,11 @@
             </div>
             <div class="agent-state ${escapeHtml(status)}">${escapeHtml(status)}</div>
           </summary>
-          <div class="session-detail">
-            ${promptHtml}
-            ${agentsHtml}
-            ${emptyHtml}
+              <div class="session-detail">
+                ${roleHtml}
+                ${promptHtml}
+                ${agentsHtml}
+                ${emptyHtml}
           </div>
         </details>
       `;
@@ -478,14 +550,15 @@
       return `${count} ${count === 1 ? one : many}`;
     }
 
-    function renderProjectGroup(group) {
-      const projectDisplayPath = displayPath(group.projectPath);
-      const projectLabel = projectName(group.projectPath);
-      const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
-      const agentCount = group.workers.length;
-      const projectCount = [sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
-        .filter(Boolean)
-        .join(' · ') || 'empty';
+        function renderProjectGroup(group) {
+          const projectDisplayPath = displayPath(group.projectPath);
+          const projectLabel = projectName(group.projectPath);
+          const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
+          const agentCount = group.workers.length;
+          const ctoCount = group.ctos.length;
+          const projectCount = [ctoCount ? pluralize(ctoCount, 'CTO') : '', sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
+            .filter(Boolean)
+            .join(' · ') || 'empty';
       let html = `
         <details class="project-group" data-open-key="project:${dataAttr(group.projectPath)}">
           <summary class="project-summary">
@@ -496,26 +569,49 @@
           <div class="project-path">${escapeHtml(projectDisplayPath)}</div>
           <div class="project-body">
       `;
-      const ctos = group.ctos.slice(0, 6);
-      const workers = group.workers.slice(0, 10);
-      for (const [index, ctoRow] of ctos.entries()) {
-        html += renderCtoChat(ctoRow, index === 0 ? workers : []);
-      }
-      html += '</div></details>';
-      return html;
-    }
+          const ctos = group.ctos.slice(0, 6);
+          const workers = group.workers.slice(0, 10);
+          for (const [index, ctoRow] of ctos.entries()) {
+            html += renderCtoChat(ctoRow, index === 0 ? workers : []);
+          }
+          if (ctos.length === 0 && workers.length > 0) {
+            const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+            html += `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`;
+          }
+          html += '</div></details>';
+          return html;
+        }
+
+        function renderCtoRoleBanner(ctoRole) {
+          if (!ctoRole) return '';
+          const status = ctoRole.status || 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'none';
+          return `
+            <div class="section">
+              <div class="section-title">CTO Succession</div>
+              <div class="mini-card">
+                <div style="display:flex;align-items:center;gap:8px;justify-content:space-between;">
+                  <div class="mini-title"><span class="agent-badge">T</span> ${escapeHtml(leader)}</div>
+                  <div class="value-pill status-text ${escapeHtml(status)}">${escapeHtml(status)}</div>
+                </div>
+                <div class="path-text">epoch ${escapeHtml(ctoRole.leader_epoch || 0)} · pending ${escapeHtml(ctoRole.pending_count || 0)} · candidates ${escapeHtml(ctoRole.live_candidate_count || 0)}/${escapeHtml(ctoRole.candidate_count || 0)}${ctoRole.candidate_source ? ` · ${escapeHtml(ctoRole.candidate_source)}` : ''}</div>
+              </div>
+            </div>
+          `;
+        }
 
     function renderSessions(data) {
       const container = document.getElementById('tab-sessions');
       const openKeys = collectOpenDetailKeys(container);
       const hub = data?.hub || {};
       const sessions = Array.isArray(data?.sessions) ? data.sessions : [];
-      const cto = data?.cto || {};
-      const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
-      const runtime = data?.runtime || {};
-      const activeSessions = sessions.filter(s => s.status !== 'stale');
-      const liveRows = liveFallbackRows(live);
-      const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub);
+          const cto = data?.cto || {};
+          const ctoRole = ctoRoleFromPayload(cto);
+          const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
+          const runtime = data?.runtime || {};
+          const activeSessions = sessions.filter(s => s.status !== 'stale');
+          const liveRows = liveFallbackRows(live);
+          const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub, ctoRole);
       const activeCount = activeSessions.filter(s => s.status === 'active').length;
       const idleCount = activeSessions.filter(s => s.status === 'idle').length;
       const staleCount = sessions.filter(s => s.status === 'stale').length;
@@ -530,11 +626,12 @@
           </div>
           <div class="path-text">${projectGroups.length} ${projectGroups.length === 1 ? 'workspace' : 'workspaces'} · ${cto.active_shards?.length || 0} shards · ${renderCopyChip('Hub', hub.id || String(hub.pid || ''))}</div>
         </div>
-        <div class="section">
-          <div class="section-title">Agent Mix</div>
-          <div class="models-list">${renderRuntimeClients(runtime)}</div>
-        </div>
-        ${renderCtoHygiene(cto.hygiene)}
+            <div class="section">
+              <div class="section-title">Agent Mix</div>
+              <div class="models-list">${renderRuntimeClients(runtime)}</div>
+            </div>
+            ${renderCtoRoleBanner(ctoRole)}
+            ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -4,6 +4,11 @@ import { EventEmitter, once } from "node:events";
 import { uuidv7 } from "./lib/uuidv7.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
+const ROLE_TOPICS = new Set(["cto"]);
+const ROLE_SOURCE_RANK = Object.freeze({
+  explicit: 2,
+  "topic-fallback": 1,
+});
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -11,6 +16,37 @@ function uniqueStrings(values = []) {
       (values || []).map((value) => String(value || "").trim()).filter(Boolean),
     ),
   );
+}
+
+function normalizeRoleName(value) {
+  const role = String(value || "")
+    .trim()
+    .toLowerCase();
+  return ROLE_TOPICS.has(role) ? role : "";
+}
+
+function normalizeRoleValues(value) {
+  if (Array.isArray(value))
+    return uniqueStrings(value).map((item) => item.toLowerCase());
+  if (typeof value === "string") {
+    return uniqueStrings(value.split(/[,\s]+/u)).map((item) =>
+      item.toLowerCase(),
+    );
+  }
+  return [];
+}
+
+function rolePriority(metadata = {}, roleName = "") {
+  const candidates = [
+    metadata?.[`${roleName}_priority`],
+    metadata?.role_priority,
+    metadata?.priority,
+  ];
+  for (const value of candidates) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return 0;
 }
 
 function clampAssignDuration(
@@ -90,6 +126,7 @@ export function createRouter(store) {
   const runtimeTopics = new Map();
   const queuesByAgent = new Map();
   const liveMessages = new Map();
+  const roleStates = new Map();
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -121,6 +158,340 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function ensureRoleState(roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!role) return null;
+    if (!roleStates.has(role)) {
+      roleStates.set(role, {
+        role,
+        leaderAgentId: null,
+        previousLeaderAgentId: null,
+        leaderEpoch: 0,
+        leaderSource: null,
+        status: "offline",
+        candidates: new Map(),
+        lastTransitionMs: null,
+        lastReason: "init",
+        transferredCount: 0,
+      });
+    }
+    return roleStates.get(role);
+  }
+
+  function hasRoleCapability(capabilities = [], roleName) {
+    const normalized = normalizeRoleValues(capabilities);
+    return normalized.some(
+      (capability) =>
+        capability === roleName ||
+        capability === `role:${roleName}` ||
+        capability === `${roleName}:leader` ||
+        capability === `${roleName}:candidate`,
+    );
+  }
+
+  function getRoleCandidateSource(agent, topics, roleName) {
+    if (!agent) return null;
+    const metadata = agent.metadata || {};
+    const roles = [
+      ...normalizeRoleValues(metadata.role),
+      ...normalizeRoleValues(metadata.roles),
+    ];
+    const explicit =
+      roles.includes(roleName) ||
+      metadata?.[roleName] === true ||
+      metadata?.is_cto === true ||
+      hasRoleCapability(agent.capabilities, roleName);
+    if (explicit) return "explicit";
+    return topics.includes(roleName) ? "topic-fallback" : null;
+  }
+
+  function buildRoleCandidate(agentId, roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!agentId || !role) return null;
+    const agent = store.getAgent(agentId);
+    if (!agent) return null;
+    const topics = listRuntimeTopics(agentId);
+    const source = getRoleCandidateSource(agent, topics, role);
+    if (!source) return null;
+    return {
+      agent_id: agent.agent_id,
+      status: agent.status,
+      source,
+      priority: rolePriority(agent.metadata, role),
+      last_seen_ms: agent.last_seen_ms || 0,
+      lease_expires_ms: agent.lease_expires_ms || 0,
+      topics,
+      capabilities: agent.capabilities || [],
+    };
+  }
+
+  function refreshRoleCandidateForAgent(agentId) {
+    if (!agentId) return;
+    for (const roleName of ROLE_TOPICS) {
+      const role = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(agentId, roleName);
+      if (candidate) role.candidates.set(agentId, candidate);
+      else role.candidates.delete(agentId);
+    }
+  }
+
+  function refreshRoleCandidates(roleName) {
+    const role = ensureRoleState(roleName);
+    if (!role) return [];
+    const ids = new Set(role.candidates.keys());
+    for (const [agentId, topics] of runtimeTopics) {
+      if (topics.has(role.role)) ids.add(agentId);
+    }
+    for (const agent of store.getAgentsByTopic(role.role)) {
+      ids.add(agent.agent_id);
+    }
+    if (typeof store.listAllAgents === "function") {
+      for (const agent of store.listAllAgents()) ids.add(agent.agent_id);
+    }
+    for (const agentId of ids) refreshRoleCandidateForAgent(agentId);
+    return Array.from(role.candidates.values());
+  }
+
+  function isCandidateLive(candidate, now = Date.now()) {
+    return (
+      candidate?.status === "online" && Number(candidate.lease_expires_ms) > now
+    );
+  }
+
+  function sortRoleCandidates(candidates = []) {
+    return [...candidates].sort((left, right) => {
+      const sourceDelta =
+        (ROLE_SOURCE_RANK[right.source] || 0) -
+        (ROLE_SOURCE_RANK[left.source] || 0);
+      if (sourceDelta !== 0) return sourceDelta;
+      const priorityDelta =
+        Number(right.priority || 0) - Number(left.priority || 0);
+      if (priorityDelta !== 0) return priorityDelta;
+      const seenDelta =
+        Number(right.last_seen_ms || 0) - Number(left.last_seen_ms || 0);
+      if (seenDelta !== 0) return seenDelta;
+      return String(left.agent_id).localeCompare(String(right.agent_id));
+    });
+  }
+
+  function chooseRoleLeader(roleName) {
+    const now = Date.now();
+    return (
+      sortRoleCandidates(refreshRoleCandidates(roleName)).find((candidate) =>
+        isCandidateLive(candidate, now),
+      ) || null
+    );
+  }
+
+  function messageMatchesRole(record, roleName) {
+    const message = record?.message || {};
+    const to = message.to_agent ?? message.to;
+    return to === `topic:${roleName}`;
+  }
+
+  function roleTopicForMessage(message = {}) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return "";
+    return normalizeRoleName(String(to).slice(6));
+  }
+
+  function isReplayAllowedForAgent(agentId, message = {}) {
+    const roleName = roleTopicForMessage(message);
+    if (!roleName) return true;
+    const targetAgentId = String(agentId || "").trim();
+    if (!targetAgentId) return false;
+    const role = getRoleSnapshot(roleName);
+    return role?.leader_agent_id === targetAgentId;
+  }
+
+  function shouldTrackWithoutRecipients(message) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return false;
+    return ROLE_TOPICS.has(String(to).slice(6));
+  }
+
+  function isRoleMessageFullyHandled(record, roleName) {
+    if (!messageMatchesRole(record, roleName)) return true;
+    return (
+      record.recipients.size > 0 &&
+      record.ackedBy.size >= record.recipients.size
+    );
+  }
+
+  function isRoleRecipient(agentId, roleName, previousLeaderAgentId = null) {
+    if (!agentId) return false;
+    if (agentId === previousLeaderAgentId) return true;
+    return Boolean(buildRoleCandidate(agentId, roleName));
+  }
+
+  function countPendingForRole(roleName) {
+    const now = Date.now();
+    let count = 0;
+    for (const record of liveMessages.values()) {
+      if (!messageMatchesRole(record, roleName)) continue;
+      if (record.message.expires_at_ms <= now) continue;
+      if (isRoleMessageFullyHandled(record, roleName)) continue;
+      count += 1;
+    }
+    return count;
+  }
+
+  function transferRoleBacklog(
+    roleName,
+    newLeaderAgentId,
+    previousLeaderAgentId,
+  ) {
+    const role = ensureRoleState(roleName);
+    const now = Date.now();
+    const stats = { transferred_count: 0, skipped_count: 0, removed_count: 0 };
+    if (!role || !newLeaderAgentId) return stats;
+
+    for (const record of liveMessages.values()) {
+      const { message, recipients, ackedBy } = record;
+      if (!messageMatchesRole(record, role.role)) continue;
+      if (message.expires_at_ms <= now) {
+        stats.skipped_count += 1;
+        continue;
+      }
+      if (isRoleMessageFullyHandled(record, role.role)) {
+        stats.skipped_count += 1;
+        continue;
+      }
+
+      for (const recipient of Array.from(recipients)) {
+        if (
+          recipient !== newLeaderAgentId &&
+          isRoleRecipient(recipient, role.role, previousLeaderAgentId)
+        ) {
+          queuesByAgent.get(recipient)?.delete(message.id);
+          recipients.delete(recipient);
+          ackedBy.delete(recipient);
+          stats.removed_count += 1;
+        }
+      }
+
+      recipients.add(newLeaderAgentId);
+      const alreadyQueued = queuesByAgent
+        .get(newLeaderAgentId)
+        ?.has(message.id);
+      if (!alreadyQueued && !ackedBy.has(newLeaderAgentId)) {
+        queueMessage(newLeaderAgentId, message);
+        stats.transferred_count += 1;
+      } else {
+        stats.skipped_count += 1;
+      }
+      message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+
+    role.transferredCount += stats.transferred_count;
+    return stats;
+  }
+
+  function buildRoleSnapshot(roleName, { refreshCandidates = true } = {}) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const candidates = sortRoleCandidates(
+      refreshCandidates
+        ? refreshRoleCandidates(role.role)
+        : Array.from(role.candidates.values()),
+    );
+    const leader =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const leaderLive = isCandidateLive(leader, now);
+    const liveCandidates = candidates.filter((candidate) =>
+      isCandidateLive(candidate, now),
+    );
+    return {
+      role: role.role,
+      status: leaderLive
+        ? "active"
+        : liveCandidates.length
+          ? "electable"
+          : "offline",
+      leader_agent_id: leaderLive ? role.leaderAgentId : null,
+      previous_leader_agent_id: role.previousLeaderAgentId || null,
+      leader_epoch: role.leaderEpoch,
+      lease_expires_ms: leaderLive ? leader.lease_expires_ms : null,
+      candidate_source: leaderLive
+        ? leader.source
+        : liveCandidates[0]?.source || null,
+      candidate_count: candidates.length,
+      live_candidate_count: liveCandidates.length,
+      pending_count: countPendingForRole(role.role),
+      transferred_count: role.transferredCount,
+      last_transition_ms: role.lastTransitionMs,
+      last_reason: role.lastReason,
+      candidates: candidates.slice(0, 16).map((candidate) => ({
+        agent_id: candidate.agent_id,
+        status: isCandidateLive(candidate, now) ? "online" : candidate.status,
+        source: candidate.source,
+        priority: candidate.priority,
+        last_seen_ms: candidate.last_seen_ms,
+        lease_expires_ms: candidate.lease_expires_ms,
+      })),
+    };
+  }
+
+  function ensureRoleLeader(
+    roleName,
+    { reason = "ensure", transferBacklog = true } = {},
+  ) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const current =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const best = chooseRoleLeader(role.role);
+    const currentLive = isCandidateLive(current, now);
+    const shouldPreemptFallback =
+      currentLive &&
+      current?.source === "topic-fallback" &&
+      best?.source === "explicit" &&
+      best.agent_id !== current.agent_id;
+
+    if (currentLive && !shouldPreemptFallback) {
+      role.status = "active";
+      role.leaderSource = current.source;
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (!best) {
+      if (role.leaderAgentId) {
+        role.previousLeaderAgentId = role.leaderAgentId;
+        role.leaderAgentId = null;
+        role.leaderSource = null;
+        role.leaderEpoch += 1;
+        role.lastTransitionMs = Date.now();
+        role.lastReason = reason;
+      }
+      role.status = "offline";
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (role.leaderAgentId !== best.agent_id) {
+      const previousLeaderAgentId = role.leaderAgentId;
+      role.previousLeaderAgentId =
+        previousLeaderAgentId || role.previousLeaderAgentId;
+      role.leaderAgentId = best.agent_id;
+      role.leaderSource = best.source;
+      role.leaderEpoch += 1;
+      role.status = "active";
+      role.lastTransitionMs = Date.now();
+      role.lastReason = reason;
+      if (transferBacklog) {
+        transferRoleBacklog(role.role, best.agent_id, previousLeaderAgentId);
+      }
+    }
+
+    return buildRoleSnapshot(role.role);
+  }
+
+  function getRoleSnapshot(roleName) {
+    return buildRoleSnapshot(roleName, { refreshCandidates: true });
   }
 
   function trackMessage(message, recipients) {
@@ -162,6 +533,14 @@ export function createRouter(store) {
     }
 
     const topic = to.slice(6);
+    if (ROLE_TOPICS.has(topic)) {
+      const role = ensureRoleLeader(topic, {
+        reason: "route",
+        transferBacklog: true,
+      });
+      return role?.leader_agent_id ? [role.leader_agent_id] : [];
+    }
+
     const recipients = new Set();
     for (const [agentId, topics] of runtimeTopics) {
       if (topics.has(topic)) recipients.add(agentId);
@@ -258,8 +637,10 @@ export function createRouter(store) {
       correlation_id,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
-    if (recipients.length) {
+    if (recipients.length || shouldTrackWithoutRecipients(msg)) {
       trackMessage(msg, recipients);
+    }
+    if (recipients.length) {
       for (const agentId of recipients) {
         queueMessage(agentId, msg);
       }
@@ -422,15 +803,37 @@ export function createRouter(store) {
     registerAgent(args) {
       const result = store.registerAgent(args);
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
+      refreshRoleCandidateForAgent(args.agent_id);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "register",
+          transferBacklog: true,
+        });
+      }
       return result;
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {
-      return store.refreshLease(agentId, ttlMs);
+      const result = store.refreshLease(agentId, ttlMs);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "heartbeat",
+          transferBacklog: true,
+        });
+      }
+      return result;
     },
 
     subscribeAgent(agentId, topics, { replace = false } = {}) {
       const nextTopics = upsertRuntimeTopics(agentId, topics, { replace });
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "subscribe",
+          transferBacklog: true,
+        });
+      }
       return { agent_id: agentId, topics: nextTopics };
     },
 
@@ -442,12 +845,25 @@ export function createRouter(store) {
       if (status === "offline") {
         runtimeTopics.delete(agentId);
       }
-      return store.updateAgentStatus(agentId, status);
+      const updated = store.updateAgentStatus(agentId, status);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: `status:${status}`,
+          transferBacklog: true,
+        });
+      }
+      return updated;
     },
 
     route(msg) {
       const recipients = uniqueStrings(resolveRecipients(msg));
-      if (!recipients.length) return 0;
+      if (!recipients.length) {
+        if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
+          trackMessage(msg, []);
+        }
+        return 0;
+      }
       if (!getMessageRecord(msg.id)) {
         trackMessage(msg, recipients);
       }
@@ -460,6 +876,10 @@ export function createRouter(store) {
 
     getPendingMessages(agentId, options = {}) {
       return sortedPending(agentId, options);
+    },
+
+    canReplayMessageForAgent(agentId, message) {
+      return isReplayAllowedForAgent(agentId, message);
     },
 
     countPendingMessages(agentId) {
@@ -610,6 +1030,87 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
+          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+        },
+      };
+    },
+
+    takeoverRole({
+      role = "cto",
+      agent_id,
+      reason = "manual",
+      requested_by = "manual",
+    } = {}) {
+      const roleName = normalizeRoleName(role);
+      if (!roleName) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_NOT_SUPPORTED",
+            message: `unsupported role: ${role}`,
+          },
+        };
+      }
+      const targetAgentId = String(agent_id || "").trim();
+      if (!targetAgentId) {
+        return {
+          ok: false,
+          error: {
+            code: "AGENT_ID_REQUIRED",
+            message: "agent_id required",
+          },
+        };
+      }
+
+      refreshRoleCandidates(roleName);
+      const roleState = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(targetAgentId, roleName);
+      if (!isCandidateLive(candidate)) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_CANDIDATE_UNAVAILABLE",
+            message: `${targetAgentId} is not a live ${roleName} candidate`,
+          },
+          data: {
+            role: buildRoleSnapshot(roleName),
+          },
+        };
+      }
+
+      const previousLeaderAgentId =
+        roleState.leaderAgentId && roleState.leaderAgentId !== targetAgentId
+          ? roleState.leaderAgentId
+          : roleState.previousLeaderAgentId || null;
+      const changed = roleState.leaderAgentId !== targetAgentId;
+      if (changed) {
+        roleState.previousLeaderAgentId = previousLeaderAgentId || null;
+        roleState.leaderAgentId = targetAgentId;
+        roleState.leaderSource = candidate.source;
+        roleState.leaderEpoch += 1;
+        roleState.status = "active";
+        roleState.lastTransitionMs = Date.now();
+        roleState.lastReason = reason || "manual";
+      }
+
+      const transfer = transferRoleBacklog(
+        roleName,
+        targetAgentId,
+        previousLeaderAgentId,
+      );
+      const snapshot = buildRoleSnapshot(roleName);
+      return {
+        ok: true,
+        data: {
+          role: roleName,
+          requested_by,
+          reason,
+          changed,
+          previous_leader_agent_id: previousLeaderAgentId,
+          leader_agent_id: snapshot.leader_agent_id,
+          leader_epoch: snapshot.leader_epoch,
+          ...transfer,
+          status: snapshot,
         },
       };
     },
@@ -897,6 +1398,9 @@ export function createRouter(store) {
           realtime_transport: "named-pipe",
           audit_store: store.type || "sqlite",
         };
+        data.roles = {
+          cto: getRoleSnapshot("cto"),
+        };
         if (include_metrics) {
           const depths = router.getQueueDepths();
           const stats = router.getDeliveryStats();
@@ -919,6 +1423,7 @@ export function createRouter(store) {
       if (scope === "agent" && agent_id) {
         const agent = store.getAgent(agent_id);
         if (agent) {
+          refreshRoleCandidateForAgent(agent_id);
           data.agent = {
             agent_id: agent.agent_id,
             status: agent.status,
@@ -926,6 +1431,18 @@ export function createRouter(store) {
             last_seen_ms: agent.last_seen_ms,
             topics: listRuntimeTopics(agent_id),
           };
+          const roles = {};
+          for (const roleName of ROLE_TOPICS) {
+            const candidate = buildRoleCandidate(agent_id, roleName);
+            if (candidate) {
+              roles[roleName] = {
+                candidate_source: candidate.source,
+                priority: candidate.priority,
+                leader: getRoleSnapshot(roleName)?.leader_agent_id === agent_id,
+              };
+            }
+          }
+          if (Object.keys(roles).length) data.agent.roles = roles;
         }
       }
 

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -22,6 +22,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { runCollect } from "../cto/collect.mjs";
+import { resolveLakeRootDir } from "../cto/lake-root.mjs";
 import { runStatus as runCtoStatus } from "../cto/status.mjs";
 import { createModuleLogger } from "../scripts/lib/logger.mjs";
 import {
@@ -95,6 +96,7 @@ const LOOPBACK_REMOTE_ADDRESSES = new Set([
 const ALLOWED_ORIGIN_RE =
   /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
 const PROJECT_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CANONICAL_PROJECT_ROOT = resolveLakeRootDir(PROJECT_ROOT) || PROJECT_ROOT;
 const PUBLIC_DIR = resolve(join(PROJECT_ROOT, "hub", "public"));
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const HUB_DEFAULT_PORT = 27888;
@@ -865,7 +867,7 @@ function getBrokerPublicSnapshot(currentBroker = brokerInstance) {
 async function getTrayCtoStatus() {
   try {
     return await runCtoStatus(["--json"], {
-      rootDir: PROJECT_ROOT,
+      rootDir: CANONICAL_PROJECT_ROOT,
       stdout: { write() {} },
     });
   } catch (error) {
@@ -1446,12 +1448,22 @@ export async function startHub({
         const synapseSnapshot = synapseRegistry.snapshot();
         const broker = getBrokerPublicSnapshot(brokerInstance);
         const runtimeStatus = getRuntimeStatus({
-          projectRoots: [PROJECT_ROOT],
+          projectRoots: [
+            ...new Set([CANONICAL_PROJECT_ROOT, PROJECT_ROOT].filter(Boolean)),
+          ],
         });
-        const [ctoStatus, mcpStatus] = await Promise.all([
+        const [ctoStatus, mcpStatus, hubStatus] = await Promise.all([
           getTrayCtoStatus(),
           Promise.resolve(getTrayMcpStatus()),
+          pipe.executeQuery("status", {
+            scope: "hub",
+            include_metrics: true,
+          }),
         ]);
+        const mergedCtoStatus = {
+          ...(ctoStatus || {}),
+          roles: hubStatus?.data?.roles || ctoStatus?.roles || {},
+        };
 
         return writeJson(
           res,
@@ -1462,12 +1474,12 @@ export async function startHub({
               pid: process.pid,
               port,
               url: buildHubUrl(host, port),
-              projectRoot: PROJECT_ROOT,
+              projectRoot: CANONICAL_PROJECT_ROOT,
             },
             qos,
             synapseSnapshot,
             broker,
-            ctoStatus,
+            ctoStatus: mergedCtoStatus,
             mcpStatus,
             runtimeStatus,
           }),
@@ -1650,6 +1662,28 @@ export async function startHub({
           if (path === "/bridge/hitl/pending" && req.method === "GET") {
             const result = { ok: true, data: hitl.getPendingRequests() };
             return writeJson(res, result.ok ? 200 : 400, result);
+          }
+
+          if (path === "/bridge/takeover-role" && req.method === "POST") {
+            const {
+              role = "cto",
+              agent_id,
+              reason = "manual",
+              requested_by = "http",
+            } = body;
+            if (!role || !agent_id) {
+              return writeJson(res, 400, {
+                ok: false,
+                error: "role, agent_id 필수",
+              });
+            }
+            const result = await pipe.executeCommand("takeover_role", {
+              role,
+              agent_id,
+              reason,
+              requested_by,
+            });
+            return writeJson(res, result.ok ? 200 : 409, result);
           }
 
           if (path === "/bridge/register" && req.method === "POST") {

--- a/hub/tools.mjs
+++ b/hub/tools.mjs
@@ -183,6 +183,26 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
+    // ── 2-1. takeover_role ──
+    {
+      name: "takeover_role",
+      description:
+        "CTO 같은 허브 역할의 active leader를 명시적으로 승계하고 미처리 역할 메시지를 새 leader에게 이전합니다",
+      inputSchema: {
+        type: "object",
+        required: ["role", "agent_id"],
+        properties: {
+          role: { type: "string", enum: ["cto"], default: "cto" },
+          agent_id: { type: "string", pattern: "^[a-zA-Z0-9._:-]{3,64}$" },
+          reason: { type: "string" },
+          requested_by: { type: "string" },
+        },
+      },
+      handler: wrap("TAKEOVER_ROLE_FAILED", (args) => {
+        return router.takeoverRole(args);
+      }),
+    },
+
     // ── 3. publish ──
     {
       name: "publish",
@@ -841,7 +861,7 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
-    // ── 21. send_input ──
+    // ── 22. send_input ──
     {
       name: "send_input",
       description: "Send input text to a worker in INPUT_WAIT state",

--- a/hub/tray-state.mjs
+++ b/hub/tray-state.mjs
@@ -49,6 +49,10 @@ function normalizeAgentId(value) {
   return "";
 }
 
+function rawAgentId(value) {
+  return String(value ?? "").trim();
+}
+
 function inferAgentId(value = {}) {
   const direct = normalizeAgentId(
     value.agent_id ??
@@ -84,7 +88,11 @@ function agentMeta(agentId) {
 export function normalizeTraySessions(snapshot) {
   return readSynapseSessions(snapshot)
     .map((session) => {
-      const agentId = inferAgentId(session);
+      const directAgentId = session?.agent_id ?? session?.agentId;
+      const agentId =
+        normalizeAgentId(directAgentId) ||
+        rawAgentId(directAgentId) ||
+        inferAgentId(session);
       return {
         sessionId: String(session?.sessionId || ""),
         host: typeof session?.host === "string" ? session.host : "local",
@@ -368,7 +376,11 @@ function runtimeToLiveOverlay(runtime) {
 }
 
 function normalizeLiveSession(session = {}) {
-  const agentId = inferAgentId(session);
+  const directAgentId = session.agent_id ?? session.agentId;
+  const agentId =
+    normalizeAgentId(directAgentId) ||
+    rawAgentId(directAgentId) ||
+    inferAgentId(session);
   return {
     ...session,
     sessionId: String(session.sessionId || ""),
@@ -460,11 +472,21 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
     ? ctoStatus.active_shards
     : [];
   const hygiene = normalizeCtoHygiene(ctoStatus);
+  const roles =
+    ctoStatus?.roles && typeof ctoStatus.roles === "object"
+      ? ctoStatus.roles
+      : null;
+  const succession =
+    ctoStatus?.succession && typeof ctoStatus.succession === "object"
+      ? ctoStatus.succession
+      : null;
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(roles ? { roles } : {}),
+    ...(succession ? { succession } : {}),
     ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,

--- a/packages/core/hub/bridge.mjs
+++ b/packages/core/hub/bridge.mjs
@@ -119,6 +119,11 @@ const HUB_OPERATIONS = Object.freeze({
     action: "publish",
     httpPath: "/bridge/publish",
   },
+  takeoverRole: {
+    transport: "command",
+    action: "takeover_role",
+    httpPath: "/bridge/takeover-role",
+  },
   sendInput: {
     transport: "command",
     action: "send_input",
@@ -365,6 +370,7 @@ export function parseArgs(argv) {
     args: argv,
     options: {
       agent: { type: "string" },
+      "agent-id": { type: "string" },
       cli: { type: "string" },
       timeout: { type: "string" },
       topics: { type: "string" },
@@ -387,6 +393,7 @@ export function parseArgs(argv) {
       claim: { type: "boolean" },
       actor: { type: "string" },
       command: { type: "string" },
+      role: { type: "string" },
       "session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
@@ -699,6 +706,19 @@ async function cmdPublish(args) {
     HUB_OPERATIONS.publish,
     buildPublishBody(from, to, type, payload),
   );
+  const result = outcome?.result;
+  return emitJson(result || unavailableResult());
+}
+
+async function cmdTakeoverRole(args) {
+  const role = args.role || args[1] || "cto";
+  const agentId = args.agent || args["agent-id"] || args[2];
+  const outcome = await requestHub(HUB_OPERATIONS.takeoverRole, {
+    role,
+    agent_id: agentId,
+    reason: args.reason || "manual",
+    requested_by: args["requested-by"] || "bridge",
+  });
   const result = outcome?.result;
   return emitJson(result || unavailableResult());
 }
@@ -1554,6 +1574,8 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdHandoff(args);
     case "publish":
       return await cmdPublish(args);
+    case "takeover-role":
+      return await cmdTakeoverRole(args);
     case "send-input":
       return await cmdSendInput(args);
     case "context":
@@ -1610,7 +1632,7 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdRetryStatus(args);
     default:
       console.error(
-        "사용법: bridge.mjs <register|result|control|handoff|publish|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
+        "사용법: bridge.mjs <register|result|control|handoff|publish|takeover-role|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
       );
       process.exit(1);
   }

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -4,6 +4,11 @@ import { EventEmitter, once } from "node:events";
 import { uuidv7 } from "./lib/uuidv7.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
+const ROLE_TOPICS = new Set(["cto"]);
+const ROLE_SOURCE_RANK = Object.freeze({
+  explicit: 2,
+  "topic-fallback": 1,
+});
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -11,6 +16,37 @@ function uniqueStrings(values = []) {
       (values || []).map((value) => String(value || "").trim()).filter(Boolean),
     ),
   );
+}
+
+function normalizeRoleName(value) {
+  const role = String(value || "")
+    .trim()
+    .toLowerCase();
+  return ROLE_TOPICS.has(role) ? role : "";
+}
+
+function normalizeRoleValues(value) {
+  if (Array.isArray(value))
+    return uniqueStrings(value).map((item) => item.toLowerCase());
+  if (typeof value === "string") {
+    return uniqueStrings(value.split(/[,\s]+/u)).map((item) =>
+      item.toLowerCase(),
+    );
+  }
+  return [];
+}
+
+function rolePriority(metadata = {}, roleName = "") {
+  const candidates = [
+    metadata?.[`${roleName}_priority`],
+    metadata?.role_priority,
+    metadata?.priority,
+  ];
+  for (const value of candidates) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return 0;
 }
 
 function clampAssignDuration(
@@ -90,6 +126,7 @@ export function createRouter(store) {
   const runtimeTopics = new Map();
   const queuesByAgent = new Map();
   const liveMessages = new Map();
+  const roleStates = new Map();
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -121,6 +158,340 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function ensureRoleState(roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!role) return null;
+    if (!roleStates.has(role)) {
+      roleStates.set(role, {
+        role,
+        leaderAgentId: null,
+        previousLeaderAgentId: null,
+        leaderEpoch: 0,
+        leaderSource: null,
+        status: "offline",
+        candidates: new Map(),
+        lastTransitionMs: null,
+        lastReason: "init",
+        transferredCount: 0,
+      });
+    }
+    return roleStates.get(role);
+  }
+
+  function hasRoleCapability(capabilities = [], roleName) {
+    const normalized = normalizeRoleValues(capabilities);
+    return normalized.some(
+      (capability) =>
+        capability === roleName ||
+        capability === `role:${roleName}` ||
+        capability === `${roleName}:leader` ||
+        capability === `${roleName}:candidate`,
+    );
+  }
+
+  function getRoleCandidateSource(agent, topics, roleName) {
+    if (!agent) return null;
+    const metadata = agent.metadata || {};
+    const roles = [
+      ...normalizeRoleValues(metadata.role),
+      ...normalizeRoleValues(metadata.roles),
+    ];
+    const explicit =
+      roles.includes(roleName) ||
+      metadata?.[roleName] === true ||
+      metadata?.is_cto === true ||
+      hasRoleCapability(agent.capabilities, roleName);
+    if (explicit) return "explicit";
+    return topics.includes(roleName) ? "topic-fallback" : null;
+  }
+
+  function buildRoleCandidate(agentId, roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!agentId || !role) return null;
+    const agent = store.getAgent(agentId);
+    if (!agent) return null;
+    const topics = listRuntimeTopics(agentId);
+    const source = getRoleCandidateSource(agent, topics, role);
+    if (!source) return null;
+    return {
+      agent_id: agent.agent_id,
+      status: agent.status,
+      source,
+      priority: rolePriority(agent.metadata, role),
+      last_seen_ms: agent.last_seen_ms || 0,
+      lease_expires_ms: agent.lease_expires_ms || 0,
+      topics,
+      capabilities: agent.capabilities || [],
+    };
+  }
+
+  function refreshRoleCandidateForAgent(agentId) {
+    if (!agentId) return;
+    for (const roleName of ROLE_TOPICS) {
+      const role = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(agentId, roleName);
+      if (candidate) role.candidates.set(agentId, candidate);
+      else role.candidates.delete(agentId);
+    }
+  }
+
+  function refreshRoleCandidates(roleName) {
+    const role = ensureRoleState(roleName);
+    if (!role) return [];
+    const ids = new Set(role.candidates.keys());
+    for (const [agentId, topics] of runtimeTopics) {
+      if (topics.has(role.role)) ids.add(agentId);
+    }
+    for (const agent of store.getAgentsByTopic(role.role)) {
+      ids.add(agent.agent_id);
+    }
+    if (typeof store.listAllAgents === "function") {
+      for (const agent of store.listAllAgents()) ids.add(agent.agent_id);
+    }
+    for (const agentId of ids) refreshRoleCandidateForAgent(agentId);
+    return Array.from(role.candidates.values());
+  }
+
+  function isCandidateLive(candidate, now = Date.now()) {
+    return (
+      candidate?.status === "online" && Number(candidate.lease_expires_ms) > now
+    );
+  }
+
+  function sortRoleCandidates(candidates = []) {
+    return [...candidates].sort((left, right) => {
+      const sourceDelta =
+        (ROLE_SOURCE_RANK[right.source] || 0) -
+        (ROLE_SOURCE_RANK[left.source] || 0);
+      if (sourceDelta !== 0) return sourceDelta;
+      const priorityDelta =
+        Number(right.priority || 0) - Number(left.priority || 0);
+      if (priorityDelta !== 0) return priorityDelta;
+      const seenDelta =
+        Number(right.last_seen_ms || 0) - Number(left.last_seen_ms || 0);
+      if (seenDelta !== 0) return seenDelta;
+      return String(left.agent_id).localeCompare(String(right.agent_id));
+    });
+  }
+
+  function chooseRoleLeader(roleName) {
+    const now = Date.now();
+    return (
+      sortRoleCandidates(refreshRoleCandidates(roleName)).find((candidate) =>
+        isCandidateLive(candidate, now),
+      ) || null
+    );
+  }
+
+  function messageMatchesRole(record, roleName) {
+    const message = record?.message || {};
+    const to = message.to_agent ?? message.to;
+    return to === `topic:${roleName}`;
+  }
+
+  function roleTopicForMessage(message = {}) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return "";
+    return normalizeRoleName(String(to).slice(6));
+  }
+
+  function isReplayAllowedForAgent(agentId, message = {}) {
+    const roleName = roleTopicForMessage(message);
+    if (!roleName) return true;
+    const targetAgentId = String(agentId || "").trim();
+    if (!targetAgentId) return false;
+    const role = getRoleSnapshot(roleName);
+    return role?.leader_agent_id === targetAgentId;
+  }
+
+  function shouldTrackWithoutRecipients(message) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return false;
+    return ROLE_TOPICS.has(String(to).slice(6));
+  }
+
+  function isRoleMessageFullyHandled(record, roleName) {
+    if (!messageMatchesRole(record, roleName)) return true;
+    return (
+      record.recipients.size > 0 &&
+      record.ackedBy.size >= record.recipients.size
+    );
+  }
+
+  function isRoleRecipient(agentId, roleName, previousLeaderAgentId = null) {
+    if (!agentId) return false;
+    if (agentId === previousLeaderAgentId) return true;
+    return Boolean(buildRoleCandidate(agentId, roleName));
+  }
+
+  function countPendingForRole(roleName) {
+    const now = Date.now();
+    let count = 0;
+    for (const record of liveMessages.values()) {
+      if (!messageMatchesRole(record, roleName)) continue;
+      if (record.message.expires_at_ms <= now) continue;
+      if (isRoleMessageFullyHandled(record, roleName)) continue;
+      count += 1;
+    }
+    return count;
+  }
+
+  function transferRoleBacklog(
+    roleName,
+    newLeaderAgentId,
+    previousLeaderAgentId,
+  ) {
+    const role = ensureRoleState(roleName);
+    const now = Date.now();
+    const stats = { transferred_count: 0, skipped_count: 0, removed_count: 0 };
+    if (!role || !newLeaderAgentId) return stats;
+
+    for (const record of liveMessages.values()) {
+      const { message, recipients, ackedBy } = record;
+      if (!messageMatchesRole(record, role.role)) continue;
+      if (message.expires_at_ms <= now) {
+        stats.skipped_count += 1;
+        continue;
+      }
+      if (isRoleMessageFullyHandled(record, role.role)) {
+        stats.skipped_count += 1;
+        continue;
+      }
+
+      for (const recipient of Array.from(recipients)) {
+        if (
+          recipient !== newLeaderAgentId &&
+          isRoleRecipient(recipient, role.role, previousLeaderAgentId)
+        ) {
+          queuesByAgent.get(recipient)?.delete(message.id);
+          recipients.delete(recipient);
+          ackedBy.delete(recipient);
+          stats.removed_count += 1;
+        }
+      }
+
+      recipients.add(newLeaderAgentId);
+      const alreadyQueued = queuesByAgent
+        .get(newLeaderAgentId)
+        ?.has(message.id);
+      if (!alreadyQueued && !ackedBy.has(newLeaderAgentId)) {
+        queueMessage(newLeaderAgentId, message);
+        stats.transferred_count += 1;
+      } else {
+        stats.skipped_count += 1;
+      }
+      message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+
+    role.transferredCount += stats.transferred_count;
+    return stats;
+  }
+
+  function buildRoleSnapshot(roleName, { refreshCandidates = true } = {}) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const candidates = sortRoleCandidates(
+      refreshCandidates
+        ? refreshRoleCandidates(role.role)
+        : Array.from(role.candidates.values()),
+    );
+    const leader =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const leaderLive = isCandidateLive(leader, now);
+    const liveCandidates = candidates.filter((candidate) =>
+      isCandidateLive(candidate, now),
+    );
+    return {
+      role: role.role,
+      status: leaderLive
+        ? "active"
+        : liveCandidates.length
+          ? "electable"
+          : "offline",
+      leader_agent_id: leaderLive ? role.leaderAgentId : null,
+      previous_leader_agent_id: role.previousLeaderAgentId || null,
+      leader_epoch: role.leaderEpoch,
+      lease_expires_ms: leaderLive ? leader.lease_expires_ms : null,
+      candidate_source: leaderLive
+        ? leader.source
+        : liveCandidates[0]?.source || null,
+      candidate_count: candidates.length,
+      live_candidate_count: liveCandidates.length,
+      pending_count: countPendingForRole(role.role),
+      transferred_count: role.transferredCount,
+      last_transition_ms: role.lastTransitionMs,
+      last_reason: role.lastReason,
+      candidates: candidates.slice(0, 16).map((candidate) => ({
+        agent_id: candidate.agent_id,
+        status: isCandidateLive(candidate, now) ? "online" : candidate.status,
+        source: candidate.source,
+        priority: candidate.priority,
+        last_seen_ms: candidate.last_seen_ms,
+        lease_expires_ms: candidate.lease_expires_ms,
+      })),
+    };
+  }
+
+  function ensureRoleLeader(
+    roleName,
+    { reason = "ensure", transferBacklog = true } = {},
+  ) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const current =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const best = chooseRoleLeader(role.role);
+    const currentLive = isCandidateLive(current, now);
+    const shouldPreemptFallback =
+      currentLive &&
+      current?.source === "topic-fallback" &&
+      best?.source === "explicit" &&
+      best.agent_id !== current.agent_id;
+
+    if (currentLive && !shouldPreemptFallback) {
+      role.status = "active";
+      role.leaderSource = current.source;
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (!best) {
+      if (role.leaderAgentId) {
+        role.previousLeaderAgentId = role.leaderAgentId;
+        role.leaderAgentId = null;
+        role.leaderSource = null;
+        role.leaderEpoch += 1;
+        role.lastTransitionMs = Date.now();
+        role.lastReason = reason;
+      }
+      role.status = "offline";
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (role.leaderAgentId !== best.agent_id) {
+      const previousLeaderAgentId = role.leaderAgentId;
+      role.previousLeaderAgentId =
+        previousLeaderAgentId || role.previousLeaderAgentId;
+      role.leaderAgentId = best.agent_id;
+      role.leaderSource = best.source;
+      role.leaderEpoch += 1;
+      role.status = "active";
+      role.lastTransitionMs = Date.now();
+      role.lastReason = reason;
+      if (transferBacklog) {
+        transferRoleBacklog(role.role, best.agent_id, previousLeaderAgentId);
+      }
+    }
+
+    return buildRoleSnapshot(role.role);
+  }
+
+  function getRoleSnapshot(roleName) {
+    return buildRoleSnapshot(roleName, { refreshCandidates: true });
   }
 
   function trackMessage(message, recipients) {
@@ -162,6 +533,14 @@ export function createRouter(store) {
     }
 
     const topic = to.slice(6);
+    if (ROLE_TOPICS.has(topic)) {
+      const role = ensureRoleLeader(topic, {
+        reason: "route",
+        transferBacklog: true,
+      });
+      return role?.leader_agent_id ? [role.leader_agent_id] : [];
+    }
+
     const recipients = new Set();
     for (const [agentId, topics] of runtimeTopics) {
       if (topics.has(topic)) recipients.add(agentId);
@@ -258,8 +637,10 @@ export function createRouter(store) {
       correlation_id,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
-    if (recipients.length) {
+    if (recipients.length || shouldTrackWithoutRecipients(msg)) {
       trackMessage(msg, recipients);
+    }
+    if (recipients.length) {
       for (const agentId of recipients) {
         queueMessage(agentId, msg);
       }
@@ -422,15 +803,37 @@ export function createRouter(store) {
     registerAgent(args) {
       const result = store.registerAgent(args);
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
+      refreshRoleCandidateForAgent(args.agent_id);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "register",
+          transferBacklog: true,
+        });
+      }
       return result;
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {
-      return store.refreshLease(agentId, ttlMs);
+      const result = store.refreshLease(agentId, ttlMs);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "heartbeat",
+          transferBacklog: true,
+        });
+      }
+      return result;
     },
 
     subscribeAgent(agentId, topics, { replace = false } = {}) {
       const nextTopics = upsertRuntimeTopics(agentId, topics, { replace });
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "subscribe",
+          transferBacklog: true,
+        });
+      }
       return { agent_id: agentId, topics: nextTopics };
     },
 
@@ -442,12 +845,25 @@ export function createRouter(store) {
       if (status === "offline") {
         runtimeTopics.delete(agentId);
       }
-      return store.updateAgentStatus(agentId, status);
+      const updated = store.updateAgentStatus(agentId, status);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: `status:${status}`,
+          transferBacklog: true,
+        });
+      }
+      return updated;
     },
 
     route(msg) {
       const recipients = uniqueStrings(resolveRecipients(msg));
-      if (!recipients.length) return 0;
+      if (!recipients.length) {
+        if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
+          trackMessage(msg, []);
+        }
+        return 0;
+      }
       if (!getMessageRecord(msg.id)) {
         trackMessage(msg, recipients);
       }
@@ -460,6 +876,10 @@ export function createRouter(store) {
 
     getPendingMessages(agentId, options = {}) {
       return sortedPending(agentId, options);
+    },
+
+    canReplayMessageForAgent(agentId, message) {
+      return isReplayAllowedForAgent(agentId, message);
     },
 
     countPendingMessages(agentId) {
@@ -610,6 +1030,87 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
+          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+        },
+      };
+    },
+
+    takeoverRole({
+      role = "cto",
+      agent_id,
+      reason = "manual",
+      requested_by = "manual",
+    } = {}) {
+      const roleName = normalizeRoleName(role);
+      if (!roleName) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_NOT_SUPPORTED",
+            message: `unsupported role: ${role}`,
+          },
+        };
+      }
+      const targetAgentId = String(agent_id || "").trim();
+      if (!targetAgentId) {
+        return {
+          ok: false,
+          error: {
+            code: "AGENT_ID_REQUIRED",
+            message: "agent_id required",
+          },
+        };
+      }
+
+      refreshRoleCandidates(roleName);
+      const roleState = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(targetAgentId, roleName);
+      if (!isCandidateLive(candidate)) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_CANDIDATE_UNAVAILABLE",
+            message: `${targetAgentId} is not a live ${roleName} candidate`,
+          },
+          data: {
+            role: buildRoleSnapshot(roleName),
+          },
+        };
+      }
+
+      const previousLeaderAgentId =
+        roleState.leaderAgentId && roleState.leaderAgentId !== targetAgentId
+          ? roleState.leaderAgentId
+          : roleState.previousLeaderAgentId || null;
+      const changed = roleState.leaderAgentId !== targetAgentId;
+      if (changed) {
+        roleState.previousLeaderAgentId = previousLeaderAgentId || null;
+        roleState.leaderAgentId = targetAgentId;
+        roleState.leaderSource = candidate.source;
+        roleState.leaderEpoch += 1;
+        roleState.status = "active";
+        roleState.lastTransitionMs = Date.now();
+        roleState.lastReason = reason || "manual";
+      }
+
+      const transfer = transferRoleBacklog(
+        roleName,
+        targetAgentId,
+        previousLeaderAgentId,
+      );
+      const snapshot = buildRoleSnapshot(roleName);
+      return {
+        ok: true,
+        data: {
+          role: roleName,
+          requested_by,
+          reason,
+          changed,
+          previous_leader_agent_id: previousLeaderAgentId,
+          leader_agent_id: snapshot.leader_agent_id,
+          leader_epoch: snapshot.leader_epoch,
+          ...transfer,
+          status: snapshot,
         },
       };
     },
@@ -897,6 +1398,9 @@ export function createRouter(store) {
           realtime_transport: "named-pipe",
           audit_store: store.type || "sqlite",
         };
+        data.roles = {
+          cto: getRoleSnapshot("cto"),
+        };
         if (include_metrics) {
           const depths = router.getQueueDepths();
           const stats = router.getDeliveryStats();
@@ -919,6 +1423,7 @@ export function createRouter(store) {
       if (scope === "agent" && agent_id) {
         const agent = store.getAgent(agent_id);
         if (agent) {
+          refreshRoleCandidateForAgent(agent_id);
           data.agent = {
             agent_id: agent.agent_id,
             status: agent.status,
@@ -926,6 +1431,18 @@ export function createRouter(store) {
             last_seen_ms: agent.last_seen_ms,
             topics: listRuntimeTopics(agent_id),
           };
+          const roles = {};
+          for (const roleName of ROLE_TOPICS) {
+            const candidate = buildRoleCandidate(agent_id, roleName);
+            if (candidate) {
+              roles[roleName] = {
+                candidate_source: candidate.source,
+                priority: candidate.priority,
+                leader: getRoleSnapshot(roleName)?.leader_agent_id === agent_id,
+              };
+            }
+          }
+          if (Object.keys(roles).length) data.agent.roles = roles;
         }
       }
 

--- a/packages/remote/cto/status.mjs
+++ b/packages/remote/cto/status.mjs
@@ -55,6 +55,17 @@ export function deriveRepoRootFromCwd(cwd) {
   if (cwd.includes("\\") || /^[A-Za-z]:/u.test(cwd)) return cwd;
 
   const normalized = cwd.replace(/\/+$/u, "");
+  const gitWorktreeMarker = "/.worktrees/";
+  const gitWorktreeIndex = normalized.indexOf(gitWorktreeMarker);
+  if (gitWorktreeIndex > 0) {
+    const suffix = normalized.slice(
+      gitWorktreeIndex + gitWorktreeMarker.length,
+    );
+    if (/^[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, gitWorktreeIndex);
+    }
+  }
+
   const claudeMarker = "/.claude/worktrees/";
   const claudeIndex = normalized.indexOf(claudeMarker);
   if (claudeIndex > 0) {

--- a/packages/remote/hub/pipe.mjs
+++ b/packages/remote/hub/pipe.mjs
@@ -29,6 +29,17 @@ function normalizeTopics(topics) {
   return topics.map((topic) => String(topic || "").trim()).filter(Boolean);
 }
 
+function normalizeReplayTopics(topics) {
+  if (Array.isArray(topics)) return normalizeTopics(topics);
+  if (typeof topics === "string") {
+    return topics
+      .split(/[,\s]+/u)
+      .map((topic) => topic.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
 function getTeamBridgeMethod(methodName) {
   const method = getTeamBridge()?.[methodName];
   return typeof method === "function" ? method : null;
@@ -266,6 +277,12 @@ export function createPipeServer({
         return result;
       }
 
+      case "takeover_role": {
+        const result = router.takeoverRole(payload);
+        if (client) touchClient(client);
+        return result;
+      }
+
       case "handoff": {
         const result = router.handleHandoff(payload);
         if (client) touchClient(client);
@@ -454,13 +471,34 @@ export function createPipeServer({
       return pending.slice(0, maxMessages);
     }
 
+    const requestedTopics = normalizeReplayTopics(payload.topics);
+    const auditTopics = new Set(requestedTopics);
+    if (auditTopics.size === 0) {
+      const persistedTopics = store?.getAgent?.(agentId)?.topics || [];
+      for (const topic of persistedTopics) auditTopics.add(topic);
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        router.canReplayMessageForAgent(agentId, {
+          to_agent: "topic:cto",
+          topic: "cto",
+        })
+      ) {
+        auditTopics.add("cto");
+      }
+    }
+
     const audit = store.getAuditMessagesForAgent(agentId, {
       max_messages: maxMessages,
-      include_topics: payload.topics,
+      include_topics: Array.from(auditTopics),
     });
     const byId = new Map();
     for (const message of [...pending, ...audit]) {
       if (!message?.id || byId.has(message.id)) continue;
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        !router.canReplayMessageForAgent(agentId, message)
+      )
+        continue;
       byId.set(message.id, message);
     }
     return Array.from(byId.values())

--- a/packages/remote/hub/public/tray.html
+++ b/packages/remote/hub/public/tray.html
@@ -259,27 +259,31 @@
       `;
     }
 
-    function liveFallbackRows(live) {
-      return live.map(session => ({
-        sessionId: session.sessionId,
-        status: session.phase || 'active',
-        agent_id: session.agent_id || session.agent?.id || '',
-        agent: session.agent || null,
-        promptText: session.promptText || '',
-        prompt: session.prompt || '',
-        userPrompt: session.userPrompt || '',
-        handoffPrompt: session.handoffPrompt || '',
-        command: session.command || '',
+        function liveFallbackRows(live) {
+          return live.map(session => ({
+            sessionId: session.sessionId,
+            status: session.phase || 'active',
+            agent_id: session.agent_id || session.agent?.id || '',
+            agent: session.agent || null,
+            role: session.role || '',
+            roles: session.roles || [],
+            metadata: session.metadata || {},
+            promptText: session.promptText || '',
+            prompt: session.prompt || '',
+            userPrompt: session.userPrompt || '',
+            handoffPrompt: session.handoffPrompt || '',
+            command: session.command || '',
         source: session.source || '',
         conversationId: session.conversationId || '',
         focusable: session.focusable !== false,
-        taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
-        pid: session.pid || '',
-        cwd: session.cwd || session.host || 'local runtime',
-        elapsed: session.elapsed || '',
-        started_at: session.started_at || null,
-      }));
-    }
+            taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
+            pid: session.pid || '',
+            cwd: session.cwd || session.host || 'local runtime',
+            worktreePath: session.worktreePath || '',
+            elapsed: session.elapsed || '',
+            started_at: session.started_at || null,
+          }));
+        }
 
     function compactText(value, fallback = '') {
       const text = String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -293,12 +297,20 @@
       return path.replace(/^\/Users\/[^/]+/, '~');
     }
 
-    function normalizeProjectPath(value) {
-      const path = String(value || '').trim();
-      if (!path) return '';
-      if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
-      return path.replace(/[\\/]+$/u, '') || path;
-    }
+        function normalizeProjectPath(value) {
+          const path = String(value || '').trim();
+          if (!path) return '';
+          if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
+          return path.replace(/[\\/]+$/u, '') || path;
+        }
+
+        function worktreeFamilyRoot(path) {
+          const normalized = normalizeProjectPath(path);
+          const parts = normalized.split(/[\\/]/u);
+          const index = parts.lastIndexOf('.worktrees');
+          if (index <= 0) return '';
+          return parts.slice(0, index).join(normalized.includes('\\') ? '\\' : '/') || '';
+        }
 
     function projectName(value) {
       const path = normalizeProjectPath(value);
@@ -306,12 +318,14 @@
       return path.split(/[\\/]/u).filter(Boolean).pop() || path;
     }
 
-    function projectPathFor(row, hub, fallback = '') {
-      const cwd = String(row?.cwd || row?.worktreePath || '').trim();
-      if (cwd && cwd !== 'local' && cwd !== 'local runtime') return normalizeProjectPath(cwd);
-      const root = String(hub?.projectRoot || fallback || '').trim();
-      return normalizeProjectPath(root || cwd || 'local');
-    }
+        function projectPathFor(row, hub, fallback = '') {
+          const cwd = normalizeProjectPath(String(row?.cwd || row?.worktreePath || '').trim());
+          const rawRoot = normalizeProjectPath(String(hub?.projectRoot || fallback || '').trim());
+          const familyRoot = worktreeFamilyRoot(rawRoot) || rawRoot;
+          if (familyRoot && cwd && (cwd === familyRoot || cwd.startsWith(`${familyRoot}/.worktrees/`) || cwd.startsWith(`${familyRoot}/worktrees/`))) return familyRoot;
+          if (cwd && cwd !== 'local' && cwd !== 'local runtime') return worktreeFamilyRoot(cwd) || cwd;
+          return normalizeProjectPath(familyRoot || cwd || 'local');
+        }
 
     function getProjectGroup(groups, projectPath) {
       const key = normalizeProjectPath(projectPath) || 'local';
@@ -319,33 +333,86 @@
       return groups.get(key);
     }
 
-    function buildProjectGroups(activeSessions, liveRows, hub) {
-      const groups = new Map();
-      const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
-      for (const session of activeSessions) {
-        getProjectGroup(groups, projectPathFor(session, hub, fallbackProject)).ctos.push(session);
-      }
-
-      const ctoIds = new Set(activeSessions.map(session => session.sessionId).filter(Boolean));
-      for (const worker of liveRows) {
-        if (ctoIds.has(worker.sessionId)) continue;
-        getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject)).workers.push(worker);
-      }
-
-      if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
-      for (const group of groups.values()) {
-        if (group.ctos.length === 0 && group.workers.length > 0) {
-          group.ctos.push({
-            sessionId: `cto-${shortId(hub.id || group.projectPath)}`,
-            status: 'active',
-            cwd: group.projectPath,
-            taskSummary: 'CTO runtime overlay',
-            synthetic: true,
-          });
+        function ctoRoleFromPayload(cto) {
+          return cto?.roles?.cto || cto?.succession?.cto || null;
         }
-      }
-      return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+
+        function normalizedRoleValue(value) {
+          return String(value || '').trim().toLowerCase();
+        }
+
+    function rowHasCtoRole(row, ctoRole) {
+      const sid = String(row?.sessionId || '').trim();
+      const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+      const leader = String(ctoRole?.leader_agent_id || '').trim();
+      if (leader) return Boolean(agentId === leader || sid === leader || sid === `cto:${leader}`);
+      if (ctoRole) return false;
+      const role = normalizedRoleValue(row?.role || row?.metadata?.role || row?.sessionKind);
+      const roles = Array.isArray(row?.roles || row?.metadata?.roles)
+        ? (row.roles || row.metadata.roles).map(normalizedRoleValue)
+        : String(row?.roles || row?.metadata?.roles || '').split(/[,\s]+/u).map(normalizedRoleValue);
+      if (role === 'cto' || roles.includes('cto') || row?.metadata?.cto === true) return true;
+      if (agentId === 'cto') return true;
+      if (/^cto[:._-]/iu.test(sid)) return true;
+      return false;
     }
+
+        function ctoRoleRow(ctoRole, hub, fallbackProject) {
+          if (!ctoRole) return null;
+          const status = ctoRole.status === 'active' ? 'active' : 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'unassigned';
+          return {
+            sessionId: ctoRole.leader_agent_id ? `cto:${ctoRole.leader_agent_id}` : `cto:${shortId(hub.id || fallbackProject || 'role')}`,
+            status,
+            cwd: hub.projectRoot || fallbackProject || 'local',
+            taskSummary: status === 'active'
+              ? `CTO leader ${leader} · epoch ${ctoRole.leader_epoch || 0} · pending ${ctoRole.pending_count || 0}`
+              : `CTO offline · previous ${leader} · candidates ${ctoRole.live_candidate_count || 0}`,
+            synthetic: true,
+            roleStatus: ctoRole,
+          };
+        }
+
+        function buildProjectGroups(activeSessions, liveRows, hub, ctoRole = null) {
+          const groups = new Map();
+          const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
+          for (const session of activeSessions) {
+            const group = getProjectGroup(groups, projectPathFor(session, hub, fallbackProject));
+            if (rowHasCtoRole(session, ctoRole)) group.ctos.push(session);
+            else group.workers.push(session);
+          }
+
+          const activeSessionIds = new Set(
+            activeSessions
+              .map(session => session.sessionId)
+              .filter(Boolean)
+          );
+          for (const worker of liveRows) {
+            if (activeSessionIds.has(worker.sessionId)) continue;
+            const group = getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject));
+            if (rowHasCtoRole(worker, ctoRole)) group.ctos.push(worker);
+            else group.workers.push(worker);
+          }
+
+          if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
+          const roleRow = ctoRoleRow(ctoRole, hub, fallbackProject);
+          if (roleRow) {
+            const project = projectPathFor(roleRow, hub, fallbackProject);
+            const group = getProjectGroup(groups, project);
+            const leader = String(ctoRole?.leader_agent_id || '').trim();
+            const existing = group.ctos.find(row => {
+              const sid = String(row?.sessionId || '').trim();
+              const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+              return sid === roleRow.sessionId || (leader && (sid === leader || agentId === leader));
+            });
+            if (existing) {
+              existing.roleStatus = ctoRole;
+            } else {
+              group.ctos.unshift(roleRow);
+            }
+          }
+          return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+        }
 
     function explicitPromptText(row) {
       return String(row?.promptText || row?.prompt || row?.userPrompt || row?.handoffPrompt || '').trim();
@@ -443,20 +510,24 @@
       `;
     }
 
-    function renderCtoChat(ctoRow, workers) {
-      const status = ctoRow.status || ctoRow.phase || 'active';
-      const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
-      const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
-      const promptHtml = hasPromptText(ctoRow)
-        ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
-        : '';
-      const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
-      const agentsHtml = workers.length
-        ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
-        : '';
-      const emptyHtml = promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
-      return `
-        <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
+        function renderCtoChat(ctoRow, workers) {
+          const status = ctoRow.status || ctoRow.phase || 'active';
+          const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
+          const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
+          const role = ctoRow.roleStatus || null;
+          const roleHtml = role
+            ? `<div class="detail-section"><div class="detail-label">Succession</div><div class="path-text">leader ${escapeHtml(role.leader_agent_id || 'none')} · epoch ${escapeHtml(role.leader_epoch || 0)} · pending ${escapeHtml(role.pending_count || 0)} · candidates ${escapeHtml(role.live_candidate_count || 0)}/${escapeHtml(role.candidate_count || 0)}</div></div>`
+            : '';
+          const promptHtml = hasPromptText(ctoRow)
+            ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
+            : '';
+          const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+          const agentsHtml = workers.length
+            ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
+            : '';
+          const emptyHtml = roleHtml || promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
+          return `
+            <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
           <summary class="session-summary">
             <span class="agent-badge">T</span>
             <div style="min-width:0;">
@@ -465,10 +536,11 @@
             </div>
             <div class="agent-state ${escapeHtml(status)}">${escapeHtml(status)}</div>
           </summary>
-          <div class="session-detail">
-            ${promptHtml}
-            ${agentsHtml}
-            ${emptyHtml}
+              <div class="session-detail">
+                ${roleHtml}
+                ${promptHtml}
+                ${agentsHtml}
+                ${emptyHtml}
           </div>
         </details>
       `;
@@ -478,14 +550,15 @@
       return `${count} ${count === 1 ? one : many}`;
     }
 
-    function renderProjectGroup(group) {
-      const projectDisplayPath = displayPath(group.projectPath);
-      const projectLabel = projectName(group.projectPath);
-      const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
-      const agentCount = group.workers.length;
-      const projectCount = [sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
-        .filter(Boolean)
-        .join(' · ') || 'empty';
+        function renderProjectGroup(group) {
+          const projectDisplayPath = displayPath(group.projectPath);
+          const projectLabel = projectName(group.projectPath);
+          const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
+          const agentCount = group.workers.length;
+          const ctoCount = group.ctos.length;
+          const projectCount = [ctoCount ? pluralize(ctoCount, 'CTO') : '', sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
+            .filter(Boolean)
+            .join(' · ') || 'empty';
       let html = `
         <details class="project-group" data-open-key="project:${dataAttr(group.projectPath)}">
           <summary class="project-summary">
@@ -496,26 +569,49 @@
           <div class="project-path">${escapeHtml(projectDisplayPath)}</div>
           <div class="project-body">
       `;
-      const ctos = group.ctos.slice(0, 6);
-      const workers = group.workers.slice(0, 10);
-      for (const [index, ctoRow] of ctos.entries()) {
-        html += renderCtoChat(ctoRow, index === 0 ? workers : []);
-      }
-      html += '</div></details>';
-      return html;
-    }
+          const ctos = group.ctos.slice(0, 6);
+          const workers = group.workers.slice(0, 10);
+          for (const [index, ctoRow] of ctos.entries()) {
+            html += renderCtoChat(ctoRow, index === 0 ? workers : []);
+          }
+          if (ctos.length === 0 && workers.length > 0) {
+            const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+            html += `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`;
+          }
+          html += '</div></details>';
+          return html;
+        }
+
+        function renderCtoRoleBanner(ctoRole) {
+          if (!ctoRole) return '';
+          const status = ctoRole.status || 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'none';
+          return `
+            <div class="section">
+              <div class="section-title">CTO Succession</div>
+              <div class="mini-card">
+                <div style="display:flex;align-items:center;gap:8px;justify-content:space-between;">
+                  <div class="mini-title"><span class="agent-badge">T</span> ${escapeHtml(leader)}</div>
+                  <div class="value-pill status-text ${escapeHtml(status)}">${escapeHtml(status)}</div>
+                </div>
+                <div class="path-text">epoch ${escapeHtml(ctoRole.leader_epoch || 0)} · pending ${escapeHtml(ctoRole.pending_count || 0)} · candidates ${escapeHtml(ctoRole.live_candidate_count || 0)}/${escapeHtml(ctoRole.candidate_count || 0)}${ctoRole.candidate_source ? ` · ${escapeHtml(ctoRole.candidate_source)}` : ''}</div>
+              </div>
+            </div>
+          `;
+        }
 
     function renderSessions(data) {
       const container = document.getElementById('tab-sessions');
       const openKeys = collectOpenDetailKeys(container);
       const hub = data?.hub || {};
       const sessions = Array.isArray(data?.sessions) ? data.sessions : [];
-      const cto = data?.cto || {};
-      const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
-      const runtime = data?.runtime || {};
-      const activeSessions = sessions.filter(s => s.status !== 'stale');
-      const liveRows = liveFallbackRows(live);
-      const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub);
+          const cto = data?.cto || {};
+          const ctoRole = ctoRoleFromPayload(cto);
+          const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
+          const runtime = data?.runtime || {};
+          const activeSessions = sessions.filter(s => s.status !== 'stale');
+          const liveRows = liveFallbackRows(live);
+          const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub, ctoRole);
       const activeCount = activeSessions.filter(s => s.status === 'active').length;
       const idleCount = activeSessions.filter(s => s.status === 'idle').length;
       const staleCount = sessions.filter(s => s.status === 'stale').length;
@@ -530,11 +626,12 @@
           </div>
           <div class="path-text">${projectGroups.length} ${projectGroups.length === 1 ? 'workspace' : 'workspaces'} · ${cto.active_shards?.length || 0} shards · ${renderCopyChip('Hub', hub.id || String(hub.pid || ''))}</div>
         </div>
-        <div class="section">
-          <div class="section-title">Agent Mix</div>
-          <div class="models-list">${renderRuntimeClients(runtime)}</div>
-        </div>
-        ${renderCtoHygiene(cto.hygiene)}
+            <div class="section">
+              <div class="section-title">Agent Mix</div>
+              <div class="models-list">${renderRuntimeClients(runtime)}</div>
+            </div>
+            ${renderCtoRoleBanner(ctoRole)}
+            ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -22,6 +22,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { runCollect } from "../cto/collect.mjs";
+import { resolveLakeRootDir } from "../cto/lake-root.mjs";
 import { runStatus as runCtoStatus } from "../cto/status.mjs";
 import { createModuleLogger } from "../scripts/lib/logger.mjs";
 import {
@@ -95,6 +96,7 @@ const LOOPBACK_REMOTE_ADDRESSES = new Set([
 const ALLOWED_ORIGIN_RE =
   /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
 const PROJECT_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CANONICAL_PROJECT_ROOT = resolveLakeRootDir(PROJECT_ROOT) || PROJECT_ROOT;
 const PUBLIC_DIR = resolve(join(PROJECT_ROOT, "hub", "public"));
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const HUB_DEFAULT_PORT = 27888;
@@ -865,7 +867,7 @@ function getBrokerPublicSnapshot(currentBroker = brokerInstance) {
 async function getTrayCtoStatus() {
   try {
     return await runCtoStatus(["--json"], {
-      rootDir: PROJECT_ROOT,
+      rootDir: CANONICAL_PROJECT_ROOT,
       stdout: { write() {} },
     });
   } catch (error) {
@@ -1446,12 +1448,22 @@ export async function startHub({
         const synapseSnapshot = synapseRegistry.snapshot();
         const broker = getBrokerPublicSnapshot(brokerInstance);
         const runtimeStatus = getRuntimeStatus({
-          projectRoots: [PROJECT_ROOT],
+          projectRoots: [
+            ...new Set([CANONICAL_PROJECT_ROOT, PROJECT_ROOT].filter(Boolean)),
+          ],
         });
-        const [ctoStatus, mcpStatus] = await Promise.all([
+        const [ctoStatus, mcpStatus, hubStatus] = await Promise.all([
           getTrayCtoStatus(),
           Promise.resolve(getTrayMcpStatus()),
+          pipe.executeQuery("status", {
+            scope: "hub",
+            include_metrics: true,
+          }),
         ]);
+        const mergedCtoStatus = {
+          ...(ctoStatus || {}),
+          roles: hubStatus?.data?.roles || ctoStatus?.roles || {},
+        };
 
         return writeJson(
           res,
@@ -1462,12 +1474,12 @@ export async function startHub({
               pid: process.pid,
               port,
               url: buildHubUrl(host, port),
-              projectRoot: PROJECT_ROOT,
+              projectRoot: CANONICAL_PROJECT_ROOT,
             },
             qos,
             synapseSnapshot,
             broker,
-            ctoStatus,
+            ctoStatus: mergedCtoStatus,
             mcpStatus,
             runtimeStatus,
           }),
@@ -1650,6 +1662,28 @@ export async function startHub({
           if (path === "/bridge/hitl/pending" && req.method === "GET") {
             const result = { ok: true, data: hitl.getPendingRequests() };
             return writeJson(res, result.ok ? 200 : 400, result);
+          }
+
+          if (path === "/bridge/takeover-role" && req.method === "POST") {
+            const {
+              role = "cto",
+              agent_id,
+              reason = "manual",
+              requested_by = "http",
+            } = body;
+            if (!role || !agent_id) {
+              return writeJson(res, 400, {
+                ok: false,
+                error: "role, agent_id 필수",
+              });
+            }
+            const result = await pipe.executeCommand("takeover_role", {
+              role,
+              agent_id,
+              reason,
+              requested_by,
+            });
+            return writeJson(res, result.ok ? 200 : 409, result);
           }
 
           if (path === "/bridge/register" && req.method === "POST") {

--- a/packages/remote/hub/tools.mjs
+++ b/packages/remote/hub/tools.mjs
@@ -183,6 +183,26 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
+    // ── 2-1. takeover_role ──
+    {
+      name: "takeover_role",
+      description:
+        "CTO 같은 허브 역할의 active leader를 명시적으로 승계하고 미처리 역할 메시지를 새 leader에게 이전합니다",
+      inputSchema: {
+        type: "object",
+        required: ["role", "agent_id"],
+        properties: {
+          role: { type: "string", enum: ["cto"], default: "cto" },
+          agent_id: { type: "string", pattern: "^[a-zA-Z0-9._:-]{3,64}$" },
+          reason: { type: "string" },
+          requested_by: { type: "string" },
+        },
+      },
+      handler: wrap("TAKEOVER_ROLE_FAILED", (args) => {
+        return router.takeoverRole(args);
+      }),
+    },
+
     // ── 3. publish ──
     {
       name: "publish",
@@ -841,7 +861,7 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
-    // ── 21. send_input ──
+    // ── 22. send_input ──
     {
       name: "send_input",
       description: "Send input text to a worker in INPUT_WAIT state",

--- a/packages/remote/hub/tray-state.mjs
+++ b/packages/remote/hub/tray-state.mjs
@@ -49,6 +49,10 @@ function normalizeAgentId(value) {
   return "";
 }
 
+function rawAgentId(value) {
+  return String(value ?? "").trim();
+}
+
 function inferAgentId(value = {}) {
   const direct = normalizeAgentId(
     value.agent_id ??
@@ -84,7 +88,11 @@ function agentMeta(agentId) {
 export function normalizeTraySessions(snapshot) {
   return readSynapseSessions(snapshot)
     .map((session) => {
-      const agentId = inferAgentId(session);
+      const directAgentId = session?.agent_id ?? session?.agentId;
+      const agentId =
+        normalizeAgentId(directAgentId) ||
+        rawAgentId(directAgentId) ||
+        inferAgentId(session);
       return {
         sessionId: String(session?.sessionId || ""),
         host: typeof session?.host === "string" ? session.host : "local",
@@ -368,7 +376,11 @@ function runtimeToLiveOverlay(runtime) {
 }
 
 function normalizeLiveSession(session = {}) {
-  const agentId = inferAgentId(session);
+  const directAgentId = session.agent_id ?? session.agentId;
+  const agentId =
+    normalizeAgentId(directAgentId) ||
+    rawAgentId(directAgentId) ||
+    inferAgentId(session);
   return {
     ...session,
     sessionId: String(session.sessionId || ""),
@@ -460,11 +472,21 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
     ? ctoStatus.active_shards
     : [];
   const hygiene = normalizeCtoHygiene(ctoStatus);
+  const roles =
+    ctoStatus?.roles && typeof ctoStatus.roles === "object"
+      ? ctoStatus.roles
+      : null;
+  const succession =
+    ctoStatus?.succession && typeof ctoStatus.succession === "object"
+      ? ctoStatus.succession
+      : null;
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(roles ? { roles } : {}),
+    ...(succession ? { succession } : {}),
     ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,

--- a/packages/triflux/cto/status.mjs
+++ b/packages/triflux/cto/status.mjs
@@ -55,6 +55,17 @@ export function deriveRepoRootFromCwd(cwd) {
   if (cwd.includes("\\") || /^[A-Za-z]:/u.test(cwd)) return cwd;
 
   const normalized = cwd.replace(/\/+$/u, "");
+  const gitWorktreeMarker = "/.worktrees/";
+  const gitWorktreeIndex = normalized.indexOf(gitWorktreeMarker);
+  if (gitWorktreeIndex > 0) {
+    const suffix = normalized.slice(
+      gitWorktreeIndex + gitWorktreeMarker.length,
+    );
+    if (/^[^/]+(?:\/|$)/u.test(suffix)) {
+      return normalized.slice(0, gitWorktreeIndex);
+    }
+  }
+
   const claudeMarker = "/.claude/worktrees/";
   const claudeIndex = normalized.indexOf(claudeMarker);
   if (claudeIndex > 0) {

--- a/packages/triflux/hub/bridge.mjs
+++ b/packages/triflux/hub/bridge.mjs
@@ -119,6 +119,11 @@ const HUB_OPERATIONS = Object.freeze({
     action: "publish",
     httpPath: "/bridge/publish",
   },
+  takeoverRole: {
+    transport: "command",
+    action: "takeover_role",
+    httpPath: "/bridge/takeover-role",
+  },
   sendInput: {
     transport: "command",
     action: "send_input",
@@ -365,6 +370,7 @@ export function parseArgs(argv) {
     args: argv,
     options: {
       agent: { type: "string" },
+      "agent-id": { type: "string" },
       cli: { type: "string" },
       timeout: { type: "string" },
       topics: { type: "string" },
@@ -387,6 +393,7 @@ export function parseArgs(argv) {
       claim: { type: "boolean" },
       actor: { type: "string" },
       command: { type: "string" },
+      role: { type: "string" },
       "session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
@@ -699,6 +706,19 @@ async function cmdPublish(args) {
     HUB_OPERATIONS.publish,
     buildPublishBody(from, to, type, payload),
   );
+  const result = outcome?.result;
+  return emitJson(result || unavailableResult());
+}
+
+async function cmdTakeoverRole(args) {
+  const role = args.role || args[1] || "cto";
+  const agentId = args.agent || args["agent-id"] || args[2];
+  const outcome = await requestHub(HUB_OPERATIONS.takeoverRole, {
+    role,
+    agent_id: agentId,
+    reason: args.reason || "manual",
+    requested_by: args["requested-by"] || "bridge",
+  });
   const result = outcome?.result;
   return emitJson(result || unavailableResult());
 }
@@ -1554,6 +1574,8 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdHandoff(args);
     case "publish":
       return await cmdPublish(args);
+    case "takeover-role":
+      return await cmdTakeoverRole(args);
     case "send-input":
       return await cmdSendInput(args);
     case "context":
@@ -1610,7 +1632,7 @@ export async function main(argv = process.argv.slice(2)) {
       return await cmdRetryStatus(args);
     default:
       console.error(
-        "사용법: bridge.mjs <register|result|control|handoff|publish|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
+        "사용법: bridge.mjs <register|result|control|handoff|publish|takeover-role|send-input|context|deregister|assign-async|assign-result|assign-status|assign-retry|team-info|team-task-list|team-task-update|team-send-message|pipeline-state|pipeline-advance|pipeline-init|pipeline-list|ping|delegator-delegate|delegator-reply|delegator-status|hitl-request|hitl-submit|hitl-pending|daemon-probe|daemon-attach|daemon-interrupt|retry-run|retry-status> [--옵션]",
       );
       process.exit(1);
   }

--- a/packages/triflux/hub/pipe.mjs
+++ b/packages/triflux/hub/pipe.mjs
@@ -29,6 +29,17 @@ function normalizeTopics(topics) {
   return topics.map((topic) => String(topic || "").trim()).filter(Boolean);
 }
 
+function normalizeReplayTopics(topics) {
+  if (Array.isArray(topics)) return normalizeTopics(topics);
+  if (typeof topics === "string") {
+    return topics
+      .split(/[,\s]+/u)
+      .map((topic) => topic.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
 function getTeamBridgeMethod(methodName) {
   const method = getTeamBridge()?.[methodName];
   return typeof method === "function" ? method : null;
@@ -266,6 +277,12 @@ export function createPipeServer({
         return result;
       }
 
+      case "takeover_role": {
+        const result = router.takeoverRole(payload);
+        if (client) touchClient(client);
+        return result;
+      }
+
       case "handoff": {
         const result = router.handleHandoff(payload);
         if (client) touchClient(client);
@@ -454,13 +471,34 @@ export function createPipeServer({
       return pending.slice(0, maxMessages);
     }
 
+    const requestedTopics = normalizeReplayTopics(payload.topics);
+    const auditTopics = new Set(requestedTopics);
+    if (auditTopics.size === 0) {
+      const persistedTopics = store?.getAgent?.(agentId)?.topics || [];
+      for (const topic of persistedTopics) auditTopics.add(topic);
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        router.canReplayMessageForAgent(agentId, {
+          to_agent: "topic:cto",
+          topic: "cto",
+        })
+      ) {
+        auditTopics.add("cto");
+      }
+    }
+
     const audit = store.getAuditMessagesForAgent(agentId, {
       max_messages: maxMessages,
-      include_topics: payload.topics,
+      include_topics: Array.from(auditTopics),
     });
     const byId = new Map();
     for (const message of [...pending, ...audit]) {
       if (!message?.id || byId.has(message.id)) continue;
+      if (
+        typeof router.canReplayMessageForAgent === "function" &&
+        !router.canReplayMessageForAgent(agentId, message)
+      )
+        continue;
       byId.set(message.id, message);
     }
     return Array.from(byId.values())

--- a/packages/triflux/hub/public/tray.html
+++ b/packages/triflux/hub/public/tray.html
@@ -259,27 +259,31 @@
       `;
     }
 
-    function liveFallbackRows(live) {
-      return live.map(session => ({
-        sessionId: session.sessionId,
-        status: session.phase || 'active',
-        agent_id: session.agent_id || session.agent?.id || '',
-        agent: session.agent || null,
-        promptText: session.promptText || '',
-        prompt: session.prompt || '',
-        userPrompt: session.userPrompt || '',
-        handoffPrompt: session.handoffPrompt || '',
-        command: session.command || '',
+        function liveFallbackRows(live) {
+          return live.map(session => ({
+            sessionId: session.sessionId,
+            status: session.phase || 'active',
+            agent_id: session.agent_id || session.agent?.id || '',
+            agent: session.agent || null,
+            role: session.role || '',
+            roles: session.roles || [],
+            metadata: session.metadata || {},
+            promptText: session.promptText || '',
+            prompt: session.prompt || '',
+            userPrompt: session.userPrompt || '',
+            handoffPrompt: session.handoffPrompt || '',
+            command: session.command || '',
         source: session.source || '',
         conversationId: session.conversationId || '',
         focusable: session.focusable !== false,
-        taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
-        pid: session.pid || '',
-        cwd: session.cwd || session.host || 'local runtime',
-        elapsed: session.elapsed || '',
-        started_at: session.started_at || null,
-      }));
-    }
+            taskSummary: session.taskSummary || session.command || (session.pid ? `PID ${session.pid}` : ''),
+            pid: session.pid || '',
+            cwd: session.cwd || session.host || 'local runtime',
+            worktreePath: session.worktreePath || '',
+            elapsed: session.elapsed || '',
+            started_at: session.started_at || null,
+          }));
+        }
 
     function compactText(value, fallback = '') {
       const text = String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -293,12 +297,20 @@
       return path.replace(/^\/Users\/[^/]+/, '~');
     }
 
-    function normalizeProjectPath(value) {
-      const path = String(value || '').trim();
-      if (!path) return '';
-      if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
-      return path.replace(/[\\/]+$/u, '') || path;
-    }
+        function normalizeProjectPath(value) {
+          const path = String(value || '').trim();
+          if (!path) return '';
+          if (path === '/' || /^\/+$/u.test(path) || /^[A-Za-z]:[\\/]$/u.test(path)) return path;
+          return path.replace(/[\\/]+$/u, '') || path;
+        }
+
+        function worktreeFamilyRoot(path) {
+          const normalized = normalizeProjectPath(path);
+          const parts = normalized.split(/[\\/]/u);
+          const index = parts.lastIndexOf('.worktrees');
+          if (index <= 0) return '';
+          return parts.slice(0, index).join(normalized.includes('\\') ? '\\' : '/') || '';
+        }
 
     function projectName(value) {
       const path = normalizeProjectPath(value);
@@ -306,12 +318,14 @@
       return path.split(/[\\/]/u).filter(Boolean).pop() || path;
     }
 
-    function projectPathFor(row, hub, fallback = '') {
-      const cwd = String(row?.cwd || row?.worktreePath || '').trim();
-      if (cwd && cwd !== 'local' && cwd !== 'local runtime') return normalizeProjectPath(cwd);
-      const root = String(hub?.projectRoot || fallback || '').trim();
-      return normalizeProjectPath(root || cwd || 'local');
-    }
+        function projectPathFor(row, hub, fallback = '') {
+          const cwd = normalizeProjectPath(String(row?.cwd || row?.worktreePath || '').trim());
+          const rawRoot = normalizeProjectPath(String(hub?.projectRoot || fallback || '').trim());
+          const familyRoot = worktreeFamilyRoot(rawRoot) || rawRoot;
+          if (familyRoot && cwd && (cwd === familyRoot || cwd.startsWith(`${familyRoot}/.worktrees/`) || cwd.startsWith(`${familyRoot}/worktrees/`))) return familyRoot;
+          if (cwd && cwd !== 'local' && cwd !== 'local runtime') return worktreeFamilyRoot(cwd) || cwd;
+          return normalizeProjectPath(familyRoot || cwd || 'local');
+        }
 
     function getProjectGroup(groups, projectPath) {
       const key = normalizeProjectPath(projectPath) || 'local';
@@ -319,33 +333,86 @@
       return groups.get(key);
     }
 
-    function buildProjectGroups(activeSessions, liveRows, hub) {
-      const groups = new Map();
-      const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
-      for (const session of activeSessions) {
-        getProjectGroup(groups, projectPathFor(session, hub, fallbackProject)).ctos.push(session);
-      }
-
-      const ctoIds = new Set(activeSessions.map(session => session.sessionId).filter(Boolean));
-      for (const worker of liveRows) {
-        if (ctoIds.has(worker.sessionId)) continue;
-        getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject)).workers.push(worker);
-      }
-
-      if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
-      for (const group of groups.values()) {
-        if (group.ctos.length === 0 && group.workers.length > 0) {
-          group.ctos.push({
-            sessionId: `cto-${shortId(hub.id || group.projectPath)}`,
-            status: 'active',
-            cwd: group.projectPath,
-            taskSummary: 'CTO runtime overlay',
-            synthetic: true,
-          });
+        function ctoRoleFromPayload(cto) {
+          return cto?.roles?.cto || cto?.succession?.cto || null;
         }
-      }
-      return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+
+        function normalizedRoleValue(value) {
+          return String(value || '').trim().toLowerCase();
+        }
+
+    function rowHasCtoRole(row, ctoRole) {
+      const sid = String(row?.sessionId || '').trim();
+      const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+      const leader = String(ctoRole?.leader_agent_id || '').trim();
+      if (leader) return Boolean(agentId === leader || sid === leader || sid === `cto:${leader}`);
+      if (ctoRole) return false;
+      const role = normalizedRoleValue(row?.role || row?.metadata?.role || row?.sessionKind);
+      const roles = Array.isArray(row?.roles || row?.metadata?.roles)
+        ? (row.roles || row.metadata.roles).map(normalizedRoleValue)
+        : String(row?.roles || row?.metadata?.roles || '').split(/[,\s]+/u).map(normalizedRoleValue);
+      if (role === 'cto' || roles.includes('cto') || row?.metadata?.cto === true) return true;
+      if (agentId === 'cto') return true;
+      if (/^cto[:._-]/iu.test(sid)) return true;
+      return false;
     }
+
+        function ctoRoleRow(ctoRole, hub, fallbackProject) {
+          if (!ctoRole) return null;
+          const status = ctoRole.status === 'active' ? 'active' : 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'unassigned';
+          return {
+            sessionId: ctoRole.leader_agent_id ? `cto:${ctoRole.leader_agent_id}` : `cto:${shortId(hub.id || fallbackProject || 'role')}`,
+            status,
+            cwd: hub.projectRoot || fallbackProject || 'local',
+            taskSummary: status === 'active'
+              ? `CTO leader ${leader} · epoch ${ctoRole.leader_epoch || 0} · pending ${ctoRole.pending_count || 0}`
+              : `CTO offline · previous ${leader} · candidates ${ctoRole.live_candidate_count || 0}`,
+            synthetic: true,
+            roleStatus: ctoRole,
+          };
+        }
+
+        function buildProjectGroups(activeSessions, liveRows, hub, ctoRole = null) {
+          const groups = new Map();
+          const fallbackProject = hub.projectRoot || activeSessions[0]?.cwd || activeSessions[0]?.worktreePath || 'local';
+          for (const session of activeSessions) {
+            const group = getProjectGroup(groups, projectPathFor(session, hub, fallbackProject));
+            if (rowHasCtoRole(session, ctoRole)) group.ctos.push(session);
+            else group.workers.push(session);
+          }
+
+          const activeSessionIds = new Set(
+            activeSessions
+              .map(session => session.sessionId)
+              .filter(Boolean)
+          );
+          for (const worker of liveRows) {
+            if (activeSessionIds.has(worker.sessionId)) continue;
+            const group = getProjectGroup(groups, projectPathFor(worker, hub, fallbackProject));
+            if (rowHasCtoRole(worker, ctoRole)) group.ctos.push(worker);
+            else group.workers.push(worker);
+          }
+
+          if (groups.size === 0 && fallbackProject) getProjectGroup(groups, fallbackProject);
+          const roleRow = ctoRoleRow(ctoRole, hub, fallbackProject);
+          if (roleRow) {
+            const project = projectPathFor(roleRow, hub, fallbackProject);
+            const group = getProjectGroup(groups, project);
+            const leader = String(ctoRole?.leader_agent_id || '').trim();
+            const existing = group.ctos.find(row => {
+              const sid = String(row?.sessionId || '').trim();
+              const agentId = String(row?.agent_id || row?.agent?.id || '').trim();
+              return sid === roleRow.sessionId || (leader && (sid === leader || agentId === leader));
+            });
+            if (existing) {
+              existing.roleStatus = ctoRole;
+            } else {
+              group.ctos.unshift(roleRow);
+            }
+          }
+          return [...groups.values()].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
+        }
 
     function explicitPromptText(row) {
       return String(row?.promptText || row?.prompt || row?.userPrompt || row?.handoffPrompt || '').trim();
@@ -443,20 +510,24 @@
       `;
     }
 
-    function renderCtoChat(ctoRow, workers) {
-      const status = ctoRow.status || ctoRow.phase || 'active';
-      const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
-      const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
-      const promptHtml = hasPromptText(ctoRow)
-        ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
-        : '';
-      const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
-      const agentsHtml = workers.length
-        ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
-        : '';
-      const emptyHtml = promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
-      return `
-        <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
+        function renderCtoChat(ctoRow, workers) {
+          const status = ctoRow.status || ctoRow.phase || 'active';
+          const title = compactText(ctoRow.sessionId || ctoRow.taskSummary || 'Session', 'Session');
+          const subtitle = compactText(hasPromptText(ctoRow) ? ctoRow.taskSummary || ctoRow.sessionKind || '' : displayPath(ctoRow.cwd || ctoRow.worktreePath || ''), '');
+          const role = ctoRow.roleStatus || null;
+          const roleHtml = role
+            ? `<div class="detail-section"><div class="detail-label">Succession</div><div class="path-text">leader ${escapeHtml(role.leader_agent_id || 'none')} · epoch ${escapeHtml(role.leader_epoch || 0)} · pending ${escapeHtml(role.pending_count || 0)} · candidates ${escapeHtml(role.live_candidate_count || 0)}/${escapeHtml(role.candidate_count || 0)}</div></div>`
+            : '';
+          const promptHtml = hasPromptText(ctoRow)
+            ? `<div class="detail-section"><div class="detail-label">Prompt</div>${renderChatBubble(ctoRow, { side: 'cto' })}</div>`
+            : '';
+          const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+          const agentsHtml = workers.length
+            ? `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`
+            : '';
+          const emptyHtml = roleHtml || promptHtml || agentsHtml ? '' : '<div class="detail-empty">No session details yet</div>';
+          return `
+            <details class="session-card" data-open-key="cto:${dataAttr(ctoRow.sessionId || title)}">
           <summary class="session-summary">
             <span class="agent-badge">T</span>
             <div style="min-width:0;">
@@ -465,10 +536,11 @@
             </div>
             <div class="agent-state ${escapeHtml(status)}">${escapeHtml(status)}</div>
           </summary>
-          <div class="session-detail">
-            ${promptHtml}
-            ${agentsHtml}
-            ${emptyHtml}
+              <div class="session-detail">
+                ${roleHtml}
+                ${promptHtml}
+                ${agentsHtml}
+                ${emptyHtml}
           </div>
         </details>
       `;
@@ -478,14 +550,15 @@
       return `${count} ${count === 1 ? one : many}`;
     }
 
-    function renderProjectGroup(group) {
-      const projectDisplayPath = displayPath(group.projectPath);
-      const projectLabel = projectName(group.projectPath);
-      const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
-      const agentCount = group.workers.length;
-      const projectCount = [sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
-        .filter(Boolean)
-        .join(' · ') || 'empty';
+        function renderProjectGroup(group) {
+          const projectDisplayPath = displayPath(group.projectPath);
+          const projectLabel = projectName(group.projectPath);
+          const sessionCount = group.ctos.filter(row => !isSyntheticCto(row)).length;
+          const agentCount = group.workers.length;
+          const ctoCount = group.ctos.length;
+          const projectCount = [ctoCount ? pluralize(ctoCount, 'CTO') : '', sessionCount ? pluralize(sessionCount, 'session') : '', agentCount ? pluralize(agentCount, 'agent') : '']
+            .filter(Boolean)
+            .join(' · ') || 'empty';
       let html = `
         <details class="project-group" data-open-key="project:${dataAttr(group.projectPath)}">
           <summary class="project-summary">
@@ -496,26 +569,49 @@
           <div class="project-path">${escapeHtml(projectDisplayPath)}</div>
           <div class="project-body">
       `;
-      const ctos = group.ctos.slice(0, 6);
-      const workers = group.workers.slice(0, 10);
-      for (const [index, ctoRow] of ctos.entries()) {
-        html += renderCtoChat(ctoRow, index === 0 ? workers : []);
-      }
-      html += '</div></details>';
-      return html;
-    }
+          const ctos = group.ctos.slice(0, 6);
+          const workers = group.workers.slice(0, 10);
+          for (const [index, ctoRow] of ctos.entries()) {
+            html += renderCtoChat(ctoRow, index === 0 ? workers : []);
+          }
+          if (ctos.length === 0 && workers.length > 0) {
+            const agentRows = workers.map(worker => hasPromptText(worker) ? renderChatBubble(worker, { side: 'worker' }) : renderRuntimeCard(worker)).join('');
+            html += `<div class="detail-section"><div class="detail-label">Agents</div><div class="runtime-list">${agentRows}</div></div>`;
+          }
+          html += '</div></details>';
+          return html;
+        }
+
+        function renderCtoRoleBanner(ctoRole) {
+          if (!ctoRole) return '';
+          const status = ctoRole.status || 'offline';
+          const leader = ctoRole.leader_agent_id || ctoRole.previous_leader_agent_id || 'none';
+          return `
+            <div class="section">
+              <div class="section-title">CTO Succession</div>
+              <div class="mini-card">
+                <div style="display:flex;align-items:center;gap:8px;justify-content:space-between;">
+                  <div class="mini-title"><span class="agent-badge">T</span> ${escapeHtml(leader)}</div>
+                  <div class="value-pill status-text ${escapeHtml(status)}">${escapeHtml(status)}</div>
+                </div>
+                <div class="path-text">epoch ${escapeHtml(ctoRole.leader_epoch || 0)} · pending ${escapeHtml(ctoRole.pending_count || 0)} · candidates ${escapeHtml(ctoRole.live_candidate_count || 0)}/${escapeHtml(ctoRole.candidate_count || 0)}${ctoRole.candidate_source ? ` · ${escapeHtml(ctoRole.candidate_source)}` : ''}</div>
+              </div>
+            </div>
+          `;
+        }
 
     function renderSessions(data) {
       const container = document.getElementById('tab-sessions');
       const openKeys = collectOpenDetailKeys(container);
       const hub = data?.hub || {};
       const sessions = Array.isArray(data?.sessions) ? data.sessions : [];
-      const cto = data?.cto || {};
-      const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
-      const runtime = data?.runtime || {};
-      const activeSessions = sessions.filter(s => s.status !== 'stale');
-      const liveRows = liveFallbackRows(live);
-      const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub);
+          const cto = data?.cto || {};
+          const ctoRole = ctoRoleFromPayload(cto);
+          const live = Array.isArray(cto.live_sessions) ? cto.live_sessions : [];
+          const runtime = data?.runtime || {};
+          const activeSessions = sessions.filter(s => s.status !== 'stale');
+          const liveRows = liveFallbackRows(live);
+          const projectGroups = buildProjectGroups(activeSessions.slice(0, 10), liveRows, hub, ctoRole);
       const activeCount = activeSessions.filter(s => s.status === 'active').length;
       const idleCount = activeSessions.filter(s => s.status === 'idle').length;
       const staleCount = sessions.filter(s => s.status === 'stale').length;
@@ -530,11 +626,12 @@
           </div>
           <div class="path-text">${projectGroups.length} ${projectGroups.length === 1 ? 'workspace' : 'workspaces'} · ${cto.active_shards?.length || 0} shards · ${renderCopyChip('Hub', hub.id || String(hub.pid || ''))}</div>
         </div>
-        <div class="section">
-          <div class="section-title">Agent Mix</div>
-          <div class="models-list">${renderRuntimeClients(runtime)}</div>
-        </div>
-        ${renderCtoHygiene(cto.hygiene)}
+            <div class="section">
+              <div class="section-title">Agent Mix</div>
+              <div class="models-list">${renderRuntimeClients(runtime)}</div>
+            </div>
+            ${renderCtoRoleBanner(ctoRole)}
+            ${renderCtoHygiene(cto.hygiene)}
         <div class="section">
           <div class="section-title">Workspaces</div>
           <div class="agent-view">

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -4,6 +4,11 @@ import { EventEmitter, once } from "node:events";
 import { uuidv7 } from "./lib/uuidv7.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
+const ROLE_TOPICS = new Set(["cto"]);
+const ROLE_SOURCE_RANK = Object.freeze({
+  explicit: 2,
+  "topic-fallback": 1,
+});
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -11,6 +16,37 @@ function uniqueStrings(values = []) {
       (values || []).map((value) => String(value || "").trim()).filter(Boolean),
     ),
   );
+}
+
+function normalizeRoleName(value) {
+  const role = String(value || "")
+    .trim()
+    .toLowerCase();
+  return ROLE_TOPICS.has(role) ? role : "";
+}
+
+function normalizeRoleValues(value) {
+  if (Array.isArray(value))
+    return uniqueStrings(value).map((item) => item.toLowerCase());
+  if (typeof value === "string") {
+    return uniqueStrings(value.split(/[,\s]+/u)).map((item) =>
+      item.toLowerCase(),
+    );
+  }
+  return [];
+}
+
+function rolePriority(metadata = {}, roleName = "") {
+  const candidates = [
+    metadata?.[`${roleName}_priority`],
+    metadata?.role_priority,
+    metadata?.priority,
+  ];
+  for (const value of candidates) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return 0;
 }
 
 function clampAssignDuration(
@@ -90,6 +126,7 @@ export function createRouter(store) {
   const runtimeTopics = new Map();
   const queuesByAgent = new Map();
   const liveMessages = new Map();
+  const roleStates = new Map();
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -121,6 +158,340 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function ensureRoleState(roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!role) return null;
+    if (!roleStates.has(role)) {
+      roleStates.set(role, {
+        role,
+        leaderAgentId: null,
+        previousLeaderAgentId: null,
+        leaderEpoch: 0,
+        leaderSource: null,
+        status: "offline",
+        candidates: new Map(),
+        lastTransitionMs: null,
+        lastReason: "init",
+        transferredCount: 0,
+      });
+    }
+    return roleStates.get(role);
+  }
+
+  function hasRoleCapability(capabilities = [], roleName) {
+    const normalized = normalizeRoleValues(capabilities);
+    return normalized.some(
+      (capability) =>
+        capability === roleName ||
+        capability === `role:${roleName}` ||
+        capability === `${roleName}:leader` ||
+        capability === `${roleName}:candidate`,
+    );
+  }
+
+  function getRoleCandidateSource(agent, topics, roleName) {
+    if (!agent) return null;
+    const metadata = agent.metadata || {};
+    const roles = [
+      ...normalizeRoleValues(metadata.role),
+      ...normalizeRoleValues(metadata.roles),
+    ];
+    const explicit =
+      roles.includes(roleName) ||
+      metadata?.[roleName] === true ||
+      metadata?.is_cto === true ||
+      hasRoleCapability(agent.capabilities, roleName);
+    if (explicit) return "explicit";
+    return topics.includes(roleName) ? "topic-fallback" : null;
+  }
+
+  function buildRoleCandidate(agentId, roleName) {
+    const role = normalizeRoleName(roleName);
+    if (!agentId || !role) return null;
+    const agent = store.getAgent(agentId);
+    if (!agent) return null;
+    const topics = listRuntimeTopics(agentId);
+    const source = getRoleCandidateSource(agent, topics, role);
+    if (!source) return null;
+    return {
+      agent_id: agent.agent_id,
+      status: agent.status,
+      source,
+      priority: rolePriority(agent.metadata, role),
+      last_seen_ms: agent.last_seen_ms || 0,
+      lease_expires_ms: agent.lease_expires_ms || 0,
+      topics,
+      capabilities: agent.capabilities || [],
+    };
+  }
+
+  function refreshRoleCandidateForAgent(agentId) {
+    if (!agentId) return;
+    for (const roleName of ROLE_TOPICS) {
+      const role = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(agentId, roleName);
+      if (candidate) role.candidates.set(agentId, candidate);
+      else role.candidates.delete(agentId);
+    }
+  }
+
+  function refreshRoleCandidates(roleName) {
+    const role = ensureRoleState(roleName);
+    if (!role) return [];
+    const ids = new Set(role.candidates.keys());
+    for (const [agentId, topics] of runtimeTopics) {
+      if (topics.has(role.role)) ids.add(agentId);
+    }
+    for (const agent of store.getAgentsByTopic(role.role)) {
+      ids.add(agent.agent_id);
+    }
+    if (typeof store.listAllAgents === "function") {
+      for (const agent of store.listAllAgents()) ids.add(agent.agent_id);
+    }
+    for (const agentId of ids) refreshRoleCandidateForAgent(agentId);
+    return Array.from(role.candidates.values());
+  }
+
+  function isCandidateLive(candidate, now = Date.now()) {
+    return (
+      candidate?.status === "online" && Number(candidate.lease_expires_ms) > now
+    );
+  }
+
+  function sortRoleCandidates(candidates = []) {
+    return [...candidates].sort((left, right) => {
+      const sourceDelta =
+        (ROLE_SOURCE_RANK[right.source] || 0) -
+        (ROLE_SOURCE_RANK[left.source] || 0);
+      if (sourceDelta !== 0) return sourceDelta;
+      const priorityDelta =
+        Number(right.priority || 0) - Number(left.priority || 0);
+      if (priorityDelta !== 0) return priorityDelta;
+      const seenDelta =
+        Number(right.last_seen_ms || 0) - Number(left.last_seen_ms || 0);
+      if (seenDelta !== 0) return seenDelta;
+      return String(left.agent_id).localeCompare(String(right.agent_id));
+    });
+  }
+
+  function chooseRoleLeader(roleName) {
+    const now = Date.now();
+    return (
+      sortRoleCandidates(refreshRoleCandidates(roleName)).find((candidate) =>
+        isCandidateLive(candidate, now),
+      ) || null
+    );
+  }
+
+  function messageMatchesRole(record, roleName) {
+    const message = record?.message || {};
+    const to = message.to_agent ?? message.to;
+    return to === `topic:${roleName}`;
+  }
+
+  function roleTopicForMessage(message = {}) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return "";
+    return normalizeRoleName(String(to).slice(6));
+  }
+
+  function isReplayAllowedForAgent(agentId, message = {}) {
+    const roleName = roleTopicForMessage(message);
+    if (!roleName) return true;
+    const targetAgentId = String(agentId || "").trim();
+    if (!targetAgentId) return false;
+    const role = getRoleSnapshot(roleName);
+    return role?.leader_agent_id === targetAgentId;
+  }
+
+  function shouldTrackWithoutRecipients(message) {
+    const to = message?.to_agent ?? message?.to;
+    if (!String(to || "").startsWith("topic:")) return false;
+    return ROLE_TOPICS.has(String(to).slice(6));
+  }
+
+  function isRoleMessageFullyHandled(record, roleName) {
+    if (!messageMatchesRole(record, roleName)) return true;
+    return (
+      record.recipients.size > 0 &&
+      record.ackedBy.size >= record.recipients.size
+    );
+  }
+
+  function isRoleRecipient(agentId, roleName, previousLeaderAgentId = null) {
+    if (!agentId) return false;
+    if (agentId === previousLeaderAgentId) return true;
+    return Boolean(buildRoleCandidate(agentId, roleName));
+  }
+
+  function countPendingForRole(roleName) {
+    const now = Date.now();
+    let count = 0;
+    for (const record of liveMessages.values()) {
+      if (!messageMatchesRole(record, roleName)) continue;
+      if (record.message.expires_at_ms <= now) continue;
+      if (isRoleMessageFullyHandled(record, roleName)) continue;
+      count += 1;
+    }
+    return count;
+  }
+
+  function transferRoleBacklog(
+    roleName,
+    newLeaderAgentId,
+    previousLeaderAgentId,
+  ) {
+    const role = ensureRoleState(roleName);
+    const now = Date.now();
+    const stats = { transferred_count: 0, skipped_count: 0, removed_count: 0 };
+    if (!role || !newLeaderAgentId) return stats;
+
+    for (const record of liveMessages.values()) {
+      const { message, recipients, ackedBy } = record;
+      if (!messageMatchesRole(record, role.role)) continue;
+      if (message.expires_at_ms <= now) {
+        stats.skipped_count += 1;
+        continue;
+      }
+      if (isRoleMessageFullyHandled(record, role.role)) {
+        stats.skipped_count += 1;
+        continue;
+      }
+
+      for (const recipient of Array.from(recipients)) {
+        if (
+          recipient !== newLeaderAgentId &&
+          isRoleRecipient(recipient, role.role, previousLeaderAgentId)
+        ) {
+          queuesByAgent.get(recipient)?.delete(message.id);
+          recipients.delete(recipient);
+          ackedBy.delete(recipient);
+          stats.removed_count += 1;
+        }
+      }
+
+      recipients.add(newLeaderAgentId);
+      const alreadyQueued = queuesByAgent
+        .get(newLeaderAgentId)
+        ?.has(message.id);
+      if (!alreadyQueued && !ackedBy.has(newLeaderAgentId)) {
+        queueMessage(newLeaderAgentId, message);
+        stats.transferred_count += 1;
+      } else {
+        stats.skipped_count += 1;
+      }
+      message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+
+    role.transferredCount += stats.transferred_count;
+    return stats;
+  }
+
+  function buildRoleSnapshot(roleName, { refreshCandidates = true } = {}) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const candidates = sortRoleCandidates(
+      refreshCandidates
+        ? refreshRoleCandidates(role.role)
+        : Array.from(role.candidates.values()),
+    );
+    const leader =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const leaderLive = isCandidateLive(leader, now);
+    const liveCandidates = candidates.filter((candidate) =>
+      isCandidateLive(candidate, now),
+    );
+    return {
+      role: role.role,
+      status: leaderLive
+        ? "active"
+        : liveCandidates.length
+          ? "electable"
+          : "offline",
+      leader_agent_id: leaderLive ? role.leaderAgentId : null,
+      previous_leader_agent_id: role.previousLeaderAgentId || null,
+      leader_epoch: role.leaderEpoch,
+      lease_expires_ms: leaderLive ? leader.lease_expires_ms : null,
+      candidate_source: leaderLive
+        ? leader.source
+        : liveCandidates[0]?.source || null,
+      candidate_count: candidates.length,
+      live_candidate_count: liveCandidates.length,
+      pending_count: countPendingForRole(role.role),
+      transferred_count: role.transferredCount,
+      last_transition_ms: role.lastTransitionMs,
+      last_reason: role.lastReason,
+      candidates: candidates.slice(0, 16).map((candidate) => ({
+        agent_id: candidate.agent_id,
+        status: isCandidateLive(candidate, now) ? "online" : candidate.status,
+        source: candidate.source,
+        priority: candidate.priority,
+        last_seen_ms: candidate.last_seen_ms,
+        lease_expires_ms: candidate.lease_expires_ms,
+      })),
+    };
+  }
+
+  function ensureRoleLeader(
+    roleName,
+    { reason = "ensure", transferBacklog = true } = {},
+  ) {
+    const role = ensureRoleState(roleName);
+    if (!role) return null;
+    const now = Date.now();
+    const current =
+      role.leaderAgentId && buildRoleCandidate(role.leaderAgentId, role.role);
+    const best = chooseRoleLeader(role.role);
+    const currentLive = isCandidateLive(current, now);
+    const shouldPreemptFallback =
+      currentLive &&
+      current?.source === "topic-fallback" &&
+      best?.source === "explicit" &&
+      best.agent_id !== current.agent_id;
+
+    if (currentLive && !shouldPreemptFallback) {
+      role.status = "active";
+      role.leaderSource = current.source;
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (!best) {
+      if (role.leaderAgentId) {
+        role.previousLeaderAgentId = role.leaderAgentId;
+        role.leaderAgentId = null;
+        role.leaderSource = null;
+        role.leaderEpoch += 1;
+        role.lastTransitionMs = Date.now();
+        role.lastReason = reason;
+      }
+      role.status = "offline";
+      return buildRoleSnapshot(role.role);
+    }
+
+    if (role.leaderAgentId !== best.agent_id) {
+      const previousLeaderAgentId = role.leaderAgentId;
+      role.previousLeaderAgentId =
+        previousLeaderAgentId || role.previousLeaderAgentId;
+      role.leaderAgentId = best.agent_id;
+      role.leaderSource = best.source;
+      role.leaderEpoch += 1;
+      role.status = "active";
+      role.lastTransitionMs = Date.now();
+      role.lastReason = reason;
+      if (transferBacklog) {
+        transferRoleBacklog(role.role, best.agent_id, previousLeaderAgentId);
+      }
+    }
+
+    return buildRoleSnapshot(role.role);
+  }
+
+  function getRoleSnapshot(roleName) {
+    return buildRoleSnapshot(roleName, { refreshCandidates: true });
   }
 
   function trackMessage(message, recipients) {
@@ -162,6 +533,14 @@ export function createRouter(store) {
     }
 
     const topic = to.slice(6);
+    if (ROLE_TOPICS.has(topic)) {
+      const role = ensureRoleLeader(topic, {
+        reason: "route",
+        transferBacklog: true,
+      });
+      return role?.leader_agent_id ? [role.leader_agent_id] : [];
+    }
+
     const recipients = new Set();
     for (const [agentId, topics] of runtimeTopics) {
       if (topics.has(topic)) recipients.add(agentId);
@@ -258,8 +637,10 @@ export function createRouter(store) {
       correlation_id,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
-    if (recipients.length) {
+    if (recipients.length || shouldTrackWithoutRecipients(msg)) {
       trackMessage(msg, recipients);
+    }
+    if (recipients.length) {
       for (const agentId of recipients) {
         queueMessage(agentId, msg);
       }
@@ -422,15 +803,37 @@ export function createRouter(store) {
     registerAgent(args) {
       const result = store.registerAgent(args);
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
+      refreshRoleCandidateForAgent(args.agent_id);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "register",
+          transferBacklog: true,
+        });
+      }
       return result;
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {
-      return store.refreshLease(agentId, ttlMs);
+      const result = store.refreshLease(agentId, ttlMs);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "heartbeat",
+          transferBacklog: true,
+        });
+      }
+      return result;
     },
 
     subscribeAgent(agentId, topics, { replace = false } = {}) {
       const nextTopics = upsertRuntimeTopics(agentId, topics, { replace });
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: "subscribe",
+          transferBacklog: true,
+        });
+      }
       return { agent_id: agentId, topics: nextTopics };
     },
 
@@ -442,12 +845,25 @@ export function createRouter(store) {
       if (status === "offline") {
         runtimeTopics.delete(agentId);
       }
-      return store.updateAgentStatus(agentId, status);
+      const updated = store.updateAgentStatus(agentId, status);
+      refreshRoleCandidateForAgent(agentId);
+      for (const roleName of ROLE_TOPICS) {
+        ensureRoleLeader(roleName, {
+          reason: `status:${status}`,
+          transferBacklog: true,
+        });
+      }
+      return updated;
     },
 
     route(msg) {
       const recipients = uniqueStrings(resolveRecipients(msg));
-      if (!recipients.length) return 0;
+      if (!recipients.length) {
+        if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
+          trackMessage(msg, []);
+        }
+        return 0;
+      }
       if (!getMessageRecord(msg.id)) {
         trackMessage(msg, recipients);
       }
@@ -460,6 +876,10 @@ export function createRouter(store) {
 
     getPendingMessages(agentId, options = {}) {
       return sortedPending(agentId, options);
+    },
+
+    canReplayMessageForAgent(agentId, message) {
+      return isReplayAllowedForAgent(agentId, message);
     },
 
     countPendingMessages(agentId) {
@@ -610,6 +1030,87 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
+          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+        },
+      };
+    },
+
+    takeoverRole({
+      role = "cto",
+      agent_id,
+      reason = "manual",
+      requested_by = "manual",
+    } = {}) {
+      const roleName = normalizeRoleName(role);
+      if (!roleName) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_NOT_SUPPORTED",
+            message: `unsupported role: ${role}`,
+          },
+        };
+      }
+      const targetAgentId = String(agent_id || "").trim();
+      if (!targetAgentId) {
+        return {
+          ok: false,
+          error: {
+            code: "AGENT_ID_REQUIRED",
+            message: "agent_id required",
+          },
+        };
+      }
+
+      refreshRoleCandidates(roleName);
+      const roleState = ensureRoleState(roleName);
+      const candidate = buildRoleCandidate(targetAgentId, roleName);
+      if (!isCandidateLive(candidate)) {
+        return {
+          ok: false,
+          error: {
+            code: "ROLE_CANDIDATE_UNAVAILABLE",
+            message: `${targetAgentId} is not a live ${roleName} candidate`,
+          },
+          data: {
+            role: buildRoleSnapshot(roleName),
+          },
+        };
+      }
+
+      const previousLeaderAgentId =
+        roleState.leaderAgentId && roleState.leaderAgentId !== targetAgentId
+          ? roleState.leaderAgentId
+          : roleState.previousLeaderAgentId || null;
+      const changed = roleState.leaderAgentId !== targetAgentId;
+      if (changed) {
+        roleState.previousLeaderAgentId = previousLeaderAgentId || null;
+        roleState.leaderAgentId = targetAgentId;
+        roleState.leaderSource = candidate.source;
+        roleState.leaderEpoch += 1;
+        roleState.status = "active";
+        roleState.lastTransitionMs = Date.now();
+        roleState.lastReason = reason || "manual";
+      }
+
+      const transfer = transferRoleBacklog(
+        roleName,
+        targetAgentId,
+        previousLeaderAgentId,
+      );
+      const snapshot = buildRoleSnapshot(roleName);
+      return {
+        ok: true,
+        data: {
+          role: roleName,
+          requested_by,
+          reason,
+          changed,
+          previous_leader_agent_id: previousLeaderAgentId,
+          leader_agent_id: snapshot.leader_agent_id,
+          leader_epoch: snapshot.leader_epoch,
+          ...transfer,
+          status: snapshot,
         },
       };
     },
@@ -897,6 +1398,9 @@ export function createRouter(store) {
           realtime_transport: "named-pipe",
           audit_store: store.type || "sqlite",
         };
+        data.roles = {
+          cto: getRoleSnapshot("cto"),
+        };
         if (include_metrics) {
           const depths = router.getQueueDepths();
           const stats = router.getDeliveryStats();
@@ -919,6 +1423,7 @@ export function createRouter(store) {
       if (scope === "agent" && agent_id) {
         const agent = store.getAgent(agent_id);
         if (agent) {
+          refreshRoleCandidateForAgent(agent_id);
           data.agent = {
             agent_id: agent.agent_id,
             status: agent.status,
@@ -926,6 +1431,18 @@ export function createRouter(store) {
             last_seen_ms: agent.last_seen_ms,
             topics: listRuntimeTopics(agent_id),
           };
+          const roles = {};
+          for (const roleName of ROLE_TOPICS) {
+            const candidate = buildRoleCandidate(agent_id, roleName);
+            if (candidate) {
+              roles[roleName] = {
+                candidate_source: candidate.source,
+                priority: candidate.priority,
+                leader: getRoleSnapshot(roleName)?.leader_agent_id === agent_id,
+              };
+            }
+          }
+          if (Object.keys(roles).length) data.agent.roles = roles;
         }
       }
 

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -22,6 +22,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { runCollect } from "../cto/collect.mjs";
+import { resolveLakeRootDir } from "../cto/lake-root.mjs";
 import { runStatus as runCtoStatus } from "../cto/status.mjs";
 import { createModuleLogger } from "../scripts/lib/logger.mjs";
 import {
@@ -95,6 +96,7 @@ const LOOPBACK_REMOTE_ADDRESSES = new Set([
 const ALLOWED_ORIGIN_RE =
   /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i;
 const PROJECT_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CANONICAL_PROJECT_ROOT = resolveLakeRootDir(PROJECT_ROOT) || PROJECT_ROOT;
 const PUBLIC_DIR = resolve(join(PROJECT_ROOT, "hub", "public"));
 const CACHE_DIR = join(homedir(), ".claude", "cache");
 const HUB_DEFAULT_PORT = 27888;
@@ -865,7 +867,7 @@ function getBrokerPublicSnapshot(currentBroker = brokerInstance) {
 async function getTrayCtoStatus() {
   try {
     return await runCtoStatus(["--json"], {
-      rootDir: PROJECT_ROOT,
+      rootDir: CANONICAL_PROJECT_ROOT,
       stdout: { write() {} },
     });
   } catch (error) {
@@ -1446,12 +1448,22 @@ export async function startHub({
         const synapseSnapshot = synapseRegistry.snapshot();
         const broker = getBrokerPublicSnapshot(brokerInstance);
         const runtimeStatus = getRuntimeStatus({
-          projectRoots: [PROJECT_ROOT],
+          projectRoots: [
+            ...new Set([CANONICAL_PROJECT_ROOT, PROJECT_ROOT].filter(Boolean)),
+          ],
         });
-        const [ctoStatus, mcpStatus] = await Promise.all([
+        const [ctoStatus, mcpStatus, hubStatus] = await Promise.all([
           getTrayCtoStatus(),
           Promise.resolve(getTrayMcpStatus()),
+          pipe.executeQuery("status", {
+            scope: "hub",
+            include_metrics: true,
+          }),
         ]);
+        const mergedCtoStatus = {
+          ...(ctoStatus || {}),
+          roles: hubStatus?.data?.roles || ctoStatus?.roles || {},
+        };
 
         return writeJson(
           res,
@@ -1462,12 +1474,12 @@ export async function startHub({
               pid: process.pid,
               port,
               url: buildHubUrl(host, port),
-              projectRoot: PROJECT_ROOT,
+              projectRoot: CANONICAL_PROJECT_ROOT,
             },
             qos,
             synapseSnapshot,
             broker,
-            ctoStatus,
+            ctoStatus: mergedCtoStatus,
             mcpStatus,
             runtimeStatus,
           }),
@@ -1650,6 +1662,28 @@ export async function startHub({
           if (path === "/bridge/hitl/pending" && req.method === "GET") {
             const result = { ok: true, data: hitl.getPendingRequests() };
             return writeJson(res, result.ok ? 200 : 400, result);
+          }
+
+          if (path === "/bridge/takeover-role" && req.method === "POST") {
+            const {
+              role = "cto",
+              agent_id,
+              reason = "manual",
+              requested_by = "http",
+            } = body;
+            if (!role || !agent_id) {
+              return writeJson(res, 400, {
+                ok: false,
+                error: "role, agent_id 필수",
+              });
+            }
+            const result = await pipe.executeCommand("takeover_role", {
+              role,
+              agent_id,
+              reason,
+              requested_by,
+            });
+            return writeJson(res, result.ok ? 200 : 409, result);
           }
 
           if (path === "/bridge/register" && req.method === "POST") {

--- a/packages/triflux/hub/tools.mjs
+++ b/packages/triflux/hub/tools.mjs
@@ -183,6 +183,26 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
+    // ── 2-1. takeover_role ──
+    {
+      name: "takeover_role",
+      description:
+        "CTO 같은 허브 역할의 active leader를 명시적으로 승계하고 미처리 역할 메시지를 새 leader에게 이전합니다",
+      inputSchema: {
+        type: "object",
+        required: ["role", "agent_id"],
+        properties: {
+          role: { type: "string", enum: ["cto"], default: "cto" },
+          agent_id: { type: "string", pattern: "^[a-zA-Z0-9._:-]{3,64}$" },
+          reason: { type: "string" },
+          requested_by: { type: "string" },
+        },
+      },
+      handler: wrap("TAKEOVER_ROLE_FAILED", (args) => {
+        return router.takeoverRole(args);
+      }),
+    },
+
     // ── 3. publish ──
     {
       name: "publish",
@@ -841,7 +861,7 @@ export function createTools(store, router, hitl, pipe = null) {
       }),
     },
 
-    // ── 21. send_input ──
+    // ── 22. send_input ──
     {
       name: "send_input",
       description: "Send input text to a worker in INPUT_WAIT state",

--- a/packages/triflux/hub/tray-state.mjs
+++ b/packages/triflux/hub/tray-state.mjs
@@ -49,6 +49,10 @@ function normalizeAgentId(value) {
   return "";
 }
 
+function rawAgentId(value) {
+  return String(value ?? "").trim();
+}
+
 function inferAgentId(value = {}) {
   const direct = normalizeAgentId(
     value.agent_id ??
@@ -84,7 +88,11 @@ function agentMeta(agentId) {
 export function normalizeTraySessions(snapshot) {
   return readSynapseSessions(snapshot)
     .map((session) => {
-      const agentId = inferAgentId(session);
+      const directAgentId = session?.agent_id ?? session?.agentId;
+      const agentId =
+        normalizeAgentId(directAgentId) ||
+        rawAgentId(directAgentId) ||
+        inferAgentId(session);
       return {
         sessionId: String(session?.sessionId || ""),
         host: typeof session?.host === "string" ? session.host : "local",
@@ -368,7 +376,11 @@ function runtimeToLiveOverlay(runtime) {
 }
 
 function normalizeLiveSession(session = {}) {
-  const agentId = inferAgentId(session);
+  const directAgentId = session.agent_id ?? session.agentId;
+  const agentId =
+    normalizeAgentId(directAgentId) ||
+    rawAgentId(directAgentId) ||
+    inferAgentId(session);
   return {
     ...session,
     sessionId: String(session.sessionId || ""),
@@ -460,11 +472,21 @@ function normalizeCtoStatus(ctoStatus = {}, sessions = [], runtime = {}) {
     ? ctoStatus.active_shards
     : [];
   const hygiene = normalizeCtoHygiene(ctoStatus);
+  const roles =
+    ctoStatus?.roles && typeof ctoStatus.roles === "object"
+      ? ctoStatus.roles
+      : null;
+  const succession =
+    ctoStatus?.succession && typeof ctoStatus.succession === "object"
+      ? ctoStatus.succession
+      : null;
   return {
     schema_version: String(ctoStatus?.schema_version || "cto-lake.v1"),
     generated_at: ctoStatus?.generated_at || null,
     live_sessions: normalizedLiveSessions,
     active_shards: activeShards,
+    ...(roles ? { roles } : {}),
+    ...(succession ? { succession } : {}),
     ...(hygiene ? { hygiene } : {}),
     summary: {
       live_session_count: normalizedLiveSessions.length,

--- a/tests/integration/pipe.test.mjs
+++ b/tests/integration/pipe.test.mjs
@@ -9,6 +9,9 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 
 import { startHub } from "../../hub/server.mjs";
+import { createMemoryStore } from "../../packages/core/hub/lib/memory-store.mjs";
+import { createRouter as createCoreRouter } from "../../packages/core/hub/router.mjs";
+import { createPipeServer as createRemotePipeServer } from "../../packages/remote/hub/pipe.mjs";
 
 function tempDbPath() {
   const dir = join(tmpdir(), `tfx-hub-pipe-test-${randomUUID()}`);
@@ -259,6 +262,324 @@ describe("Named Pipe 실시간 채널", () => {
     assert.deepEqual(drained.data.messages[0].payload, { command: "pause" });
 
     client.close();
+  });
+
+  it("takeover_role command는 CTO leader를 바꾸고 미처리 CTO 메시지를 새 leader에게 push해야 한다", async () => {
+    const oldLeader = await createPipeClient(hub.pipePath);
+    const newLeader = await createPipeClient(hub.pipePath);
+    const lead = await createPipeClient(hub.pipePath);
+
+    await oldLeader.request("command", {
+      action: "register",
+      agent_id: "pipe-cto-old",
+      cli: "claude",
+      capabilities: ["code"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 10 },
+      heartbeat_ttl_ms: 60000,
+    });
+    await newLeader.request("command", {
+      action: "register",
+      agent_id: "pipe-cto-new",
+      cli: "codex",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 1 },
+      heartbeat_ttl_ms: 60000,
+    });
+
+    const oldEventPromise = oldLeader.nextEvent();
+    const published = await lead.request("command", {
+      action: "publish",
+      from: "pipe-lead",
+      to: "topic:cto",
+      topic: "cto",
+      payload: { decision: "pipe takeover" },
+    });
+    assert.equal(published.ok, true);
+    assert.equal(published.data.fanout_count, 1);
+    assert.equal((await oldEventPromise).payload.message.topic, "cto");
+
+    const newEventPromise = newLeader.nextEvent();
+    const takeover = await lead.request("command", {
+      action: "takeover_role",
+      role: "cto",
+      agent_id: "pipe-cto-new",
+      reason: "pipe_test",
+      requested_by: "test",
+    });
+    assert.equal(takeover.ok, true);
+    assert.equal(takeover.data.leader_agent_id, "pipe-cto-new");
+    assert.equal(takeover.data.transferred_count, 1);
+
+    const transferred = await newEventPromise;
+    assert.equal(transferred.payload.message.topic, "cto");
+    assert.deepEqual(transferred.payload.message.payload, {
+      decision: "pipe takeover",
+    });
+
+    const status = await lead.request("query", {
+      action: "status",
+      scope: "hub",
+    });
+    assert.equal(status.ok, true);
+    assert.equal(status.data.roles.cto.leader_agent_id, "pipe-cto-new");
+
+    oldLeader.close();
+    newLeader.close();
+    lead.close();
+  });
+
+  it("context replay는 topic:cto 감사 로그를 elected leader에게만 보여줘야 한다", async () => {
+    hub.router.registerAgent({
+      agent_id: "pipe-cto-audit-leader",
+      cli: "codex",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto" },
+      heartbeat_ttl_ms: 60000,
+    });
+    hub.router.registerAgent({
+      agent_id: "pipe-cto-audit-standby",
+      cli: "claude",
+      capabilities: ["code"],
+      topics: ["cto"],
+      heartbeat_ttl_ms: 60000,
+    });
+    const takeover = hub.router.takeoverRole({
+      role: "cto",
+      agent_id: "pipe-cto-audit-leader",
+      reason: "audit_replay_test",
+      requested_by: "test",
+    });
+    assert.equal(takeover.ok, true);
+
+    const published = hub.router.handlePublish({
+      from: "lead",
+      to: "topic:cto",
+      topic: "cto",
+      payload: { decision: "audit replay must not fan out" },
+    });
+    assert.equal(published.ok, true);
+    assert.equal(published.data.fanout_count, 1);
+
+    const client = await createPipeClient(hub.pipePath);
+    const standbyContext = await client.request("query", {
+      action: "context",
+      agent_id: "pipe-cto-audit-standby",
+      max_messages: 20,
+    });
+    assert.equal(standbyContext.ok, true);
+    assert.deepEqual(standbyContext.data.messages, []);
+
+    const leaderContext = await client.request("query", {
+      action: "context",
+      agent_id: "pipe-cto-audit-leader",
+      max_messages: 20,
+    });
+    assert.equal(leaderContext.ok, true);
+    assert.equal(
+      leaderContext.data.messages.some(
+        (message) =>
+          message.topic === "cto" &&
+          message.payload?.decision === "audit replay must not fan out",
+      ),
+      true,
+    );
+
+    client.close();
+  });
+
+  it("context replay는 topic 구독 없는 explicit CTO leader에게도 감사 로그를 보여줘야 한다", async () => {
+    hub.router.registerAgent({
+      agent_id: "pipe-cto-explicit-audit-leader",
+      cli: "codex",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 99 },
+      heartbeat_ttl_ms: 60000,
+    });
+    hub.router.registerAgent({
+      agent_id: "pipe-cto-explicit-audit-standby",
+      cli: "claude",
+      capabilities: ["code"],
+      topics: ["cto"],
+      heartbeat_ttl_ms: 60000,
+    });
+    const takeover = hub.router.takeoverRole({
+      role: "cto",
+      agent_id: "pipe-cto-explicit-audit-leader",
+      reason: "explicit_audit_replay_test",
+      requested_by: "test",
+    });
+    assert.equal(takeover.ok, true);
+
+    const payload = {
+      decision: `explicit audit replay ${randomUUID()}`,
+    };
+    const published = hub.router.handlePublish({
+      from: "lead",
+      to: "topic:cto",
+      topic: "cto",
+      payload,
+    });
+    assert.equal(published.ok, true);
+    assert.equal(published.data.fanout_count, 1);
+
+    const client = await createPipeClient(hub.pipePath);
+    const drained = await client.request("query", {
+      action: "drain",
+      agent_id: "pipe-cto-explicit-audit-leader",
+      max_messages: 10,
+      auto_ack: true,
+    });
+    assert.equal(drained.ok, true);
+    assert.equal(
+      drained.data.messages.some(
+        (message) => message.payload?.decision === payload.decision,
+      ),
+      true,
+    );
+    assert.equal(
+      hub.router
+        .getPendingMessages("pipe-cto-explicit-audit-leader")
+        .some((message) => message.payload?.decision === payload.decision),
+      false,
+    );
+
+    const leaderContext = await client.request("query", {
+      action: "context",
+      agent_id: "pipe-cto-explicit-audit-leader",
+      max_messages: 50,
+    });
+    assert.equal(leaderContext.ok, true);
+    assert.equal(
+      leaderContext.data.messages.some(
+        (message) => message.payload?.decision === payload.decision,
+      ),
+      true,
+    );
+
+    const standbyContext = await client.request("query", {
+      action: "context",
+      agent_id: "pipe-cto-explicit-audit-standby",
+      max_messages: 50,
+    });
+    assert.equal(standbyContext.ok, true);
+    assert.equal(
+      standbyContext.data.messages.some(
+        (message) => message.payload?.decision === payload.decision,
+      ),
+      false,
+    );
+
+    client.close();
+  });
+
+  it("HTTP /bridge/takeover-role도 CTO 승계 surface를 제공해야 한다", async () => {
+    hub.router.registerAgent({
+      agent_id: "http-cto-new",
+      cli: "codex",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 3 },
+      heartbeat_ttl_ms: 60000,
+    });
+
+    const response = await fetch(
+      `http://127.0.0.1:${TEST_PORT}/bridge/takeover-role`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          role: "cto",
+          agent_id: "http-cto-new",
+          reason: "http_test",
+          requested_by: "test",
+        }),
+      },
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.data.leader_agent_id, "http-cto-new");
+  });
+
+  it("HTTP /bridge/takeover-role은 malformed 요청을 거부해야 한다", async () => {
+    const missingAgent = await fetch(
+      `http://127.0.0.1:${TEST_PORT}/bridge/takeover-role`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role: "cto" }),
+      },
+    );
+    const missingAgentBody = await missingAgent.json();
+    assert.equal(missingAgent.status, 400);
+    assert.equal(missingAgentBody.ok, false);
+
+    const unsupportedRole = await fetch(
+      `http://127.0.0.1:${TEST_PORT}/bridge/takeover-role`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          role: "ceo",
+          agent_id: "http-cto-new",
+        }),
+      },
+    );
+    const unsupportedRoleBody = await unsupportedRole.json();
+    assert.equal(unsupportedRole.status, 409);
+    assert.equal(unsupportedRoleBody.ok, false);
+    assert.equal(unsupportedRoleBody.error.code, "ROLE_NOT_SUPPORTED");
+  });
+
+  it("packaged remote pipe uses packaged core router with takeover_role support", async () => {
+    const router = createCoreRouter(createMemoryStore());
+    const pipe = createRemotePipeServer({
+      router,
+      sessionId: `remote-package-${randomUUID()}`,
+    });
+
+    const oldRegister = await pipe.executeCommand("register", {
+      agent_id: "pkg-cto-old",
+      cli: "claude",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 10 },
+      heartbeat_ttl_ms: 60000,
+    });
+    const newRegister = await pipe.executeCommand("register", {
+      agent_id: "pkg-cto-new",
+      cli: "codex",
+      capabilities: ["cto"],
+      topics: [],
+      metadata: { role: "cto", cto_priority: 1 },
+      heartbeat_ttl_ms: 60000,
+    });
+    assert.equal(oldRegister.ok, true);
+    assert.equal(newRegister.ok, true);
+
+    const published = await pipe.executeCommand("publish", {
+      from: "lead",
+      to: "topic:cto",
+      topic: "cto",
+      payload: { decision: "remote package takeover" },
+    });
+    assert.equal(published.ok, true);
+    assert.equal(published.data.fanout_count, 1);
+
+    const takeover = await pipe.executeCommand("takeover_role", {
+      role: "cto",
+      agent_id: "pkg-cto-new",
+      reason: "package_test",
+      requested_by: "test",
+    });
+    assert.equal(takeover.ok, true);
+    assert.equal(takeover.data.leader_agent_id, "pkg-cto-new");
+    assert.equal(takeover.data.transferred_count, 1);
   });
 
   it("assign/assign_result/assign_status 명령은 pipe 경로로 동작해야 한다", async () => {

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -17,6 +17,27 @@ function tempDbPath() {
   return join(dir, "test.db");
 }
 
+function createIsolatedRouter() {
+  const dbPath = tempDbPath();
+  const store = createStore(dbPath);
+  const router = createRouter(store);
+  return {
+    store,
+    router,
+    cleanup() {
+      router.stopSweeper();
+      store.close();
+      try {
+        rmSync(join(dbPath, ".."), { recursive: true, force: true });
+      } catch {}
+    },
+  };
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe("createRouter()", { skip: SQLITE_SKIP }, () => {
   let store;
   let router;
@@ -135,6 +156,456 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
         result.data.fanout_count >= 2,
         `fanout_count(${result.data.fanout_count})는 최소 2여야 한다`,
       );
+    });
+  });
+
+  describe("CTO 역할 승계", () => {
+    it("topic:cto는 전체 팬아웃이 아니라 현재 CTO leader 한 명에게만 라우팅해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-route-leader",
+          cli: "claude",
+          capabilities: ["code"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "cto-topic-worker",
+          cli: "codex",
+          capabilities: ["code"],
+          topics: ["cto"],
+          heartbeat_ttl_ms: 60000,
+        });
+
+        const result = isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "please coordinate" },
+        });
+
+        assert.equal(result.ok, true);
+        assert.equal(result.data.fanout_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-route-leader").length,
+          1,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-topic-worker").length,
+          0,
+        );
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "cto-route-leader");
+        assert.equal(status.data.roles.cto.candidate_source, "explicit");
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("leader가 없을 때 들어온 topic:cto 메시지는 후보 등록 시 새 leader에게 이전되어야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        const published = isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "wait for a CTO" },
+        });
+
+        assert.equal(published.ok, true);
+        assert.equal(published.data.fanout_count, 0);
+        assert.equal(published.data.role.pending_count, 1);
+
+        isolated.router.registerAgent({
+          agent_id: "cto-late-leader",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto" },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "cto-late-leader");
+        assert.equal(status.data.roles.cto.pending_count, 1);
+
+        const pending = isolated.router.getPendingMessages("cto-late-leader");
+        assert.equal(pending.length, 1);
+        assert.equal(pending[0].topic, "cto");
+        assert.deepEqual(pending[0].payload, { decision: "wait for a CTO" });
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("legacy route(msg) 경로도 leader 없는 topic:cto backlog를 보존해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        const msg = isolated.store.enqueueMessage({
+          type: "event",
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "legacy route backlog" },
+        });
+
+        assert.equal(isolated.router.route(msg), 0);
+        assert.equal(
+          isolated.router.getStatus("hub").data.roles.cto.pending_count,
+          1,
+        );
+
+        isolated.router.registerAgent({
+          agent_id: "cto-legacy-route",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto" },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        const pending = isolated.router.getPendingMessages("cto-legacy-route");
+        assert.equal(pending.length, 1);
+        assert.deepEqual(pending[0].payload, {
+          decision: "legacy route backlog",
+        });
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("이전 leader가 먼저 offline 된 뒤 나중에 새 후보가 등록되어도 backlog를 이전해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-gap-old",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto" },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "survive leader gap" },
+        });
+        assert.equal(
+          isolated.router.getPendingMessages("cto-gap-old").length,
+          1,
+        );
+
+        isolated.router.updateAgentStatus("cto-gap-old", "offline");
+        const gapStatus = isolated.router.getStatus("hub");
+        assert.equal(gapStatus.data.roles.cto.leader_agent_id, null);
+        assert.equal(
+          gapStatus.data.roles.cto.previous_leader_agent_id,
+          "cto-gap-old",
+        );
+        assert.equal(gapStatus.data.roles.cto.pending_count, 1);
+
+        isolated.router.registerAgent({
+          agent_id: "cto-gap-new",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto" },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "cto-gap-new");
+        assert.equal(
+          status.data.roles.cto.previous_leader_agent_id,
+          "cto-gap-old",
+        );
+        assert.equal(status.data.roles.cto.pending_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-gap-old").length,
+          0,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-gap-new").length,
+          1,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("leader가 offline 되면 새 CTO 후보로 승계하고 미처리 CTO 메시지를 이전해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-old-leader",
+          cli: "claude",
+          capabilities: ["code"],
+          topics: [],
+          metadata: { roles: ["cto"], cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "cto-new-leader",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 5 },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        const ctoMessage = isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "unacked backlog" },
+        });
+        const directMessage = isolated.router.handlePublish({
+          from: "lead",
+          to: "cto-old-leader",
+          topic: "lead.control",
+          payload: { command: "do not reroute" },
+        });
+        const misleadingDirectMessage = isolated.router.handlePublish({
+          from: "lead",
+          to: "cto-old-leader",
+          topic: "ops.direct",
+          payload: { role: "cto", command: "metadata only; do not reroute" },
+        });
+        const directCtoTopicMessage = isolated.router.handlePublish({
+          from: "lead",
+          to: "cto-old-leader",
+          topic: "cto",
+          payload: { command: "direct topic metadata; do not reroute" },
+        });
+        assert.equal(ctoMessage.data.fanout_count, 1);
+        assert.equal(directMessage.data.fanout_count, 1);
+        assert.equal(misleadingDirectMessage.data.fanout_count, 1);
+        assert.equal(directCtoTopicMessage.data.fanout_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-old-leader").length,
+          4,
+        );
+
+        isolated.router.updateAgentStatus("cto-old-leader", "offline");
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "cto-new-leader");
+        assert.equal(
+          status.data.roles.cto.previous_leader_agent_id,
+          "cto-old-leader",
+        );
+        assert.equal(status.data.roles.cto.pending_count, 1);
+
+        const newPending = isolated.router.getPendingMessages("cto-new-leader");
+        assert.equal(newPending.length, 1);
+        assert.equal(newPending[0].topic, "cto");
+
+        const oldPending = isolated.router.getPendingMessages("cto-old-leader");
+        assert.equal(oldPending.length, 3);
+        assert.deepEqual(oldPending.map((message) => message.topic).sort(), [
+          "cto",
+          "lead.control",
+          "ops.direct",
+        ]);
+
+        isolated.router.refreshAgentLease("cto-old-leader", 60000);
+        const afterOldHeartbeat = isolated.router.getStatus("hub");
+        assert.equal(
+          afterOldHeartbeat.data.roles.cto.leader_agent_id,
+          "cto-new-leader",
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("getStatus()는 read-only이며 만료 leader의 CTO backlog를 승계 이전하지 않아야 한다", async () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-status-old",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "cto-status-new",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 1 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "status must not move this" },
+        });
+        isolated.store.db
+          .prepare("UPDATE agents SET lease_expires_ms=? WHERE agent_id=?")
+          .run(Date.now() - 1, "cto-status-old");
+
+        await delay(5);
+        const status = isolated.router.getStatus("hub");
+
+        assert.equal(status.ok, true);
+        assert.equal(status.data.roles.cto.leader_agent_id, null);
+        assert.equal(status.data.roles.cto.pending_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-status-old").length,
+          1,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-status-new").length,
+          0,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("직접 cto topic publish는 leader를 바꾸거나 CTO backlog를 고립시키면 안 된다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-direct-topic-old",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "cto-direct-topic-new",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 1 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "move only on real role election" },
+        });
+        assert.equal(
+          isolated.router.getPendingMessages("cto-direct-topic-old").length,
+          1,
+        );
+
+        isolated.store.db
+          .prepare("UPDATE agents SET lease_expires_ms=? WHERE agent_id=?")
+          .run(Date.now() - 1, "cto-direct-topic-old");
+
+        const direct = isolated.router.handlePublish({
+          from: "lead",
+          to: "some-direct-recipient",
+          topic: "cto",
+          payload: { command: "not role addressed" },
+        });
+        assert.equal(direct.ok, true);
+        assert.equal(direct.data.role, undefined);
+
+        const afterDirect = isolated.router.getStatus("hub");
+        assert.equal(afterDirect.data.roles.cto.leader_agent_id, null);
+        assert.equal(afterDirect.data.roles.cto.pending_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-direct-topic-old").length,
+          1,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-direct-topic-new").length,
+          0,
+        );
+
+        isolated.router.refreshAgentLease("cto-direct-topic-new", 60000);
+        const afterHeartbeat = isolated.router.getStatus("hub");
+        assert.equal(
+          afterHeartbeat.data.roles.cto.leader_agent_id,
+          "cto-direct-topic-new",
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-direct-topic-old").length,
+          0,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-direct-topic-new").length,
+          1,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("takeoverRole()은 명시 승계와 백로그 이전을 멱등하게 수행해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-manual-old",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "cto-manual-new",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 1 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "manual takeover" },
+        });
+
+        const takeover = isolated.router.takeoverRole({
+          role: "cto",
+          agent_id: "cto-manual-new",
+          reason: "operator_request",
+          requested_by: "test",
+        });
+
+        assert.equal(takeover.ok, true);
+        assert.equal(takeover.data.changed, true);
+        assert.equal(takeover.data.previous_leader_agent_id, "cto-manual-old");
+        assert.equal(takeover.data.leader_agent_id, "cto-manual-new");
+        assert.equal(takeover.data.transferred_count, 1);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-manual-new").length,
+          1,
+        );
+        assert.equal(
+          isolated.router.getPendingMessages("cto-manual-old").length,
+          0,
+        );
+
+        const again = isolated.router.takeoverRole({
+          role: "cto",
+          agent_id: "cto-manual-new",
+          reason: "operator_request",
+          requested_by: "test",
+        });
+        assert.equal(again.ok, true);
+        assert.equal(again.data.changed, false);
+        assert.equal(again.data.transferred_count, 0);
+        assert.equal(
+          isolated.router.getPendingMessages("cto-manual-new").length,
+          1,
+        );
+      } finally {
+        isolated.cleanup();
+      }
     });
   });
 

--- a/tests/unit/conductor-registry.test.mjs
+++ b/tests/unit/conductor-registry.test.mjs
@@ -26,9 +26,10 @@ describe("conductor-registry send_input integration", () => {
     setConductorRegistry(previousRegistry);
   });
 
-  it("createTools는 send_input을 21번째 MCP 도구로 노출해야 한다", () => {
+  it("createTools는 takeover_role을 추가하고 send_input을 마지막 MCP 도구로 노출해야 한다", () => {
     const tools = createTools({}, {}, {}, null);
-    assert.equal(tools.length, 21);
+    assert.equal(tools.length, 22);
+    assert.ok(tools.some((tool) => tool.name === "takeover_role"));
     assert.equal(tools.at(-1)?.name, "send_input");
   });
 

--- a/tests/unit/cto-status.test.mjs
+++ b/tests/unit/cto-status.test.mjs
@@ -190,6 +190,14 @@ describe("cto status active_shards / live_sessions projection", () => {
       deriveRepoRootFromCwd("/repo/app/.codex-swarm/wt-auth/src"),
       "/repo/app",
     );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.worktrees/feature"),
+      "/repo/app",
+    );
+    assert.equal(
+      deriveRepoRootFromCwd("/repo/app/.worktrees/feature/src"),
+      "/repo/app",
+    );
     assert.equal(deriveRepoRootFromCwd("/repo/sibling"), "/repo/sibling");
     assert.equal(
       deriveRepoRootFromCwd("C:\\Users\\dev\\repo\\.claude\\worktrees\\x"),
@@ -216,6 +224,7 @@ describe("cto status active_shards / live_sessions projection", () => {
       "wt-feature-b",
       "src",
     );
+    const gitWorktreeCwd = join(parentCwd, ".worktrees", "feature-c", "src");
     const siblingCwd = join(sandboxDir, "sibling-repo");
 
     const status = await runStatus(["--json"], {
@@ -227,6 +236,7 @@ describe("cto status active_shards / live_sessions projection", () => {
           { sessionId: "parent", cwd: parentCwd },
           { sessionId: "claude-wt", cwd: claudeWorktreeCwd },
           { sessionId: "codex-wt", cwd: codexWorktreeCwd },
+          { sessionId: "git-wt", cwd: gitWorktreeCwd },
           { sessionId: "sibling", cwd: siblingCwd },
         ],
         active_shards: [],
@@ -239,9 +249,11 @@ describe("cto status active_shards / live_sessions projection", () => {
     assert.equal(byId.parent.cwdLabel, "parent-repo");
     assert.equal(byId["claude-wt"].cwdLabel, "feature-a");
     assert.equal(byId["codex-wt"].cwdLabel, "src");
+    assert.equal(byId["git-wt"].cwdLabel, "src");
     assert.equal(byId.parent.repoRootLabel, "parent-repo");
     assert.equal(byId["claude-wt"].repoRootHash, byId.parent.repoRootHash);
     assert.equal(byId["codex-wt"].repoRootHash, byId.parent.repoRootHash);
+    assert.equal(byId["git-wt"].repoRootHash, byId.parent.repoRootHash);
     assert.notEqual(byId.sibling.repoRootHash, byId.parent.repoRootHash);
 
     assert.equal(status.live_session_groups.length, 2);
@@ -252,6 +264,7 @@ describe("cto status active_shards / live_sessions projection", () => {
       "parent",
       "claude-wt",
       "codex-wt",
+      "git-wt",
     ]);
     assert.deepEqual(groupsByLabel["sibling-repo"].sessions, ["sibling"]);
 
@@ -259,6 +272,7 @@ describe("cto status active_shards / live_sessions projection", () => {
     assert.equal(serialized.includes(parentCwd), false);
     assert.equal(serialized.includes(claudeWorktreeCwd), false);
     assert.equal(serialized.includes(codexWorktreeCwd), false);
+    assert.equal(serialized.includes(gitWorktreeCwd), false);
     assert.equal(serialized.includes(siblingCwd), false);
   });
 });

--- a/tests/unit/tray-html.test.mjs
+++ b/tests/unit/tray-html.test.mjs
@@ -137,6 +137,262 @@ describe("tray Sessions frontend", () => {
     assert.match(tabSessions.innerHTML, /data-agent-id="antigravity"/u);
   });
 
+  it("does not render every active session as a CTO T card", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: {
+        id: "hub-abcdef",
+        projectRoot: "/Users/tellang/Projects/tools/triflux",
+      },
+      sessions: [
+        {
+          sessionId: "codex-active-1",
+          status: "active",
+          cwd: "/Users/tellang/Projects/tools/triflux",
+          taskSummary: "ordinary codex session",
+        },
+        {
+          sessionId: "claude-active-2",
+          status: "active",
+          cwd: "/Users/tellang/Projects/tools/triflux",
+          taskSummary: "ordinary claude session",
+        },
+        {
+          sessionId: "old-stale-session",
+          status: "stale",
+          cwd: "/Users/tellang/Projects/tools/triflux",
+          taskSummary: "stale should not become CTO",
+        },
+      ],
+      cto: {
+        live_sessions: [],
+        active_shards: [],
+      },
+      runtime: { summary: { total: 0, clients: [] } },
+    });
+
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /data-open-key="cto:codex-active-1"/u,
+    );
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /data-open-key="cto:claude-active-2"/u,
+    );
+    assert.doesNotMatch(tabSessions.innerHTML, /old-stale-session/u);
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /<span class="agent-badge">T<\/span>/u,
+    );
+    assert.match(tabSessions.innerHTML, /ordinary codex session/u);
+    assert.match(tabSessions.innerHTML, /ordinary claude session/u);
+  });
+
+  it("renders one project-level CTO card from role succession state", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: {
+        id: "hub-abcdef",
+        projectRoot: "/Users/tellang/Projects/tools/triflux",
+      },
+      sessions: [
+        {
+          sessionId: "codex-worker",
+          status: "active",
+          cwd: "/Users/tellang/Projects/tools/triflux/.worktrees/fix-441",
+          taskSummary: "worker in a worktree",
+        },
+      ],
+      cto: {
+        roles: {
+          cto: {
+            status: "active",
+            leader_agent_id: "cto-agent",
+            leader_epoch: 4,
+            pending_count: 2,
+            candidate_count: 2,
+            live_candidate_count: 1,
+            candidate_source: "explicit",
+          },
+        },
+        live_sessions: [
+          {
+            sessionId: "cto-agent",
+            phase: "active",
+            agent_id: "cto-agent",
+            cwd: "/Users/tellang/Projects/tools/triflux/.worktrees/fix-441",
+            taskSummary: "actual CTO leader",
+          },
+        ],
+        active_shards: [],
+      },
+      runtime: { summary: { total: 1, clients: [] } },
+    });
+
+    assert.match(tabSessions.innerHTML, /CTO Succession/u);
+    assert.match(tabSessions.innerHTML, /epoch 4 · pending 2/u);
+    assert.match(tabSessions.innerHTML, /data-open-key="cto:cto-agent"/u);
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /data-open-key="cto:codex-worker"/u,
+    );
+    const ctoCardMatches = tabSessions.innerHTML.match(
+      /<details class="session-card"/gu,
+    );
+    assert.equal(ctoCardMatches?.length, 1);
+    const projectNameMatches = tabSessions.innerHTML.match(
+      /<span class="project-name">triflux<\/span>/gu,
+    );
+    assert.equal(projectNameMatches?.length, 1);
+  });
+
+  it("renders standby CTO candidates as agents, not extra CTO cards", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: {
+        id: "hub-abcdef",
+        projectRoot: "/Users/tellang/Projects/tools/triflux",
+      },
+      sessions: [],
+      cto: {
+        roles: {
+          cto: {
+            status: "active",
+            leader_agent_id: "cto-leader",
+            leader_epoch: 6,
+            pending_count: 1,
+            candidate_count: 2,
+            live_candidate_count: 2,
+          },
+        },
+        live_sessions: [
+          {
+            sessionId: "cto-leader",
+            phase: "active",
+            agent_id: "cto-leader",
+            cwd: "/Users/tellang/Projects/tools/triflux",
+            role: "cto",
+            taskSummary: "elected CTO leader",
+          },
+          {
+            sessionId: "cto-standby",
+            phase: "active",
+            agent_id: "cto-standby",
+            cwd: "/Users/tellang/Projects/tools/triflux",
+            role: "cto",
+            taskSummary: "hot standby candidate",
+          },
+        ],
+        active_shards: [],
+      },
+      runtime: { summary: { total: 2, clients: [] } },
+    });
+
+    const ctoCards = tabSessions.innerHTML.match(
+      /<details class="session-card"/gu,
+    );
+    assert.equal(ctoCards?.length, 1);
+    assert.match(tabSessions.innerHTML, /data-open-key="cto:cto-leader"/u);
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /data-open-key="cto:cto-standby"/u,
+    );
+    assert.match(tabSessions.innerHTML, /hot standby candidate/u);
+    assert.match(tabSessions.innerHTML, /<div class="detail-label">Agents/u);
+  });
+
+  it("deduplicates rows that appear in both synapse sessions and CTO live overlay", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: { id: "hub-abcdef", projectRoot: "/repo" },
+      sessions: [
+        {
+          sessionId: "worker-duplicate",
+          status: "active",
+          cwd: "/repo",
+          taskSummary: "same worker prompt",
+        },
+      ],
+      cto: {
+        live_sessions: [
+          {
+            sessionId: "worker-duplicate",
+            phase: "active",
+            cwd: "/repo",
+            taskSummary: "same worker prompt",
+          },
+        ],
+        active_shards: [],
+      },
+      runtime: { summary: { total: 1, clients: [] } },
+    });
+
+    const promptOccurrences =
+      tabSessions.innerHTML.match(/same worker prompt/gu) || [];
+    assert.equal(promptOccurrences.length, 2);
+  });
+
+  it("coalesces sibling linked worktrees when the hub project root is itself a worktree", () => {
+    const { context, tabSessions } = loadTrayRenderer();
+
+    context.renderSessions({
+      hub: {
+        id: "hub-abcdef",
+        projectRoot:
+          "/Users/tellang/Projects/tools/triflux/.worktrees/fix-cto-succession-441",
+      },
+      sessions: [
+        {
+          sessionId: "worker-a",
+          status: "active",
+          cwd: "/Users/tellang/Projects/tools/triflux/.worktrees/other-branch",
+          taskSummary: "sibling worktree worker",
+        },
+      ],
+      cto: {
+        roles: {
+          cto: {
+            status: "active",
+            leader_agent_id: "cto-agent",
+            leader_epoch: 5,
+            pending_count: 0,
+            candidate_count: 1,
+            live_candidate_count: 1,
+          },
+        },
+        live_sessions: [
+          {
+            sessionId: "cto-agent",
+            phase: "active",
+            agent_id: "cto-agent",
+            cwd: "/Users/tellang/Projects/tools/triflux/.worktrees/fix-cto-succession-441",
+            taskSummary: "CTO leader in current worktree",
+          },
+        ],
+        active_shards: [],
+      },
+      runtime: { summary: { total: 2, clients: [] } },
+    });
+
+    const projectNameMatches = tabSessions.innerHTML.match(
+      /<span class="project-name">triflux<\/span>/gu,
+    );
+    assert.equal(projectNameMatches?.length, 1);
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /<span class="project-name">other-branch<\/span>/u,
+    );
+    assert.doesNotMatch(
+      tabSessions.innerHTML,
+      /<span class="project-name">fix-cto-succession-441<\/span>/u,
+    );
+    assert.match(tabSessions.innerHTML, /sibling worktree worker/u);
+  });
+
   it("renders compact CTO Hygiene from the provided tray payload", () => {
     const { context, tabSessions } = loadTrayRenderer();
 

--- a/tests/unit/tray-state.test.mjs
+++ b/tests/unit/tray-state.test.mjs
@@ -111,6 +111,60 @@ describe("tray-state contract", () => {
     assert.equal(payload.cto.summary.live_session_count, 0);
   });
 
+  it("passes CTO succession role metadata through to the tray payload", () => {
+    const payload = buildTrayStatePayload({
+      ctoStatus: {
+        roles: {
+          cto: {
+            status: "active",
+            leader_agent_id: "cto-leader",
+            previous_leader_agent_id: "cto-old",
+            leader_epoch: 3,
+            pending_count: 7,
+            candidate_source: "explicit",
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(payload.cto.roles.cto, {
+      status: "active",
+      leader_agent_id: "cto-leader",
+      previous_leader_agent_id: "cto-old",
+      leader_epoch: 3,
+      pending_count: 7,
+      candidate_source: "explicit",
+    });
+  });
+
+  it("preserves arbitrary CTO leader agent ids in normalized live sessions", () => {
+    const payload = buildTrayStatePayload({
+      ctoStatus: {
+        roles: {
+          cto: {
+            status: "active",
+            leader_agent_id: "cto-agent-1",
+            leader_epoch: 2,
+          },
+        },
+        live_sessions: [
+          {
+            sessionId: "synapse-session-123",
+            agent_id: "cto-agent-1",
+            phase: "active",
+            cwd: "/repo",
+            role: "cto",
+            taskSummary: "actual role leader",
+          },
+        ],
+      },
+    });
+
+    assert.equal(payload.cto.live_sessions[0].agent_id, "cto-agent-1");
+    assert.equal(payload.cto.live_sessions[0].role, "cto");
+    assert.equal(payload.cto.roles.cto.leader_agent_id, "cto-agent-1");
+  });
+
   it("includes CTO overlay and MCP rows in one tray payload", () => {
     const payload = buildTrayStatePayload({
       hub: { id: "hub-123456", pid: 123456, port: 27888 },


### PR DESCRIPTION
## 문제 (#441)

CTO coordinator 가 succession/failover 가 없어, 리더 CTO 가 offline 되면 live cross-session coordination 이 멈춘다.

## 해결

`topic:cto` 역할에 단일 리더 선출 + 대기 heir failover 도입.

- **hub/router.mjs**: role candidate 추적, lease 기반 liveness, 단일 리더 선출(`chooseRoleLeader`/`ensureRoleLeader`), 리더 offline 시 heir 승격, 미ack 백로그를 신규 리더로 이관(`transferRoleBacklog`) — dedup + 죽은 리더로의 leak 방지 가드 포함.
- 수동 override(`takeover_role`) 를 MCP tool / pipe command / HTTP `/bridge/takeover-role` / bridge CLI 로 노출.
- **tray.html + tray-state.mjs**: CTO succession 상태 카드.

`packages/{core,remote,triflux}` byte-identical 미러 (remote 는 `@triflux/core` import 경로 유지).

## 검증

- 타깃 테스트 **76 pass / 0 fail** (router/pipe/tray-html/tray-state/cto-status/conductor-registry — 실제 takeover: 리더 사망 → heir 승격 → 백로그 이관 경로 포함).
- 교차 리뷰 (Codex 작성 → Claude 리뷰): **APPROVE-WITH-NITS**, P0/P1 0건. lease 권위로 split-brain 없음, 백로그 이관 idempotent/no-leak 검증.
- 미러 byte-identical, LSP 진단 0.

## Follow-up (비차단, 후속 이슈 권장)

- P2: sweeper 가 크래시 리더를 능동 재선출하지 않음 (평시엔 standby heartbeat 가 커버).
- P2: CTO 리더가 hub 전역 스코프인데 tray 는 프로젝트 단위 표시 (기존 `topic:cto` 의미와 정합 — 회귀 아님).

Closes #441