### PR TITLE
fix(tfx-live): follow symlinks in CLI main-module guard

### DIFF
--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join as pathJoin, resolve as pathResolve } from "node:path";
@@ -2368,11 +2369,19 @@ export {
   resolveAskTransport,
 };
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === pathResolve(process.argv[1]);
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(process.argv[1]) === modulePath;
+  } catch {
+    // process.argv[1] doesn't resolve on disk (e.g. `node -e`) — fall back
+    // to a non-symlink-aware comparison instead of treating it as not-main.
+    return pathResolve(process.argv[1]) === modulePath;
+  }
+}
 
-if (isDirectRun) {
+if (isMainModule()) {
   main().catch((error) => {
     printJson({
       ok: false,

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join as pathJoin, resolve as pathResolve } from "node:path";
@@ -2368,11 +2369,19 @@ export {
   resolveAskTransport,
 };
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === pathResolve(process.argv[1]);
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(process.argv[1]) === modulePath;
+  } catch {
+    // process.argv[1] doesn't resolve on disk (e.g. `node -e`) — fall back
+    // to a non-symlink-aware comparison instead of treating it as not-main.
+    return pathResolve(process.argv[1]) === modulePath;
+  }
+}
 
-if (isDirectRun) {
+if (isMainModule()) {
   main().catch((error) => {
     printJson({
       ok: false,

--- a/tests/unit/tfx-live-cli.test.mjs
+++ b/tests/unit/tfx-live-cli.test.mjs
@@ -10,8 +10,8 @@ const execFileAsync = promisify(execFile);
 const CLI = path.resolve("bin/tfx-live.mjs");
 
 async function runTfxLive(args, options = {}) {
-  const { env: extraEnv, ...execOptions } = options;
-  const result = await execFileAsync(process.execPath, [CLI, ...args], {
+  const { env: extraEnv, cli, ...execOptions } = options;
+  const result = await execFileAsync(process.execPath, [cli || CLI, ...args], {
     timeout: 20_000,
     maxBuffer: 5 * 1024 * 1024,
     ...execOptions,
@@ -60,6 +60,19 @@ test("tfx-live help documents UDS-first auto default", async () => {
     stdout,
     /auto is the default for Claude when --short\/--session-id is present/,
   );
+});
+
+test("tfx-live runs main() when invoked through a symlink (npm global bin shim)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-live-symlink-"));
+  try {
+    const symlinkPath = path.join(dir, "tfx-live");
+    await fs.symlink(CLI, symlinkPath);
+    const stdout = await runTfxLive(["--help"], { cli: symlinkPath });
+
+    assert.match(stdout, /tfx-live ask/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("tfx-live probe returns daemon-probe JSON through bundled bridge", async () => {


### PR DESCRIPTION
## Summary
- `bin/tfx-live.mjs`'s CLI entry-point guard compared `fileURLToPath(import.meta.url)` against `pathResolve(process.argv[1])`. `path.resolve()` does not follow symlinks, but npm global installs always expose the CLI as a symlink (`tfx-live -> .../triflux/bin/tfx-live.mjs`), so every real invocation of the installed `tfx-live` command failed this comparison, `main()` was never called, and the process silently exited 0 with no output.
- Ported the `realpathSync`-based `isMainModule()` guard already used by `bin/triflux.mjs` (which is why `tfx`/`triflux` were unaffected by this bug) into `bin/tfx-live.mjs`, mirrored byte-identically to `packages/triflux/bin/tfx-live.mjs`.
- Added a regression test that creates a real symlink to the CLI and invokes it through that symlink, since the existing test suite only ever invoked `node bin/tfx-live.mjs` directly and never exercised the symlink path that npm global install actually uses.
- Also added a short rationale comment for the `realpathSync` → `pathResolve` fallback branch (readability nit from cross-review).

## Verification
- Confirmed the bug live: `node bin/tfx-live.mjs --help` printed usage; `tfx-live --help` (via the actual installed global symlink) printed nothing, exit 0.
- New regression test fails against the pre-fix guard (confirmed via `git stash`) and passes with the fix.
- `node --test tests/unit/tfx-live-cli.test.mjs` — 10/10 pass.
- `npx biome check` on changed files — clean.
- Cross-reviewed independently by Codex and Antigravity (triflux's own cross-review policy): both converged on a real bug in the first draft of the regression test (wrong options key caused a false-positive pass without exercising the symlink at all) — caught and fixed before this PR.

## Test plan
- [x] `node --test tests/unit/tfx-live-cli.test.mjs`
- [x] Manual repro: `node bin/tfx-live.mjs --help` vs `tfx-live --help` before the fix
- [x] `npx biome check bin/tfx-live.mjs packages/triflux/bin/tfx-live.mjs tests/unit/tfx-live-cli.test.mjs`

https://claude.ai/code/session_01GTyg41JKiTZKPiRV38YknU