### PR TITLE
fix(bin): tfx-doctor/tfx-setup shims silently no-op via installed CLI

### DIFF
--- a/bin/tfx-doctor.mjs
+++ b/bin/tfx-doctor.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 // tfx-doctor — triflux doctor 바로가기
+import { fileURLToPath } from "node:url";
+
 process.argv = [
   process.argv[0],
-  process.argv[1],
+  // triflux.mjs's own isMainModule() guard compares this against its real
+  // path, not this shim's — point argv[1] at triflux.mjs so it recognizes
+  // itself as the entry point instead of silently no-op'ing.
+  fileURLToPath(new URL("./triflux.mjs", import.meta.url)),
   "doctor",
   ...process.argv.slice(2),
 ];

--- a/bin/tfx-setup.mjs
+++ b/bin/tfx-setup.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 // tfx-setup — triflux setup 바로가기
+import { fileURLToPath } from "node:url";
+
 process.argv = [
   process.argv[0],
-  process.argv[1],
+  // triflux.mjs's own isMainModule() guard compares this against its real
+  // path, not this shim's — point argv[1] at triflux.mjs so it recognizes
+  // itself as the entry point instead of silently no-op'ing.
+  fileURLToPath(new URL("./triflux.mjs", import.meta.url)),
   "setup",
   ...process.argv.slice(2),
 ];

--- a/packages/triflux/bin/tfx-doctor.mjs
+++ b/packages/triflux/bin/tfx-doctor.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 // tfx-doctor — triflux doctor 바로가기
+import { fileURLToPath } from "node:url";
+
 process.argv = [
   process.argv[0],
-  process.argv[1],
+  // triflux.mjs's own isMainModule() guard compares this against its real
+  // path, not this shim's — point argv[1] at triflux.mjs so it recognizes
+  // itself as the entry point instead of silently no-op'ing.
+  fileURLToPath(new URL("./triflux.mjs", import.meta.url)),
   "doctor",
   ...process.argv.slice(2),
 ];

--- a/packages/triflux/bin/tfx-setup.mjs
+++ b/packages/triflux/bin/tfx-setup.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 // tfx-setup — triflux setup 바로가기
+import { fileURLToPath } from "node:url";
+
 process.argv = [
   process.argv[0],
-  process.argv[1],
+  // triflux.mjs's own isMainModule() guard compares this against its real
+  // path, not this shim's — point argv[1] at triflux.mjs so it recognizes
+  // itself as the entry point instead of silently no-op'ing.
+  fileURLToPath(new URL("./triflux.mjs", import.meta.url)),
   "setup",
   ...process.argv.slice(2),
 ];

--- a/tests/unit/tfx-cli-shim-entrypoint.test.mjs
+++ b/tests/unit/tfx-cli-shim-entrypoint.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SHIMS = [
+  { name: "tfx-doctor", file: path.resolve("bin/tfx-doctor.mjs") },
+  { name: "tfx-setup", file: path.resolve("bin/tfx-setup.mjs") },
+];
+
+async function run(cliPath, args) {
+  const result = await execFileAsync(process.execPath, [cliPath, ...args], {
+    timeout: 20_000,
+    maxBuffer: 5 * 1024 * 1024,
+  });
+  return result.stdout;
+}
+
+for (const { name, file } of SHIMS) {
+  test(`${name} shim runs triflux.mjs main() directly (regression: argv[1] mismatch silent no-op)`, async () => {
+    const stdout = await run(file, ["--help"]);
+
+    assert.notEqual(
+      stdout.length,
+      0,
+      `${name} produced no output — triflux.mjs's isMainModule() guard likely rejected process.argv[1]`,
+    );
+  });
+
+  test(`${name} shim still runs triflux.mjs main() when invoked through a symlink`, async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-symlink-`));
+    try {
+      const symlinkPath = path.join(dir, name);
+      await fs.symlink(file, symlinkPath);
+      const stdout = await run(symlinkPath, ["--help"]);
+
+      assert.notEqual(stdout.length, 0);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `bin/tfx-doctor.mjs` and `bin/tfx-setup.mjs` inject a subcommand into `process.argv` and `await import("./triflux.mjs")`, but left `process.argv[1]` pointing at the shim's own path. `triflux.mjs`'s `isMainModule()` guard compares `process.argv[1]` against its own resolved module path to decide whether to call `main()`, so the comparison never matched — the installed `tfx-doctor`/`tfx-setup` commands silently exited 0 with zero output.
- Same bug *class* as the `tfx-live` symlink guard fix in #448, but a different mechanism: that one was `path.resolve()` not following a symlink; this one is a shim deliberately keeping its own `argv[1]` while importing a different file whose guard expects `argv[1]` to be itself.
- Fix: point `process.argv[1]` at `triflux.mjs`'s own resolved path (`fileURLToPath(new URL("./triflux.mjs", import.meta.url))`) before the dynamic import.
- Confirmed via repo-wide search that no other `bin/*.mjs` shim has this pattern (`tfx-profile.mjs`, `tfx-doctor-tui.mjs`, `tfx-setup-tui.mjs` import different targets without this guard and are unaffected).

## Verification
- Live repro before fix: `tfx-doctor --help` / `tfx-setup --help` (installed global commands) → 0 bytes, exit 0.
- After fix: both print usage as expected, including via a fresh symlink (simulating the npm global bin shim).
- New regression tests (`tests/unit/tfx-cli-shim-entrypoint.test.mjs`, 4 tests: direct + symlink invocation for each shim) confirmed to FAIL against the pre-fix shims and PASS after, via `git stash`.
- `packages/triflux` mirror confirmed byte-identical (`diff -q`).
- `npx biome check` on changed files — clean.
- Cross-reviewed by Codex (triflux's own cross-review policy — Claude-authored code must be reviewed by a different model): no findings, fix confirmed correct for both the repo layout and the published `packages/triflux` npm layout.

## Test plan
- [x] `node --test tests/unit/tfx-cli-shim-entrypoint.test.mjs` (4/4 pass)
- [x] Manual repro: installed `tfx-doctor --help` / `tfx-setup --help` before vs after
- [x] `npx biome check bin/tfx-doctor.mjs bin/tfx-setup.mjs packages/triflux/bin/tfx-doctor.mjs packages/triflux/bin/tfx-setup.mjs tests/unit/tfx-cli-shim-entrypoint.test.mjs`

https://claude.ai/code/session_01GTyg41JKiTZKPiRV38YknU