### PR TITLE
fix(hub): sweeper actively re-elects stale role leaders (CTO failover)

### DIFF
--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -1343,6 +1343,7 @@ export function createRouter(store) {
       staleTimer = setInterval(() => {
         try {
           store.sweepStaleAgents();
+          router.reelectStaleRoles();
         } catch {}
       }, 120000);
       sweepTimer.unref();
@@ -1357,6 +1358,18 @@ export function createRouter(store) {
       if (staleTimer) {
         clearInterval(staleTimer);
         staleTimer = null;
+      }
+    },
+
+    reelectStaleRoles({ reason = "sweep" } = {}) {
+      for (const roleName of ROLE_TOPICS) {
+        const role = roleStates.get(roleName);
+        const leader = role?.leaderAgentId
+          ? buildRoleCandidate(role.leaderAgentId, roleName)
+          : null;
+        if (!isCandidateLive(leader)) {
+          ensureRoleLeader(roleName, { reason });
+        }
       }
     },
 

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -1343,6 +1343,7 @@ export function createRouter(store) {
       staleTimer = setInterval(() => {
         try {
           store.sweepStaleAgents();
+          router.reelectStaleRoles();
         } catch {}
       }, 120000);
       sweepTimer.unref();
@@ -1357,6 +1358,18 @@ export function createRouter(store) {
       if (staleTimer) {
         clearInterval(staleTimer);
         staleTimer = null;
+      }
+    },
+
+    reelectStaleRoles({ reason = "sweep" } = {}) {
+      for (const roleName of ROLE_TOPICS) {
+        const role = roleStates.get(roleName);
+        const leader = role?.leaderAgentId
+          ? buildRoleCandidate(role.leaderAgentId, roleName)
+          : null;
+        if (!isCandidateLive(leader)) {
+          ensureRoleLeader(roleName, { reason });
+        }
       }
     },
 

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -1343,6 +1343,7 @@ export function createRouter(store) {
       staleTimer = setInterval(() => {
         try {
           store.sweepStaleAgents();
+          router.reelectStaleRoles();
         } catch {}
       }, 120000);
       sweepTimer.unref();
@@ -1357,6 +1358,18 @@ export function createRouter(store) {
       if (staleTimer) {
         clearInterval(staleTimer);
         staleTimer = null;
+      }
+    },
+
+    reelectStaleRoles({ reason = "sweep" } = {}) {
+      for (const roleName of ROLE_TOPICS) {
+        const role = roleStates.get(roleName);
+        const leader = role?.leaderAgentId
+          ? buildRoleCandidate(role.leaderAgentId, roleName)
+          : null;
+        if (!isCandidateLive(leader)) {
+          ensureRoleLeader(roleName, { reason });
+        }
       }
     },
 

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -607,6 +607,142 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
         isolated.cleanup();
       }
     });
+
+    it("동일 우선순위 CTO 후보는 agent_id 오름차순으로 결정적으로 leader를 선출해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        for (const agent_id of ["cto-aaa", "cto-bbb", "cto-ccc"]) {
+          isolated.store.registerAgent({
+            agent_id,
+            cli: "codex",
+            capabilities: ["cto"],
+            topics: [],
+            metadata: { role: "cto", cto_priority: 5 },
+            heartbeat_ttl_ms: 60000,
+          });
+        }
+        isolated.store.db
+          .prepare(
+            "UPDATE agents SET last_seen_ms=? WHERE agent_id IN (?, ?, ?)",
+          )
+          .run(1234567890, "cto-aaa", "cto-bbb", "cto-ccc");
+
+        isolated.router.reelectStaleRoles();
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "cto-aaa");
+
+        isolated.router.reelectStaleRoles();
+        const again = isolated.router.getStatus("hub");
+        assert.equal(again.data.roles.cto.leader_agent_id, "cto-aaa");
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("leader 장애 시 2개 이상 CTO backlog를 새 heir에게 모두 이전해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "A",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "B",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 1 },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        for (const decision of ["one", "two", "three"]) {
+          isolated.router.handlePublish({
+            from: "lead",
+            to: "topic:cto",
+            topic: "cto",
+            payload: { decision },
+          });
+        }
+
+        assert.equal(isolated.router.getPendingMessages("A").length, 3);
+
+        isolated.router.updateAgentStatus("A", "offline");
+        const status = isolated.router.getStatus("hub");
+        assert.equal(status.data.roles.cto.leader_agent_id, "B");
+        assert.equal(status.data.roles.cto.pending_count, 3);
+        assert.equal(status.data.roles.cto.transferred_count, 3);
+        assert.equal(isolated.router.getPendingMessages("B").length, 3);
+        assert.equal(isolated.router.getPendingMessages("A").length, 0);
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("sweep 재선출 경로는 A→B→C 연쇄 승계 후 후보 snapshot을 누수 없이 유지해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "A",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "B",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 5 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.registerAgent({
+          agent_id: "C",
+          cli: "codex",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 1 },
+          heartbeat_ttl_ms: 60000,
+        });
+        isolated.router.handlePublish({
+          from: "lead",
+          to: "topic:cto",
+          topic: "cto",
+          payload: { decision: "chain failover" },
+        });
+
+        isolated.store.db
+          .prepare("UPDATE agents SET lease_expires_ms=? WHERE agent_id=?")
+          .run(Date.now() - 1, "A");
+        isolated.router.reelectStaleRoles();
+        const afterA = isolated.router.getStatus("hub");
+        assert.equal(afterA.data.roles.cto.leader_agent_id, "B");
+        assert.equal(afterA.data.roles.cto.previous_leader_agent_id, "A");
+
+        isolated.store.db
+          .prepare("UPDATE agents SET lease_expires_ms=? WHERE agent_id=?")
+          .run(Date.now() - 1, "B");
+        isolated.router.reelectStaleRoles();
+        const afterB = isolated.router.getStatus("hub");
+        const cto = afterB.data.roles.cto;
+        assert.equal(cto.leader_agent_id, "C");
+        assert.equal(cto.previous_leader_agent_id, "B");
+        assert.equal(cto.candidate_count, 3);
+        assert.equal(cto.live_candidate_count, 1);
+        assert.equal(cto.candidates.length, 3);
+        assert.equal(
+          new Set(cto.candidates.map((candidate) => candidate.agent_id)).size,
+          3,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
   });
 
   // ── handleAsk ──


### PR DESCRIPTION
## Summary
Follow-up **P2-①** to CTO role succession/failover (#442): the 120s stale-agent sweep now **actively re-elects** a crashed/stale role leader instead of waiting for an agent event. Without this, a leader that crashes silently (no further heartbeat / register / inbound route) leaves the role pointing at a dead agent until some unrelated event happens to fire re-election.

## Changes
- `hub/router.mjs`: new `reelectStaleRoles({ reason = "sweep" })` — for each `ROLE_TOPICS`, if the current leader is no longer live (`!isCandidateLive`), call `ensureRoleLeader` (elects heir + transfers backlog). Wired into `startSweeper`'s `staleTimer`, right after `store.sweepStaleAgents()`. The liveness guard keeps it a pure no-op (no epoch churn, no candidate scan) when the leader is healthy.
- Mirrored byte-identical to `packages/core/hub/router.mjs` and `packages/triflux/hub/router.mjs` (remote imports `@triflux/core`, so no separate `packages/remote` copy).

## Tests (`tests/integration/router.test.mjs`)
- Deterministic heir tiebreak — equal priority resolves by `agent_id` ascending.
- N>1 backlog handoff — 3 `topic:cto` messages all transfer on leader change; `transferred_count` correct.
- 3-leader chain A→B→C driven **through the new sweep path** (`reelectStaleRoles()`), asserting no candidate leak: bounded `candidate_count`, single previous-leader scalar, no duplicate `agent_id`s.

## Verification
- `node --test tests/integration/router.test.mjs` → 28 pass, 0 fail, 0 skipped.
- core + triflux mirrors byte-identical; biome clean.
- Independent cross-review (Codex-authored → Claude-reviewed): APPROVE, 0 blocking.

## Out of scope
P2-② (per-project leader keying) deliberately not implemented — the current global `topic:cto` scope is intentional and not a regression. `ROLE_TOPICS` stays `Set(["cto"])`.
