### PR TITLE
docs(adr): ADR-0010 CTO lake ↔ Hub role 경계 + 실행 규칙 SSOT

### DIFF
--- a/.claude/rules/tfx-cto-hub-boundary.md
+++ b/.claude/rules/tfx-cto-hub-boundary.md
@@ -1,0 +1,89 @@
+# CTO lake ↔ Hub role 경계 규칙
+
+> 근거(why): [ADR-0010 — CTO lake ↔ Hub role 경계](../../docs/adr/0010-cto-lake-hub-role-boundary.md). 이 문서가 SSOT(어떻게), ADR은 결정 이력(왜).
+
+## 두 평면 정의
+
+| 평면 | 소유 | 데이터 | 수명 |
+|------|------|--------|------|
+| **Hub** (liveness/coordination) | 지금 누가 살아있고 누가 리더인가 | store `agents` 테이블(=presence SSOT), in-memory `roleStates`(파생 캐시), 메시지 배달 | 에페메랄 — 데몬 재시작 시 store에서 재구성 |
+| **CTO lake** (history/authority) | 이 repo에 무슨 일이 있었나, 권위 스냅샷 | `.triflux/lake/*` (append-only ledger + current.json/md) | durable — hub 없이 파일만으로 동작 |
+
+lake는 live 상태의 **스냅샷 기록자**이지 실시간 뷰가 아니다.
+
+## 의존 방향 (단방향)
+
+```
+hub/*  →  cto/*          (허용 — auto-collect, tray, 이벤트 기록)
+cto/*  →  hub/*          (금지)
+cto/*  →  공용 하위 계층   (허용 — 아래 allowlist만)
+```
+
+**공용 하위 계층 allowlist** (의존성 없는 프리미티브만, 추가 시 이 표를 갱신):
+
+| 모듈 | 사유 |
+|------|------|
+| `hub/lib/cto-env.mjs` | TFX_CTO_* kill-switch 판독. env만 읽는 dep-free 프리미티브 |
+
+**금지 패턴**: `cto/*`가 `hub/team/*`를 import(현재 잔존 위반: `cto/status.mjs`·
+`cto/hygiene.mjs`의 synapse-registry — reader 주입 seam 또는 공용 계층 강등으로 해소
+예정). synapse TTL/phase **판정 로직을 cto에 복제하는 것도 금지**(판정 기계 4중화).
+
+## Presence 계약 (false-positive 성공 금지)
+
+- presence 갱신을 주장하는 모든 응답(register/heartbeat)은 store 반영을 검증하거나
+  (`effective` readback), 반영 실패를 `ok:false`로 명시 반환한다.
+- 응답에는 발신자가 대조할 수 있는 신원을 싣는다: `hub_pid`,
+  `effective.store_type`(sqlite|memory), `effective.db_path`.
+- 큐잉만 하고 배달을 보장하지 않는 응답(ask/publish)은 "성공"이 배달을 뜻하지 않음을
+  응답 필드로 구분해야 한다(#450 수리 방향).
+- 아무 것도 하지 않은 작업을 ack/성공으로 기록하지 않는다(hygiene skip은 skip으로).
+
+## 용어표
+
+| 단어 | 평면 | 정확한 의미 | 코드 |
+|------|------|------------|------|
+| stale (lease) | hub | agents lease 만료 | `store.sweepStaleAgents` |
+| stale (session) | synapse | registry TTL 초과 | `hub/team/synapse-registry.mjs` |
+| stale (hygiene) | lake | ledger/overlay 판정 | `cto/hygiene.mjs` |
+| steward lock | lake | hygiene **apply 직렬화** 락 (`*.apply.lock`) | `cto/hygiene.mjs` |
+| steward loop | lake | `tfx cto steward` 주기 루프 (lake당 단일 인스턴스, `steward-loop.lock`) | `cto/steward.mjs` |
+
+UI/문서에서 "stale"을 표기할 때는 어느 평면인지 라벨을 붙인다.
+
+## 소비 표면 계약
+
+- tray payload: `cto`(lake, 현재 tray read는 단일 repo) ↔ `roles`(hub 전역)를 형제
+  키로 분리. 섹션 라벨에 스코프 명시("CTO Hygiene (this repo)" / "CTO Succession
+  (hub-wide)"). lake 합성물에 hub 데이터를 주입한 채 `cto-lake.v1` 스키마를 붙이지
+  않는다.
+- hub의 lake **write**(auto-collect)는 세션 cwd별 멀티레포, tray의 lake **read**는
+  현재 단일 repo — 이 비대칭을 없애거나 라벨로 명시하기 전까지 "hub가 모든 프로젝트
+  lake를 보여준다"고 서술하지 않는다.
+
+## 커밋 스코프 규약
+
+| 작업 | 스코프 |
+|------|--------|
+| roleStates/선출/sweeper/presence/메시징 | `feat(hub)` / `fix(hub)` |
+| lake/collect/status/hygiene/steward/events | `feat(cto)` / `fix(cto)` |
+
+(PR #442가 `feat(cto)`로 hub/router 작업을 표기한 오표기 재발 방지.)
+
+## steward 시퀀싱 조건
+
+`tfx cto steward`(주기 루프)는 resident-cto-manager PRD T2의 선행 슬라이스다.
+가드레일 2종은 필수 불변식: **TFX_CTO kill-switch 매 cycle 확인** + **lake당
+single-instance 락**. hygiene 실제 archive 실행부(T4)와 결합할 때도 이 게이트를
+우회하는 경로를 만들지 않는다. collect 트리거 정책 소유자는 hub auto-collect
+(debounce + fresh-lake 게이트)와 steward 루프 둘이며, 셋째 드라이버(PRD Tier-1 데몬)
+추가 시 이 문서에 조정 규칙을 먼저 기록한다.
+
+## 관련
+
+| 대상 | 포인터 |
+|------|--------|
+| 결정 근거 | `docs/adr/0010-cto-lake-hub-role-boundary.md` |
+| role 스코프(전역 vs per-project) | 이슈 #447 (의도적 DEFER — ADR 하위 결정으로 별도 확정) |
+| 미러 범위(cto/ 포함) | `.claude/rules/tfx-mirror-policy.md` |
+| resident CTO PRD | `.triflux/plans/resident-cto-manager.md` (precursor 브랜치) |

--- a/.claude/rules/tfx-mirror-policy.md
+++ b/.claude/rules/tfx-mirror-policy.md
@@ -62,6 +62,7 @@ mirror 변경은 **`Edit` 도구로 개별 수정**한다. `cp` 사용 금지 (�
 ## mirror 범위 (in / out)
 
 **mirror 대상** (root → packages 동기 필수):
+- `cto/*` → `packages/triflux/cto/` (byte-identical), `packages/remote/cto/` (root 상대 import 는 그대로, `../hub/lib/*` 등 hub 의존은 `@triflux/core/hub/...` 로 import 변환 — Edit 만, cp 는 변환 없는 파일 한정). remote 는 CLI 디스패처 `cto/index.mjs` 를 mirror 하지 않는다(모듈만). packages/core 는 cto/ 를 mirror 하지 않는다.
 - `hub/lib/*` → `packages/core/hub/lib/`, `packages/triflux/hub/lib/`
 - `hub/team/*`, `hub/*.mjs` (entry/runtime) → `packages/triflux/hub/`, `packages/remote/hub/` (해당 모듈만; `packages/core/hub/team/` 는 self-import 대상만 minimal mirror, 예: `retry-state-machine.mjs`)
 - `mesh/*` → `packages/core/mesh/`, `packages/triflux/mesh/` (PR #320 — root subset)

--- a/docs/adr/0010-cto-lake-hub-role-boundary.md
+++ b/docs/adr/0010-cto-lake-hub-role-boundary.md
@@ -1,0 +1,89 @@
+---
+id: 0010
+title: CTO lake ↔ Hub role 경계 — liveness/history 평면 분리
+status: proposed
+date: 2026-07-07
+deciders: [tellang]
+supersedes: []
+superseded_by: null
+relates: [0005, 0007]
+pr: null
+---
+
+# ADR-0010: CTO lake ↔ Hub role 경계 — liveness/history 평면 분리
+
+## 컨텍스트와 문제 (Context)
+
+"CTO"가 코드베이스에서 세 실체를 동시에 지칭한다: (a) `cto/` 레포-로컬 authority lake
+콘솔, (b) `hub/router.mjs`의 라이브 리더 role(`roleStates`, 선출/승계/failover —
+PR #442/#444/#445), (c) 그 role을 맡은 실제 세션. 경계가 문서화된 적이 없어 다음이
+누적됐다 (2026-07-07 감사, 23-agent 워크플로우 + 적대적 검증):
+
+- **양방향 의존**: hub→cto(server.mjs가 collect/status import, tray, auto-collect)와
+  cto→hub(`cto/status.mjs`·`cto/hygiene.mjs`가 `hub/team/synapse-registry.mjs` 직접
+  import)가 공존 — 레이어 순환.
+- **tray 스키마 거짓말**: `mergedCtoStatus`가 lake JSON에 hub roles를 주입하고도
+  `schema_version: "cto-lake.v1"`을 유지. lake(단일 repo) + synapse live(전 repo) +
+  hub roles(전역)가 한 키에 병합.
+- **presence SSOT 미정의**: register 응답(lease 발급)과 store agents row가 따로 노는
+  false-positive 성공 계열(#450/#451/#454)이 반복 — "지금 누가 살아있는가"의 소유자가
+  결정된 적 없음.
+- **read/write 비대칭**: hub의 lake write(auto-collect)는 세션 cwd별 멀티레포인데
+  tray의 lake read는 `CANONICAL_PROJECT_ROOT` 단일 고정.
+- **용어 충돌**: "stale"이 세 판정 기계(hub lease 만료 / synapse TTL / hygiene ledger
+  판정)를, "steward"가 두 실체(hygiene apply lock / 주기 루프 명령)를 가리킴.
+
+## 결정 (Decision)
+
+두 평면의 단일 목적과 의존 방향을 다음과 같이 확정한다.
+
+1. **Hub = liveness/coordination 평면.** "지금 누가 살아있고 누가 리더인가"를 소유한다.
+   **presence의 SSOT는 store(agents 테이블)다** — in-memory `roleStates`는 파생 캐시로,
+   데몬 재시작 시 소실되어도 store에서 재구성 가능해야 한다. 상태 갱신을 주장하는 응답
+   (register/heartbeat)은 store 반영을 검증하거나 반영 실패를 명시적으로 반환한다
+   (false-positive 성공 금지 — PR #455의 effective 계약이 이 방향).
+2. **CTO lake = history/authority 평면.** "이 repo에 무슨 일이 있었고 권위 스냅샷이
+   무엇인가"를 소유한다. `.triflux/lake/*`(append-only ledger + 파생 current.json/md)가
+   데이터이고, hub 없이 파일만으로 동작해야 한다. lake는 live 상태의 **스냅샷 기록자**이지
+   실시간 뷰가 아니다.
+3. **의존 방향은 hub→cto 단방향만 허용한다.** `cto/*`에서 `hub/*` import는 금지한다.
+   예외는 **공용 하위 계층** 하나뿐: 의존성 없는 프리미티브(`hub/lib/cto-env.mjs` 등
+   `hub/lib/` 일부)는 양쪽이 쓸 수 있는 공용 계층으로 지정하되, 목록은
+   `.claude/rules/tfx-cto-hub-boundary.md`(실행 SSOT)가 관리한다. 현재 위반 2건
+   (`cto/status.mjs`·`cto/hygiene.mjs`의 synapse-registry import)은 reader 주입 seam
+   또는 공용 계층 강등으로 해소한다 — TTL/phase 판정 로직을 cto에 복제하는 방식은
+   금지한다(판정 기계 4중화 방지, DRY).
+4. **소비 표면은 lake와 live를 형제 키로 분리한다.** tray payload는 `cto`(lake)와
+   `roles`(live)를 분리하고 각 섹션 라벨에 스코프("this repo" / "hub-wide")를 명시한다.
+   MCP `status`·CLI 표면도 같은 계약을 따른다.
+5. **role 스코프(#447 전역 vs per-project)는 이 ADR의 하위 결정으로 별도 확정한다.**
+   확정 전까지 전역 단일 "cto" 스코프(의도된 DEFER)를 유지한다.
+
+## 검토한 대안 (Considered Options)
+
+- **A안 — 두 레이어 통합(단일 CTO 모듈)**: 이름 충돌은 사라지지만 수명주기가 다른 두
+  관심사(에페메랄 조율 vs durable 히스토리)가 한 모듈에 묶여 hub 재시작·오프라인 동작이
+  꼬인다. 기각.
+- **B안 — cto가 hub HTTP를 직접 조회해 라이브 뷰 제공**: lake가 실시간 뷰가 되면
+  "hub 없이 동작"이라는 lake의 핵심 성질이 깨지고 의존 방향도 역전된다. 기각 —
+  라이브 시야가 필요하면 hub가 lake에 스냅샷/이벤트를 기록하는 방향(hub→cto)으로.
+- **C안 — synapse-registry 판정 로직을 cto에 복제해 import 절단**: 순환은 풀리지만
+  v10.33.1 TTL 사고 이력이 있는 판정 로직 사본이 생겨 "stale 3중 판정"을 4중으로
+  악화. 기각.
+- **D안(채택) — 단방향 + 공용 하위 계층 + 표면 분리**: 위 결정.
+
+## 결과 (Consequences)
+
+- 긍정: false-positive 성공 계열 결함의 구조적 뿌리(소유자 미정)가 제거된다. tray/MCP
+  표면에서 스코프 오독이 사라진다. 커밋 스코프(`feat(hub)` vs `feat(cto)`)가 결정
+  가능해진다.
+- 비용: tray 키 분리와 import 절단은 packages 미러 3-layer 전체에 파급된다 —
+  `packages/remote`는 `hub/server.mjs`·`tray-state.mjs`뿐 아니라 **`cto/` 8파일도
+  미러**하므로 blast radius 산정에 반드시 포함한다(체크리스트는
+  `.claude/rules/tfx-mirror-policy.md`).
+- 후속(순서): ① 실행 규칙 파일(`.claude/rules/tfx-cto-hub-boundary.md`) — 이 ADR과 동시.
+  ② tray 키 분리. ③ cto→hub import 절단. ④ collect의 죽은 hub 아티팩트 경로 정리.
+  ⑤ hub role 전이의 lake ledger 기록(`role_leader_changed`) — #447 스코프 확정 이후.
+  ⑥ #447 per-project keying 별도 결정.
+- 되돌릴 조건: 공용 하위 계층 목록이 비대해져 사실상 양방향 의존이 되면 이 결정은
+  실패한 것이다 — 그 시점에 새 ADR로 재설계한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ triflux의 아키텍처·정책·횡단 결정을 ADR(Architecture Decision Reco
 | [0007](0007-hub-default-port-27888.md) | hub 기본 포트 27888 고정 | Accepted | 0002 |
 | [0008](0008-native-bridge-ui-default-on.md) | headless 워커 native-bridge 기본 노출 | Accepted | 0002 |
 | [0009](0009-stack-coexistence-three-layer.md) | gstack·sp·triflux 단방향 3-layer 공존 | Accepted | 0002 |
+| [0010](0010-cto-lake-hub-role-boundary.md) | CTO lake ↔ Hub role 경계 — liveness/history 평면 분리 | Proposed | 0005, 0007 |
 
 상태 범례: **Proposed**(제안) · **Accepted**(확정, 불변) · **Superseded**(대체됨 → `_archive/`) · **Deprecated**/**Rejected**/**Withdrawn**(무효화 → `_archive/`).
 


### PR DESCRIPTION
## 무엇
2026-07-07 CTO/Hub 심층 감사(23-agent 워크플로우, 유의 finding 17건 전건 적대적 검증 CONFIRMED)의 아키텍처 결론을 결정으로 고정:

- **ADR-0010** (proposed): hub=liveness/coordination 평면(presence SSOT=store agents 테이블), cto lake=history/authority 평면(durable, hub 없이 동작), 의존은 hub→cto 단방향(공용 하위 계층 allowlist 예외), 소비 표면은 lake/live 형제 키 분리, #447 스코프는 하위 결정으로 별도 확정.
- **`.claude/rules/tfx-cto-hub-boundary.md`** (실행 SSOT): 의존 방향 규칙 + allowlist, presence 계약(false-positive 성공 금지), stale 3중/steward 2중 용어표, 커밋 스코프 규약(feat(hub) vs feat(cto)), steward 시퀀싱 불변식.
- **tfx-mirror-policy 보강**: mirror 대상 표에 `cto/` 행 추가 (remote가 cto/ 8모듈을 미러함에도 표에 없어 blast radius 과소산정 발생했던 갭).

## 검증
- `node --test tests/unit/docs-adr-structure.test.mjs`: pass (필수 헤딩 계약)
- 상태보드(docs/adr/README.md) 0010 행 등록
- Codex 교차리뷰 (gpt55_high): PASS (allowlist가 단방향 규칙을 무력화하는지 포함 검토)

https://claude.ai/code/session_016AbhD7od7ZWYYRzshM1Mwn
