### PR TITLE
fix(hub): verify register presence persistence

### DIFF
--- a/hub/lib/memory-store.mjs
+++ b/hub/lib/memory-store.mjs
@@ -183,6 +183,8 @@ export function createMemoryStore() {
           status: next.status,
           last_seen_ms: next.last_seen_ms,
           lease_expires_ms: next.lease_expires_ms,
+          store_type: "memory",
+          db_path: null,
         },
       };
     },

--- a/hub/lib/memory-store.mjs
+++ b/hub/lib/memory-store.mjs
@@ -177,6 +177,13 @@ export function createMemoryStore() {
         lease_id: uuidv7(),
         lease_expires_ms: next.lease_expires_ms,
         server_time_ms: now,
+        effective: {
+          updated: true,
+          online: next.status === "online",
+          status: next.status,
+          last_seen_ms: next.last_seen_ms,
+          lease_expires_ms: next.lease_expires_ms,
+        },
       };
     },
 

--- a/hub/pipe.mjs
+++ b/hub/pipe.mjs
@@ -222,6 +222,7 @@ export function createPipeServer({
     switch (action) {
       case "register": {
         const result = router.registerAgent(payload);
+        if (!result?.ok) return result;
         if (client) {
           client.agentId = payload.agent_id;
           client.subscriptions = new Set(
@@ -230,7 +231,7 @@ export function createPipeServer({
           touchClient(client);
           pushPendingMessages(client.agentId);
         }
-        return { ok: true, data: { ...result, pipe_path: pipePath } };
+        return { ok: true, data: { ...result.data, pipe_path: pipePath } };
       }
 
       case "subscribe": {

--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -276,7 +276,7 @@ export function createRouter(store) {
         code: "REGISTER_PRESENCE_NOT_UPDATED",
         message: `${agentId} register did not update effective presence`,
       },
-      data: result,
+      data: { ...result, hub_pid: process.pid },
     };
   }
 
@@ -833,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return { ok: true, data: result };
+      return { ok: true, data: { ...result, hub_pid: process.pid } };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -260,6 +260,26 @@ export function createRouter(store) {
     );
   }
 
+  function registerPresenceIsEffective(result) {
+    const effective = result?.effective;
+    return (
+      effective?.online === true &&
+      effective.status === "online" &&
+      Number(effective.lease_expires_ms) === Number(result?.lease_expires_ms)
+    );
+  }
+
+  function registerPresenceFailure(agentId, result) {
+    return {
+      ok: false,
+      error: {
+        code: "REGISTER_PRESENCE_NOT_UPDATED",
+        message: `${agentId} register did not update effective presence`,
+      },
+      data: result,
+    };
+  }
+
   function sortRoleCandidates(candidates = []) {
     return [...candidates].sort((left, right) => {
       const sourceDelta =
@@ -802,6 +822,9 @@ export function createRouter(store) {
 
     registerAgent(args) {
       const result = store.registerAgent(args);
+      if (!registerPresenceIsEffective(result)) {
+        return registerPresenceFailure(args.agent_id, result);
+      }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);
       for (const roleName of ROLE_TOPICS) {
@@ -810,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return result;
+      return { ok: true, data: result };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -1725,7 +1725,7 @@ export async function startHub({
               });
               recordWorker(agent_id, "spawned", command, 0);
             }
-            return writeJson(res, 200, result);
+            return writeJson(res, result.ok ? 200 : 409, result);
           }
 
           if (path === "/bridge/result" && req.method === "POST") {

--- a/hub/store.mjs
+++ b/hub/store.mjs
@@ -407,6 +407,8 @@ export function createStore(dbPath, options = {}) {
           status: persisted?.status ?? null,
           last_seen_ms: persisted?.last_seen_ms ?? null,
           lease_expires_ms: persisted?.lease_expires_ms ?? null,
+          store_type: "sqlite",
+          db_path: dbPath ?? null,
         },
       };
     },

--- a/hub/store.mjs
+++ b/hub/store.mjs
@@ -381,7 +381,8 @@ export function createStore(dbPath, options = {}) {
     }) {
       const now = Date.now();
       const leaseExpires = now + heartbeat_ttl_ms;
-      S.upsertAgent.run({
+      const leaseId = uuidv7();
+      const write = S.upsertAgent.run({
         agent_id,
         cli,
         pid: pid ?? null,
@@ -392,11 +393,21 @@ export function createStore(dbPath, options = {}) {
         status: "online",
         metadata_json: JSON.stringify(metadata),
       });
+      const persisted = parseAgentRow(S.getAgent.get(agent_id));
       return {
         agent_id,
-        lease_id: uuidv7(),
+        lease_id: leaseId,
         lease_expires_ms: leaseExpires,
         server_time_ms: now,
+        effective: {
+          updated: write.changes > 0,
+          online:
+            persisted?.status === "online" &&
+            Number(persisted.lease_expires_ms) === leaseExpires,
+          status: persisted?.status ?? null,
+          last_seen_ms: persisted?.last_seen_ms ?? null,
+          lease_expires_ms: persisted?.lease_expires_ms ?? null,
+        },
       };
     },
 

--- a/hub/tools.mjs
+++ b/hub/tools.mjs
@@ -155,10 +155,7 @@ export function createTools(store, router, hitl, pipe = null) {
           },
         },
       },
-      handler: wrap("REGISTER_FAILED", (args) => {
-        const data = router.registerAgent(args);
-        return { ok: true, data };
-      }),
+      handler: wrap("REGISTER_FAILED", (args) => router.registerAgent(args)),
     },
 
     // ── 2. status ──

--- a/packages/core/hub/lib/memory-store.mjs
+++ b/packages/core/hub/lib/memory-store.mjs
@@ -183,6 +183,8 @@ export function createMemoryStore() {
           status: next.status,
           last_seen_ms: next.last_seen_ms,
           lease_expires_ms: next.lease_expires_ms,
+          store_type: "memory",
+          db_path: null,
         },
       };
     },

--- a/packages/core/hub/lib/memory-store.mjs
+++ b/packages/core/hub/lib/memory-store.mjs
@@ -177,6 +177,13 @@ export function createMemoryStore() {
         lease_id: uuidv7(),
         lease_expires_ms: next.lease_expires_ms,
         server_time_ms: now,
+        effective: {
+          updated: true,
+          online: next.status === "online",
+          status: next.status,
+          last_seen_ms: next.last_seen_ms,
+          lease_expires_ms: next.lease_expires_ms,
+        },
       };
     },
 

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -276,7 +276,7 @@ export function createRouter(store) {
         code: "REGISTER_PRESENCE_NOT_UPDATED",
         message: `${agentId} register did not update effective presence`,
       },
-      data: result,
+      data: { ...result, hub_pid: process.pid },
     };
   }
 
@@ -833,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return { ok: true, data: result };
+      return { ok: true, data: { ...result, hub_pid: process.pid } };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -260,6 +260,26 @@ export function createRouter(store) {
     );
   }
 
+  function registerPresenceIsEffective(result) {
+    const effective = result?.effective;
+    return (
+      effective?.online === true &&
+      effective.status === "online" &&
+      Number(effective.lease_expires_ms) === Number(result?.lease_expires_ms)
+    );
+  }
+
+  function registerPresenceFailure(agentId, result) {
+    return {
+      ok: false,
+      error: {
+        code: "REGISTER_PRESENCE_NOT_UPDATED",
+        message: `${agentId} register did not update effective presence`,
+      },
+      data: result,
+    };
+  }
+
   function sortRoleCandidates(candidates = []) {
     return [...candidates].sort((left, right) => {
       const sourceDelta =
@@ -802,6 +822,9 @@ export function createRouter(store) {
 
     registerAgent(args) {
       const result = store.registerAgent(args);
+      if (!registerPresenceIsEffective(result)) {
+        return registerPresenceFailure(args.agent_id, result);
+      }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);
       for (const roleName of ROLE_TOPICS) {
@@ -810,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return result;
+      return { ok: true, data: result };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/packages/remote/hub/pipe.mjs
+++ b/packages/remote/hub/pipe.mjs
@@ -222,6 +222,7 @@ export function createPipeServer({
     switch (action) {
       case "register": {
         const result = router.registerAgent(payload);
+        if (!result?.ok) return result;
         if (client) {
           client.agentId = payload.agent_id;
           client.subscriptions = new Set(
@@ -230,7 +231,7 @@ export function createPipeServer({
           touchClient(client);
           pushPendingMessages(client.agentId);
         }
-        return { ok: true, data: { ...result, pipe_path: pipePath } };
+        return { ok: true, data: { ...result.data, pipe_path: pipePath } };
       }
 
       case "subscribe": {

--- a/packages/remote/hub/schema.sql
+++ b/packages/remote/hub/schema.sql
@@ -1,0 +1,148 @@
+-- tfx-hub 상태 저장소 스키마
+-- SQLite WAL 모드 기반 메시지 버스
+
+-- 에이전트 등록 테이블
+CREATE TABLE IF NOT EXISTS agents (
+  agent_id TEXT PRIMARY KEY,
+  cli TEXT NOT NULL CHECK (cli IN ('codex','gemini','claude','other')),
+  pid INTEGER,
+  capabilities_json TEXT NOT NULL DEFAULT '[]',
+  topics_json TEXT NOT NULL DEFAULT '[]',
+  last_seen_ms INTEGER NOT NULL,
+  lease_expires_ms INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('online','stale','offline')),
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+
+-- 메시지 테이블
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL CHECK (type IN ('request','response','event','handoff','human_request','human_response','system')),
+  from_agent TEXT NOT NULL,
+  to_agent TEXT NOT NULL,
+  topic TEXT NOT NULL,
+  priority INTEGER NOT NULL CHECK (priority BETWEEN 1 AND 9),
+  ttl_ms INTEGER NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  correlation_id TEXT NOT NULL,
+  trace_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter'))
+);
+
+-- 메시지 수신함 (배달 추적)
+CREATE TABLE IF NOT EXISTS message_inbox (
+  delivery_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  delivered_at_ms INTEGER,
+  acked_at_ms INTEGER,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(message_id, agent_id),
+  FOREIGN KEY(message_id) REFERENCES messages(id) ON DELETE CASCADE
+);
+
+-- 사용자 입력 요청 테이블
+CREATE TABLE IF NOT EXISTS human_requests (
+  request_id TEXT PRIMARY KEY,
+  requester_agent TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('captcha','approval','credential','choice','text')),
+  prompt TEXT NOT NULL,
+  schema_json TEXT NOT NULL DEFAULT '{}',
+  state TEXT NOT NULL CHECK (state IN ('pending','accepted','declined','cancelled','timed_out')),
+  deadline_ms INTEGER NOT NULL,
+  default_action TEXT NOT NULL CHECK (default_action IN ('decline','cancel','timeout_continue')),
+  correlation_id TEXT NOT NULL,
+  trace_id TEXT NOT NULL,
+  response_json TEXT
+);
+
+-- 데드 레터 큐
+CREATE TABLE IF NOT EXISTS dead_letters (
+  message_id TEXT PRIMARY KEY,
+  reason TEXT NOT NULL,
+  failed_at_ms INTEGER NOT NULL,
+  last_error TEXT
+);
+
+-- 인덱스
+CREATE INDEX IF NOT EXISTS idx_messages_status ON messages(status);
+CREATE INDEX IF NOT EXISTS idx_messages_to_agent ON messages(to_agent, status);
+CREATE INDEX IF NOT EXISTS idx_messages_correlation ON messages(correlation_id);
+CREATE INDEX IF NOT EXISTS idx_messages_trace ON messages(trace_id);
+CREATE INDEX IF NOT EXISTS idx_messages_expires ON messages(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority DESC, created_at_ms ASC);
+CREATE INDEX IF NOT EXISTS idx_inbox_agent ON message_inbox(agent_id, delivered_at_ms);
+CREATE INDEX IF NOT EXISTS idx_inbox_message ON message_inbox(message_id);
+CREATE INDEX IF NOT EXISTS idx_human_requests_state ON human_requests(state);
+CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+CREATE INDEX IF NOT EXISTS idx_agents_lease ON agents(lease_expires_ms);
+
+-- Assign Job 테이블
+CREATE TABLE IF NOT EXISTS assign_jobs (
+  job_id TEXT PRIMARY KEY,
+  supervisor_agent TEXT NOT NULL,
+  worker_agent TEXT NOT NULL,
+  topic TEXT NOT NULL DEFAULT 'assign.job',
+  task TEXT NOT NULL DEFAULT '',
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL CHECK (status IN ('queued','running','succeeded','failed','timed_out')),
+  attempt INTEGER NOT NULL DEFAULT 1,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  max_retries INTEGER NOT NULL DEFAULT 0,
+  priority INTEGER NOT NULL DEFAULT 5 CHECK (priority BETWEEN 1 AND 9),
+  ttl_ms INTEGER NOT NULL DEFAULT 600000,
+  timeout_ms INTEGER NOT NULL DEFAULT 600000,
+  deadline_ms INTEGER,
+  trace_id TEXT NOT NULL,
+  correlation_id TEXT NOT NULL,
+  last_message_id TEXT,
+  result_json TEXT,
+  error_json TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  started_at_ms INTEGER,
+  completed_at_ms INTEGER,
+  last_retry_at_ms INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_assign_jobs_status ON assign_jobs(status, updated_at_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_assign_jobs_supervisor ON assign_jobs(supervisor_agent, updated_at_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_assign_jobs_worker ON assign_jobs(worker_agent, updated_at_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_assign_jobs_deadline ON assign_jobs(deadline_ms, status);
+
+-- 파이프라인 상태 테이블 (Phase 2)
+CREATE TABLE IF NOT EXISTS pipeline_state (
+  team_name TEXT PRIMARY KEY,
+  phase TEXT NOT NULL DEFAULT 'plan',
+  fix_attempt INTEGER DEFAULT 0,
+  fix_max INTEGER DEFAULT 3,
+  ralph_iteration INTEGER DEFAULT 0,
+  ralph_max INTEGER DEFAULT 10,
+  artifacts TEXT DEFAULT '{}',
+  phase_history TEXT DEFAULT '[]',
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+-- Reflexion 에러 학습 테이블
+CREATE TABLE IF NOT EXISTS reflexion_entries (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL DEFAULT 'reflexion', -- reflexion | adaptive
+  error_pattern TEXT NOT NULL,          -- 에러 시그니처 (정규화)
+  error_message TEXT NOT NULL,          -- 원본 에러 메시지
+  context_json TEXT NOT NULL DEFAULT '{}', -- { file, function, cli, agent }
+  solution TEXT NOT NULL,               -- 해결책 설명
+  solution_code TEXT,                   -- 해결 코드 스니펫 (있으면)
+  adaptive_state_json TEXT NOT NULL DEFAULT '{}', -- adaptive rule metadata
+  confidence REAL NOT NULL DEFAULT 0.5, -- 솔루션 신뢰도 (0-1)
+  hit_count INTEGER NOT NULL DEFAULT 1, -- 매칭 횟수
+  success_count INTEGER NOT NULL DEFAULT 0, -- 성공 횟수
+  last_hit_ms INTEGER NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_reflexion_pattern ON reflexion_entries(error_pattern);
+CREATE INDEX IF NOT EXISTS idx_reflexion_confidence ON reflexion_entries(confidence DESC);

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -407,6 +407,8 @@ export function createStore(dbPath, options = {}) {
           status: persisted?.status ?? null,
           last_seen_ms: persisted?.last_seen_ms ?? null,
           lease_expires_ms: persisted?.lease_expires_ms ?? null,
+          store_type: "sqlite",
+          db_path: dbPath ?? null,
         },
       };
     },

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -381,7 +381,8 @@ export function createStore(dbPath, options = {}) {
     }) {
       const now = Date.now();
       const leaseExpires = now + heartbeat_ttl_ms;
-      S.upsertAgent.run({
+      const leaseId = uuidv7();
+      const write = S.upsertAgent.run({
         agent_id,
         cli,
         pid: pid ?? null,
@@ -392,11 +393,21 @@ export function createStore(dbPath, options = {}) {
         status: "online",
         metadata_json: JSON.stringify(metadata),
       });
+      const persisted = parseAgentRow(S.getAgent.get(agent_id));
       return {
         agent_id,
-        lease_id: uuidv7(),
+        lease_id: leaseId,
         lease_expires_ms: leaseExpires,
         server_time_ms: now,
+        effective: {
+          updated: write.changes > 0,
+          online:
+            persisted?.status === "online" &&
+            Number(persisted.lease_expires_ms) === leaseExpires,
+          status: persisted?.status ?? null,
+          last_seen_ms: persisted?.last_seen_ms ?? null,
+          lease_expires_ms: persisted?.lease_expires_ms ?? null,
+        },
       };
     },
 

--- a/packages/remote/hub/tools.mjs
+++ b/packages/remote/hub/tools.mjs
@@ -155,10 +155,7 @@ export function createTools(store, router, hitl, pipe = null) {
           },
         },
       },
-      handler: wrap("REGISTER_FAILED", (args) => {
-        const data = router.registerAgent(args);
-        return { ok: true, data };
-      }),
+      handler: wrap("REGISTER_FAILED", (args) => router.registerAgent(args)),
     },
 
     // ── 2. status ──

--- a/packages/triflux/hub/lib/memory-store.mjs
+++ b/packages/triflux/hub/lib/memory-store.mjs
@@ -183,6 +183,8 @@ export function createMemoryStore() {
           status: next.status,
           last_seen_ms: next.last_seen_ms,
           lease_expires_ms: next.lease_expires_ms,
+          store_type: "memory",
+          db_path: null,
         },
       };
     },

--- a/packages/triflux/hub/lib/memory-store.mjs
+++ b/packages/triflux/hub/lib/memory-store.mjs
@@ -177,6 +177,13 @@ export function createMemoryStore() {
         lease_id: uuidv7(),
         lease_expires_ms: next.lease_expires_ms,
         server_time_ms: now,
+        effective: {
+          updated: true,
+          online: next.status === "online",
+          status: next.status,
+          last_seen_ms: next.last_seen_ms,
+          lease_expires_ms: next.lease_expires_ms,
+        },
       };
     },
 

--- a/packages/triflux/hub/pipe.mjs
+++ b/packages/triflux/hub/pipe.mjs
@@ -222,6 +222,7 @@ export function createPipeServer({
     switch (action) {
       case "register": {
         const result = router.registerAgent(payload);
+        if (!result?.ok) return result;
         if (client) {
           client.agentId = payload.agent_id;
           client.subscriptions = new Set(
@@ -230,7 +231,7 @@ export function createPipeServer({
           touchClient(client);
           pushPendingMessages(client.agentId);
         }
-        return { ok: true, data: { ...result, pipe_path: pipePath } };
+        return { ok: true, data: { ...result.data, pipe_path: pipePath } };
       }
 
       case "subscribe": {

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -276,7 +276,7 @@ export function createRouter(store) {
         code: "REGISTER_PRESENCE_NOT_UPDATED",
         message: `${agentId} register did not update effective presence`,
       },
-      data: result,
+      data: { ...result, hub_pid: process.pid },
     };
   }
 
@@ -833,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return { ok: true, data: result };
+      return { ok: true, data: { ...result, hub_pid: process.pid } };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -260,6 +260,26 @@ export function createRouter(store) {
     );
   }
 
+  function registerPresenceIsEffective(result) {
+    const effective = result?.effective;
+    return (
+      effective?.online === true &&
+      effective.status === "online" &&
+      Number(effective.lease_expires_ms) === Number(result?.lease_expires_ms)
+    );
+  }
+
+  function registerPresenceFailure(agentId, result) {
+    return {
+      ok: false,
+      error: {
+        code: "REGISTER_PRESENCE_NOT_UPDATED",
+        message: `${agentId} register did not update effective presence`,
+      },
+      data: result,
+    };
+  }
+
   function sortRoleCandidates(candidates = []) {
     return [...candidates].sort((left, right) => {
       const sourceDelta =
@@ -802,6 +822,9 @@ export function createRouter(store) {
 
     registerAgent(args) {
       const result = store.registerAgent(args);
+      if (!registerPresenceIsEffective(result)) {
+        return registerPresenceFailure(args.agent_id, result);
+      }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);
       for (const roleName of ROLE_TOPICS) {
@@ -810,7 +833,7 @@ export function createRouter(store) {
           transferBacklog: true,
         });
       }
-      return result;
+      return { ok: true, data: result };
     },
 
     refreshAgentLease(agentId, ttlMs = 30000) {

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -1725,7 +1725,7 @@ export async function startHub({
               });
               recordWorker(agent_id, "spawned", command, 0);
             }
-            return writeJson(res, 200, result);
+            return writeJson(res, result.ok ? 200 : 409, result);
           }
 
           if (path === "/bridge/result" && req.method === "POST") {

--- a/packages/triflux/hub/store.mjs
+++ b/packages/triflux/hub/store.mjs
@@ -407,6 +407,8 @@ export function createStore(dbPath, options = {}) {
           status: persisted?.status ?? null,
           last_seen_ms: persisted?.last_seen_ms ?? null,
           lease_expires_ms: persisted?.lease_expires_ms ?? null,
+          store_type: "sqlite",
+          db_path: dbPath ?? null,
         },
       };
     },

--- a/packages/triflux/hub/store.mjs
+++ b/packages/triflux/hub/store.mjs
@@ -381,7 +381,8 @@ export function createStore(dbPath, options = {}) {
     }) {
       const now = Date.now();
       const leaseExpires = now + heartbeat_ttl_ms;
-      S.upsertAgent.run({
+      const leaseId = uuidv7();
+      const write = S.upsertAgent.run({
         agent_id,
         cli,
         pid: pid ?? null,
@@ -392,11 +393,21 @@ export function createStore(dbPath, options = {}) {
         status: "online",
         metadata_json: JSON.stringify(metadata),
       });
+      const persisted = parseAgentRow(S.getAgent.get(agent_id));
       return {
         agent_id,
-        lease_id: uuidv7(),
+        lease_id: leaseId,
         lease_expires_ms: leaseExpires,
         server_time_ms: now,
+        effective: {
+          updated: write.changes > 0,
+          online:
+            persisted?.status === "online" &&
+            Number(persisted.lease_expires_ms) === leaseExpires,
+          status: persisted?.status ?? null,
+          last_seen_ms: persisted?.last_seen_ms ?? null,
+          lease_expires_ms: persisted?.lease_expires_ms ?? null,
+        },
       };
     },
 

--- a/packages/triflux/hub/tools.mjs
+++ b/packages/triflux/hub/tools.mjs
@@ -155,10 +155,7 @@ export function createTools(store, router, hitl, pipe = null) {
           },
         },
       },
-      handler: wrap("REGISTER_FAILED", (args) => {
-        const data = router.registerAgent(args);
-        return { ok: true, data };
-      }),
+      handler: wrap("REGISTER_FAILED", (args) => router.registerAgent(args)),
     },
 
     // ── 2. status ──

--- a/packages/triflux/scripts/pack.mjs
+++ b/packages/triflux/scripts/pack.mjs
@@ -73,6 +73,7 @@ const CORE_DIRS = [
 const REMOTE_FILES = [
   "hub/server.mjs",
   "hub/store.mjs",
+  "hub/schema.sql",
   "hub/store-adapter.mjs",
   "hub/pipe.mjs",
   "hub/tools.mjs",

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -73,6 +73,7 @@ const CORE_DIRS = [
 const REMOTE_FILES = [
   "hub/server.mjs",
   "hub/store.mjs",
+  "hub/schema.sql",
   "hub/store-adapter.mjs",
   "hub/pipe.mjs",
   "hub/tools.mjs",

--- a/tests/integration/pipe.test.mjs
+++ b/tests/integration/pipe.test.mjs
@@ -191,6 +191,40 @@ describe("Named Pipe 실시간 채널", () => {
     restoreHubStateDir?.();
   });
 
+  it("register presence 실패는 pipe transport가 ok:true로 감싸지 않아야 한다", async () => {
+    const pipe = createRemotePipeServer({
+      sessionId: `remote-register-failure-${randomUUID()}`,
+      router: {
+        registerAgent() {
+          return {
+            ok: false,
+            error: {
+              code: "REGISTER_PRESENCE_NOT_UPDATED",
+              message: "stuck-agent register did not update effective presence",
+            },
+            data: {
+              agent_id: "stuck-agent",
+              lease_expires_ms: Date.now() + 60000,
+              effective: { online: false, status: "offline" },
+            },
+          };
+        },
+      },
+    });
+
+    const result = await pipe.executeCommand("register", {
+      agent_id: "stuck-agent",
+      cli: "claude",
+      capabilities: ["cto"],
+      topics: [],
+      heartbeat_ttl_ms: 60000,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "REGISTER_PRESENCE_NOT_UPDATED");
+    assert.equal(result.data.effective.status, "offline");
+  });
+
   it("구독된 에이전트는 publish 후 메시지를 실시간 push로 받아야 한다", async () => {
     const subscriber = await createPipeClient(hub.pipePath);
     const publisher = await createPipeClient(hub.pipePath);

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -9,6 +9,8 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { createRouter } from "../../hub/router.mjs";
 import { createStore } from "../../hub/store.mjs";
+import { createRouter as createCoreRouter } from "../../packages/core/hub/router.mjs";
+import { createStore as createRemoteStore } from "../../packages/remote/hub/store.mjs";
 import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
 
 function tempDbPath() {
@@ -21,6 +23,23 @@ function createIsolatedRouter() {
   const dbPath = tempDbPath();
   const store = createStore(dbPath);
   const router = createRouter(store);
+  return {
+    store,
+    router,
+    cleanup() {
+      router.stopSweeper();
+      store.close();
+      try {
+        rmSync(join(dbPath, ".."), { recursive: true, force: true });
+      } catch {}
+    },
+  };
+}
+
+function createIsolatedRemoteRouter() {
+  const dbPath = tempDbPath();
+  const store = createRemoteStore(dbPath);
+  const router = createCoreRouter(store);
   return {
     store,
     router,
@@ -58,6 +77,43 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
   });
 
   // ── handlePublish ──
+
+  describe("remote SQLite store compatibility", () => {
+    it("core router registration succeeds and returns effective online presence", () => {
+      const isolated = createIsolatedRemoteRouter();
+      try {
+        const registered = isolated.router.registerAgent({
+          agent_id: "remote-sqlite-agent",
+          cli: "codex",
+          capabilities: ["code"],
+          topics: ["remote.test"],
+          heartbeat_ttl_ms: 60000,
+        });
+
+        assert.equal(registered.ok, true);
+        assert.equal(registered.data.effective.updated, true);
+        assert.equal(registered.data.effective.online, true);
+        assert.equal(registered.data.effective.status, "online");
+        assert.equal(
+          registered.data.effective.lease_expires_ms,
+          registered.data.lease_expires_ms,
+        );
+        assert.ok(
+          registered.data.effective.last_seen_ms <=
+            registered.data.server_time_ms,
+        );
+
+        const persisted = isolated.store.getAgent("remote-sqlite-agent");
+        assert.equal(persisted.status, "online");
+        assert.equal(
+          persisted.lease_expires_ms,
+          registered.data.lease_expires_ms,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+  });
 
   describe("handlePublish()", () => {
     it("직접 에이전트 대상 발행 시 ok: true와 message_id를 반환해야 한다", () => {

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -92,6 +92,8 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
 
         assert.equal(registered.ok, true);
         assert.equal(registered.data.effective.updated, true);
+        assert.equal(registered.data.hub_pid, process.pid);
+        assert.equal(registered.data.effective.store_type, "sqlite");
         assert.equal(registered.data.effective.online, true);
         assert.equal(registered.data.effective.status, "online");
         assert.equal(
@@ -244,6 +246,7 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
 
         assert.equal(registered.ok, false);
         assert.equal(registered.error.code, "REGISTER_PRESENCE_NOT_UPDATED");
+        assert.equal(registered.data.hub_pid, process.pid);
         assert.equal(
           isolated.router.getStatus("hub").data.roles.cto.leader_agent_id,
           null,

--- a/tests/integration/router.test.mjs
+++ b/tests/integration/router.test.mjs
@@ -160,6 +160,103 @@ describe("createRouter()", { skip: SQLITE_SKIP }, () => {
   });
 
   describe("CTO 역할 승계", () => {
+    it("ineffective register는 ok:false로 반환하고 role election을 진행하지 않아야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        isolated.store.registerAgent = () => ({
+          agent_id: "stuck-cto",
+          lease_id: "lease-stuck",
+          lease_expires_ms: Date.now() + 60000,
+          server_time_ms: Date.now(),
+          effective: {
+            updated: false,
+            online: false,
+            status: "offline",
+            last_seen_ms: Date.now() - 60000,
+            lease_expires_ms: Date.now() - 1,
+          },
+        });
+
+        const registered = isolated.router.registerAgent({
+          agent_id: "stuck-cto",
+          cli: "claude",
+          capabilities: ["cto"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 100 },
+          heartbeat_ttl_ms: 60000,
+        });
+
+        assert.equal(registered.ok, false);
+        assert.equal(registered.error.code, "REGISTER_PRESENCE_NOT_UPDATED");
+        assert.equal(
+          isolated.router.getStatus("hub").data.roles.cto.leader_agent_id,
+          null,
+        );
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
+    it("offline explicit CTO 재등록은 DB presence를 복구하고 takeover 가능해야 한다", () => {
+      const isolated = createIsolatedRouter();
+      try {
+        let registered = isolated.router.registerAgent({
+          agent_id: "claude-callbot-main",
+          cli: "claude",
+          capabilities: ["code"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 100, cwd: process.cwd() },
+          heartbeat_ttl_ms: 60000,
+        });
+        assert.equal(registered.ok, true);
+
+        isolated.router.updateAgentStatus("claude-callbot-main", "offline");
+        registered = isolated.router.registerAgent({
+          agent_id: "fallback-cto",
+          cli: "claude",
+          capabilities: ["code"],
+          topics: ["cto"],
+          metadata: { cwd: process.cwd() },
+          heartbeat_ttl_ms: 60000,
+        });
+        assert.equal(registered.ok, true);
+        assert.equal(
+          isolated.router.getStatus("hub").data.roles.cto.leader_agent_id,
+          "fallback-cto",
+        );
+
+        const before = isolated.store.getAgent("claude-callbot-main");
+        assert.equal(before.status, "offline");
+
+        registered = isolated.router.registerAgent({
+          agent_id: "claude-callbot-main",
+          cli: "claude",
+          capabilities: ["code"],
+          topics: [],
+          metadata: { role: "cto", cto_priority: 100, cwd: process.cwd() },
+          heartbeat_ttl_ms: 7200000,
+        });
+        assert.equal(registered.ok, true);
+        assert.equal(registered.data.effective.status, "online");
+
+        const row = isolated.store.getAgent("claude-callbot-main");
+        assert.equal(row.status, "online");
+        assert.equal(row.lease_expires_ms, registered.data.lease_expires_ms);
+        assert.ok(row.last_seen_ms >= registered.data.server_time_ms - 50);
+
+        const takeover = isolated.router.takeoverRole({
+          role: "cto",
+          agent_id: "claude-callbot-main",
+          reason: "regression-454",
+          requested_by: "test",
+        });
+        assert.equal(takeover.ok, true);
+        assert.equal(takeover.data.leader_agent_id, "claude-callbot-main");
+      } finally {
+        isolated.cleanup();
+      }
+    });
+
     it("topic:cto는 전체 팬아웃이 아니라 현재 CTO leader 한 명에게만 라우팅해야 한다", () => {
       const isolated = createIsolatedRouter();
       try {

--- a/tests/integration/store.test.mjs
+++ b/tests/integration/store.test.mjs
@@ -75,6 +75,8 @@ describe("createStore()", { skip: SQLITE_SKIP }, () => {
       assert.equal(result.effective?.online, true);
       assert.equal(result.effective?.status, "online");
       assert.equal(result.effective?.lease_expires_ms, result.lease_expires_ms);
+      assert.equal(result.effective?.store_type, "sqlite");
+      assert.equal(result.effective?.db_path, dbPath);
     });
 
     it("getAgent()는 등록된 에이전트를 반환해야 한다", () => {

--- a/tests/integration/store.test.mjs
+++ b/tests/integration/store.test.mjs
@@ -72,6 +72,9 @@ describe("createStore()", { skip: SQLITE_SKIP }, () => {
       assert.ok(result.agent_id);
       assert.ok(result.lease_expires_ms > Date.now());
       assert.ok(result.lease_id);
+      assert.equal(result.effective?.online, true);
+      assert.equal(result.effective?.status, "online");
+      assert.equal(result.effective?.lease_expires_ms, result.lease_expires_ms);
     });
 
     it("getAgent()는 등록된 에이전트를 반환해야 한다", () => {
@@ -131,6 +134,36 @@ describe("createStore()", { skip: SQLITE_SKIP }, () => {
       });
       const agent = store.getAgent("upsert-agent");
       assert.equal(agent.cli, "gemini");
+    });
+
+    it("offline agent 재등록 시 persisted presence를 online으로 복구해야 한다", () => {
+      store.registerAgent({
+        agent_id: "revived-agent",
+        cli: "claude",
+        capabilities: ["cto"],
+        topics: [],
+        metadata: { role: "cto" },
+        heartbeat_ttl_ms: 30000,
+      });
+      assert.equal(store.updateAgentStatus("revived-agent", "offline"), true);
+      assert.equal(store.getAgent("revived-agent").status, "offline");
+
+      const result = store.registerAgent({
+        agent_id: "revived-agent",
+        cli: "claude",
+        capabilities: ["cto"],
+        topics: ["cto"],
+        metadata: { role: "cto", cto_priority: 100 },
+        heartbeat_ttl_ms: 7200000,
+      });
+      const agent = store.getAgent("revived-agent");
+
+      assert.equal(result.effective?.online, true);
+      assert.equal(result.effective?.status, "online");
+      assert.equal(agent.status, "online");
+      assert.equal(agent.lease_expires_ms, result.lease_expires_ms);
+      assert.equal(result.effective?.lease_expires_ms, result.lease_expires_ms);
+      assert.ok(agent.last_seen_ms >= result.server_time_ms - 50);
     });
   });
 

--- a/tests/unit/store-adapter.test.mjs
+++ b/tests/unit/store-adapter.test.mjs
@@ -85,6 +85,7 @@ describe("hub/store-adapter.mjs", () => {
         heartbeat_ttl_ms: 30000,
       });
       assert.equal(agent.agent_id, "sqlite-agent");
+      assert.equal(agent.effective?.store_type, "sqlite");
 
       const message = store.enqueueMessage({
         type: "event",
@@ -126,6 +127,8 @@ describe("hub/store-adapter.mjs", () => {
       heartbeat_ttl_ms: 60000,
     });
     assert.equal(registered.agent_id, "memory-agent");
+    assert.equal(registered.effective?.store_type, "memory");
+    assert.equal(registered.effective?.db_path, null);
     assert.equal(store.getAgent("memory-agent")?.status, "online");
 
     const message = store.enqueueMessage({


### PR DESCRIPTION
Refs #454 (부분 수정 — 이슈는 열어둠)

## 왜 Fixes가 아니라 Refs인가

이 PR의 verify-after-write 가드는 **같은 store 인스턴스** 안에서의 write→readback 불일치만 잡는다. 그런데 in-process SQLite upsert는 `ON CONFLICT DO UPDATE`(status='online' 고정)라 같은 인스턴스 내 no-op 경로가 사실상 존재하지 않는다. #454 실측 재현(register ok:true + 데몬 DB row 미갱신)의 유력 원인은 **register를 받은 프로세스가 관찰 대상 hub와 다른 경우**(다른 hub 인스턴스/게이트웨이, 또는 better-sqlite3 로드 실패 시 `console.warn`만 남기는 memory 폴백)이며, 이 시나리오는 same-store readback으로 원리적으로 감지 불가.

그래서 3번째 커밋이 발신자가 대조할 수 있는 신원을 응답에 싣는다:

- `data.hub_pid` — register를 처리한 hub 프로세스 pid (성공/실패 응답 모두)
- `data.effective.store_type` — `"sqlite"` | `"memory"` (memory 폴백 = 비영속 등록임을 발신자가 감지)
- `data.effective.db_path` — 실제로 write된 DB 경로 (기대 경로와 대조 가능)

근본 원인(어느 프로세스가 register를 받았는가) 규명은 #454에서 계속한다.

## Verification
- `node --test tests/integration/store.test.mjs tests/integration/router.test.mjs tests/integration/pipe.test.mjs tests/integration/hub-server.test.mjs tests/unit/store-adapter.test.mjs`: 112 pass, 0 fail
- `npm run release:check-mirror`: Mirror OK
- `npm run release:check-sync`: Version sync OK (10.41.1)
- `npx biome check` (변경 파일): OK
- `git diff --check`: OK

## Scope
register/presence recovery 파일과 통합 테스트만 포함. Tray UX, CTO steward PR2, 기타 무관 로컬 작업은 별도 브랜치로 분리됨(의도적 제외).

https://claude.ai/code/session_016AbhD7od7ZWYYRzshM1Mwn
