### PR TITLE
docs(adr): 과거 횡단 결정 backfill (ADR-0004..0009) + Phase 5 게이트 defer (Phase 4)

### DIFF
--- a/.claude/rules/tfx-escalation-chain.md
+++ b/.claude/rules/tfx-escalation-chain.md
@@ -3,6 +3,8 @@
 `/tfx-auto --retry auto-escalate` 가 사용하는 CLI 승격 체인.
 각 단계에서 `--max-iterations` (기본 3) 소진 시 다음 단계로 전이.
 
+> 근거(why): [ADR-0006 — 재시도 승격 체인 codex→claude opus 2단계](../../docs/adr/0006-escalation-chain-codex-to-claude-opus.md). 이 문서가 SSOT(어떻게), ADR은 결정 이력(왜).
+
 ## DEFAULT_ESCALATION_CHAIN
 
 `hub/team/retry-state-machine.mjs` 의 `DEFAULT_ESCALATION_CHAIN` 상수.

--- a/.claude/rules/tfx-mirror-policy.md
+++ b/.claude/rules/tfx-mirror-policy.md
@@ -2,6 +2,8 @@
 
 ## 멘탈 모델
 
+> 근거(why): [ADR-0005 — packages/ 3-layer single-source 미러](../../docs/adr/0005-packages-three-layer-mirror.md). 이 문서가 SSOT(어떻게), ADR은 결정 이력(왜).
+
 triflux 는 root 와 `packages/{core,remote,triflux}/` 3개 published 레이어를 동시에 유지한다. root 가 source of truth 다. mirror 작업은 drift 가 생기지 않도록 레이어별 룰을 다르게 적용한다.
 
 | 레이어 | 역할 | mirror 룰 |

--- a/.claude/rules/tfx-routing.md
+++ b/.claude/rules/tfx-routing.md
@@ -59,6 +59,8 @@ description에는 해당 스킬을 고르는 데 필요한 좁은 activation phr
 
 ## CLI 우선순위 정책 — default = Codex
 
+> 근거(why): [ADR-0004 — 기본 구현 CLI = Codex](../../docs/adr/0004-codex-as-default-cli.md). 이 절이 SSOT(어떻게), ADR은 결정 이력(왜).
+
 triflux 본체 개발의 실측 운영 패턴 (v10.18.0 ~ v10.20.2, 2주, 25+ PR) 이 거의 전부 Codex 단독 또는 Codex worker spawn 으로 진행됐다. 이 운영 fact 를 default policy 로 명시한다.
 
 | 우선순위 | CLI / 모델 | default 적용 lane |
@@ -106,7 +108,7 @@ headless-guard 가 `codex exec` / `agy -y -p` 직접 호출을 차단한다. tfx
 
 **Claude 네이티브** (CLI 불필요): tfx-find, tfx-forge, tfx-prune, tfx-index, tfx-setup, tfx-doctor, tfx-hooks, tfx-hub
 
-**Headless UI default** — `tfx-auto`, `tfx multi`, `tfx swarm` 로컬 shard 의 headless 워커는 default 로 `claude agents` 패널에 노출 (`--native-bridge-ui agents`). opt-out: `--no-native-bridge-ui`. interactive (tmux/wt) 경로는 default-off. `tfx swarm` 원격 shard 는 `registerSwarmShard()` 가 warn + skip 만 하고 원격 daemon 등록은 후속 PRD. 상세 행동표는 `CLAUDE.md` 의 `<native-bridge>` 섹션.
+**Headless UI default** — `tfx-auto`, `tfx multi`, `tfx swarm` 로컬 shard 의 headless 워커는 default 로 `claude agents` 패널에 노출 (`--native-bridge-ui agents`). opt-out: `--no-native-bridge-ui`. interactive (tmux/wt) 경로는 default-off. `tfx swarm` 원격 shard 는 `registerSwarmShard()` 가 warn + skip 만 하고 원격 daemon 등록은 후속 PRD. 상세 행동표는 `CLAUDE.md` 의 `<native-bridge>` 섹션. 근거(why): [ADR-0008 — headless 워커 native-bridge 기본 노출](../../docs/adr/0008-native-bridge-ui-default-on.md).
 
 자원 우선순위: remote-spawn > swarm > multi > Light > 로컬 단독
 

--- a/.claude/rules/tfx-stack-coexistence.md
+++ b/.claude/rules/tfx-stack-coexistence.md
@@ -1,5 +1,7 @@
 # 스택 공존 가이드 — gstack + superpowers + triflux
 
+> 근거(why): [ADR-0009 — gstack·sp·triflux 단방향 3-layer 공존](../../docs/adr/0009-stack-coexistence-three-layer.md). 이 문서가 SSOT(어떻게), ADR은 결정 이력(왜).
+
 ## 공존 원칙
 
 - 세 시스템은 흡수/대체 관계가 아니라 레이어 분리 관계다.

--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -7,7 +7,7 @@
 | **gstack** | `~/.gstack/last-update-check` 훅 / 세션 시작 배너 | `/gstack-upgrade` 스킬 (git install이면 `git merge --ff-only origin/main` + `./setup` + migrations) |
 | **Codex CLI** | `codex --version` / `~/.codex/auth.json` mtime | `npm i -g @openai/codex` / 토큰 만료 시 `codex login` (인터랙티브) + 메시지 한 번 날려 refresh 트리거 |
 | **Antigravity CLI** | `agy --version` | CLI: `curl -fsSL https://antigravity.google/cli/install.sh \| bash`. IDE Cask: `brew install --cask antigravity`. 인증: ChainedAuth (Mac Keychain → oauth_creds.json). 자세히는 memory:[[reference-antigravity-cli-sanity-matrix]] |
-| **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거). 근거(why): [ADR-0007](../../docs/adr/0007-hub-default-port-27888.md) |
+| **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거). 근거(why): [ADR-0007 — hub 기본 포트 27888 고정](../../docs/adr/0007-hub-default-port-27888.md) |
 | **Codex auth 캐시** (pte1024 등) | 병렬 codex exec 시 `refresh_token_reused` | `cp ~/.codex/auth.json ~/.claude/cache/tfx-hub/codex-auth-<account>.json` 수동 (Issue #78 자동화 대기) |
 
 ## 주의

--- a/.claude/rules/tfx-update-logic.md
+++ b/.claude/rules/tfx-update-logic.md
@@ -7,7 +7,7 @@
 | **gstack** | `~/.gstack/last-update-check` 훅 / 세션 시작 배너 | `/gstack-upgrade` 스킬 (git install이면 `git merge --ff-only origin/main` + `./setup` + migrations) |
 | **Codex CLI** | `codex --version` / `~/.codex/auth.json` mtime | `npm i -g @openai/codex` / 토큰 만료 시 `codex login` (인터랙티브) + 메시지 한 번 날려 refresh 트리거 |
 | **Antigravity CLI** | `agy --version` | CLI: `curl -fsSL https://antigravity.google/cli/install.sh \| bash`. IDE Cask: `brew install --cask antigravity`. 인증: ChainedAuth (Mac Keychain → oauth_creds.json). 자세히는 memory:[[reference-antigravity-cli-sanity-matrix]] |
-| **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거) |
+| **Hub MCP URL 동기화** | Hub 시작 시 `resolveHubTarget()` (env `TFX_HUB_PORT` 없으면 `HUB_DEFAULT_PORT=27888`) vs client configs의 `tfx-hub.url` | PR #82 auto sync + PR #158 port cascade fix. `scripts/sync-hub-mcp-settings.mjs`의 `syncHubMcpSettings({hubUrl})` + `syncProjectMcpJson({projectRoot: process.cwd()})`를 hub-ensure에서 호출. pid-file은 host 힌트 전용 (port 재사용 제거). 근거(why): [ADR-0007](../../docs/adr/0007-hub-default-port-27888.md) |
 | **Codex auth 캐시** (pte1024 등) | 병렬 codex exec 시 `refresh_token_reused` | `cp ~/.codex/auth.json ~/.claude/cache/tfx-hub/codex-auth-<account>.json` 수동 (Issue #78 자동화 대기) |
 
 ## 주의

--- a/.triflux/plans/2026-07-01-docs-adr-foundation.md
+++ b/.triflux/plans/2026-07-01-docs-adr-foundation.md
@@ -13,8 +13,9 @@
 - ✅ **Phase 0 완료·커밋** — gitignore 공개경계 교정(`e4b7f47f`), ADR 부트스트랩 0001/0002+보드+CONVENTIONS(`79d37f69`), `.document-harness.toml`(`eae48822`), 구조 테스트(`9be4cba2`). ADR 구조 테스트 3/3 pass. gitignore 교정 untracked-probe로 검증(docs/adr 등 trackable, superpowers/plans LOCAL 유지).
 - ✅ **Phase 1 완료·커밋** — docs/README 인덱스+_archive 규약(`dedb865d`), CONTRIBUTING+ARCHITECTURE+README 포인터(`557da744`), docs/process(`db6f2967`), tfx-doc-governance 규칙(`0d9cca3c`). 5종 병렬 서브에이전트 저작, 링크 정합.
 - ✅ **Phase 2 완료·커밋** — design PRD 2건 → docs/prd 이동(`b3eb78c2`), decision-tfx-skill-passing → ADR-0003 승격+보드등재+원본배너(`f35ad3bb`). 구조 테스트 3/3(0003 포함).
-- ⏳ **Phase 3 미착수** — 3.1 psmux 3-way(psmux 버전 실측 + 결정 + 코드/미러 가능성, Windows 전용), 3.2 CODEX/GEMINI resync, 3.3 ROADMAP/TODOS/decisions.md, 3.4 PRD 템플릿 codex-exec 정합. 판단·검증 필요 항목이라 별도 리뷰 배치로 진행.
-- 📋 **Phase 4~5** — 로드맵(backfill ADR / threshold-gated 자동화).
+- ✅ **Phase 3 완료·머지(PR #452)** — 3.1 psmux 정책 3-way 정합(codex-conventions → tfx-psmux RULE 5 SSOT + 버전-safe fallback, 코드/미러 무변경 = option B), 3.2 CODEX/GEMINI resync(deprecated alias 제거), 3.3 ROADMAP/TODOS stale 배너, 3.4 PRD 템플릿 codex-exec 축약. `docs/decisions.md`는 `docs/*` ignore로 드롭(ADR 보드가 정본).
+- ✅ **Phase 4 완료·커밋(브랜치 `worktree-docs-adr-phase4`)** — 과거 횡단 결정 6건 backfill: ADR-0004(Codex 기본 CLI)·0005(packages 3-layer mirror)·0006(escalation chain, #356/#363)·0007(hub 포트 27888, #82/#158)·0008(native-bridge UI default, #323)·0009(stack 3-layer 공존). 각 accepted + 상태보드 등재(9행) + 대응 `.claude/rules/` 역참조 링크. 구조 테스트 3/3, PR 참조 실측 검증.
+- 🚧 **Phase 5 게이트 미충족 → 의도적 defer** — `.document-harness.toml` `automation_trigger`(ADR>25 **또는** drift 2회) 미달(현재 ADR **9개** < 25, 관측 drift **0**). ADR-0002 거버넌스가 "조기 자동화 금지(P4)"를 명시하므로, 게이트 미충족 시 자동화(link-check·상태보드 autogen·PATCHLOG)를 짓지 않는 것이 설계상 정답. 게이트 도달(ADR 26개째 또는 보드 drift 2회 관측) 시 별도 plan으로 착수.
 
 ## Global Constraints
 

--- a/docs/adr/0004-codex-as-default-cli.md
+++ b/docs/adr/0004-codex-as-default-cli.md
@@ -1,0 +1,32 @@
+---
+id: 0004
+title: Codex를 기본 구현 CLI로 사용한다
+status: accepted
+date: 2026-04-30
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002]
+pr: null
+---
+
+# ADR-0004: Codex를 기본 구현 CLI로 사용한다
+
+## 컨텍스트와 문제 (Context)
+triflux는 Codex(gpt-5.5) · Antigravity · Claude(opus-4-8) 세 CLI를 오케스트레이션한다. `tfx-auto`·`tfx-review`·`tfx-analysis`·`tfx-plan`·`tfx-find` 같은 multi-CLI wrapper가 어느 lane을 default head로 삼을지 정해지지 않으면, 스킬마다 라우팅이 비결정적이 되고 비용·품질이 흔들린다. 근거가 필요한 건 취향이 아니라 실측 운영 패턴이다: triflux 본체 개발의 v10.18.0 ~ v10.20.2 구간(약 2주, 25+ PR)이 거의 전부 Codex 단독 또는 Codex worker spawn으로 진행됐다.
+
+## 결정 (Decision)
+우리는 구현·수정·디버그·리뷰·분석·테스트 작성·회귀 가드·릴리즈 prepare lane의 default CLI를 **Codex(gpt-5.5)**로 한다.
+
+- **1차(default) = Codex.** 위 lane 전부.
+- **2차 = Antigravity.** Codex quota exhaust, 가독성 cross-check, 별도 시각 검토.
+- **한정(Claude opus-4-8만) = 메타 라우팅(`/tfx-harness`), planning gate(`/office-hours`·`/autoplan`), gstack-specific surface(`/gstack-context-*`·`/gstack /qa`), 또는 Codex/Antigravity 미가용.**
+- 명시 플래그(`--cli codex`·`--cli claude`·`--cli antigravity`)가 있으면 override. `--mode consensus`(3-CLI 합의)의 default head도 Codex.
+
+## 검토한 대안 (Considered Options)
+- **A안: Codex default (채택)** — 장점: 실측 운영 fact와 정합, 코드/추론/비용에서 우위, `--retry auto-escalate` 체인 1단계(ADR-0006)와 정합. 단점: Codex quota/auth 장애에 라우팅이 민감 → Antigravity fallback으로 완화.
+- **B안: Claude opus default** — 장점: 메타 판단 강함. 단점: 코드/비용 lane에서 Codex 대비 열세, 운영 실측과 불일치.
+- **C안: 매 태스크 수동 CLI 선택** — 장점: 최대 유연성. 단점: 판단 비용이 매 호출마다 발생, 비결정적 라우팅.
+
+## 결과 (Consequences)
+긍정: 모든 multi-CLI wrapper가 하나의 default policy를 공유해 라우팅이 결정적이 된다. `--retry auto-escalate` 체인의 1단계가 Codex인 것(ADR-0006)과 정합한다. 부정/리스크: Codex 계정 장애·quota 소진이 광역 영향 → Antigravity 2차 lane + AccountBroker CircuitBreaker로 격리. 되돌릴 조건: Codex 대비 다른 CLI의 코드 품질·비용 우위가 실측으로 뒤집히면 default를 재지정하고 이 ADR을 superseded 처리. SSOT(가변 "어떻게")는 `.claude/rules/tfx-routing.md`의 "CLI 우선순위 정책 — default = Codex" 절.

--- a/docs/adr/0005-packages-three-layer-mirror.md
+++ b/docs/adr/0005-packages-three-layer-mirror.md
@@ -1,0 +1,31 @@
+---
+id: 0005
+title: packages/를 3-layer single-source로 미러링한다
+status: accepted
+date: 2026-04-30
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002]
+pr: null
+---
+
+# ADR-0005: packages/를 3-layer single-source로 미러링한다
+
+## 컨텍스트와 문제 (Context)
+triflux는 npm에 세 패키지를 발행한다: `triflux`(사용자 CLI), `@triflux/core`(공용 라이브러리), `@triflux/remote`(원격 entry/store/pipe/server). 소스는 repo root에 있고 `packages/{core,remote,triflux}/`가 published 레이어다. root와 packages가 갈라지면(drift) 발행본이 조용히 깨진다 — 특히 `@triflux/remote`는 root의 상대경로 import를 그대로 복사하면 자기 모듈을 못 찾는다. 미러 규칙이 레이어마다 달라야 하는데 그 규칙이 명문화돼 있지 않았다.
+
+## 결정 (Decision)
+우리는 **root를 single source of truth**로 두고 3개 published 레이어를 레이어별 다른 규칙으로 미러링한다.
+
+- **`packages/core`(`@triflux/core`)** — root와 **byte-identical `cp`**. import 변환 없음. `hub/lib/*`, `scripts/lib/*`, `mesh/*`, `hooks/*`, `hud/*` 등. `hub/team/*`는 전체 미러하지 않고 `bridge.mjs`가 self-import하는 파일만 minimal cp.
+- **`packages/remote`(`@triflux/remote`)** — root subset을 **`Edit`로 개별 수정**하며 상대경로 import를 `@triflux/core/...`로 변환. **`cp` 금지**(덮어쓰면 import path가 revert됨).
+- **`packages/triflux`(`triflux` npm)** — root `package.json`의 `files` 교집합을 **byte-identical mirror**. `tests/`는 npm files 미포함이라 **미러 제외**. binary 산출물(`references/*-snapshots/` 등) 추가 시 `files` 부정 패턴 동반(npm pack tarball 폭증 방지).
+
+## 검토한 대안 (Considered Options)
+- **A안: 3-layer 명시 미러 + 레이어별 규칙 (채택)** — 장점: 각 패키지의 발행 요건(byte-identical vs import 변환 vs npm files)을 정확히 반영, 기존 구조 유지. 단점: 수동 미러라 drift 위험 → `release:check-mirror` + `scripts/pack.mjs`로 가드.
+- **B안: 단일 패키지 발행** — 장점: 미러 부담 0. 단점: core/remote를 별도 dep로 쓰는 소비자가 전체 CLI를 받아야 함, 발행 유연성 상실.
+- **C안: monorepo 빌드 툴(turbo/tsup 등)로 자동 생성** — 장점: drift 원천 차단. 단점: 신규 빌드 인프라·학습곡선이 현재 규모에 과잉(explicit-over-clever 위반), `.mjs` 무번들 런타임 특성과 불일치.
+
+## 결과 (Consequences)
+긍정: 3패키지가 발행 시 일관성을 유지하고, 레이어별 미러 규칙이 문서화돼 신규 기여자가 `cp`/`Edit` 오용(remote import revert)을 피한다. 부정/리스크: 수동 미러라 root 변경 시 packages 누락 가능 → PR 단위 `diff -q` 체크리스트 + `release:check-mirror` + `npm pack --dry-run` size(~1MB) 검증. 관련 PR: #219(v10.18.0 mirror sync)·#314(v10.25.0 catch-up)·#320(remote mesh gap)·#222(lint baseline). SSOT는 `.claude/rules/tfx-mirror-policy.md`.

--- a/docs/adr/0006-escalation-chain-codex-to-claude-opus.md
+++ b/docs/adr/0006-escalation-chain-codex-to-claude-opus.md
@@ -1,0 +1,32 @@
+---
+id: 0006
+title: 재시도 승격 체인을 codex→claude opus 2단계로 한다
+status: accepted
+date: 2026-05-27
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002, 0004]
+pr: "#356"
+---
+
+# ADR-0006: 재시도 승격 체인을 codex→claude opus 2단계로 한다
+
+## 컨텍스트와 문제 (Context)
+`/tfx-auto --retry auto-escalate`는 태스크가 실패하면 더 강한 모델로 승격한다. 승격 체인이 너무 길면(mini→codex→pro→opus …) 비용·지연이 폭증하고, 너무 짧으면 회복력이 없다. 또한 같은 실패가 반복될 때 무한 승격을 막을 종료 조건이 필요하다. gpt-5.5 등장으로 과거의 gpt-5.4-mini / gpt-5.3-codex 중간 단계가 단일 모델로 대체 가능해졌다.
+
+## 결정 (Decision)
+우리는 `DEFAULT_ESCALATION_CHAIN`을 **2단계**로 한다.
+
+1. **codex / gpt-5.5** (profile 미지정 → `config.toml` 기본값). 코드/추론/비용의 중간 단계를 대체.
+2. **claude / opus-4-8** (profile 미지정). 최종 수단 — 복잡 아키텍처/합의 요구 시.
+
+전이 규약: 각 단계 default `max_iterations = 3`(`--max-iterations N`으로 override), 소진 시 다음 단계로 전이하며 iterations/stuckCounter/lastFailureReason 리셋. **동일 failureReason 3회 연속 = `STUCK` → 체인과 무관하게 즉시 중단.** 체인 소진 시 `BUDGET_EXCEEDED`(reason `escalation-chain-exhausted`). 프로젝트별 override는 `.triflux/config/escalation-chain.json`(있으면 default 대체). 이 체인의 1단계가 Codex인 것은 ADR-0004(기본 CLI = Codex)와 정합한다.
+
+## 검토한 대안 (Considered Options)
+- **A안: codex→claude opus 2단계 (채택)** — 장점: gpt-5.5가 중간 티어를 흡수해 단계 최소화, opus-4-8이 명확한 최종 수단. 단점: 두 CLI 모두 장애 시 회복 경로 없음 → `STUCK`/`BUDGET_EXCEEDED`로 명시적 중단(무한 루프보다 안전).
+- **B안: 다단계 체인(mini→codex→pro→opus)** — 장점: 세밀한 비용 계단. 단점: gpt-5.5로 중간 단계가 무의미해짐, 지연·복잡도 증가.
+- **C안: Claude opus 우선 단일 티어** — 장점: 최고 품질 즉시. 단점: 비용 과다, ADR-0004 default=Codex와 불일치.
+
+## 결과 (Consequences)
+긍정: 승격 경로가 명시적·짧고 비용 예측 가능, `STUCK` 종료 조건으로 무한 승격 차단. ADR-0004와 정합. 부정/리스크: opus 이후 상위 티어 없음(설계상 의도 — 그 이상은 human gate). 구현: `hub/team/retry-state-machine.mjs`의 `DEFAULT_ESCALATION_CHAIN`. 관련 PR: #356(2단계 재이관 + profile 필드), #363(opus-4-7→4-8 bump). SSOT는 `.claude/rules/tfx-escalation-chain.md`.

--- a/docs/adr/0007-hub-default-port-27888.md
+++ b/docs/adr/0007-hub-default-port-27888.md
@@ -1,0 +1,32 @@
+---
+id: 0007
+title: hub 기본 포트를 27888로 고정한다
+status: accepted
+date: 2026-04-17
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002]
+pr: "#82"
+---
+
+# ADR-0007: hub 기본 포트를 27888로 고정한다
+
+## 컨텍스트와 문제 (Context)
+tfx-hub는 로컬 MCP·에이전트 조율 데몬이고, 클라이언트(Claude·Gemini `settings.json`, 프로젝트 `.mcp.json`)가 `tfx-hub.url`로 이 데몬을 가리킨다. 초기엔 포트가 사용 중이면 다음 포트로 넘어가는 cascade 방식이었는데, 이 때문에 hub가 재시작될 때마다 포트가 바뀌고 클라이언트 config가 stale해져(예: `:27888` → `:27889`) MCP 연결이 조용히 끊겼다. 데몬 위치의 single source of truth가 필요했다.
+
+## 결정 (Decision)
+우리는 hub 기본 포트를 **27888로 단일 고정**한다.
+
+- `resolveHubTarget()`은 env `TFX_HUB_PORT`가 없으면 `HUB_DEFAULT_PORT = 27888`을 쓴다. env가 유일한 override source다.
+- **port cascade 제거** — 포트 재사용 로직을 없애 데몬 위치를 결정적으로 만든다.
+- hub 시작 시 `hub-ensure`가 클라이언트 config(gemini/claude `settings.json`, 프로젝트 `.mcp.json`)의 `tfx-hub.url`을 27888로 auto-sync한다(`syncHubMcpSettings` / `syncProjectMcpJson`).
+- pid-file은 host 힌트 전용이며 포트 결정에 쓰지 않는다.
+
+## 검토한 대안 (Considered Options)
+- **A안: 고정 27888 + env override (채택)** — 장점: MCP url 안정, config drift 원천 차단, 단일 override 경로. 단점: 27888 충돌 시 env 지정 필요(드묾).
+- **B안: 동적 포트 cascade** — 장점: 포트 충돌 자동 회피. 단점: 재시작마다 포트 변동 → 클라이언트 config stale → 연결 단절(실제 발생한 회귀).
+- **C안: 사용자가 매번 포트 수동 지정** — 장점: 완전 제어. 단점: 온보딩 마찰, 자동 sync 불가.
+
+## 결과 (Consequences)
+긍정: MCP url이 안정되고 hub 재시작이 클라이언트 연결을 깨지 않는다. config auto-sync로 수동 편집 불필요. 부정/리스크: 27888이 다른 프로세스와 충돌하면 `TFX_HUB_PORT` env override 필요. 관련 PR: #82(포트 고정 + Gemini/Claude settings auto-sync), #158(port cascade 제거 + env single source of truth). 참고 SSOT는 `.claude/rules/tfx-update-logic.md`의 "Hub MCP URL 동기화" 절.

--- a/docs/adr/0008-native-bridge-ui-default-on.md
+++ b/docs/adr/0008-native-bridge-ui-default-on.md
@@ -1,0 +1,32 @@
+---
+id: 0008
+title: headless 워커를 기본으로 native-bridge claude agents 패널에 노출한다
+status: accepted
+date: 2026-05-21
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002]
+pr: "#323"
+---
+
+# ADR-0008: headless 워커를 기본으로 native-bridge `claude agents` 패널에 노출한다
+
+## 컨텍스트와 문제 (Context)
+triflux는 `tfx-auto`·`tfx multi`·`tfx swarm` 로컬 shard를 headless 워커로 돌린다. 이 워커들이 사용자에게 보이지 않으면 진행 상황을 파악할 수 없고, "시작만 하고 멈춘 것"으로 오진하기 쉽다. Claude Code의 `claude agents` 패널에 워커를 row로 노출할 수 있는 native-bridge가 생겼는데, 이걸 opt-in으로 둘지 default-on으로 둘지 결정이 필요했다.
+
+## 결정 (Decision)
+우리는 headless 워커를 **default로 `claude agents` 패널에 row로 노출**한다.
+
+- `tfx-auto` / `tfx multi`(headless) / `tfx swarm` 로컬 shard = default **on**(`--native-bridge-ui agents`). opt-out은 `--no-native-bridge-ui`.
+- interactive(tmux/wt) 경로 = default **off**.
+- `tfx swarm` **원격** shard = `registerSwarmShard()`가 host≠local일 때 `{ ok: true, skipped: true }` 반환 + warn만 하고 skip. 원격 daemon 실제 등록은 후속 PRD.
+- sentinel exit 즉시 daemon `sendKillBySessionId` 발사 → stale row 잔존 없음.
+
+## 검토한 대안 (Considered Options)
+- **A안: default-on 노출 (채택)** — 장점: 로컬 워커 진행이 기본으로 보임, 오진 방지, sentinel-exit로 정리 자동. 단점: 원격 shard는 아직 미노출(warn+skip, 후속).
+- **B안: default-off (opt-in)** — 장점: 패널 노이즈 없음. 단점: 대부분의 사용자가 워커 가시성을 못 얻음, "멈춤" 오진 반복.
+- **C안: triflux 자체 대시보드만 사용** — 장점: CLI 독립. 단점: `claude agents`와 중복 인프라, 네이티브 UI 레버리지 상실.
+
+## 결과 (Consequences)
+긍정: 로컬 headless 워커가 기본으로 가시화되고 종료 시 자동 정리된다. 부정/리스크: 원격 swarm shard는 현재 미등록(warn+skip)이라 원격 진행은 별도 경로로 확인해야 함 — 후속 PRD 대상. 구현 PRD: `.triflux/plans/native-bridge-ui-default-expansion.md`. 관련 PR: #323. 운영 상세는 `CLAUDE.md`의 `<native-bridge>` 섹션과 `.claude/rules/tfx-routing.md`의 "Headless UI default" 절.

--- a/docs/adr/0009-stack-coexistence-three-layer.md
+++ b/docs/adr/0009-stack-coexistence-three-layer.md
@@ -1,0 +1,33 @@
+---
+id: 0009
+title: gstack·superpowers·triflux를 단방향 3-layer로 공존시킨다
+status: accepted
+date: 2026-07-01
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0002]
+pr: null
+---
+
+# ADR-0009: gstack·superpowers·triflux를 단방향 3-layer로 공존시킨다
+
+## 컨텍스트와 문제 (Context)
+이 환경은 세 스킬 시스템을 동시에 쓴다: gstack(`/`), superpowers(`/superpowers:*`), triflux(`/tfx-*`). 80+ 스킬이 기능적으로 겹치기 때문에(각자 review·plan·qa·ship 유사물 보유), 흡수/대체하려 들면 순환 참조와 비결정적 라우팅이 생긴다. 세 시스템의 책임 경계와 의존 방향을 명시하지 않으면 triflux 코어가 gstack/superpowers에 얽혀 독립성을 잃는다.
+
+## 결정 (Decision)
+우리는 세 시스템을 **흡수/대체가 아닌 레이어 분리**로 공존시킨다.
+
+- **무대(Stage) = gstack** — 워크플로우 게이트(언제 무엇을 부를지). `/ship`·`/qa`·`/checkpoint`·`/investigate`.
+- **엔진(Engine) = superpowers** — 리뷰 프리미티브(입력 diff → 출력 verdict). `/review`·`/design-review`·`/security-review`.
+- **백엔드(Backend) = triflux** — 오케스트레이션(병렬 worker 배분·모델 선택·실행). `/tfx-*` 전체.
+- **의존 방향은 단방향**: `gstack → triflux` 허용, `gstack → superpowers` 허용, `superpowers → triflux` 허용. **`triflux → gstack` 금지, `triflux → superpowers` 금지.** triflux 코어는 절대 gstack/superpowers에 의존하지 않는다.
+- 기본 진입점은 `tfx-*`. 기능 경계가 명확하면 owner 시스템 1순위, 모호하면 triflux 우선.
+
+## 검토한 대안 (Considered Options)
+- **A안: 단방향 3-layer 공존 (채택)** — 장점: 각 시스템 책임 경계 보존, triflux 코어 독립성 유지, 흐름이 `사용자 → gstack(게이트) → triflux(실행) → superpowers(판정) → gstack(결과)`로 명확. 단점: 겹치는 스킬의 충돌 해소 표를 유지해야 함.
+- **B안: triflux가 gstack/superpowers를 흡수** — 장점: 단일 시스템. 단점: 역방향 의존 → 순환 참조 가능성, 세 시스템 각각의 업스트림 업데이트를 못 받음.
+- **C안: 완전 분리(상호 무연동)** — 장점: 결합 0. 단점: 워크플로우 게이트가 실행 백엔드를 못 부름 → 각 시스템이 중복 기능을 재구현.
+
+## 결과 (Consequences)
+긍정: triflux 코어가 gstack/superpowers 없이 독립 동작하고(단방향), 세 시스템이 책임을 나눠 중복 재구현을 피한다. 부정/리스크: 스킬 키워드 충돌 시 비결정적 라우팅 위험 → 충돌 해소 우선순위 표로 방어(gstack이 triflux를 우회해 codex 직접 호출하면 headless-guard 차단). 되돌릴 조건: 세 시스템 중 하나가 사실상 미사용이 되면 레이어를 통합. SSOT는 `.claude/rules/tfx-stack-coexistence.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,12 @@ triflux의 아키텍처·정책·횡단 결정을 ADR(Architecture Decision Reco
 | [0001](0001-record-architecture-decisions.md) | ADR로 아키텍처 결정을 기록한다 | Accepted | — |
 | [0002](0002-doc-and-devflow-architecture.md) | 문서 파운데이션 + 개발 플로우 아키텍처 | Accepted | 0001 |
 | [0003](0003-tfx-skill-passing-prose-injection.md) | headless CLI 스킬 전달 = 즉석 prose 주입 | Accepted | 0002 |
+| [0004](0004-codex-as-default-cli.md) | 기본 구현 CLI = Codex | Accepted | 0002 |
+| [0005](0005-packages-three-layer-mirror.md) | packages/ 3-layer single-source 미러 | Accepted | 0002 |
+| [0006](0006-escalation-chain-codex-to-claude-opus.md) | 재시도 승격 체인 codex→claude opus 2단계 | Accepted | 0002, 0004 |
+| [0007](0007-hub-default-port-27888.md) | hub 기본 포트 27888 고정 | Accepted | 0002 |
+| [0008](0008-native-bridge-ui-default-on.md) | headless 워커 native-bridge 기본 노출 | Accepted | 0002 |
+| [0009](0009-stack-coexistence-three-layer.md) | gstack·sp·triflux 단방향 3-layer 공존 | Accepted | 0002 |
 
 상태 범례: **Proposed**(제안) · **Accepted**(확정, 불변) · **Superseded**(대체됨 → `_archive/`) · **Deprecated**/**Rejected**/**Withdrawn**(무효화 → `_archive/`).
 


### PR DESCRIPTION
## 목적
문서 파운데이션 PR #452(Phase 0-3)에 이어, 이미 확정된 **횡단 결정 6건을 소급 ADR로 기록**하고(Phase 4), Phase 5 자동화 게이트 상태를 명시한다. rules는 SSOT(어떻게)로 그대로 두고 ADR은 결정 이력(왜)을 소유한다.

## 변경 (Phase 4 backfill)
| ADR | 결정 | SSOT rules | PR 근거 |
|---|---|---|---|
| 0004 | 기본 구현 CLI = Codex | tfx-routing | 운영 패턴 v10.18.0~v10.20.2 |
| 0005 | packages/ 3-layer single-source 미러 | tfx-mirror-policy | #219·#222·#314·#320 |
| 0006 | 재시도 승격 체인 codex→claude opus 2단계 | tfx-escalation-chain | #356·#363 |
| 0007 | hub 기본 포트 27888 고정 | tfx-update-logic | #82·#158 |
| 0008 | headless 워커 native-bridge 기본 노출 | tfx-routing | #323 |
| 0009 | gstack·sp·triflux 단방향 3-layer 공존 | tfx-stack-coexistence | (정책) |

- 각 ADR: status `accepted`, MADR-minimal 포맷(`## 결정`·`## 검토한 대안` 필수 헤딩), 상태보드 등재(총 9행).
- 해당 `.claude/rules/` 5개 파일에 ADR 역참조 링크 6개 추가 — **순수 additive 포인터**(정책 재작성/흡수 없음, Global Constraint 준수).

## Phase 5 = 의도적 defer (게이트 미충족)
`.document-harness.toml` `automation_trigger`(ADR>25 **또는** drift 2회) 미달 — 현재 ADR **9개**(< 25), 관측 drift **0**. ADR-0002 거버넌스의 "조기 자동화 금지(P4)"에 따라 게이트 도달 전까지 자동화(link-check·상태보드 autogen·PATCHLOG)를 짓지 않는 것이 설계상 정답. 계획 파일 실행상태에 기록.

## 검증
- `npm test`: **4437 pass / 0 fail** / 17 skip, `lint:skills` PASS, `npm run lint`(biome 806파일) clean.
- ADR 구조 테스트 3/3(9개 ADR 커버), 상태보드 링크 9개 + rules 역참조 6개 전부 resolve, 신규 ADR 6개 전부 trackable(check-ignore).
- PR 참조 10건 전부 `gh pr view`로 MERGED·내용 실측 검증.

## Cross-model review
Claude 작성 → **fresh-context critic(opus, 별도 컨텍스트) 적대적 독립 리뷰 → VERDICT ACCEPT**. PR 참조 사실성·SSOT 정합·포맷 계약·민감정보·additive-only 전부 clean, LOW nit 1건(ADR-0007 백링크 제목 parity) 반영. docs-only 변경이라 Codex 대신 fresh-context Claude 리뷰 사용(worktree Codex 디스패치 hub-rebind 리스크 회피).

## 미러
docs/·`.claude/rules/`·`.triflux/plans/`는 packages/ 미러 대상 아님(tests 제외, docs는 assets만 npm). 미러 부담 없음.