### PR TITLE
feat(route): claude --model/--effort ladder (Claude lane)

### DIFF
--- a/hub/workers/claude-worker.mjs
+++ b/hub/workers/claude-worker.mjs
@@ -113,6 +113,7 @@ function buildClaudeArgs(worker, options) {
   if (options.includePartialMessages) args.push("--include-partial-messages");
   if (options.replayUserMessages) args.push("--replay-user-messages");
   if (options.model) args.push("--model", options.model);
+  if (options.effort) args.push("--effort", options.effort);
   if (options.allowDangerouslySkipPermissions)
     args.push("--dangerously-skip-permissions");
   if (options.permissionMode)
@@ -143,6 +144,7 @@ export class ClaudeWorker {
     this.cwd = options.cwd || process.cwd();
     this.env = { ...process.env, ...(options.env || {}) };
     this.model = options.model || null;
+    this.effort = options.effort || null;
     this.permissionMode = options.permissionMode || null;
     this.allowDangerouslySkipPermissions =
       options.allowDangerouslySkipPermissions !== false;
@@ -323,6 +325,7 @@ export class ClaudeWorker {
 
     const args = buildClaudeArgs(this, {
       model: this.model,
+      effort: this.effort,
       permissionMode: this.permissionMode,
       allowDangerouslySkipPermissions: this.allowDangerouslySkipPermissions,
       includePartialMessages: this.includePartialMessages,

--- a/packages/remote/hub/workers/claude-worker.mjs
+++ b/packages/remote/hub/workers/claude-worker.mjs
@@ -113,6 +113,7 @@ function buildClaudeArgs(worker, options) {
   if (options.includePartialMessages) args.push("--include-partial-messages");
   if (options.replayUserMessages) args.push("--replay-user-messages");
   if (options.model) args.push("--model", options.model);
+  if (options.effort) args.push("--effort", options.effort);
   if (options.allowDangerouslySkipPermissions)
     args.push("--dangerously-skip-permissions");
   if (options.permissionMode)
@@ -143,6 +144,7 @@ export class ClaudeWorker {
     this.cwd = options.cwd || process.cwd();
     this.env = { ...process.env, ...(options.env || {}) };
     this.model = options.model || null;
+    this.effort = options.effort || null;
     this.permissionMode = options.permissionMode || null;
     this.allowDangerouslySkipPermissions =
       options.allowDangerouslySkipPermissions !== false;
@@ -323,6 +325,7 @@ export class ClaudeWorker {
 
     const args = buildClaudeArgs(this, {
       model: this.model,
+      effort: this.effort,
       permissionMode: this.permissionMode,
       allowDangerouslySkipPermissions: this.allowDangerouslySkipPermissions,
       includePartialMessages: this.includePartialMessages,

--- a/packages/triflux/hub/workers/claude-worker.mjs
+++ b/packages/triflux/hub/workers/claude-worker.mjs
@@ -113,6 +113,7 @@ function buildClaudeArgs(worker, options) {
   if (options.includePartialMessages) args.push("--include-partial-messages");
   if (options.replayUserMessages) args.push("--replay-user-messages");
   if (options.model) args.push("--model", options.model);
+  if (options.effort) args.push("--effort", options.effort);
   if (options.allowDangerouslySkipPermissions)
     args.push("--dangerously-skip-permissions");
   if (options.permissionMode)
@@ -143,6 +144,7 @@ export class ClaudeWorker {
     this.cwd = options.cwd || process.cwd();
     this.env = { ...process.env, ...(options.env || {}) };
     this.model = options.model || null;
+    this.effort = options.effort || null;
     this.permissionMode = options.permissionMode || null;
     this.allowDangerouslySkipPermissions =
       options.allowDangerouslySkipPermissions !== false;
@@ -323,6 +325,7 @@ export class ClaudeWorker {
 
     const args = buildClaudeArgs(this, {
       model: this.model,
+      effort: this.effort,
       permissionMode: this.permissionMode,
       allowDangerouslySkipPermissions: this.allowDangerouslySkipPermissions,
       includePartialMessages: this.includePartialMessages,

--- a/packages/triflux/scripts/tfx-route-worker.mjs
+++ b/packages/triflux/scripts/tfx-route-worker.mjs
@@ -77,6 +77,10 @@ function parseArgs(argv) {
         args.model = next;
         index += 1;
         break;
+      case "--effort":
+        args.effort = next;
+        index += 1;
+        break;
       case "--timeout-ms":
         args.timeoutMs = Number(next);
         index += 1;
@@ -219,6 +223,7 @@ const worker = await createWorker(args.type, {
   command: args.command,
   commandArgs: parseJsonArray(args.commandArgsJson, "--command-args-json"),
   model: args.model,
+  effort: args.effort,
   timeoutMs: args.timeoutMs,
   approvalMode: args.approvalMode,
   permissionMode: args.permissionMode,

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1887,9 +1887,10 @@ get_claude_effort() {
     *max*) echo "max" ;;
     *xhigh*) echo "xhigh" ;;
     *high*) echo "high" ;;
-    *med*|n/a|agy_v1|"") echo "medium" ;;
+    *med*) echo "medium" ;;
+    n/a|agy_v1|"") echo "" ;;
     *low*) echo "low" ;;
-    *) echo "medium" ;;
+    *) echo "" ;;
   esac
 }
 
@@ -3052,10 +3053,10 @@ EOF
       "--command" "$CLI_CMD"
       "--command-args-json" "$CLAUDE_BIN_ARGS_JSON"
       "--model" "$claude_model"
-      "--effort" "$claude_effort"
       "--permission-mode" "bypassPermissions"
       "--allow-dangerously-skip-permissions"
     )
+    [ -n "$claude_effort" ] && claude_worker_args+=("--effort" "$claude_effort")
 
     run_stream_worker "claude" "$FULL_PROMPT" "$use_tee" "${claude_worker_args[@]}" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -1873,12 +1873,35 @@ get_claude_model() {
   esac
 }
 
+get_claude_effort() {
+  # Claude Code exposes a separate --effort flag. Preserve high-end effort
+  # levels instead of collapsing them into "high". `claude --effort` accepts
+  # exactly low/medium/high/xhigh/max (an unknown value warns and falls back to
+  # the default).
+  case "$CLI_EFFORT" in
+    low) echo "low" ;;
+    medium) echo "medium" ;;
+    high) echo "high" ;;
+    xhigh) echo "xhigh" ;;
+    max) echo "max" ;;
+    *max*) echo "max" ;;
+    *xhigh*) echo "xhigh" ;;
+    *high*) echo "high" ;;
+    *med*|n/a|agy_v1|"") echo "medium" ;;
+    *low*) echo "low" ;;
+    *) echo "medium" ;;
+  esac
+}
+
 emit_claude_native_metadata() {
   local model
   model=$(get_claude_model)
+  local effort
+  effort=$(get_claude_effort)
   echo "ROUTE_TYPE=claude-native"
   echo "AGENT=$AGENT_TYPE"
   echo "MODEL=$model"
+  echo "EFFORT=$effort"
   echo "RUN_MODE=$RUN_MODE"
   echo "OPUS_OVERSIGHT=$OPUS_OVERSIGHT"
   echo "TIMEOUT=$TIMEOUT_SEC"
@@ -3022,12 +3045,14 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "claude" ]]; then
-    local claude_model
+    local claude_model claude_effort
     claude_model=$(get_claude_model)
+    claude_effort=$(get_claude_effort)
     local -a claude_worker_args=(
       "--command" "$CLI_CMD"
       "--command-args-json" "$CLAUDE_BIN_ARGS_JSON"
       "--model" "$claude_model"
+      "--effort" "$claude_effort"
       "--permission-mode" "bypassPermissions"
       "--allow-dangerously-skip-permissions"
     )

--- a/packages/triflux/skills/tfx-auto/SKILL.md
+++ b/packages/triflux/skills/tfx-auto/SKILL.md
@@ -72,7 +72,9 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용/편향 분리**: 실행 워커 비용은 Codex/Antigravity 우선으로 낮추되, consensus/debate/panel에서는 Claude/Opus를 최후수단이 아니라 counter-bias outvoice로 둔다. Claude가 실행을 맡는 경우는 명시적 `--cli claude`, Claude-native host role, 또는 fallback뿐이다.
+> 2-a. **Anti-bias triad**: Triflux의 본가 목적은 Codex↔Claude 균형으로 단일 모델 편향을 줄이는 것이다. `triad`는 Claude/Opus(counter-bias outvoice) + Codex(implementation/reality check) + Antigravity(product/UX auxiliary)를 보존하고, disputed/minority view를 삭제하지 않는다.
+> 2-b. **Claude effort**: Claude lane은 Claude Code CLI의 `--model`과 `--effort`를 사용한다. Triflux의 `CLI_EFFORT`/profile 값은 `low|medium|high|xhigh|max` Claude effort로 매핑한다(`ultracode`는 `claude --effort` 값이 아니라 하니스 모드이므로 기본 effort로 매핑된다). skill 문서가 모델 ID를 하드코딩하지 않는다.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
@@ -114,7 +116,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--shape` | `debate` | 옵션 비교 + 점수화 + 최종 추천 | debate renderer |
 | `--shape` | `panel` | 전문가 roster 기반 시뮬레이션 | panel renderer |
 | `--cli-set` | `triad` (기본) | Claude + Codex + Antigravity | consensus participants |
-| `--cli-set` | `no-antigravity` | Claude + Codex partial degrade | consensus participants |
+| `--cli-set` | `no-antigravity` | Claude/Opus outvoice + Codex partial degrade | consensus participants |
 | `--cli-set` | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | consensus participants |
 | `--options` | `"A|B|C"` | debate 비교 대상 | debate normalizer |
 | `--criteria` | `"latency|complexity|operability"` | debate 평가 기준 | debate normalizer |
@@ -284,8 +286,8 @@ shape 의미:
 
 | 값 | 의미 | 비고 |
 |----|------|------|
-| `triad` | Claude + Codex + Antigravity | 기본값 |
-| `no-antigravity` | Claude + Codex | Antigravity 미가용 degrade |
+| `triad` | Claude/Opus outvoice + Codex + Antigravity | 기본값 |
+| `no-antigravity` | Claude/Opus outvoice + Codex | Antigravity 미가용 degrade |
 | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | 신규 provider 추가 금지 |
 
 shape 입력 정규화:
@@ -331,7 +333,7 @@ shape 별 `shape_input`:
 2. `--mode consensus` 확인
 3. `--shape` 기본값 보정 (`consensus`)
 4. shape 별 payload 정규화
-5. Claude native + headless Codex/Antigravity 동시 dispatch
+5. Claude/Opus outvoice + headless Codex/Antigravity 동시 dispatch
 6. 결과 수집
 7. 공통 `meta_judgment` 생성
 8. shape renderer 로 markdown/json 출력
@@ -386,7 +388,7 @@ shape 별 orchestration 정책:
 
 - 목적: 각 participant 의 findings 를 합의/충돌 항목으로 압축하고 `FIX_FIRST` / `merge` / `defer` 같은 실행 결정을 빠르게 내린다.
 - 수집 단위: 옵션 비교가 아니라 finding/assertion 단위다. 동일 결론이라도 근거가 다르면 separate evidence 로 보존한다.
-- 합의 판정: 3자 중 2자 이상이 같은 remediation 또는 risk assessment 를 지지하면 provisional agreement 로 분류하고, Claude 가 최종 `resolved_items` 승격 여부를 결정한다.
+- 합의 판정: 3자 중 2자 이상이 같은 remediation 또는 risk assessment 를 지지하면 provisional agreement 로 분류하고, Claude/Opus outvoice가 반론을 제공하고 lead가 최종 `resolved_items` 승격 여부를 결정한다.
 - 충돌 승격: P1/P2 급 충돌은 score 와 무관하게 `user_decision_needed` 또는 `FIX_FIRST` 로 승격한다. score 가 높아도 안전 이슈를 묻지 않는다.
 - degrade: `no-antigravity` 또는 partial timeout 시 2자 합의를 허용하되 root meta 의 `status=partial` 과 누락 participant 이유를 반드시 남긴다.
 
@@ -559,7 +561,7 @@ shape 별 orchestration 정책:
 - roster 규칙: `--experts` 미지정 시 기본 roster 를 채우되 각 CLI 가 서로 다른 전문성을 대표하도록 배분한다. 동일 전문가를 중복 배정하지 않는다.
 - 발언 구조: participant raw answer 를 그대로 이어붙이지 말고 `expert -> thesis -> supporting evidence -> concern -> recommendation` 구조로 정리한다.
 - 합의 규칙: panel 은 unanimity 보다 "majority view + minority view + open questions" 보존이 중요하다. minority 가 P1/P2 를 제기하면 별도 `open_questions` 로 승격한다.
-- moderator 역할: Claude 는 moderator 로서 panel synthesis 를 담당하지만, 자기 의견을 추가 participant 처럼 중복 집계하지 않는다.
+- moderator 역할: Claude/Opus outvoice 는 moderator 로서 panel synthesis 를 담당하지만, 자기 의견을 추가 participant 처럼 중복 집계하지 않는다.
 
 출력 schema 예시:
 
@@ -853,7 +855,9 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 
 | 입력 | CLI | MCP |
 |------|-----|-----|
-| codex / executor / build-fixer / spark / debugger / deep-executor | Codex | implement |
+| codex / executor / spark | Codex (high; 복잡 구현은 deep-executor/xhigh) | implement |
+| debugger / deep-executor | Codex (xhigh) | implement |
+| build-fixer | Codex (low) | implement |
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |

--- a/packages/triflux/skills/tfx-consensus/SKILL.md
+++ b/packages/triflux/skills/tfx-consensus/SKILL.md
@@ -43,6 +43,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-consensus -> tfx-auto --mode consensus"
 tfx-consensus 는 여전히 consensus family 의 canonical semantics 를 대표하지만, 별도 엔진으로 유지하지 않는다. Phase 4a 부터 공통 orchestration, participant 상태, artifact 경로, `meta_judgment` 스키마를 `tfx-auto --mode consensus` 가 소유한다.
 
 공통 계약:
+- Triflux anti-bias contract: `triad`는 Claude/Opus counter-bias outvoice + Codex implementation/reality check + Antigravity product/UX auxiliary 관점을 보존한다. Claude/Opus는 합의에서 minority/dispute를 지우는 최종 심판이 아니라 반론/위험/필요 증거를 명시하는 outvoice다.
 - artifact 경로: `.omc/artifacts/consensus/<session-id>/consensus.{md,json}`
 - 공통 메타 유틸: `hub/team/consensus-meta.mjs`
 - 공통 root 메타: `mode`, `shape`, `topic`, `cli_set`, `participants`, `status`

--- a/packages/triflux/skills/tfx-debate/SKILL.md
+++ b/packages/triflux/skills/tfx-debate/SKILL.md
@@ -48,8 +48,8 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-debate -> tfx-auto --mode consensus --s
 tfx-debate 의 본질은 "3-CLI 토론 엔진"이 아니라 "옵션 비교와 최종 추천을 내는 보고서 shape" 였다. Phase 4a 부터 orchestration root 는 `--mode consensus` 로 통합되고, debate 의미는 `--shape debate` 로 보존된다.
 
 공통 규약:
-- participants 기본값은 `triad` (Claude + Codex + Antigravity)
-- `--cli-set no-antigravity` 시 partial consensus 로 degrade 가능
+- participants 기본값은 `triad` (Claude/Opus counter-bias outvoice + Codex + Antigravity)
+- `--cli-set no-antigravity` 시 Claude/Opus + Codex partial consensus 로 degrade 가능
 - 공통 `meta_judgment` 는 `hub/team/consensus-meta.mjs` 스키마를 따른다
 
 ## 마이그레이션 가이드

--- a/packages/triflux/skills/tfx-panel/SKILL.md
+++ b/packages/triflux/skills/tfx-panel/SKILL.md
@@ -48,7 +48,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-panel -> tfx-auto --mode consensus --sh
 tfx-panel 의 본질은 "패널 전용 orchestration" 이 아니라 "전문가 roster 를 주입한 뒤 panel 보고서로 렌더링하는 shape" 였다. Phase 4a 부터 공통 합의 루프는 `--mode consensus` 아래에 남기고, 전문가 분배와 panel renderer 만 `--shape panel` 이 책임진다.
 
 공통 규약:
-- participants 기본값은 `triad`
+- participants 기본값은 `triad` (Claude/Opus counter-bias outvoice + Codex + Antigravity)
 - 공통 `meta_judgment` 는 `mode_specific_meta.panel_size`, `mode_specific_meta.expert_distribution` 만 shape 확장으로 추가한다
 - artifact 경로는 `.omc/artifacts/consensus/<session-id>/panel.{md,json}` 로 통일한다
 

--- a/scripts/tfx-route-worker.mjs
+++ b/scripts/tfx-route-worker.mjs
@@ -77,6 +77,10 @@ function parseArgs(argv) {
         args.model = next;
         index += 1;
         break;
+      case "--effort":
+        args.effort = next;
+        index += 1;
+        break;
       case "--timeout-ms":
         args.timeoutMs = Number(next);
         index += 1;
@@ -219,6 +223,7 @@ const worker = await createWorker(args.type, {
   command: args.command,
   commandArgs: parseJsonArray(args.commandArgsJson, "--command-args-json"),
   model: args.model,
+  effort: args.effort,
   timeoutMs: args.timeoutMs,
   approvalMode: args.approvalMode,
   permissionMode: args.permissionMode,

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1887,9 +1887,10 @@ get_claude_effort() {
     *max*) echo "max" ;;
     *xhigh*) echo "xhigh" ;;
     *high*) echo "high" ;;
-    *med*|n/a|agy_v1|"") echo "medium" ;;
+    *med*) echo "medium" ;;
+    n/a|agy_v1|"") echo "" ;;
     *low*) echo "low" ;;
-    *) echo "medium" ;;
+    *) echo "" ;;
   esac
 }
 
@@ -3052,10 +3053,10 @@ EOF
       "--command" "$CLI_CMD"
       "--command-args-json" "$CLAUDE_BIN_ARGS_JSON"
       "--model" "$claude_model"
-      "--effort" "$claude_effort"
       "--permission-mode" "bypassPermissions"
       "--allow-dangerously-skip-permissions"
     )
+    [ -n "$claude_effort" ] && claude_worker_args+=("--effort" "$claude_effort")
 
     run_stream_worker "claude" "$FULL_PROMPT" "$use_tee" "${claude_worker_args[@]}" || exit_code=$?
     if [[ "$exit_code" -ne 0 && "$exit_code" -ne 124 ]]; then

--- a/scripts/tfx-route.sh
+++ b/scripts/tfx-route.sh
@@ -1873,12 +1873,35 @@ get_claude_model() {
   esac
 }
 
+get_claude_effort() {
+  # Claude Code exposes a separate --effort flag. Preserve high-end effort
+  # levels instead of collapsing them into "high". `claude --effort` accepts
+  # exactly low/medium/high/xhigh/max (an unknown value warns and falls back to
+  # the default).
+  case "$CLI_EFFORT" in
+    low) echo "low" ;;
+    medium) echo "medium" ;;
+    high) echo "high" ;;
+    xhigh) echo "xhigh" ;;
+    max) echo "max" ;;
+    *max*) echo "max" ;;
+    *xhigh*) echo "xhigh" ;;
+    *high*) echo "high" ;;
+    *med*|n/a|agy_v1|"") echo "medium" ;;
+    *low*) echo "low" ;;
+    *) echo "medium" ;;
+  esac
+}
+
 emit_claude_native_metadata() {
   local model
   model=$(get_claude_model)
+  local effort
+  effort=$(get_claude_effort)
   echo "ROUTE_TYPE=claude-native"
   echo "AGENT=$AGENT_TYPE"
   echo "MODEL=$model"
+  echo "EFFORT=$effort"
   echo "RUN_MODE=$RUN_MODE"
   echo "OPUS_OVERSIGHT=$OPUS_OVERSIGHT"
   echo "TIMEOUT=$TIMEOUT_SEC"
@@ -3022,12 +3045,14 @@ EOF
     fi
 
   elif [[ "$CLI_TYPE" == "claude" ]]; then
-    local claude_model
+    local claude_model claude_effort
     claude_model=$(get_claude_model)
+    claude_effort=$(get_claude_effort)
     local -a claude_worker_args=(
       "--command" "$CLI_CMD"
       "--command-args-json" "$CLAUDE_BIN_ARGS_JSON"
       "--model" "$claude_model"
+      "--effort" "$claude_effort"
       "--permission-mode" "bypassPermissions"
       "--allow-dangerously-skip-permissions"
     )

--- a/skills/tfx-auto/SKILL.md
+++ b/skills/tfx-auto/SKILL.md
@@ -72,7 +72,9 @@ echo "USER_PREFERRED_MODE: ${USER_MODE:-none}"
 > **MANDATORY RULES**
 >
 > 1. **실행**: CLI 에이전트는 반드시 `Bash("bash ~/.claude/scripts/tfx-route.sh ...")`. Claude 네이티브(explore/verifier/test-engineer/qa-tester)만 `Agent()`.
-> 2. **비용**: Codex 우선 → Antigravity → Claude 최후 수단. `claude` 선택 전 "Codex로 가능한가?" 재확인.
+> 2. **비용/편향 분리**: 실행 워커 비용은 Codex/Antigravity 우선으로 낮추되, consensus/debate/panel에서는 Claude/Opus를 최후수단이 아니라 counter-bias outvoice로 둔다. Claude가 실행을 맡는 경우는 명시적 `--cli claude`, Claude-native host role, 또는 fallback뿐이다.
+> 2-a. **Anti-bias triad**: Triflux의 본가 목적은 Codex↔Claude 균형으로 단일 모델 편향을 줄이는 것이다. `triad`는 Claude/Opus(counter-bias outvoice) + Codex(implementation/reality check) + Antigravity(product/UX auxiliary)를 보존하고, disputed/minority view를 삭제하지 않는다.
+> 2-b. **Claude effort**: Claude lane은 Claude Code CLI의 `--model`과 `--effort`를 사용한다. Triflux의 `CLI_EFFORT`/profile 값은 `low|medium|high|xhigh|max` Claude effort로 매핑한다(`ultracode`는 `claude --effort` 값이 아니라 하니스 모드이므로 기본 effort로 매핑된다). skill 문서가 모델 ID를 하드코딩하지 않는다.
 > 3. **DAG**: SEQUENTIAL/DAG이면 레벨 기반 순차 실행. `.omc/context/{sid}/` 생성, context_output 저장, 실패 시 후속 SKIP.
 > 4. **트리아지**: Codex `exec --full-auto` 분류 + Opus 인라인 분해. Agent 스폰 금지.
 > 5. **thorough**: `-t`/`--thorough` 시 파이프라인 init 필수. 커맨드 숏컷은 항상 quick.
@@ -114,7 +116,7 @@ ARGUMENTS 에 아래 플래그가 있으면 Step 0 스마트 라우팅의 내부
 | `--shape` | `debate` | 옵션 비교 + 점수화 + 최종 추천 | debate renderer |
 | `--shape` | `panel` | 전문가 roster 기반 시뮬레이션 | panel renderer |
 | `--cli-set` | `triad` (기본) | Claude + Codex + Antigravity | consensus participants |
-| `--cli-set` | `no-antigravity` | Claude + Codex partial degrade | consensus participants |
+| `--cli-set` | `no-antigravity` | Claude/Opus outvoice + Codex partial degrade | consensus participants |
 | `--cli-set` | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | consensus participants |
 | `--options` | `"A|B|C"` | debate 비교 대상 | debate normalizer |
 | `--criteria` | `"latency|complexity|operability"` | debate 평가 기준 | debate normalizer |
@@ -284,8 +286,8 @@ shape 의미:
 
 | 값 | 의미 | 비고 |
 |----|------|------|
-| `triad` | Claude + Codex + Antigravity | 기본값 |
-| `no-antigravity` | Claude + Codex | Antigravity 미가용 degrade |
+| `triad` | Claude/Opus outvoice + Codex + Antigravity | 기본값 |
+| `no-antigravity` | Claude/Opus outvoice + Codex | Antigravity 미가용 degrade |
 | `custom` | 기존 3 CLI 내부 subset/repetition 만 허용 | 신규 provider 추가 금지 |
 
 shape 입력 정규화:
@@ -331,7 +333,7 @@ shape 별 `shape_input`:
 2. `--mode consensus` 확인
 3. `--shape` 기본값 보정 (`consensus`)
 4. shape 별 payload 정규화
-5. Claude native + headless Codex/Antigravity 동시 dispatch
+5. Claude/Opus outvoice + headless Codex/Antigravity 동시 dispatch
 6. 결과 수집
 7. 공통 `meta_judgment` 생성
 8. shape renderer 로 markdown/json 출력
@@ -386,7 +388,7 @@ shape 별 orchestration 정책:
 
 - 목적: 각 participant 의 findings 를 합의/충돌 항목으로 압축하고 `FIX_FIRST` / `merge` / `defer` 같은 실행 결정을 빠르게 내린다.
 - 수집 단위: 옵션 비교가 아니라 finding/assertion 단위다. 동일 결론이라도 근거가 다르면 separate evidence 로 보존한다.
-- 합의 판정: 3자 중 2자 이상이 같은 remediation 또는 risk assessment 를 지지하면 provisional agreement 로 분류하고, Claude 가 최종 `resolved_items` 승격 여부를 결정한다.
+- 합의 판정: 3자 중 2자 이상이 같은 remediation 또는 risk assessment 를 지지하면 provisional agreement 로 분류하고, Claude/Opus outvoice가 반론을 제공하고 lead가 최종 `resolved_items` 승격 여부를 결정한다.
 - 충돌 승격: P1/P2 급 충돌은 score 와 무관하게 `user_decision_needed` 또는 `FIX_FIRST` 로 승격한다. score 가 높아도 안전 이슈를 묻지 않는다.
 - degrade: `no-antigravity` 또는 partial timeout 시 2자 합의를 허용하되 root meta 의 `status=partial` 과 누락 participant 이유를 반드시 남긴다.
 
@@ -559,7 +561,7 @@ shape 별 orchestration 정책:
 - roster 규칙: `--experts` 미지정 시 기본 roster 를 채우되 각 CLI 가 서로 다른 전문성을 대표하도록 배분한다. 동일 전문가를 중복 배정하지 않는다.
 - 발언 구조: participant raw answer 를 그대로 이어붙이지 말고 `expert -> thesis -> supporting evidence -> concern -> recommendation` 구조로 정리한다.
 - 합의 규칙: panel 은 unanimity 보다 "majority view + minority view + open questions" 보존이 중요하다. minority 가 P1/P2 를 제기하면 별도 `open_questions` 로 승격한다.
-- moderator 역할: Claude 는 moderator 로서 panel synthesis 를 담당하지만, 자기 의견을 추가 participant 처럼 중복 집계하지 않는다.
+- moderator 역할: Claude/Opus outvoice 는 moderator 로서 panel synthesis 를 담당하지만, 자기 의견을 추가 participant 처럼 중복 집계하지 않는다.
 
 출력 schema 예시:
 
@@ -853,7 +855,9 @@ Agent(subagent_type="oh-my-claudecode:{agent}", model="{model}", prompt="{prompt
 
 | 입력 | CLI | MCP |
 |------|-----|-----|
-| codex / executor / build-fixer / spark / debugger / deep-executor | Codex | implement |
+| codex / executor / spark | Codex (high; 복잡 구현은 deep-executor/xhigh) | implement |
+| debugger / deep-executor | Codex (xhigh) | implement |
+| build-fixer | Codex (low) | implement |
 | architect / planner / critic / analyst | Codex (xhigh) | analyze |
 | scientist / document-specialist | Codex | analyze |
 | code-reviewer / security-reviewer / quality-reviewer | Codex (review) | review |

--- a/skills/tfx-consensus/SKILL.md
+++ b/skills/tfx-consensus/SKILL.md
@@ -43,6 +43,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-consensus -> tfx-auto --mode consensus"
 tfx-consensus 는 여전히 consensus family 의 canonical semantics 를 대표하지만, 별도 엔진으로 유지하지 않는다. Phase 4a 부터 공통 orchestration, participant 상태, artifact 경로, `meta_judgment` 스키마를 `tfx-auto --mode consensus` 가 소유한다.
 
 공통 계약:
+- Triflux anti-bias contract: `triad`는 Claude/Opus counter-bias outvoice + Codex implementation/reality check + Antigravity product/UX auxiliary 관점을 보존한다. Claude/Opus는 합의에서 minority/dispute를 지우는 최종 심판이 아니라 반론/위험/필요 증거를 명시하는 outvoice다.
 - artifact 경로: `.omc/artifacts/consensus/<session-id>/consensus.{md,json}`
 - 공통 메타 유틸: `hub/team/consensus-meta.mjs`
 - 공통 root 메타: `mode`, `shape`, `topic`, `cli_set`, `participants`, `status`

--- a/skills/tfx-debate/SKILL.md
+++ b/skills/tfx-debate/SKILL.md
@@ -48,8 +48,8 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-debate -> tfx-auto --mode consensus --s
 tfx-debate 의 본질은 "3-CLI 토론 엔진"이 아니라 "옵션 비교와 최종 추천을 내는 보고서 shape" 였다. Phase 4a 부터 orchestration root 는 `--mode consensus` 로 통합되고, debate 의미는 `--shape debate` 로 보존된다.
 
 공통 규약:
-- participants 기본값은 `triad` (Claude + Codex + Antigravity)
-- `--cli-set no-antigravity` 시 partial consensus 로 degrade 가능
+- participants 기본값은 `triad` (Claude/Opus counter-bias outvoice + Codex + Antigravity)
+- `--cli-set no-antigravity` 시 Claude/Opus + Codex partial consensus 로 degrade 가능
 - 공통 `meta_judgment` 는 `hub/team/consensus-meta.mjs` 스키마를 따른다
 
 ## 마이그레이션 가이드

--- a/skills/tfx-panel/SKILL.md
+++ b/skills/tfx-panel/SKILL.md
@@ -48,7 +48,7 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) tfx-panel -> tfx-auto --mode consensus --sh
 tfx-panel 의 본질은 "패널 전용 orchestration" 이 아니라 "전문가 roster 를 주입한 뒤 panel 보고서로 렌더링하는 shape" 였다. Phase 4a 부터 공통 합의 루프는 `--mode consensus` 아래에 남기고, 전문가 분배와 panel renderer 만 `--shape panel` 이 책임진다.
 
 공통 규약:
-- participants 기본값은 `triad`
+- participants 기본값은 `triad` (Claude/Opus counter-bias outvoice + Codex + Antigravity)
 - 공통 `meta_judgment` 는 `mode_specific_meta.panel_size`, `mode_specific_meta.expert_distribution` 만 shape 확장으로 추가한다
 - artifact 경로는 `.omc/artifacts/consensus/<session-id>/panel.{md,json}` 로 통일한다
 

--- a/tests/fixtures/fake-claude-cli.mjs
+++ b/tests/fixtures/fake-claude-cli.mjs
@@ -1,6 +1,20 @@
 #!/usr/bin/env node
 
+import { writeFileSync } from "node:fs";
 import readline from "node:readline";
+
+// Test seam: when FAKE_CLAUDE_ARGV_OUT is set, dump the CLI argv the worker
+// spawned us with so a test can assert flags like --model / --effort.
+if (process.env.FAKE_CLAUDE_ARGV_OUT) {
+  try {
+    writeFileSync(
+      process.env.FAKE_CLAUDE_ARGV_OUT,
+      JSON.stringify(process.argv.slice(2)),
+    );
+  } catch {
+    /* best-effort; never block the fake session */
+  }
+}
 
 const SESSION_ID = "11111111-1111-1111-1111-111111111111";
 const rl = readline.createInterface({

--- a/tests/integration/workers.test.mjs
+++ b/tests/integration/workers.test.mjs
@@ -131,6 +131,31 @@ describe("ClaudeWorker", { timeout: 15000 }, () => {
     rmSync(argvOut, { force: true });
     argvOutFiles.delete(argvOut);
   });
+
+  it("omits --effort when no claude effort is provided", async () => {
+    const argvOut = resolve(
+      PROJECT_ROOT,
+      `.tmp-claude-argv-${process.pid}-${Date.now()}.json`,
+    );
+    argvOutFiles.add(argvOut);
+    const worker = new ClaudeWorker({
+      command: process.execPath,
+      commandArgs: [CLAUDE_FIXTURE],
+      model: "opus",
+      env: { FAKE_CLAUDE_ARGV_OUT: argvOut },
+      timeoutMs: 5000,
+      allowDangerouslySkipPermissions: true,
+    });
+
+    const result = await worker.run("argv omit effort check");
+    assert.match(result.response, /claude:argv omit effort check/);
+
+    const argv = JSON.parse(readFileSync(argvOut, "utf8"));
+    assert.equal(argv.includes("--effort"), false);
+    await worker.stop();
+    rmSync(argvOut, { force: true });
+    argvOutFiles.delete(argvOut);
+  });
 });
 
 describe("createWorker()", { timeout: 15000 }, () => {

--- a/tests/integration/workers.test.mjs
+++ b/tests/integration/workers.test.mjs
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { rmSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -61,6 +61,14 @@ describe("GeminiWorker compatibility alias", { timeout: 15000 }, () => {
 });
 
 describe("ClaudeWorker", { timeout: 15000 }, () => {
+  const argvOutFiles = new Set();
+
+  after(() => {
+    for (const file of argvOutFiles) {
+      rmSync(file, { force: true });
+    }
+  });
+
   it("여러 turn을 같은 세션으로 처리하고 history를 유지해야 한다", async () => {
     const worker = new ClaudeWorker({
       command: process.execPath,
@@ -91,6 +99,37 @@ describe("ClaudeWorker", { timeout: 15000 }, () => {
     const result = await worker.run("needs control");
     assert.match(result.response, /claude:needs control/);
     await worker.stop();
+  });
+
+  it("passes --model and --effort through to the claude CLI", async () => {
+    const argvOut = resolve(
+      PROJECT_ROOT,
+      `.tmp-claude-argv-${process.pid}-${Date.now()}.json`,
+    );
+    argvOutFiles.add(argvOut);
+    const worker = new ClaudeWorker({
+      command: process.execPath,
+      commandArgs: [CLAUDE_FIXTURE],
+      model: "opus",
+      effort: "xhigh",
+      env: { FAKE_CLAUDE_ARGV_OUT: argvOut },
+      timeoutMs: 5000,
+      allowDangerouslySkipPermissions: true,
+    });
+
+    const result = await worker.run("argv check");
+    assert.match(result.response, /claude:argv check/);
+
+    const argv = JSON.parse(readFileSync(argvOut, "utf8"));
+    const modelIndex = argv.indexOf("--model");
+    const effortIndex = argv.indexOf("--effort");
+    assert.notEqual(modelIndex, -1);
+    assert.notEqual(effortIndex, -1);
+    assert.equal(argv[modelIndex + 1], "opus");
+    assert.equal(argv[effortIndex + 1], "xhigh");
+    await worker.stop();
+    rmSync(argvOut, { force: true });
+    argvOutFiles.delete(argvOut);
   });
 });
 


### PR DESCRIPTION
## Summary
Finish the parked **claude effort-ladder**: the Claude lane now passes `--model` and `--effort` to the Claude Code CLI, driven by a profile→effort mapping in `tfx-route.sh::get_claude_effort()`. Removes a dead `ultracode→max` branch (ultracode is a harness mode, not a `claude --effort` value) and fixes a SKILL.md line that mislabeled ultracode as an effort value. Unspecified (`n/a`) routes **omit** `--effort` so claude defers to the user's `settings.json` effortLevel — no silent downgrade.

## Changes
- `scripts/tfx-route.sh`: `get_claude_effort()` maps `CLI_EFFORT`/profile → `low|medium|high|xhigh|max`; `n/a`/empty/`agy_v1`/unknown → empty → `--effort` appended only when non-empty. Dead `ultracode→max` branch removed.
- `scripts/tfx-route-worker.mjs`: `parseArgs` accepts `--effort`, forwarded to `createWorker`.
- `hub/workers/claude-worker.mjs`: `buildClaudeArgs` appends `--model`/`--effort` when set.
- `skills/tfx-{auto,consensus,debate,panel}/SKILL.md`: reframe the 3-way consensus `triad` as anti-bias (Claude/Opus counter-bias outvoice + Codex + Antigravity); document the Claude effort lane accurately (ultracode = harness mode, not an effort value).
- Tests (`tests/integration/workers.test.mjs`): argv assertions via the `FAKE_CLAUDE_ARGV_OUT` fixture seam — `--model opus`/`--effort xhigh` pass-through, and `--effort` omitted when unspecified.

## Verification
- `node --test tests/integration/workers.test.mjs` → 10 pass, 0 fail, 0 skipped.
- `claude --effort` confirmed real (accepts low/medium/high/xhigh/max; an invalid value warns and continues).
- `packages/{triflux,remote}` mirrors byte-identical; `npm run lint:skills` PASS (43 files); biome clean.
- Independent cross-review (Codex-authored → Claude-reviewed): APPROVE; both review P2s addressed (SKILL.md doc fix + n/a `--effort` omit).
