### PR TITLE
test(hub): lock CTO sweeper live-leader no-op (epoch + transfer invariance)

### DIFF
--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -639,6 +639,34 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
       }
     });
 
+    it("살아있는 leader가 있으면 reelectStaleRoles는 leader_epoch/transferred_count를 churn하지 않아야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.router.registerAgent({
+          agent_id: "cto-live-leader",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 10 },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        isolated.router.reelectStaleRoles();
+        const before = isolated.router.getStatus("hub").data.roles.cto;
+        assert.equal(before.leader_agent_id, "cto-live-leader");
+
+        isolated.router.reelectStaleRoles();
+        isolated.router.reelectStaleRoles();
+        const after = isolated.router.getStatus("hub").data.roles.cto;
+
+        assert.equal(after.leader_agent_id, "cto-live-leader");
+        assert.equal(after.leader_epoch, before.leader_epoch);
+        assert.equal(after.transferred_count, before.transferred_count);
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
     it("leader 장애 시 2개 이상 CTO backlog를 새 heir에게 모두 이전해야 한다", () => {
       const isolated = createIsolatedRouter();
       try {


### PR DESCRIPTION
## 무엇

PR #444가 도입한 CTO sweeper의 no-churn 계약을 직접 잠그는 회귀 테스트 1개를 추가한다.

## 왜

기존 `tests/integration/router.test.mjs`의 `reelectStaleRoles()` no-op 테스트(:611)는 살아있는 leader가 유지될 때 `leader_agent_id` 불변만 단언하고, `leader_epoch`/`transferred_count` 불변은 단언하지 않는다. sweeper가 살아있는 leader를 만났을 때 epoch를 bump하거나 backlog를 transfer하면(= churn) 회귀가 조용히 통과한다. 그 갭을 메운다.

## 변경

- `tests/integration/router.test.mjs`: 살아있는 CTO leader 1명 등록 → `reelectStaleRoles()` 3회 호출 → `leader_agent_id`, `leader_epoch`, `transferred_count` 모두 불변 단언. (테스트 파일이라 미러 대상 아님.)

## 검증

- `node --test tests/integration/router.test.mjs`: 28 → 29 통과, 0 실패.
- `npm run lint`: clean.
- 설계는 별도 eng-review에서 SOUND 판정(실행으로 `leader_epoch=1`/`transferred_count=0` 불변 확인).

post-v10.41.0 follow-up #1 (체크포인트 `20260630-112727`).
