### PR TITLE
fix(release): tag-only push with stale-HEAD preflight + remote-tag readiness poll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --allow-existing --execute
+        # npm-publish is triggered by explicit workflow_dispatch; GITHUB_TOKEN tag pushes do not recursively trigger it, and npm-view skips make duplicate dispatch idempotent.
+        run: node scripts/release/publish.mjs --version ${{ inputs.version }} --channel ${{ inputs.channel }} --skip-npm --allow-existing --tag-only --execute
 
       - name: Dispatch npm publish
         env:

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -165,7 +165,13 @@ describe("release governance scripts", () => {
       );
       assert.deepEqual(
         tagOnlyPublish.steps.map((step) => step.label),
-        ["git tag", "git push", "gh release create"],
+        [
+          "git tag",
+          "git push branch",
+          "git push tag",
+          "wait for tag",
+          "gh release create",
+        ],
       );
 
       const executed = [];
@@ -178,6 +184,9 @@ describe("release governance scripts", () => {
         execFileSyncFn: (command, args) => {
           executed.push([command, ...args].join(" "));
           if (command === "git" && args[0] === "rev-parse") return "tag\n";
+          if (command === "git" && args[0] === "ls-remote") {
+            return "abc123\trefs/tags/v1.2.3\n";
+          }
           if (command === "gh" && args[0] === "release") {
             return '{"tagName":"v1.2.3"}\n';
           }
@@ -187,7 +196,9 @@ describe("release governance scripts", () => {
       assert.equal(resumedPublish.allowExistingArtifacts, true);
       assert.deepEqual(executed, [
         "git rev-parse --verify v1.2.3",
-        "git push origin HEAD --tags",
+        "git push origin HEAD",
+        "git push origin v1.2.3",
+        "git ls-remote --tags origin v1.2.3",
         "gh release view v1.2.3 --json tagName",
       ]);
 
@@ -222,6 +233,41 @@ describe("release governance scripts", () => {
     }
   });
 
+  it("tag-only(CI) 모드는 preflight로 HEAD==origin/main을 검증하고 branch push를 생략한다", async () => {
+    const root = makeRepo();
+    const prevRef = process.env.GITHUB_REF_NAME;
+    process.env.GITHUB_REF_NAME = "main";
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const executed = [];
+      await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        publishNpm: false,
+        pushBranch: false,
+        createGithubRelease: false,
+        tagPoll: { attempts: 1, sleepFn: async () => {} },
+        execFileSyncFn: (command, args) => {
+          executed.push([command, ...args].join(" "));
+          if (command === "git" && args[0] === "rev-parse") {
+            return "deadbeef\n";
+          }
+          return "";
+        },
+      });
+      assert.ok(executed.includes("git fetch origin main"));
+      assert.ok(executed.includes("git rev-parse HEAD"));
+      assert.ok(executed.includes("git rev-parse origin/main"));
+      assert.ok(executed.includes("git push origin v1.2.3"));
+      assert.ok(!executed.includes("git push origin HEAD"));
+    } finally {
+      if (prevRef === undefined) delete process.env.GITHUB_REF_NAME;
+      else process.env.GITHUB_REF_NAME = prevRef;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("release workflows use trusted publishing and skip duplicate tag publishes", () => {
     const releaseWorkflow = readFileSync(
       new URL("../../.github/workflows/release.yml", import.meta.url),
@@ -230,6 +276,7 @@ describe("release governance scripts", () => {
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--tag-only/);
     assert.match(
       releaseWorkflow,
       /gh workflow run npm-publish\.yml --ref \$\{\{ github\.ref_name \}\}/,

--- a/packages/triflux/scripts/release/publish.mjs
+++ b/packages/triflux/scripts/release/publish.mjs
@@ -3,6 +3,40 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertVersionSync, parseArgs, ROOT, runCommand } from "./lib.mjs";
 
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function waitForRemoteTag(
+  tagName,
+  {
+    rootDir = ROOT,
+    execFileSyncFn,
+    attempts = 30,
+    intervalMs = 2000,
+    sleepFn = defaultSleep,
+  } = {},
+) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const out = runCommand(
+        "git",
+        ["ls-remote", "--tags", "origin", tagName],
+        {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        },
+      );
+      if (String(out).includes(`refs/tags/${tagName}`)) return true;
+    } catch {
+      // Transient network/auth blips are retried below.
+    }
+    if (attempt < attempts - 1) await sleepFn(intervalMs);
+  }
+  throw new Error(
+    `Tag ${tagName} not visible on origin after ${attempts} attempts`,
+  );
+}
+
 export async function publishRelease({
   version,
   rootDir = ROOT,
@@ -12,6 +46,8 @@ export async function publishRelease({
   publishNpm = true,
   provenance = false,
   allowExistingArtifacts = false,
+  pushBranch = true,
+  tagPoll = {},
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -73,14 +109,27 @@ export async function publishRelease({
         }))
       : []),
     { label: "git tag", command: "git", args: ["tag", `v${releaseVersion}`] },
-    {
-      label: "git push",
-      command: "git",
-      args: ["push", "origin", "HEAD", "--tags"],
-    },
   ];
+  if (pushBranch) {
+    steps.push({
+      label: "git push branch",
+      command: "git",
+      args: ["push", "origin", "HEAD"],
+    });
+  }
+  steps.push({
+    label: "git push tag",
+    command: "git",
+    args: ["push", "origin", `v${releaseVersion}`],
+  });
 
   if (createGithubRelease) {
+    steps.push({
+      label: "wait for tag",
+      kind: "wait-tag",
+      command: "git",
+      args: ["ls-remote", "--tags", "origin", `v${releaseVersion}`],
+    });
     steps.push({
       label: "gh release create",
       command: "gh",
@@ -125,9 +174,43 @@ export async function publishRelease({
   };
 
   if (!dryRun) {
+    if (!pushBranch) {
+      const branch = process.env.GITHUB_REF_NAME || "main";
+      runCommand("git", ["fetch", "origin", branch], {
+        cwd: rootDir,
+        execFileSyncFn,
+      });
+      const head = String(
+        runCommand("git", ["rev-parse", "HEAD"], {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        }),
+      ).trim();
+      const remote = String(
+        runCommand("git", ["rev-parse", `origin/${branch}`], {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        }),
+      ).trim();
+      if (head !== remote) {
+        throw new Error(
+          `Refusing tag-only publish: HEAD ${head} != origin/${branch} ${remote} (stale checkout or unpushed ${branch})`,
+        );
+      }
+    }
     for (const step of steps) {
       const tagName = `v${releaseVersion}`;
       if (step.label === "git tag" && shouldSkipExistingTag(tagName)) {
+        continue;
+      }
+      if (step.kind === "wait-tag") {
+        await waitForRemoteTag(tagName, {
+          rootDir,
+          execFileSyncFn,
+          ...tagPoll,
+        });
         continue;
       }
       if (
@@ -151,6 +234,7 @@ export async function publishRelease({
     publishNpm,
     provenance,
     allowExistingArtifacts,
+    pushBranch,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -175,6 +259,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
     allowExistingArtifacts: Boolean(args["allow-existing"]),
+    pushBranch: !args["tag-only"],
   });
   console.log(JSON.stringify(result, null, 2));
 }

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -165,7 +165,13 @@ describe("release governance scripts", () => {
       );
       assert.deepEqual(
         tagOnlyPublish.steps.map((step) => step.label),
-        ["git tag", "git push", "gh release create"],
+        [
+          "git tag",
+          "git push branch",
+          "git push tag",
+          "wait for tag",
+          "gh release create",
+        ],
       );
 
       const executed = [];
@@ -178,6 +184,9 @@ describe("release governance scripts", () => {
         execFileSyncFn: (command, args) => {
           executed.push([command, ...args].join(" "));
           if (command === "git" && args[0] === "rev-parse") return "tag\n";
+          if (command === "git" && args[0] === "ls-remote") {
+            return "abc123\trefs/tags/v1.2.3\n";
+          }
           if (command === "gh" && args[0] === "release") {
             return '{"tagName":"v1.2.3"}\n';
           }
@@ -187,7 +196,9 @@ describe("release governance scripts", () => {
       assert.equal(resumedPublish.allowExistingArtifacts, true);
       assert.deepEqual(executed, [
         "git rev-parse --verify v1.2.3",
-        "git push origin HEAD --tags",
+        "git push origin HEAD",
+        "git push origin v1.2.3",
+        "git ls-remote --tags origin v1.2.3",
         "gh release view v1.2.3 --json tagName",
       ]);
 
@@ -222,6 +233,41 @@ describe("release governance scripts", () => {
     }
   });
 
+  it("tag-only(CI) 모드는 preflight로 HEAD==origin/main을 검증하고 branch push를 생략한다", async () => {
+    const root = makeRepo();
+    const prevRef = process.env.GITHUB_REF_NAME;
+    process.env.GITHUB_REF_NAME = "main";
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const executed = [];
+      await publishRelease({
+        rootDir: root,
+        version: "1.2.3",
+        dryRun: false,
+        publishNpm: false,
+        pushBranch: false,
+        createGithubRelease: false,
+        tagPoll: { attempts: 1, sleepFn: async () => {} },
+        execFileSyncFn: (command, args) => {
+          executed.push([command, ...args].join(" "));
+          if (command === "git" && args[0] === "rev-parse") {
+            return "deadbeef\n";
+          }
+          return "";
+        },
+      });
+      assert.ok(executed.includes("git fetch origin main"));
+      assert.ok(executed.includes("git rev-parse HEAD"));
+      assert.ok(executed.includes("git rev-parse origin/main"));
+      assert.ok(executed.includes("git push origin v1.2.3"));
+      assert.ok(!executed.includes("git push origin HEAD"));
+    } finally {
+      if (prevRef === undefined) delete process.env.GITHUB_REF_NAME;
+      else process.env.GITHUB_REF_NAME = prevRef;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("release workflows use trusted publishing and skip duplicate tag publishes", () => {
     const releaseWorkflow = readFileSync(
       new URL("../../.github/workflows/release.yml", import.meta.url),
@@ -230,6 +276,7 @@ describe("release governance scripts", () => {
     assert.match(releaseWorkflow, /actions:\s*write/);
     assert.match(releaseWorkflow, /node-version:\s*24/);
     assert.match(releaseWorkflow, /publish\.mjs.*--skip-npm.*--allow-existing/);
+    assert.match(releaseWorkflow, /publish\.mjs.*--tag-only/);
     assert.match(
       releaseWorkflow,
       /gh workflow run npm-publish\.yml --ref \$\{\{ github\.ref_name \}\}/,

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -3,6 +3,40 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertVersionSync, parseArgs, ROOT, runCommand } from "./lib.mjs";
 
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function waitForRemoteTag(
+  tagName,
+  {
+    rootDir = ROOT,
+    execFileSyncFn,
+    attempts = 30,
+    intervalMs = 2000,
+    sleepFn = defaultSleep,
+  } = {},
+) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const out = runCommand(
+        "git",
+        ["ls-remote", "--tags", "origin", tagName],
+        {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        },
+      );
+      if (String(out).includes(`refs/tags/${tagName}`)) return true;
+    } catch {
+      // Transient network/auth blips are retried below.
+    }
+    if (attempt < attempts - 1) await sleepFn(intervalMs);
+  }
+  throw new Error(
+    `Tag ${tagName} not visible on origin after ${attempts} attempts`,
+  );
+}
+
 export async function publishRelease({
   version,
   rootDir = ROOT,
@@ -12,6 +46,8 @@ export async function publishRelease({
   publishNpm = true,
   provenance = false,
   allowExistingArtifacts = false,
+  pushBranch = true,
+  tagPoll = {},
   execFileSyncFn,
 } = {}) {
   const sync = assertVersionSync({ rootDir });
@@ -73,14 +109,27 @@ export async function publishRelease({
         }))
       : []),
     { label: "git tag", command: "git", args: ["tag", `v${releaseVersion}`] },
-    {
-      label: "git push",
-      command: "git",
-      args: ["push", "origin", "HEAD", "--tags"],
-    },
   ];
+  if (pushBranch) {
+    steps.push({
+      label: "git push branch",
+      command: "git",
+      args: ["push", "origin", "HEAD"],
+    });
+  }
+  steps.push({
+    label: "git push tag",
+    command: "git",
+    args: ["push", "origin", `v${releaseVersion}`],
+  });
 
   if (createGithubRelease) {
+    steps.push({
+      label: "wait for tag",
+      kind: "wait-tag",
+      command: "git",
+      args: ["ls-remote", "--tags", "origin", `v${releaseVersion}`],
+    });
     steps.push({
       label: "gh release create",
       command: "gh",
@@ -125,9 +174,43 @@ export async function publishRelease({
   };
 
   if (!dryRun) {
+    if (!pushBranch) {
+      const branch = process.env.GITHUB_REF_NAME || "main";
+      runCommand("git", ["fetch", "origin", branch], {
+        cwd: rootDir,
+        execFileSyncFn,
+      });
+      const head = String(
+        runCommand("git", ["rev-parse", "HEAD"], {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        }),
+      ).trim();
+      const remote = String(
+        runCommand("git", ["rev-parse", `origin/${branch}`], {
+          cwd: rootDir,
+          execFileSyncFn,
+          stdio: "pipe",
+        }),
+      ).trim();
+      if (head !== remote) {
+        throw new Error(
+          `Refusing tag-only publish: HEAD ${head} != origin/${branch} ${remote} (stale checkout or unpushed ${branch})`,
+        );
+      }
+    }
     for (const step of steps) {
       const tagName = `v${releaseVersion}`;
       if (step.label === "git tag" && shouldSkipExistingTag(tagName)) {
+        continue;
+      }
+      if (step.kind === "wait-tag") {
+        await waitForRemoteTag(tagName, {
+          rootDir,
+          execFileSyncFn,
+          ...tagPoll,
+        });
         continue;
       }
       if (
@@ -151,6 +234,7 @@ export async function publishRelease({
     publishNpm,
     provenance,
     allowExistingArtifacts,
+    pushBranch,
     dryRun,
     notesPath,
     steps: steps.map((step) => ({
@@ -175,6 +259,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     publishNpm: !args["skip-npm"],
     provenance: Boolean(args.provenance || envProvenance),
     allowExistingArtifacts: Boolean(args["allow-existing"]),
+    pushBranch: !args["tag-only"],
   });
   console.log(JSON.stringify(result, null, 2));
 }


### PR DESCRIPTION
## 무엇

릴리즈 publish 단계를 tag-only push + stale-HEAD preflight + 원격 tag readiness poll로 바꿔, v10.41.0에서 4연속 발생한 CI publish 플레이크의 근본을 막는다.

## 왜 (v10.41.0 CI 4연속 실패의 근본)

`scripts/release/publish.mjs`가 `git push origin HEAD --tags`로 main과 tag를 동시 push했다. release.yml 흐름은 main을 dispatch 전에 이미 push하므로, CI가 전파 지연으로 stale main을 checkout하면:
- (a) `git tag`가 stale 커밋에 박히고 `git push HEAD->main`이 non-FF
- (b) tag push 직후 `gh release create`가 tag API 전파 lag으로 "not been pushed" 실패

## 변경

- `git push origin HEAD --tags` → **branch push(local 기본)와 tag push 분리**. CI는 `--tag-only`로 branch push 생략(main 이미 push됨).
- **stale-HEAD preflight** (tag-only 모드 전용): `git fetch` 후 `HEAD == origin/<branch>` equality 검증. 불일치면 fail-loud로 잘못된 커밋 tagging을 차단(ancestor가 아니라 equality — "wrong commit" 방지 목표).
- **`waitForRemoteTag`**(export): `gh release create` 전에 `git ls-remote`로 원격 tag 가시성을 폴링. `attempts`/`intervalMs`/`sleepFn` 주입 가능(retry/failure 단위테스트 가능).
- `release.yml`: publish 호출에 `--tag-only` 추가. npm-publish는 명시 `gh workflow run` dispatch로 트리거되며(GITHUB_TOKEN tag push는 recursive trigger 억제), 중복 실행은 npm-view skip으로 idempotent(주석 명시).
- 미러: `packages/triflux/scripts/release/publish.mjs` + `packages/triflux/scripts/__tests__/release-governance.test.mjs` byte-identical.

## 검증

- `release-governance.test.mjs`: 7 통과 / 0 실패. 갱신된 step 라벨·executed 배열·신규 CI tag-only preflight 테스트 포함.
- CI tag-only 테스트는 `GITHUB_REF_NAME`을 통제해 hermetic(원래 구현이 CI 환경 `GITHUB_REF_NAME`에 따라 깨지던 회귀를 교차리뷰에서 적발·수정).
- biome check clean (format 포함), mirror gate "Mirror OK", root/mirror `diff -q` exit 0.
- eng-review APPROVE-WITH-EDITS의 5개 수정 전부 반영(preflight 실구현, equality 기준, poll 주입, mirror 필수, 중복 dispatch 문서화).

post-v10.41.0 follow-up #4 (체크포인트 `20260630-112727`).
