### PR TITLE
feat(hub): schema v6 + store role registry CAS/recovery (C6a-2)

### DIFF
--- a/hub/schema.sql
+++ b/hub/schema.sql
@@ -11,7 +11,11 @@ CREATE TABLE IF NOT EXISTS agents (
   last_seen_ms INTEGER NOT NULL,
   lease_expires_ms INTEGER NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('online','stale','offline')),
-  metadata_json TEXT NOT NULL DEFAULT '{}'
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  project_id TEXT,
+  session_id TEXT,
+  host_id TEXT,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]'
 );
 
 -- 메시지 테이블
@@ -28,7 +32,61 @@ CREATE TABLE IF NOT EXISTS messages (
   correlation_id TEXT NOT NULL,
   trace_id TEXT NOT NULL,
   payload_json TEXT NOT NULL DEFAULT '{}',
-  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter'))
+  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter')),
+  role_key_wire TEXT
+);
+
+-- 동적 역할 레지스트리 (schema v6)
+CREATE TABLE IF NOT EXISTS role_registry (
+  role_key_wire TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  role_kind TEXT NOT NULL CHECK (role_kind IN ('cto','lead')),
+  scope_id TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL CHECK (
+    state IN (
+      'electable',
+      'elected-probing',
+      'active',
+      'unreachable',
+      'quarantined'
+    )
+  ),
+  holder_agent_id TEXT,
+  previous_holder_agent_id TEXT,
+  epoch INTEGER NOT NULL DEFAULT 0 CHECK (epoch >= 0),
+  activation_seq INTEGER NOT NULL DEFAULT 0 CHECK (activation_seq >= 0),
+  activation_id TEXT,
+  activation_deadline_ms INTEGER,
+  holder_lease_expires_ms INTEGER,
+  charter_version TEXT,
+  charter_acked_epoch INTEGER,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  next_probe_ms INTEGER,
+  blocked_reason TEXT,
+  last_transition_ms INTEGER NOT NULL,
+  last_reason TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  CHECK (
+    (role_kind = 'cto' AND scope_id = '') OR
+    (role_kind = 'lead' AND scope_id <> '')
+  ),
+  UNIQUE(project_id, role_kind, scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_candidates (
+  role_key_wire TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('grant','standup','operator')),
+  priority INTEGER NOT NULL DEFAULT 0,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]',
+  consecutive_probe_failures INTEGER NOT NULL DEFAULT 0,
+  excluded_until_ms INTEGER,
+  last_probe_ms INTEGER,
+  last_probe_code TEXT,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY(role_key_wire, agent_id),
+  FOREIGN KEY(role_key_wire)
+    REFERENCES role_registry(role_key_wire) ON DELETE CASCADE
 );
 
 -- 메시지 수신함 (배달 추적)
@@ -73,6 +131,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_correlation ON messages(correlation_id);
 CREATE INDEX IF NOT EXISTS idx_messages_trace ON messages(trace_id);
 CREATE INDEX IF NOT EXISTS idx_messages_expires ON messages(expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority DESC, created_at_ms ASC);
+CREATE INDEX IF NOT EXISTS idx_messages_role_key ON messages(role_key_wire, status, expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_agent ON message_inbox(agent_id, delivered_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_message ON message_inbox(message_id);
 CREATE INDEX IF NOT EXISTS idx_human_requests_state ON human_requests(state);

--- a/hub/store.mjs
+++ b/hub/store.mjs
@@ -1,5 +1,5 @@
-// hub/store.mjs — SQLite 감사 로그/메타데이터 저장소
-// 실시간 배달 큐는 router/pipe가 담당하고, SQLite는 재생/감사 용도로만 유지한다.
+// hub/store.mjs — SQLite 감사 로그/메타데이터/역할 레지스트리 저장소
+// 실시간 배달은 router/pipe가 담당하고, 역할 권한과 복구 상태는 SQLite가 보존한다.
 
 import { mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -12,6 +12,7 @@ import {
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
 import { recalcConfidence } from "./reflexion.mjs";
+import { decodeRoleKey, ROLE_REACHABILITY_STATES } from "./role-contract.mjs";
 
 export { uuidv7 };
 
@@ -76,6 +77,21 @@ function parseReflexionRow(row) {
   };
 }
 
+function parseRoleCandidateRow(row) {
+  if (!row) return null;
+  const { transport_locators_json, ...rest } = row;
+  return {
+    ...rest,
+    transport_locators: parseJson(transport_locators_json, []),
+  };
+}
+
+function hasTable(db, tableName) {
+  return !!db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")
+    .get(tableName);
+}
+
 function hasColumn(db, tableName, columnName) {
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all();
   return rows.some((row) => row.name === columnName);
@@ -84,6 +100,23 @@ function hasColumn(db, tableName, columnName) {
 function ensureColumn(db, tableName, columnName, definition) {
   if (hasColumn(db, tableName, columnName)) return;
   db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+}
+
+function ensureV6Columns(db) {
+  if (hasTable(db, "agents")) {
+    ensureColumn(db, "agents", "project_id", "TEXT");
+    ensureColumn(db, "agents", "session_id", "TEXT");
+    ensureColumn(db, "agents", "host_id", "TEXT");
+    ensureColumn(
+      db,
+      "agents",
+      "transport_locators_json",
+      "TEXT NOT NULL DEFAULT '[]'",
+    );
+  }
+  if (hasTable(db, "messages")) {
+    ensureColumn(db, "messages", "role_key_wire", "TEXT");
+  }
 }
 
 /**
@@ -116,7 +149,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "5";
+  const SCHEMA_VERSION = "6";
   const curVer = (() => {
     try {
       return db
@@ -130,6 +163,9 @@ export function createStore(dbPath, options = {}) {
   // 마이그레이션 전략: 스키마 버전이 다르면 schema.sql을 재실행한다.
   // schema.sql은 CREATE TABLE IF NOT EXISTS 패턴을 사용하므로 멱등하게 적용된다.
   // 비파괴적 컬럼 추가는 자동으로 처리되지만, 컬럼 제거/이름 변경은 수동 마이그레이션이 필요하다.
+  // v5 테이블에는 schema.sql의 v6 인덱스가 참조하는 컬럼이 없으므로
+  // CREATE IF NOT EXISTS 재실행 전에 멱등 컬럼 seam을 먼저 적용한다.
+  ensureV6Columns(db);
   if (curVer !== SCHEMA_VERSION) {
     if (curVer != null) {
       // 이미 버전이 기록된 DB에서 버전 불일치가 발생한 경우 경고한다.
@@ -142,6 +178,8 @@ export function createStore(dbPath, options = {}) {
       "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', ?)",
     ).run(SCHEMA_VERSION);
   }
+  // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
+  ensureV6Columns(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -189,9 +227,160 @@ export function createStore(dbPath, options = {}) {
       "UPDATE agents SET status='offline' WHERE status='stale' AND lease_expires_ms < ? - 300000",
     ),
 
+    getRole: db.prepare("SELECT * FROM role_registry WHERE role_key_wire = ?"),
+    insertRoleReservation: db.prepare(`
+      INSERT INTO role_registry (
+        role_key_wire, project_id, role_kind, scope_id, state,
+        holder_agent_id, previous_holder_agent_id, epoch, activation_seq,
+        activation_id, activation_deadline_ms, holder_lease_expires_ms,
+        charter_version, charter_acked_epoch, retry_count, next_probe_ms,
+        blocked_reason, last_transition_ms, last_reason, version
+      ) VALUES (
+        @role_key_wire, @project_id, @role_kind, @scope_id, @state,
+        @holder_agent_id, @previous_holder_agent_id, @epoch, @activation_seq,
+        @activation_id, @activation_deadline_ms, @holder_lease_expires_ms,
+        @charter_version, @charter_acked_epoch, @retry_count, @next_probe_ms,
+        @blocked_reason, @last_transition_ms, @last_reason, @version
+      )`),
+    updateRoleReservation: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        epoch=@epoch,
+        activation_seq=@activation_seq,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    compareAndSetRole: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND epoch=@expected_epoch
+        AND activation_seq=@expected_activation_seq
+        AND activation_id IS @expected_activation_id
+        AND version=@expected_version`),
+    listRoles: db.prepare("SELECT * FROM role_registry ORDER BY role_key_wire"),
+    expiredHolderRoles: db.prepare(`
+      SELECT * FROM role_registry
+      WHERE holder_agent_id IS NOT NULL
+        AND (holder_lease_expires_ms IS NULL OR holder_lease_expires_ms <= ?)
+      ORDER BY role_key_wire`),
+    listRoleCandidates: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ?
+      ORDER BY priority DESC, updated_at_ms DESC, agent_id`),
+    getRoleCandidate: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ? AND agent_id = ?`),
+    upsertRoleCandidate: db.prepare(`
+      INSERT INTO role_candidates (
+        role_key_wire, agent_id, source, priority, transport_locators_json,
+        consecutive_probe_failures, excluded_until_ms, last_probe_ms,
+        last_probe_code, updated_at_ms
+      ) VALUES (
+        @role_key_wire, @agent_id, @source, @priority,
+        @transport_locators_json, @consecutive_probe_failures,
+        @excluded_until_ms, @last_probe_ms, @last_probe_code, @updated_at_ms
+      )
+      ON CONFLICT(role_key_wire, agent_id) DO UPDATE SET
+        source=excluded.source,
+        priority=excluded.priority,
+        transport_locators_json=excluded.transport_locators_json,
+        consecutive_probe_failures=excluded.consecutive_probe_failures,
+        excluded_until_ms=excluded.excluded_until_ms,
+        last_probe_ms=excluded.last_probe_ms,
+        last_probe_code=excluded.last_probe_code,
+        updated_at_ms=excluded.updated_at_ms`),
+    updateCandidateReachability: db.prepare(`
+      UPDATE role_candidates SET
+        consecutive_probe_failures=@consecutive_probe_failures,
+        excluded_until_ms=@excluded_until_ms,
+        last_probe_ms=@last_probe_ms,
+        last_probe_code=@last_probe_code,
+        updated_at_ms=@updated_at_ms
+      WHERE role_key_wire=@role_key_wire AND agent_id=@agent_id`),
+    pendingRoleMessages: db.prepare(`
+      SELECT * FROM messages
+      WHERE role_key_wire=?
+        AND status IN ('queued','delivered')
+        AND expires_at_ms > ?
+      ORDER BY priority DESC, created_at_ms ASC, id`),
+    recoverExpiredRole: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        previous_holder_agent_id=holder_agent_id,
+        holder_agent_id=NULL,
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        holder_lease_expires_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_holder_lease_expired',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverLiveRole: db.prepare(`
+      UPDATE role_registry SET
+        state='elected-probing',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=@activation_id,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_reprobe_required',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverOrphanedActivation: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_activation_fenced',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+
     insertAuditMessage: db.prepare(`
-      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status)
-      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status)`),
+      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status, role_key_wire)
+      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status, @role_key_wire)`),
     getMsg: db.prepare("SELECT * FROM messages WHERE id=?"),
     getResponse: db.prepare(
       "SELECT * FROM messages WHERE correlation_id=? AND type='response' ORDER BY created_at_ms DESC LIMIT 1",
@@ -363,6 +552,157 @@ export function createStore(dbPath, options = {}) {
     return Math.max(1, Math.min(Math.trunc(num), 9));
   }
 
+  function roleIdentity(input) {
+    const roleKeyWire = input?.role_key_wire ?? input?.roleKeyWire;
+    const decoded = decodeRoleKey(roleKeyWire);
+    const identity = {
+      role_key_wire: roleKeyWire,
+      project_id: decoded.project_id,
+      role_kind: decoded.role_kind,
+      scope_id: decoded.scope_id ?? "",
+    };
+    for (const field of ["project_id", "role_kind", "scope_id"]) {
+      if (Object.hasOwn(input, field) && input[field] !== identity[field]) {
+        throw new Error(`role key identity mismatch: ${field}`);
+      }
+    }
+    return identity;
+  }
+
+  function roleFailureReason(current, expected) {
+    if (!current) return "not_found";
+    if (current.version !== expected.version) return "stale_version";
+    if (current.epoch !== expected.epoch) return "stale_epoch";
+    if (current.activation_seq !== expected.activation_seq) {
+      return "stale_activation_seq";
+    }
+    if (current.activation_id !== expected.activation_id) {
+      return "stale_activation_id";
+    }
+    return "cas_conflict";
+  }
+
+  const reserveRole = db.transaction((input) => {
+    const identity = roleIdentity(input);
+    const current = S.getRole.get(identity.role_key_wire) ?? null;
+    const expectedVersion =
+      input.expected_version ?? input.expectedVersion ?? current?.version;
+    const expectedEpoch =
+      input.expected_epoch ?? input.expectedEpoch ?? current?.epoch;
+
+    if (current && expectedVersion !== current.version) {
+      return { ok: false, reason: "stale_version", role: current };
+    }
+    if (current && expectedEpoch !== current.epoch) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+
+    const nextEpoch =
+      input.epoch ?? input.next_epoch ?? (current ? current.epoch + 1 : 0);
+    if (current && nextEpoch !== current.epoch + 1) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+    const nextActivationSeq =
+      input.activation_seq ??
+      input.next_activation_seq ??
+      (current ? current.activation_seq + 1 : 0);
+    if (current && nextActivationSeq !== current.activation_seq + 1) {
+      return { ok: false, reason: "stale_activation_seq", role: current };
+    }
+
+    const state =
+      input.state ?? (input.holder_agent_id ? "elected-probing" : "electable");
+    if (!ROLE_REACHABILITY_STATES.includes(state)) {
+      throw new Error(`invalid role reachability state: ${state}`);
+    }
+    const row = {
+      ...identity,
+      state,
+      holder_agent_id: input.holder_agent_id ?? null,
+      previous_holder_agent_id:
+        input.previous_holder_agent_id ??
+        (current?.holder_agent_id !== input.holder_agent_id
+          ? (current?.holder_agent_id ?? null)
+          : (current?.previous_holder_agent_id ?? null)),
+      epoch: nextEpoch,
+      activation_seq: nextActivationSeq,
+      activation_id:
+        input.activation_id ??
+        (input.holder_agent_id ? uuidv7() : (current?.activation_id ?? null)),
+      activation_deadline_ms:
+        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
+      holder_lease_expires_ms:
+        input.holder_lease_expires_ms ??
+        current?.holder_lease_expires_ms ??
+        null,
+      charter_version:
+        input.charter_version ?? current?.charter_version ?? null,
+      charter_acked_epoch:
+        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      retry_count: input.retry_count ?? current?.retry_count ?? 0,
+      next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
+      blocked_reason:
+        input.blocked_reason === undefined
+          ? (current?.blocked_reason ?? null)
+          : input.blocked_reason,
+      last_transition_ms: input.last_transition_ms ?? Date.now(),
+      last_reason: input.last_reason ?? "role_reserved",
+      version: 0,
+      expected_version: current?.version,
+      expected_epoch: current?.epoch,
+    };
+
+    if (!current) {
+      S.insertRoleReservation.run(row);
+    } else if (S.updateRoleReservation.run(row).changes !== 1) {
+      const latest = S.getRole.get(identity.role_key_wire) ?? null;
+      return {
+        ok: false,
+        reason: roleFailureReason(latest, {
+          version: current.version,
+          epoch: current.epoch,
+          activation_seq: current.activation_seq,
+          activation_id: current.activation_id,
+        }),
+        role: latest,
+      };
+    }
+    return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+  });
+
+  const recoverRegistry = db.transaction((now) => {
+    for (const role of S.listRoles.all()) {
+      const guard = {
+        role_key_wire: role.role_key_wire,
+        expected_version: role.version,
+        expected_epoch: role.epoch,
+        now,
+      };
+      if (
+        role.holder_agent_id &&
+        (role.holder_lease_expires_ms == null ||
+          role.holder_lease_expires_ms <= now)
+      ) {
+        S.recoverExpiredRole.run(guard);
+      } else if (role.holder_agent_id) {
+        S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
+      } else if (role.activation_id || role.state === "elected-probing") {
+        S.recoverOrphanedActivation.run(guard);
+      }
+    }
+
+    const roles = S.listRoles.all();
+    return {
+      roles,
+      candidates: roles.flatMap((role) =>
+        S.listRoleCandidates.all(role.role_key_wire).map(parseRoleCandidateRow),
+      ),
+      pending_messages: roles.flatMap((role) =>
+        S.pendingRoleMessages.all(role.role_key_wire, now).map(parseMessageRow),
+      ),
+    };
+  });
+
   const store = {
     db,
     uuidv7,
@@ -464,6 +804,236 @@ export function createStore(dbPath, options = {}) {
       return S.setAgentStatus.run(status, agentId).changes > 0;
     },
 
+    getRole(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.getRole.get(roleKeyWire) ?? null;
+    },
+
+    upsertRoleReservation(input) {
+      return reserveRole.immediate(input);
+    },
+
+    compareAndSetRole(input) {
+      const identity = roleIdentity(input);
+      const current = S.getRole.get(identity.role_key_wire) ?? null;
+      if (!current) return { ok: false, reason: "not_found", role: null };
+
+      const hasExpectedActivationSeq =
+        Object.hasOwn(input, "expected_activation_seq") ||
+        Object.hasOwn(input, "expectedActivationSeq") ||
+        Object.hasOwn(input, "activation_seq");
+      const hasExpectedActivationId =
+        Object.hasOwn(input, "expected_activation_id") ||
+        Object.hasOwn(input, "expectedActivationId") ||
+        Object.hasOwn(input, "activation_id");
+      const expected = {
+        version:
+          input.expected_version ?? input.expectedVersion ?? input.version,
+        epoch: input.expected_epoch ?? input.expectedEpoch ?? input.epoch,
+        activation_seq:
+          input.expected_activation_seq ??
+          input.expectedActivationSeq ??
+          input.activation_seq,
+        activation_id: Object.hasOwn(input, "expected_activation_id")
+          ? input.expected_activation_id
+          : Object.hasOwn(input, "expectedActivationId")
+            ? input.expectedActivationId
+            : input.activation_id,
+      };
+      if (
+        expected.version == null ||
+        expected.epoch == null ||
+        !hasExpectedActivationSeq ||
+        !hasExpectedActivationId
+      ) {
+        return { ok: false, reason: "invalid_cas", role: current };
+      }
+
+      const reason = roleFailureReason(current, expected);
+      if (reason !== "cas_conflict") {
+        return { ok: false, reason, role: current };
+      }
+
+      const patch = input.patch ?? input.changes ?? {};
+      const state = patch.state ?? current.state;
+      if (!ROLE_REACHABILITY_STATES.includes(state)) {
+        throw new Error(`invalid role reachability state: ${state}`);
+      }
+      const next = {
+        role_key_wire: identity.role_key_wire,
+        expected_version: expected.version,
+        expected_epoch: expected.epoch,
+        expected_activation_seq: expected.activation_seq,
+        expected_activation_id: expected.activation_id,
+        state,
+        holder_agent_id:
+          patch.holder_agent_id === undefined
+            ? current.holder_agent_id
+            : patch.holder_agent_id,
+        previous_holder_agent_id:
+          patch.previous_holder_agent_id === undefined
+            ? current.previous_holder_agent_id
+            : patch.previous_holder_agent_id,
+        activation_id:
+          patch.activation_id === undefined
+            ? current.activation_id
+            : patch.activation_id,
+        activation_deadline_ms:
+          patch.activation_deadline_ms === undefined
+            ? current.activation_deadline_ms
+            : patch.activation_deadline_ms,
+        holder_lease_expires_ms:
+          patch.holder_lease_expires_ms === undefined
+            ? current.holder_lease_expires_ms
+            : patch.holder_lease_expires_ms,
+        charter_version:
+          patch.charter_version === undefined
+            ? current.charter_version
+            : patch.charter_version,
+        charter_acked_epoch:
+          patch.charter_acked_epoch === undefined
+            ? current.charter_acked_epoch
+            : patch.charter_acked_epoch,
+        retry_count: patch.retry_count ?? current.retry_count,
+        next_probe_ms:
+          patch.next_probe_ms === undefined
+            ? current.next_probe_ms
+            : patch.next_probe_ms,
+        blocked_reason:
+          patch.blocked_reason === undefined
+            ? current.blocked_reason
+            : patch.blocked_reason,
+        last_transition_ms: patch.last_transition_ms ?? Date.now(),
+        last_reason: patch.last_reason ?? current.last_reason,
+      };
+      if (S.compareAndSetRole.run(next).changes !== 1) {
+        const latest = S.getRole.get(identity.role_key_wire) ?? null;
+        return {
+          ok: false,
+          reason: roleFailureReason(latest, expected),
+          role: latest,
+        };
+      }
+      return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+    },
+
+    listRoleKeys(filter = {}) {
+      const clauses = [];
+      const params = {};
+      for (const field of ["project_id", "role_kind", "scope_id", "state"]) {
+        if (filter[field] !== undefined) {
+          clauses.push(`${field}=@${field}`);
+          params[field] = filter[field];
+        }
+      }
+      if (Array.isArray(filter.states) && filter.states.length > 0) {
+        clauses.push(
+          `state IN (${filter.states.map((_, index) => `@state_${index}`).join(",")})`,
+        );
+        filter.states.forEach((state, index) => {
+          params[`state_${index}`] = state;
+        });
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(" AND ")}` : "";
+      return db
+        .prepare(
+          `SELECT role_key_wire FROM role_registry${where} ORDER BY role_key_wire`,
+        )
+        .pluck()
+        .all(params);
+    },
+
+    listRolesWithExpiredHolder(now) {
+      return S.expiredHolderRoles.all(now);
+    },
+
+    listRoleCandidates(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.listRoleCandidates.all(roleKeyWire).map(parseRoleCandidateRow);
+    },
+
+    upsertRoleCandidate(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      S.upsertRoleCandidate.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        source: input.source ?? current?.source ?? "operator",
+        priority: input.priority ?? current?.priority ?? 0,
+        transport_locators_json: JSON.stringify(
+          input.transport_locators ??
+            parseJson(current?.transport_locators_json, []),
+        ),
+        consecutive_probe_failures:
+          input.consecutive_probe_failures ??
+          current?.consecutive_probe_failures ??
+          0,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? (current?.excluded_until_ms ?? null)
+            : input.excluded_until_ms,
+        last_probe_ms:
+          input.last_probe_ms === undefined
+            ? (current?.last_probe_ms ?? null)
+            : input.last_probe_ms,
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? (current?.last_probe_code ?? null)
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return parseRoleCandidateRow(
+        S.getRoleCandidate.get(role_key_wire, input.agent_id),
+      );
+    },
+
+    updateCandidateReachability(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      if (!current) return { ok: false, reason: "not_found" };
+
+      let failures =
+        input.consecutive_probe_failures ?? current.consecutive_probe_failures;
+      if (
+        input.probe_failed === true ||
+        input.increment_probe_failures === true
+      ) {
+        failures = current.consecutive_probe_failures + 1;
+      } else if (input.probe_succeeded === true) {
+        failures = 0;
+      }
+      S.updateCandidateReachability.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        consecutive_probe_failures: failures,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? current.excluded_until_ms
+            : input.excluded_until_ms,
+        last_probe_ms: input.last_probe_ms ?? Date.now(),
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? current.last_probe_code
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return {
+        ok: true,
+        candidate: parseRoleCandidateRow(
+          S.getRoleCandidate.get(role_key_wire, input.agent_id),
+        ),
+      };
+    },
+
+    listPendingRoleMessages(roleKeyWire, now) {
+      decodeRoleKey(roleKeyWire);
+      return S.pendingRoleMessages.all(roleKeyWire, now).map(parseMessageRow);
+    },
+
+    recoverRoleRegistry(now) {
+      return recoverRegistry.immediate(now);
+    },
+
     auditLog({
       type,
       from,
@@ -475,6 +1045,7 @@ export function createStore(dbPath, options = {}) {
       trace_id,
       correlation_id,
       status = "queued",
+      role_key_wire = null,
     }) {
       const now = Date.now();
       const row = {
@@ -491,6 +1062,7 @@ export function createStore(dbPath, options = {}) {
         trace_id: trace_id || uuidv7(),
         payload_json: JSON.stringify(payload),
         status,
+        role_key_wire,
       };
       S.insertAuditMessage.run(row);
       return { ...row, payload };

--- a/packages/remote/hub/schema.sql
+++ b/packages/remote/hub/schema.sql
@@ -11,7 +11,11 @@ CREATE TABLE IF NOT EXISTS agents (
   last_seen_ms INTEGER NOT NULL,
   lease_expires_ms INTEGER NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('online','stale','offline')),
-  metadata_json TEXT NOT NULL DEFAULT '{}'
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  project_id TEXT,
+  session_id TEXT,
+  host_id TEXT,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]'
 );
 
 -- 메시지 테이블
@@ -28,7 +32,61 @@ CREATE TABLE IF NOT EXISTS messages (
   correlation_id TEXT NOT NULL,
   trace_id TEXT NOT NULL,
   payload_json TEXT NOT NULL DEFAULT '{}',
-  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter'))
+  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter')),
+  role_key_wire TEXT
+);
+
+-- 동적 역할 레지스트리 (schema v6)
+CREATE TABLE IF NOT EXISTS role_registry (
+  role_key_wire TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  role_kind TEXT NOT NULL CHECK (role_kind IN ('cto','lead')),
+  scope_id TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL CHECK (
+    state IN (
+      'electable',
+      'elected-probing',
+      'active',
+      'unreachable',
+      'quarantined'
+    )
+  ),
+  holder_agent_id TEXT,
+  previous_holder_agent_id TEXT,
+  epoch INTEGER NOT NULL DEFAULT 0 CHECK (epoch >= 0),
+  activation_seq INTEGER NOT NULL DEFAULT 0 CHECK (activation_seq >= 0),
+  activation_id TEXT,
+  activation_deadline_ms INTEGER,
+  holder_lease_expires_ms INTEGER,
+  charter_version TEXT,
+  charter_acked_epoch INTEGER,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  next_probe_ms INTEGER,
+  blocked_reason TEXT,
+  last_transition_ms INTEGER NOT NULL,
+  last_reason TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  CHECK (
+    (role_kind = 'cto' AND scope_id = '') OR
+    (role_kind = 'lead' AND scope_id <> '')
+  ),
+  UNIQUE(project_id, role_kind, scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_candidates (
+  role_key_wire TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('grant','standup','operator')),
+  priority INTEGER NOT NULL DEFAULT 0,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]',
+  consecutive_probe_failures INTEGER NOT NULL DEFAULT 0,
+  excluded_until_ms INTEGER,
+  last_probe_ms INTEGER,
+  last_probe_code TEXT,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY(role_key_wire, agent_id),
+  FOREIGN KEY(role_key_wire)
+    REFERENCES role_registry(role_key_wire) ON DELETE CASCADE
 );
 
 -- 메시지 수신함 (배달 추적)
@@ -73,6 +131,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_correlation ON messages(correlation_id);
 CREATE INDEX IF NOT EXISTS idx_messages_trace ON messages(trace_id);
 CREATE INDEX IF NOT EXISTS idx_messages_expires ON messages(expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority DESC, created_at_ms ASC);
+CREATE INDEX IF NOT EXISTS idx_messages_role_key ON messages(role_key_wire, status, expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_agent ON message_inbox(agent_id, delivered_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_message ON message_inbox(message_id);
 CREATE INDEX IF NOT EXISTS idx_human_requests_state ON human_requests(state);

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -1,13 +1,21 @@
-// hub/store.mjs — SQLite 감사 로그/메타데이터 저장소
-// 실시간 배달 큐는 router/pipe가 담당하고, SQLite는 재생/감사 용도로만 유지한다.
+// hub/store.mjs — SQLite 감사 로그/메타데이터/역할 레지스트리 저장소
+// 실시간 배달은 router/pipe가 담당하고, 역할 권한과 복구 상태는 SQLite가 보존한다.
 
 import { mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { clampDurationMs, DEFAULT_ASSIGN_TIMEOUT_MS, DEFAULT_ASSIGN_TTL_MS } from "@triflux/core/hub/lib/timeout-defaults.mjs";
+import {
+  clampDurationMs,
+  DEFAULT_ASSIGN_TIMEOUT_MS,
+  DEFAULT_ASSIGN_TTL_MS,
+} from "@triflux/core/hub/lib/timeout-defaults.mjs";
 import { uuidv7 } from "@triflux/core/hub/lib/uuidv7.mjs";
 import { recalcConfidence } from "@triflux/core/hub/reflexion.mjs";
+import {
+  decodeRoleKey,
+  ROLE_REACHABILITY_STATES,
+} from "@triflux/core/hub/role-contract.mjs";
 
 export { uuidv7 };
 
@@ -72,6 +80,21 @@ function parseReflexionRow(row) {
   };
 }
 
+function parseRoleCandidateRow(row) {
+  if (!row) return null;
+  const { transport_locators_json, ...rest } = row;
+  return {
+    ...rest,
+    transport_locators: parseJson(transport_locators_json, []),
+  };
+}
+
+function hasTable(db, tableName) {
+  return !!db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")
+    .get(tableName);
+}
+
 function hasColumn(db, tableName, columnName) {
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all();
   return rows.some((row) => row.name === columnName);
@@ -80,6 +103,23 @@ function hasColumn(db, tableName, columnName) {
 function ensureColumn(db, tableName, columnName, definition) {
   if (hasColumn(db, tableName, columnName)) return;
   db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+}
+
+function ensureV6Columns(db) {
+  if (hasTable(db, "agents")) {
+    ensureColumn(db, "agents", "project_id", "TEXT");
+    ensureColumn(db, "agents", "session_id", "TEXT");
+    ensureColumn(db, "agents", "host_id", "TEXT");
+    ensureColumn(
+      db,
+      "agents",
+      "transport_locators_json",
+      "TEXT NOT NULL DEFAULT '[]'",
+    );
+  }
+  if (hasTable(db, "messages")) {
+    ensureColumn(db, "messages", "role_key_wire", "TEXT");
+  }
 }
 
 /**
@@ -112,7 +152,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "5";
+  const SCHEMA_VERSION = "6";
   const curVer = (() => {
     try {
       return db
@@ -126,6 +166,9 @@ export function createStore(dbPath, options = {}) {
   // 마이그레이션 전략: 스키마 버전이 다르면 schema.sql을 재실행한다.
   // schema.sql은 CREATE TABLE IF NOT EXISTS 패턴을 사용하므로 멱등하게 적용된다.
   // 비파괴적 컬럼 추가는 자동으로 처리되지만, 컬럼 제거/이름 변경은 수동 마이그레이션이 필요하다.
+  // v5 테이블에는 schema.sql의 v6 인덱스가 참조하는 컬럼이 없으므로
+  // CREATE IF NOT EXISTS 재실행 전에 멱등 컬럼 seam을 먼저 적용한다.
+  ensureV6Columns(db);
   if (curVer !== SCHEMA_VERSION) {
     if (curVer != null) {
       // 이미 버전이 기록된 DB에서 버전 불일치가 발생한 경우 경고한다.
@@ -138,6 +181,8 @@ export function createStore(dbPath, options = {}) {
       "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', ?)",
     ).run(SCHEMA_VERSION);
   }
+  // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
+  ensureV6Columns(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -185,9 +230,164 @@ export function createStore(dbPath, options = {}) {
       "UPDATE agents SET status='offline' WHERE status='stale' AND lease_expires_ms < ? - 300000",
     ),
 
+    getRole: db.prepare(
+      "SELECT * FROM role_registry WHERE role_key_wire = ?",
+    ),
+    insertRoleReservation: db.prepare(`
+      INSERT INTO role_registry (
+        role_key_wire, project_id, role_kind, scope_id, state,
+        holder_agent_id, previous_holder_agent_id, epoch, activation_seq,
+        activation_id, activation_deadline_ms, holder_lease_expires_ms,
+        charter_version, charter_acked_epoch, retry_count, next_probe_ms,
+        blocked_reason, last_transition_ms, last_reason, version
+      ) VALUES (
+        @role_key_wire, @project_id, @role_kind, @scope_id, @state,
+        @holder_agent_id, @previous_holder_agent_id, @epoch, @activation_seq,
+        @activation_id, @activation_deadline_ms, @holder_lease_expires_ms,
+        @charter_version, @charter_acked_epoch, @retry_count, @next_probe_ms,
+        @blocked_reason, @last_transition_ms, @last_reason, @version
+      )`),
+    updateRoleReservation: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        epoch=@epoch,
+        activation_seq=@activation_seq,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    compareAndSetRole: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND epoch=@expected_epoch
+        AND activation_seq=@expected_activation_seq
+        AND activation_id IS @expected_activation_id
+        AND version=@expected_version`),
+    listRoles: db.prepare(
+      "SELECT * FROM role_registry ORDER BY role_key_wire",
+    ),
+    expiredHolderRoles: db.prepare(`
+      SELECT * FROM role_registry
+      WHERE holder_agent_id IS NOT NULL
+        AND (holder_lease_expires_ms IS NULL OR holder_lease_expires_ms <= ?)
+      ORDER BY role_key_wire`),
+    listRoleCandidates: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ?
+      ORDER BY priority DESC, updated_at_ms DESC, agent_id`),
+    getRoleCandidate: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ? AND agent_id = ?`),
+    upsertRoleCandidate: db.prepare(`
+      INSERT INTO role_candidates (
+        role_key_wire, agent_id, source, priority, transport_locators_json,
+        consecutive_probe_failures, excluded_until_ms, last_probe_ms,
+        last_probe_code, updated_at_ms
+      ) VALUES (
+        @role_key_wire, @agent_id, @source, @priority,
+        @transport_locators_json, @consecutive_probe_failures,
+        @excluded_until_ms, @last_probe_ms, @last_probe_code, @updated_at_ms
+      )
+      ON CONFLICT(role_key_wire, agent_id) DO UPDATE SET
+        source=excluded.source,
+        priority=excluded.priority,
+        transport_locators_json=excluded.transport_locators_json,
+        consecutive_probe_failures=excluded.consecutive_probe_failures,
+        excluded_until_ms=excluded.excluded_until_ms,
+        last_probe_ms=excluded.last_probe_ms,
+        last_probe_code=excluded.last_probe_code,
+        updated_at_ms=excluded.updated_at_ms`),
+    updateCandidateReachability: db.prepare(`
+      UPDATE role_candidates SET
+        consecutive_probe_failures=@consecutive_probe_failures,
+        excluded_until_ms=@excluded_until_ms,
+        last_probe_ms=@last_probe_ms,
+        last_probe_code=@last_probe_code,
+        updated_at_ms=@updated_at_ms
+      WHERE role_key_wire=@role_key_wire AND agent_id=@agent_id`),
+    pendingRoleMessages: db.prepare(`
+      SELECT * FROM messages
+      WHERE role_key_wire=?
+        AND status IN ('queued','delivered')
+        AND expires_at_ms > ?
+      ORDER BY priority DESC, created_at_ms ASC, id`),
+    recoverExpiredRole: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        previous_holder_agent_id=holder_agent_id,
+        holder_agent_id=NULL,
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        holder_lease_expires_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_holder_lease_expired',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverLiveRole: db.prepare(`
+      UPDATE role_registry SET
+        state='elected-probing',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=@activation_id,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_reprobe_required',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverOrphanedActivation: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_activation_fenced',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+
     insertAuditMessage: db.prepare(`
-      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status)
-      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status)`),
+      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status, role_key_wire)
+      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status, @role_key_wire)`),
     getMsg: db.prepare("SELECT * FROM messages WHERE id=?"),
     getResponse: db.prepare(
       "SELECT * FROM messages WHERE correlation_id=? AND type='response' ORDER BY created_at_ms DESC LIMIT 1",
@@ -359,6 +559,160 @@ export function createStore(dbPath, options = {}) {
     return Math.max(1, Math.min(Math.trunc(num), 9));
   }
 
+  function roleIdentity(input) {
+    const roleKeyWire = input?.role_key_wire ?? input?.roleKeyWire;
+    const decoded = decodeRoleKey(roleKeyWire);
+    const identity = {
+      role_key_wire: roleKeyWire,
+      project_id: decoded.project_id,
+      role_kind: decoded.role_kind,
+      scope_id: decoded.scope_id ?? "",
+    };
+    for (const field of ["project_id", "role_kind", "scope_id"]) {
+      if (Object.hasOwn(input, field) && input[field] !== identity[field]) {
+        throw new Error(`role key identity mismatch: ${field}`);
+      }
+    }
+    return identity;
+  }
+
+  function roleFailureReason(current, expected) {
+    if (!current) return "not_found";
+    if (current.version !== expected.version) return "stale_version";
+    if (current.epoch !== expected.epoch) return "stale_epoch";
+    if (current.activation_seq !== expected.activation_seq) {
+      return "stale_activation_seq";
+    }
+    if (current.activation_id !== expected.activation_id) {
+      return "stale_activation_id";
+    }
+    return "cas_conflict";
+  }
+
+  const reserveRole = db.transaction((input) => {
+    const identity = roleIdentity(input);
+    const current = S.getRole.get(identity.role_key_wire) ?? null;
+    const expectedVersion =
+      input.expected_version ?? input.expectedVersion ?? current?.version;
+    const expectedEpoch =
+      input.expected_epoch ?? input.expectedEpoch ?? current?.epoch;
+
+    if (current && expectedVersion !== current.version) {
+      return { ok: false, reason: "stale_version", role: current };
+    }
+    if (current && expectedEpoch !== current.epoch) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+
+    const nextEpoch =
+      input.epoch ?? input.next_epoch ?? (current ? current.epoch + 1 : 0);
+    if (current && nextEpoch !== current.epoch + 1) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+    const nextActivationSeq =
+      input.activation_seq ??
+      input.next_activation_seq ??
+      (current ? current.activation_seq + 1 : 0);
+    if (current && nextActivationSeq !== current.activation_seq + 1) {
+      return { ok: false, reason: "stale_activation_seq", role: current };
+    }
+
+    const state =
+      input.state ?? (input.holder_agent_id ? "elected-probing" : "electable");
+    if (!ROLE_REACHABILITY_STATES.includes(state)) {
+      throw new Error(`invalid role reachability state: ${state}`);
+    }
+    const row = {
+      ...identity,
+      state,
+      holder_agent_id: input.holder_agent_id ?? null,
+      previous_holder_agent_id:
+        input.previous_holder_agent_id ??
+        (current?.holder_agent_id !== input.holder_agent_id
+          ? current?.holder_agent_id ?? null
+          : current?.previous_holder_agent_id ?? null),
+      epoch: nextEpoch,
+      activation_seq: nextActivationSeq,
+      activation_id:
+        input.activation_id ??
+        (input.holder_agent_id ? uuidv7() : current?.activation_id ?? null),
+      activation_deadline_ms:
+        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
+      holder_lease_expires_ms:
+        input.holder_lease_expires_ms ??
+        current?.holder_lease_expires_ms ??
+        null,
+      charter_version: input.charter_version ?? current?.charter_version ?? null,
+      charter_acked_epoch:
+        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      retry_count: input.retry_count ?? current?.retry_count ?? 0,
+      next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
+      blocked_reason:
+        input.blocked_reason === undefined
+          ? current?.blocked_reason ?? null
+          : input.blocked_reason,
+      last_transition_ms: input.last_transition_ms ?? Date.now(),
+      last_reason: input.last_reason ?? "role_reserved",
+      version: 0,
+      expected_version: current?.version,
+      expected_epoch: current?.epoch,
+    };
+
+    if (!current) {
+      S.insertRoleReservation.run(row);
+    } else if (S.updateRoleReservation.run(row).changes !== 1) {
+      const latest = S.getRole.get(identity.role_key_wire) ?? null;
+      return {
+        ok: false,
+        reason: roleFailureReason(latest, {
+          version: current.version,
+          epoch: current.epoch,
+          activation_seq: current.activation_seq,
+          activation_id: current.activation_id,
+        }),
+        role: latest,
+      };
+    }
+    return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+  });
+
+  const recoverRegistry = db.transaction((now) => {
+    for (const role of S.listRoles.all()) {
+      const guard = {
+        role_key_wire: role.role_key_wire,
+        expected_version: role.version,
+        expected_epoch: role.epoch,
+        now,
+      };
+      if (
+        role.holder_agent_id &&
+        (role.holder_lease_expires_ms == null ||
+          role.holder_lease_expires_ms <= now)
+      ) {
+        S.recoverExpiredRole.run(guard);
+      } else if (role.holder_agent_id) {
+        S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
+      } else if (role.activation_id || role.state === "elected-probing") {
+        S.recoverOrphanedActivation.run(guard);
+      }
+    }
+
+    const roles = S.listRoles.all();
+    return {
+      roles,
+      candidates: roles.flatMap((role) =>
+        S.listRoleCandidates
+          .all(role.role_key_wire)
+          .map(parseRoleCandidateRow),
+      ),
+      pending_messages: roles.flatMap((role) =>
+        S.pendingRoleMessages
+          .all(role.role_key_wire, now)
+          .map(parseMessageRow),
+      ),
+    };
+  });
+
   const store = {
     db,
     uuidv7,
@@ -421,7 +775,11 @@ export function createStore(dbPath, options = {}) {
         agent_id: agentId,
         lease_expires_ms: now + ttlMs,
         server_time_ms: now,
-        effective: { updated: write.changes > 0, store_type: "sqlite", db_path: dbPath ?? null },
+        effective: {
+          updated: write.changes > 0,
+          store_type: "sqlite",
+          db_path: dbPath ?? null,
+        },
       };
     },
 
@@ -456,6 +814,233 @@ export function createStore(dbPath, options = {}) {
       return S.setAgentStatus.run(status, agentId).changes > 0;
     },
 
+    getRole(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.getRole.get(roleKeyWire) ?? null;
+    },
+
+    upsertRoleReservation(input) {
+      return reserveRole.immediate(input);
+    },
+
+    compareAndSetRole(input) {
+      const identity = roleIdentity(input);
+      const current = S.getRole.get(identity.role_key_wire) ?? null;
+      if (!current) return { ok: false, reason: "not_found", role: null };
+
+      const hasExpectedActivationSeq =
+        Object.hasOwn(input, "expected_activation_seq") ||
+        Object.hasOwn(input, "expectedActivationSeq") ||
+        Object.hasOwn(input, "activation_seq");
+      const hasExpectedActivationId =
+        Object.hasOwn(input, "expected_activation_id") ||
+        Object.hasOwn(input, "expectedActivationId") ||
+        Object.hasOwn(input, "activation_id");
+      const expected = {
+        version: input.expected_version ?? input.expectedVersion ?? input.version,
+        epoch: input.expected_epoch ?? input.expectedEpoch ?? input.epoch,
+        activation_seq:
+          input.expected_activation_seq ??
+          input.expectedActivationSeq ??
+          input.activation_seq,
+        activation_id: Object.hasOwn(input, "expected_activation_id")
+          ? input.expected_activation_id
+          : Object.hasOwn(input, "expectedActivationId")
+            ? input.expectedActivationId
+            : input.activation_id,
+      };
+      if (
+        expected.version == null ||
+        expected.epoch == null ||
+        !hasExpectedActivationSeq ||
+        !hasExpectedActivationId
+      ) {
+        return { ok: false, reason: "invalid_cas", role: current };
+      }
+
+      const reason = roleFailureReason(current, expected);
+      if (reason !== "cas_conflict") {
+        return { ok: false, reason, role: current };
+      }
+
+      const patch = input.patch ?? input.changes ?? {};
+      const state = patch.state ?? current.state;
+      if (!ROLE_REACHABILITY_STATES.includes(state)) {
+        throw new Error(`invalid role reachability state: ${state}`);
+      }
+      const next = {
+        role_key_wire: identity.role_key_wire,
+        expected_version: expected.version,
+        expected_epoch: expected.epoch,
+        expected_activation_seq: expected.activation_seq,
+        expected_activation_id: expected.activation_id,
+        state,
+        holder_agent_id:
+          patch.holder_agent_id === undefined
+            ? current.holder_agent_id
+            : patch.holder_agent_id,
+        previous_holder_agent_id:
+          patch.previous_holder_agent_id === undefined
+            ? current.previous_holder_agent_id
+            : patch.previous_holder_agent_id,
+        activation_id:
+          patch.activation_id === undefined
+            ? current.activation_id
+            : patch.activation_id,
+        activation_deadline_ms:
+          patch.activation_deadline_ms === undefined
+            ? current.activation_deadline_ms
+            : patch.activation_deadline_ms,
+        holder_lease_expires_ms:
+          patch.holder_lease_expires_ms === undefined
+            ? current.holder_lease_expires_ms
+            : patch.holder_lease_expires_ms,
+        charter_version:
+          patch.charter_version === undefined
+            ? current.charter_version
+            : patch.charter_version,
+        charter_acked_epoch:
+          patch.charter_acked_epoch === undefined
+            ? current.charter_acked_epoch
+            : patch.charter_acked_epoch,
+        retry_count: patch.retry_count ?? current.retry_count,
+        next_probe_ms:
+          patch.next_probe_ms === undefined
+            ? current.next_probe_ms
+            : patch.next_probe_ms,
+        blocked_reason:
+          patch.blocked_reason === undefined
+            ? current.blocked_reason
+            : patch.blocked_reason,
+        last_transition_ms: patch.last_transition_ms ?? Date.now(),
+        last_reason: patch.last_reason ?? current.last_reason,
+      };
+      if (S.compareAndSetRole.run(next).changes !== 1) {
+        const latest = S.getRole.get(identity.role_key_wire) ?? null;
+        return {
+          ok: false,
+          reason: roleFailureReason(latest, expected),
+          role: latest,
+        };
+      }
+      return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+    },
+
+    listRoleKeys(filter = {}) {
+      const clauses = [];
+      const params = {};
+      for (const field of ["project_id", "role_kind", "scope_id", "state"]) {
+        if (filter[field] !== undefined) {
+          clauses.push(`${field}=@${field}`);
+          params[field] = filter[field];
+        }
+      }
+      if (Array.isArray(filter.states) && filter.states.length > 0) {
+        clauses.push(
+          `state IN (${filter.states.map((_, index) => `@state_${index}`).join(",")})`,
+        );
+        filter.states.forEach((state, index) => {
+          params[`state_${index}`] = state;
+        });
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(" AND ")}` : "";
+      return db
+        .prepare(
+          `SELECT role_key_wire FROM role_registry${where} ORDER BY role_key_wire`,
+        )
+        .pluck()
+        .all(params);
+    },
+
+    listRolesWithExpiredHolder(now) {
+      return S.expiredHolderRoles.all(now);
+    },
+
+    listRoleCandidates(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.listRoleCandidates.all(roleKeyWire).map(parseRoleCandidateRow);
+    },
+
+    upsertRoleCandidate(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      S.upsertRoleCandidate.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        source: input.source ?? current?.source ?? "operator",
+        priority: input.priority ?? current?.priority ?? 0,
+        transport_locators_json: JSON.stringify(
+          input.transport_locators ??
+            parseJson(current?.transport_locators_json, []),
+        ),
+        consecutive_probe_failures:
+          input.consecutive_probe_failures ??
+          current?.consecutive_probe_failures ??
+          0,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? current?.excluded_until_ms ?? null
+            : input.excluded_until_ms,
+        last_probe_ms:
+          input.last_probe_ms === undefined
+            ? current?.last_probe_ms ?? null
+            : input.last_probe_ms,
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? current?.last_probe_code ?? null
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return parseRoleCandidateRow(
+        S.getRoleCandidate.get(role_key_wire, input.agent_id),
+      );
+    },
+
+    updateCandidateReachability(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      if (!current) return { ok: false, reason: "not_found" };
+
+      let failures =
+        input.consecutive_probe_failures ??
+        current.consecutive_probe_failures;
+      if (input.probe_failed === true || input.increment_probe_failures === true) {
+        failures = current.consecutive_probe_failures + 1;
+      } else if (input.probe_succeeded === true) {
+        failures = 0;
+      }
+      S.updateCandidateReachability.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        consecutive_probe_failures: failures,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? current.excluded_until_ms
+            : input.excluded_until_ms,
+        last_probe_ms: input.last_probe_ms ?? Date.now(),
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? current.last_probe_code
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return {
+        ok: true,
+        candidate: parseRoleCandidateRow(
+          S.getRoleCandidate.get(role_key_wire, input.agent_id),
+        ),
+      };
+    },
+
+    listPendingRoleMessages(roleKeyWire, now) {
+      decodeRoleKey(roleKeyWire);
+      return S.pendingRoleMessages.all(roleKeyWire, now).map(parseMessageRow);
+    },
+
+    recoverRoleRegistry(now) {
+      return recoverRegistry.immediate(now);
+    },
+
     auditLog({
       type,
       from,
@@ -467,6 +1052,7 @@ export function createStore(dbPath, options = {}) {
       trace_id,
       correlation_id,
       status = "queued",
+      role_key_wire = null,
     }) {
       const now = Date.now();
       const row = {
@@ -483,6 +1069,7 @@ export function createStore(dbPath, options = {}) {
         trace_id: trace_id || uuidv7(),
         payload_json: JSON.stringify(payload),
         status,
+        role_key_wire,
       };
       S.insertAuditMessage.run(row);
       return { ...row, payload };
@@ -638,7 +1225,10 @@ export function createStore(dbPath, options = {}) {
       error = null,
     }) {
       const now = Date.now();
-      const normalizedTimeout = clampDurationMs(timeout_ms, DEFAULT_ASSIGN_TIMEOUT_MS);
+      const normalizedTimeout = clampDurationMs(
+        timeout_ms,
+        DEFAULT_ASSIGN_TIMEOUT_MS,
+      );
       const row = {
         job_id: job_id || uuidv7(),
         supervisor_agent,
@@ -761,7 +1351,9 @@ export function createStore(dbPath, options = {}) {
           : nextStatus === "running"
             ? current.started_at_ms || now
             : current.started_at_ms,
-        dispatched_at_ms: Object.hasOwn(patch, "dispatched_at_ms") ? patch.dispatched_at_ms : current.dispatched_at_ms,
+        dispatched_at_ms: Object.hasOwn(patch, "dispatched_at_ms")
+          ? patch.dispatched_at_ms
+          : current.dispatched_at_ms,
         completed_at_ms: Object.hasOwn(patch, "completed_at_ms")
           ? patch.completed_at_ms
           : isTerminal

--- a/packages/triflux/hub/schema.sql
+++ b/packages/triflux/hub/schema.sql
@@ -11,7 +11,11 @@ CREATE TABLE IF NOT EXISTS agents (
   last_seen_ms INTEGER NOT NULL,
   lease_expires_ms INTEGER NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('online','stale','offline')),
-  metadata_json TEXT NOT NULL DEFAULT '{}'
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  project_id TEXT,
+  session_id TEXT,
+  host_id TEXT,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]'
 );
 
 -- 메시지 테이블
@@ -28,7 +32,61 @@ CREATE TABLE IF NOT EXISTS messages (
   correlation_id TEXT NOT NULL,
   trace_id TEXT NOT NULL,
   payload_json TEXT NOT NULL DEFAULT '{}',
-  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter'))
+  status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter')),
+  role_key_wire TEXT
+);
+
+-- 동적 역할 레지스트리 (schema v6)
+CREATE TABLE IF NOT EXISTS role_registry (
+  role_key_wire TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  role_kind TEXT NOT NULL CHECK (role_kind IN ('cto','lead')),
+  scope_id TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL CHECK (
+    state IN (
+      'electable',
+      'elected-probing',
+      'active',
+      'unreachable',
+      'quarantined'
+    )
+  ),
+  holder_agent_id TEXT,
+  previous_holder_agent_id TEXT,
+  epoch INTEGER NOT NULL DEFAULT 0 CHECK (epoch >= 0),
+  activation_seq INTEGER NOT NULL DEFAULT 0 CHECK (activation_seq >= 0),
+  activation_id TEXT,
+  activation_deadline_ms INTEGER,
+  holder_lease_expires_ms INTEGER,
+  charter_version TEXT,
+  charter_acked_epoch INTEGER,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  next_probe_ms INTEGER,
+  blocked_reason TEXT,
+  last_transition_ms INTEGER NOT NULL,
+  last_reason TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  CHECK (
+    (role_kind = 'cto' AND scope_id = '') OR
+    (role_kind = 'lead' AND scope_id <> '')
+  ),
+  UNIQUE(project_id, role_kind, scope_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_candidates (
+  role_key_wire TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('grant','standup','operator')),
+  priority INTEGER NOT NULL DEFAULT 0,
+  transport_locators_json TEXT NOT NULL DEFAULT '[]',
+  consecutive_probe_failures INTEGER NOT NULL DEFAULT 0,
+  excluded_until_ms INTEGER,
+  last_probe_ms INTEGER,
+  last_probe_code TEXT,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY(role_key_wire, agent_id),
+  FOREIGN KEY(role_key_wire)
+    REFERENCES role_registry(role_key_wire) ON DELETE CASCADE
 );
 
 -- 메시지 수신함 (배달 추적)
@@ -73,6 +131,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_correlation ON messages(correlation_id);
 CREATE INDEX IF NOT EXISTS idx_messages_trace ON messages(trace_id);
 CREATE INDEX IF NOT EXISTS idx_messages_expires ON messages(expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_messages_priority ON messages(priority DESC, created_at_ms ASC);
+CREATE INDEX IF NOT EXISTS idx_messages_role_key ON messages(role_key_wire, status, expires_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_agent ON message_inbox(agent_id, delivered_at_ms);
 CREATE INDEX IF NOT EXISTS idx_inbox_message ON message_inbox(message_id);
 CREATE INDEX IF NOT EXISTS idx_human_requests_state ON human_requests(state);

--- a/packages/triflux/hub/store.mjs
+++ b/packages/triflux/hub/store.mjs
@@ -1,5 +1,5 @@
-// hub/store.mjs — SQLite 감사 로그/메타데이터 저장소
-// 실시간 배달 큐는 router/pipe가 담당하고, SQLite는 재생/감사 용도로만 유지한다.
+// hub/store.mjs — SQLite 감사 로그/메타데이터/역할 레지스트리 저장소
+// 실시간 배달은 router/pipe가 담당하고, 역할 권한과 복구 상태는 SQLite가 보존한다.
 
 import { mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -12,6 +12,7 @@ import {
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
 import { recalcConfidence } from "./reflexion.mjs";
+import { decodeRoleKey, ROLE_REACHABILITY_STATES } from "./role-contract.mjs";
 
 export { uuidv7 };
 
@@ -76,6 +77,21 @@ function parseReflexionRow(row) {
   };
 }
 
+function parseRoleCandidateRow(row) {
+  if (!row) return null;
+  const { transport_locators_json, ...rest } = row;
+  return {
+    ...rest,
+    transport_locators: parseJson(transport_locators_json, []),
+  };
+}
+
+function hasTable(db, tableName) {
+  return !!db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?")
+    .get(tableName);
+}
+
 function hasColumn(db, tableName, columnName) {
   const rows = db.prepare(`PRAGMA table_info(${tableName})`).all();
   return rows.some((row) => row.name === columnName);
@@ -84,6 +100,23 @@ function hasColumn(db, tableName, columnName) {
 function ensureColumn(db, tableName, columnName, definition) {
   if (hasColumn(db, tableName, columnName)) return;
   db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+}
+
+function ensureV6Columns(db) {
+  if (hasTable(db, "agents")) {
+    ensureColumn(db, "agents", "project_id", "TEXT");
+    ensureColumn(db, "agents", "session_id", "TEXT");
+    ensureColumn(db, "agents", "host_id", "TEXT");
+    ensureColumn(
+      db,
+      "agents",
+      "transport_locators_json",
+      "TEXT NOT NULL DEFAULT '[]'",
+    );
+  }
+  if (hasTable(db, "messages")) {
+    ensureColumn(db, "messages", "role_key_wire", "TEXT");
+  }
 }
 
 /**
@@ -116,7 +149,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "5";
+  const SCHEMA_VERSION = "6";
   const curVer = (() => {
     try {
       return db
@@ -130,6 +163,9 @@ export function createStore(dbPath, options = {}) {
   // 마이그레이션 전략: 스키마 버전이 다르면 schema.sql을 재실행한다.
   // schema.sql은 CREATE TABLE IF NOT EXISTS 패턴을 사용하므로 멱등하게 적용된다.
   // 비파괴적 컬럼 추가는 자동으로 처리되지만, 컬럼 제거/이름 변경은 수동 마이그레이션이 필요하다.
+  // v5 테이블에는 schema.sql의 v6 인덱스가 참조하는 컬럼이 없으므로
+  // CREATE IF NOT EXISTS 재실행 전에 멱등 컬럼 seam을 먼저 적용한다.
+  ensureV6Columns(db);
   if (curVer !== SCHEMA_VERSION) {
     if (curVer != null) {
       // 이미 버전이 기록된 DB에서 버전 불일치가 발생한 경우 경고한다.
@@ -142,6 +178,8 @@ export function createStore(dbPath, options = {}) {
       "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', ?)",
     ).run(SCHEMA_VERSION);
   }
+  // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
+  ensureV6Columns(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -189,9 +227,160 @@ export function createStore(dbPath, options = {}) {
       "UPDATE agents SET status='offline' WHERE status='stale' AND lease_expires_ms < ? - 300000",
     ),
 
+    getRole: db.prepare("SELECT * FROM role_registry WHERE role_key_wire = ?"),
+    insertRoleReservation: db.prepare(`
+      INSERT INTO role_registry (
+        role_key_wire, project_id, role_kind, scope_id, state,
+        holder_agent_id, previous_holder_agent_id, epoch, activation_seq,
+        activation_id, activation_deadline_ms, holder_lease_expires_ms,
+        charter_version, charter_acked_epoch, retry_count, next_probe_ms,
+        blocked_reason, last_transition_ms, last_reason, version
+      ) VALUES (
+        @role_key_wire, @project_id, @role_kind, @scope_id, @state,
+        @holder_agent_id, @previous_holder_agent_id, @epoch, @activation_seq,
+        @activation_id, @activation_deadline_ms, @holder_lease_expires_ms,
+        @charter_version, @charter_acked_epoch, @retry_count, @next_probe_ms,
+        @blocked_reason, @last_transition_ms, @last_reason, @version
+      )`),
+    updateRoleReservation: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        epoch=@epoch,
+        activation_seq=@activation_seq,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    compareAndSetRole: db.prepare(`
+      UPDATE role_registry SET
+        state=@state,
+        holder_agent_id=@holder_agent_id,
+        previous_holder_agent_id=@previous_holder_agent_id,
+        activation_id=@activation_id,
+        activation_deadline_ms=@activation_deadline_ms,
+        holder_lease_expires_ms=@holder_lease_expires_ms,
+        charter_version=@charter_version,
+        charter_acked_epoch=@charter_acked_epoch,
+        retry_count=@retry_count,
+        next_probe_ms=@next_probe_ms,
+        blocked_reason=@blocked_reason,
+        last_transition_ms=@last_transition_ms,
+        last_reason=@last_reason,
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND epoch=@expected_epoch
+        AND activation_seq=@expected_activation_seq
+        AND activation_id IS @expected_activation_id
+        AND version=@expected_version`),
+    listRoles: db.prepare("SELECT * FROM role_registry ORDER BY role_key_wire"),
+    expiredHolderRoles: db.prepare(`
+      SELECT * FROM role_registry
+      WHERE holder_agent_id IS NOT NULL
+        AND (holder_lease_expires_ms IS NULL OR holder_lease_expires_ms <= ?)
+      ORDER BY role_key_wire`),
+    listRoleCandidates: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ?
+      ORDER BY priority DESC, updated_at_ms DESC, agent_id`),
+    getRoleCandidate: db.prepare(`
+      SELECT * FROM role_candidates
+      WHERE role_key_wire = ? AND agent_id = ?`),
+    upsertRoleCandidate: db.prepare(`
+      INSERT INTO role_candidates (
+        role_key_wire, agent_id, source, priority, transport_locators_json,
+        consecutive_probe_failures, excluded_until_ms, last_probe_ms,
+        last_probe_code, updated_at_ms
+      ) VALUES (
+        @role_key_wire, @agent_id, @source, @priority,
+        @transport_locators_json, @consecutive_probe_failures,
+        @excluded_until_ms, @last_probe_ms, @last_probe_code, @updated_at_ms
+      )
+      ON CONFLICT(role_key_wire, agent_id) DO UPDATE SET
+        source=excluded.source,
+        priority=excluded.priority,
+        transport_locators_json=excluded.transport_locators_json,
+        consecutive_probe_failures=excluded.consecutive_probe_failures,
+        excluded_until_ms=excluded.excluded_until_ms,
+        last_probe_ms=excluded.last_probe_ms,
+        last_probe_code=excluded.last_probe_code,
+        updated_at_ms=excluded.updated_at_ms`),
+    updateCandidateReachability: db.prepare(`
+      UPDATE role_candidates SET
+        consecutive_probe_failures=@consecutive_probe_failures,
+        excluded_until_ms=@excluded_until_ms,
+        last_probe_ms=@last_probe_ms,
+        last_probe_code=@last_probe_code,
+        updated_at_ms=@updated_at_ms
+      WHERE role_key_wire=@role_key_wire AND agent_id=@agent_id`),
+    pendingRoleMessages: db.prepare(`
+      SELECT * FROM messages
+      WHERE role_key_wire=?
+        AND status IN ('queued','delivered')
+        AND expires_at_ms > ?
+      ORDER BY priority DESC, created_at_ms ASC, id`),
+    recoverExpiredRole: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        previous_holder_agent_id=holder_agent_id,
+        holder_agent_id=NULL,
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        holder_lease_expires_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_holder_lease_expired',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverLiveRole: db.prepare(`
+      UPDATE role_registry SET
+        state='elected-probing',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=@activation_id,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        blocked_reason=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_reprobe_required',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+    recoverOrphanedActivation: db.prepare(`
+      UPDATE role_registry SET
+        state='electable',
+        epoch=epoch + 1,
+        activation_seq=activation_seq + 1,
+        activation_id=NULL,
+        activation_deadline_ms=NULL,
+        charter_acked_epoch=NULL,
+        last_transition_ms=@now,
+        last_reason='restart_activation_fenced',
+        version=version + 1
+      WHERE role_key_wire=@role_key_wire
+        AND version=@expected_version
+        AND epoch=@expected_epoch`),
+
     insertAuditMessage: db.prepare(`
-      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status)
-      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status)`),
+      INSERT INTO messages (id, type, from_agent, to_agent, topic, priority, ttl_ms, created_at_ms, expires_at_ms, correlation_id, trace_id, payload_json, status, role_key_wire)
+      VALUES (@id, @type, @from_agent, @to_agent, @topic, @priority, @ttl_ms, @created_at_ms, @expires_at_ms, @correlation_id, @trace_id, @payload_json, @status, @role_key_wire)`),
     getMsg: db.prepare("SELECT * FROM messages WHERE id=?"),
     getResponse: db.prepare(
       "SELECT * FROM messages WHERE correlation_id=? AND type='response' ORDER BY created_at_ms DESC LIMIT 1",
@@ -363,6 +552,157 @@ export function createStore(dbPath, options = {}) {
     return Math.max(1, Math.min(Math.trunc(num), 9));
   }
 
+  function roleIdentity(input) {
+    const roleKeyWire = input?.role_key_wire ?? input?.roleKeyWire;
+    const decoded = decodeRoleKey(roleKeyWire);
+    const identity = {
+      role_key_wire: roleKeyWire,
+      project_id: decoded.project_id,
+      role_kind: decoded.role_kind,
+      scope_id: decoded.scope_id ?? "",
+    };
+    for (const field of ["project_id", "role_kind", "scope_id"]) {
+      if (Object.hasOwn(input, field) && input[field] !== identity[field]) {
+        throw new Error(`role key identity mismatch: ${field}`);
+      }
+    }
+    return identity;
+  }
+
+  function roleFailureReason(current, expected) {
+    if (!current) return "not_found";
+    if (current.version !== expected.version) return "stale_version";
+    if (current.epoch !== expected.epoch) return "stale_epoch";
+    if (current.activation_seq !== expected.activation_seq) {
+      return "stale_activation_seq";
+    }
+    if (current.activation_id !== expected.activation_id) {
+      return "stale_activation_id";
+    }
+    return "cas_conflict";
+  }
+
+  const reserveRole = db.transaction((input) => {
+    const identity = roleIdentity(input);
+    const current = S.getRole.get(identity.role_key_wire) ?? null;
+    const expectedVersion =
+      input.expected_version ?? input.expectedVersion ?? current?.version;
+    const expectedEpoch =
+      input.expected_epoch ?? input.expectedEpoch ?? current?.epoch;
+
+    if (current && expectedVersion !== current.version) {
+      return { ok: false, reason: "stale_version", role: current };
+    }
+    if (current && expectedEpoch !== current.epoch) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+
+    const nextEpoch =
+      input.epoch ?? input.next_epoch ?? (current ? current.epoch + 1 : 0);
+    if (current && nextEpoch !== current.epoch + 1) {
+      return { ok: false, reason: "stale_epoch", role: current };
+    }
+    const nextActivationSeq =
+      input.activation_seq ??
+      input.next_activation_seq ??
+      (current ? current.activation_seq + 1 : 0);
+    if (current && nextActivationSeq !== current.activation_seq + 1) {
+      return { ok: false, reason: "stale_activation_seq", role: current };
+    }
+
+    const state =
+      input.state ?? (input.holder_agent_id ? "elected-probing" : "electable");
+    if (!ROLE_REACHABILITY_STATES.includes(state)) {
+      throw new Error(`invalid role reachability state: ${state}`);
+    }
+    const row = {
+      ...identity,
+      state,
+      holder_agent_id: input.holder_agent_id ?? null,
+      previous_holder_agent_id:
+        input.previous_holder_agent_id ??
+        (current?.holder_agent_id !== input.holder_agent_id
+          ? (current?.holder_agent_id ?? null)
+          : (current?.previous_holder_agent_id ?? null)),
+      epoch: nextEpoch,
+      activation_seq: nextActivationSeq,
+      activation_id:
+        input.activation_id ??
+        (input.holder_agent_id ? uuidv7() : (current?.activation_id ?? null)),
+      activation_deadline_ms:
+        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
+      holder_lease_expires_ms:
+        input.holder_lease_expires_ms ??
+        current?.holder_lease_expires_ms ??
+        null,
+      charter_version:
+        input.charter_version ?? current?.charter_version ?? null,
+      charter_acked_epoch:
+        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      retry_count: input.retry_count ?? current?.retry_count ?? 0,
+      next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
+      blocked_reason:
+        input.blocked_reason === undefined
+          ? (current?.blocked_reason ?? null)
+          : input.blocked_reason,
+      last_transition_ms: input.last_transition_ms ?? Date.now(),
+      last_reason: input.last_reason ?? "role_reserved",
+      version: 0,
+      expected_version: current?.version,
+      expected_epoch: current?.epoch,
+    };
+
+    if (!current) {
+      S.insertRoleReservation.run(row);
+    } else if (S.updateRoleReservation.run(row).changes !== 1) {
+      const latest = S.getRole.get(identity.role_key_wire) ?? null;
+      return {
+        ok: false,
+        reason: roleFailureReason(latest, {
+          version: current.version,
+          epoch: current.epoch,
+          activation_seq: current.activation_seq,
+          activation_id: current.activation_id,
+        }),
+        role: latest,
+      };
+    }
+    return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+  });
+
+  const recoverRegistry = db.transaction((now) => {
+    for (const role of S.listRoles.all()) {
+      const guard = {
+        role_key_wire: role.role_key_wire,
+        expected_version: role.version,
+        expected_epoch: role.epoch,
+        now,
+      };
+      if (
+        role.holder_agent_id &&
+        (role.holder_lease_expires_ms == null ||
+          role.holder_lease_expires_ms <= now)
+      ) {
+        S.recoverExpiredRole.run(guard);
+      } else if (role.holder_agent_id) {
+        S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
+      } else if (role.activation_id || role.state === "elected-probing") {
+        S.recoverOrphanedActivation.run(guard);
+      }
+    }
+
+    const roles = S.listRoles.all();
+    return {
+      roles,
+      candidates: roles.flatMap((role) =>
+        S.listRoleCandidates.all(role.role_key_wire).map(parseRoleCandidateRow),
+      ),
+      pending_messages: roles.flatMap((role) =>
+        S.pendingRoleMessages.all(role.role_key_wire, now).map(parseMessageRow),
+      ),
+    };
+  });
+
   const store = {
     db,
     uuidv7,
@@ -464,6 +804,236 @@ export function createStore(dbPath, options = {}) {
       return S.setAgentStatus.run(status, agentId).changes > 0;
     },
 
+    getRole(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.getRole.get(roleKeyWire) ?? null;
+    },
+
+    upsertRoleReservation(input) {
+      return reserveRole.immediate(input);
+    },
+
+    compareAndSetRole(input) {
+      const identity = roleIdentity(input);
+      const current = S.getRole.get(identity.role_key_wire) ?? null;
+      if (!current) return { ok: false, reason: "not_found", role: null };
+
+      const hasExpectedActivationSeq =
+        Object.hasOwn(input, "expected_activation_seq") ||
+        Object.hasOwn(input, "expectedActivationSeq") ||
+        Object.hasOwn(input, "activation_seq");
+      const hasExpectedActivationId =
+        Object.hasOwn(input, "expected_activation_id") ||
+        Object.hasOwn(input, "expectedActivationId") ||
+        Object.hasOwn(input, "activation_id");
+      const expected = {
+        version:
+          input.expected_version ?? input.expectedVersion ?? input.version,
+        epoch: input.expected_epoch ?? input.expectedEpoch ?? input.epoch,
+        activation_seq:
+          input.expected_activation_seq ??
+          input.expectedActivationSeq ??
+          input.activation_seq,
+        activation_id: Object.hasOwn(input, "expected_activation_id")
+          ? input.expected_activation_id
+          : Object.hasOwn(input, "expectedActivationId")
+            ? input.expectedActivationId
+            : input.activation_id,
+      };
+      if (
+        expected.version == null ||
+        expected.epoch == null ||
+        !hasExpectedActivationSeq ||
+        !hasExpectedActivationId
+      ) {
+        return { ok: false, reason: "invalid_cas", role: current };
+      }
+
+      const reason = roleFailureReason(current, expected);
+      if (reason !== "cas_conflict") {
+        return { ok: false, reason, role: current };
+      }
+
+      const patch = input.patch ?? input.changes ?? {};
+      const state = patch.state ?? current.state;
+      if (!ROLE_REACHABILITY_STATES.includes(state)) {
+        throw new Error(`invalid role reachability state: ${state}`);
+      }
+      const next = {
+        role_key_wire: identity.role_key_wire,
+        expected_version: expected.version,
+        expected_epoch: expected.epoch,
+        expected_activation_seq: expected.activation_seq,
+        expected_activation_id: expected.activation_id,
+        state,
+        holder_agent_id:
+          patch.holder_agent_id === undefined
+            ? current.holder_agent_id
+            : patch.holder_agent_id,
+        previous_holder_agent_id:
+          patch.previous_holder_agent_id === undefined
+            ? current.previous_holder_agent_id
+            : patch.previous_holder_agent_id,
+        activation_id:
+          patch.activation_id === undefined
+            ? current.activation_id
+            : patch.activation_id,
+        activation_deadline_ms:
+          patch.activation_deadline_ms === undefined
+            ? current.activation_deadline_ms
+            : patch.activation_deadline_ms,
+        holder_lease_expires_ms:
+          patch.holder_lease_expires_ms === undefined
+            ? current.holder_lease_expires_ms
+            : patch.holder_lease_expires_ms,
+        charter_version:
+          patch.charter_version === undefined
+            ? current.charter_version
+            : patch.charter_version,
+        charter_acked_epoch:
+          patch.charter_acked_epoch === undefined
+            ? current.charter_acked_epoch
+            : patch.charter_acked_epoch,
+        retry_count: patch.retry_count ?? current.retry_count,
+        next_probe_ms:
+          patch.next_probe_ms === undefined
+            ? current.next_probe_ms
+            : patch.next_probe_ms,
+        blocked_reason:
+          patch.blocked_reason === undefined
+            ? current.blocked_reason
+            : patch.blocked_reason,
+        last_transition_ms: patch.last_transition_ms ?? Date.now(),
+        last_reason: patch.last_reason ?? current.last_reason,
+      };
+      if (S.compareAndSetRole.run(next).changes !== 1) {
+        const latest = S.getRole.get(identity.role_key_wire) ?? null;
+        return {
+          ok: false,
+          reason: roleFailureReason(latest, expected),
+          role: latest,
+        };
+      }
+      return { ok: true, role: S.getRole.get(identity.role_key_wire) };
+    },
+
+    listRoleKeys(filter = {}) {
+      const clauses = [];
+      const params = {};
+      for (const field of ["project_id", "role_kind", "scope_id", "state"]) {
+        if (filter[field] !== undefined) {
+          clauses.push(`${field}=@${field}`);
+          params[field] = filter[field];
+        }
+      }
+      if (Array.isArray(filter.states) && filter.states.length > 0) {
+        clauses.push(
+          `state IN (${filter.states.map((_, index) => `@state_${index}`).join(",")})`,
+        );
+        filter.states.forEach((state, index) => {
+          params[`state_${index}`] = state;
+        });
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(" AND ")}` : "";
+      return db
+        .prepare(
+          `SELECT role_key_wire FROM role_registry${where} ORDER BY role_key_wire`,
+        )
+        .pluck()
+        .all(params);
+    },
+
+    listRolesWithExpiredHolder(now) {
+      return S.expiredHolderRoles.all(now);
+    },
+
+    listRoleCandidates(roleKeyWire) {
+      decodeRoleKey(roleKeyWire);
+      return S.listRoleCandidates.all(roleKeyWire).map(parseRoleCandidateRow);
+    },
+
+    upsertRoleCandidate(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      S.upsertRoleCandidate.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        source: input.source ?? current?.source ?? "operator",
+        priority: input.priority ?? current?.priority ?? 0,
+        transport_locators_json: JSON.stringify(
+          input.transport_locators ??
+            parseJson(current?.transport_locators_json, []),
+        ),
+        consecutive_probe_failures:
+          input.consecutive_probe_failures ??
+          current?.consecutive_probe_failures ??
+          0,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? (current?.excluded_until_ms ?? null)
+            : input.excluded_until_ms,
+        last_probe_ms:
+          input.last_probe_ms === undefined
+            ? (current?.last_probe_ms ?? null)
+            : input.last_probe_ms,
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? (current?.last_probe_code ?? null)
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return parseRoleCandidateRow(
+        S.getRoleCandidate.get(role_key_wire, input.agent_id),
+      );
+    },
+
+    updateCandidateReachability(input) {
+      const { role_key_wire } = roleIdentity(input);
+      const current = S.getRoleCandidate.get(role_key_wire, input.agent_id);
+      if (!current) return { ok: false, reason: "not_found" };
+
+      let failures =
+        input.consecutive_probe_failures ?? current.consecutive_probe_failures;
+      if (
+        input.probe_failed === true ||
+        input.increment_probe_failures === true
+      ) {
+        failures = current.consecutive_probe_failures + 1;
+      } else if (input.probe_succeeded === true) {
+        failures = 0;
+      }
+      S.updateCandidateReachability.run({
+        role_key_wire,
+        agent_id: input.agent_id,
+        consecutive_probe_failures: failures,
+        excluded_until_ms:
+          input.excluded_until_ms === undefined
+            ? current.excluded_until_ms
+            : input.excluded_until_ms,
+        last_probe_ms: input.last_probe_ms ?? Date.now(),
+        last_probe_code:
+          input.last_probe_code === undefined
+            ? current.last_probe_code
+            : input.last_probe_code,
+        updated_at_ms: input.updated_at_ms ?? Date.now(),
+      });
+      return {
+        ok: true,
+        candidate: parseRoleCandidateRow(
+          S.getRoleCandidate.get(role_key_wire, input.agent_id),
+        ),
+      };
+    },
+
+    listPendingRoleMessages(roleKeyWire, now) {
+      decodeRoleKey(roleKeyWire);
+      return S.pendingRoleMessages.all(roleKeyWire, now).map(parseMessageRow);
+    },
+
+    recoverRoleRegistry(now) {
+      return recoverRegistry.immediate(now);
+    },
+
     auditLog({
       type,
       from,
@@ -475,6 +1045,7 @@ export function createStore(dbPath, options = {}) {
       trace_id,
       correlation_id,
       status = "queued",
+      role_key_wire = null,
     }) {
       const now = Date.now();
       const row = {
@@ -491,6 +1062,7 @@ export function createStore(dbPath, options = {}) {
         trace_id: trace_id || uuidv7(),
         payload_json: JSON.stringify(payload),
         status,
+        role_key_wire,
       };
       S.insertAuditMessage.run(row);
       return { ...row, payload };

--- a/tests/unit/store-migration-v6.test.mjs
+++ b/tests/unit/store-migration-v6.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { createStore } from "../../hub/store.mjs";
+import { loadBetterSqlite3ForTest, SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const TEMP_DIRS = [];
+
+function makeV5Database() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-store-v6-migration-"));
+  TEMP_DIRS.push(dir);
+  const dbPath = join(dir, "hub.db");
+  const Database = loadBetterSqlite3ForTest();
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT);
+    INSERT INTO _meta (key, value) VALUES ('schema_version', '5');
+
+    CREATE TABLE agents (
+      agent_id TEXT PRIMARY KEY,
+      cli TEXT NOT NULL CHECK (cli IN ('codex','gemini','claude','other')),
+      pid INTEGER,
+      capabilities_json TEXT NOT NULL DEFAULT '[]',
+      topics_json TEXT NOT NULL DEFAULT '[]',
+      last_seen_ms INTEGER NOT NULL,
+      lease_expires_ms INTEGER NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('online','stale','offline')),
+      metadata_json TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL CHECK (type IN ('request','response','event','handoff','human_request','human_response','system')),
+      from_agent TEXT NOT NULL,
+      to_agent TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      priority INTEGER NOT NULL CHECK (priority BETWEEN 1 AND 9),
+      ttl_ms INTEGER NOT NULL,
+      created_at_ms INTEGER NOT NULL,
+      expires_at_ms INTEGER NOT NULL,
+      correlation_id TEXT NOT NULL,
+      trace_id TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      status TEXT NOT NULL CHECK (status IN ('queued','delivered','acked','expired','dead_letter'))
+    );
+  `);
+  db.prepare(`
+    INSERT INTO agents (
+      agent_id, cli, pid, capabilities_json, topics_json, last_seen_ms,
+      lease_expires_ms, status, metadata_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "legacy-agent",
+    "codex",
+    42,
+    '["code"]',
+    '["legacy"]',
+    100,
+    200,
+    "online",
+    '{"kept":true}',
+  );
+  db.prepare(`
+    INSERT INTO messages (
+      id, type, from_agent, to_agent, topic, priority, ttl_ms,
+      created_at_ms, expires_at_ms, correlation_id, trace_id,
+      payload_json, status
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "legacy-message",
+    "event",
+    "legacy-agent",
+    "topic:legacy",
+    "legacy",
+    5,
+    1000,
+    100,
+    1100,
+    "legacy-correlation",
+    "legacy-trace",
+    '{"kept":true}',
+    "queued",
+  );
+  db.close();
+  return dbPath;
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("hub store schema v6 migration", { skip: SQLITE_SKIP }, () => {
+  it("migrates a real v5 database without losing agents or messages", () => {
+    const dbPath = makeV5Database();
+    const first = createStore(dbPath);
+
+    assert.equal(
+      first.db
+        .prepare("SELECT value FROM _meta WHERE key='schema_version'")
+        .pluck()
+        .get(),
+      "6",
+    );
+    assert.deepEqual(first.getAgent("legacy-agent"), {
+      agent_id: "legacy-agent",
+      cli: "codex",
+      pid: 42,
+      last_seen_ms: 100,
+      lease_expires_ms: 200,
+      status: "online",
+      project_id: null,
+      session_id: null,
+      host_id: null,
+      transport_locators_json: "[]",
+      capabilities: ["code"],
+      topics: ["legacy"],
+      metadata: { kept: true },
+    });
+    assert.equal(first.getMessage("legacy-message").payload.kept, true);
+    assert.equal(first.getMessage("legacy-message").role_key_wire, null);
+    assert.equal(
+      first.db
+        .prepare(
+          "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_messages_role_key'",
+        )
+        .pluck()
+        .get(),
+      1,
+    );
+    first.close();
+
+    const second = createStore(dbPath);
+    assert.equal(second.getAgent("legacy-agent").metadata.kept, true);
+    assert.equal(second.getMessage("legacy-message").payload.kept, true);
+    assert.equal(
+      second.db.prepare("SELECT COUNT(*) FROM role_registry").pluck().get(),
+      0,
+    );
+    second.close();
+  });
+});

--- a/tests/unit/store-role-registry.test.mjs
+++ b/tests/unit/store-role-registry.test.mjs
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { encodeRoleKey } from "../../hub/role-contract.mjs";
+import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const TEMP_DIRS = [];
+const PROJECT_A = `prj_${"a".repeat(22)}`;
+const PROJECT_B = `prj_${"b".repeat(22)}`;
+const SCOPE_A = `scp_${"a".repeat(22)}`;
+const CTO_A = encodeRoleKey({ project_id: PROJECT_A, role_kind: "cto" });
+const CTO_B = encodeRoleKey({ project_id: PROJECT_B, role_kind: "cto" });
+const LEAD_A = encodeRoleKey({
+  project_id: PROJECT_A,
+  role_kind: "lead",
+  scope_id: SCOPE_A,
+});
+
+function tempDbPath() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-role-registry-"));
+  TEMP_DIRS.push(dir);
+  return join(dir, "hub.db");
+}
+
+function reserve(store, overrides = {}) {
+  return store.upsertRoleReservation({
+    role_key_wire: CTO_A,
+    holder_agent_id: "agent-1",
+    holder_lease_expires_ms: 500,
+    activation_id: "activation-1",
+    last_transition_ms: 100,
+    last_reason: "candidate_selected",
+    ...overrides,
+  });
+}
+
+function insertRawRole(store, row) {
+  store.db
+    .prepare(`
+      INSERT INTO role_registry (
+        role_key_wire, project_id, role_kind, scope_id, state,
+        last_transition_ms, last_reason
+      ) VALUES (
+        @role_key_wire, @project_id, @role_kind, @scope_id, @state,
+        1, 'test'
+      )
+    `)
+    .run(row);
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("hub store role registry", { skip: SQLITE_SKIP }, () => {
+  it("round-trips reservations and lists filtered role keys", () => {
+    const store = createStore(tempDbPath());
+    try {
+      const result = reserve(store);
+      assert.equal(result.ok, true);
+      assert.deepEqual(store.getRole(CTO_A), result.role);
+      assert.deepEqual(store.listRoleKeys({ project_id: PROJECT_A }), [CTO_A]);
+
+      const staleVersion = reserve(store, {
+        expected_version: result.role.version - 1,
+      });
+      assert.equal(staleVersion.ok, false);
+      assert.equal(staleVersion.reason, "stale_version");
+
+      const staleEpoch = reserve(store, {
+        expected_version: result.role.version,
+        expected_epoch: result.role.epoch - 1,
+      });
+      assert.equal(staleEpoch.ok, false);
+      assert.equal(staleEpoch.reason, "stale_epoch");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("applies CAS once and rejects stale version and epoch guards", () => {
+    const store = createStore(tempDbPath());
+    try {
+      const reserved = reserve(store).role;
+      const activated = store.compareAndSetRole({
+        role_key_wire: CTO_A,
+        expected_version: reserved.version,
+        expected_epoch: reserved.epoch,
+        expected_activation_seq: reserved.activation_seq,
+        expected_activation_id: reserved.activation_id,
+        patch: {
+          state: "active",
+          charter_acked_epoch: reserved.epoch,
+          last_transition_ms: 200,
+          last_reason: "activation_acked",
+        },
+      });
+      assert.equal(activated.ok, true);
+      assert.equal(activated.role.version, reserved.version + 1);
+      assert.equal(activated.role.state, "active");
+
+      const staleVersion = store.compareAndSetRole({
+        role_key_wire: CTO_A,
+        expected_version: reserved.version,
+        expected_epoch: reserved.epoch,
+        expected_activation_seq: reserved.activation_seq,
+        expected_activation_id: reserved.activation_id,
+        patch: { state: "unreachable" },
+      });
+      assert.equal(staleVersion.ok, false);
+      assert.equal(staleVersion.reason, "stale_version");
+
+      const staleEpoch = store.compareAndSetRole({
+        role_key_wire: CTO_A,
+        expected_version: activated.role.version,
+        expected_epoch: activated.role.epoch - 1,
+        expected_activation_seq: activated.role.activation_seq,
+        expected_activation_id: activated.role.activation_id,
+        patch: { state: "unreachable" },
+      });
+      assert.equal(staleEpoch.ok, false);
+      assert.equal(staleEpoch.reason, "stale_epoch");
+
+      const staleActivation = store.compareAndSetRole({
+        role_key_wire: CTO_A,
+        expected_version: activated.role.version,
+        expected_epoch: activated.role.epoch,
+        expected_activation_seq: activated.role.activation_seq,
+        expected_activation_id: "older-activation",
+        patch: { state: "unreachable" },
+      });
+      assert.equal(staleActivation.ok, false);
+      assert.equal(staleActivation.reason, "stale_activation_id");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("enforces role kind/scope and reachability CHECK constraints", () => {
+    const store = createStore(tempDbPath());
+    try {
+      const invalidRows = [
+        {
+          role_key_wire: "invalid-cto-scope",
+          project_id: PROJECT_A,
+          role_kind: "cto",
+          scope_id: SCOPE_A,
+          state: "electable",
+        },
+        {
+          role_key_wire: "invalid-lead-scope",
+          project_id: PROJECT_A,
+          role_kind: "lead",
+          scope_id: "",
+          state: "electable",
+        },
+        {
+          role_key_wire: "invalid-state",
+          project_id: PROJECT_A,
+          role_kind: "cto",
+          scope_id: "",
+          state: "offline",
+        },
+      ];
+      for (const row of invalidRows) {
+        assert.throws(
+          () => insertRawRole(store, row),
+          /CHECK constraint failed/,
+        );
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("enforces unique project/kind/scope identity", () => {
+    const store = createStore(tempDbPath());
+    try {
+      insertRawRole(store, {
+        role_key_wire: CTO_A,
+        project_id: PROJECT_A,
+        role_kind: "cto",
+        scope_id: "",
+        state: "electable",
+      });
+      assert.throws(
+        () =>
+          insertRawRole(store, {
+            role_key_wire: "different-wire-same-role",
+            project_id: PROJECT_A,
+            role_kind: "cto",
+            scope_id: "",
+            state: "electable",
+          }),
+        /UNIQUE constraint failed/,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("persists roles across restart and exposes expired holders", () => {
+    const dbPath = tempDbPath();
+    const first = createStore(dbPath);
+    const persisted = reserve(first, {
+      state: "active",
+      holder_lease_expires_ms: 999,
+    }).role;
+    first.close();
+
+    const second = createStore(dbPath);
+    try {
+      assert.deepEqual(second.getRole(CTO_A), persisted);
+      assert.deepEqual(
+        second
+          .listRolesWithExpiredHolder(1000)
+          .map((role) => role.role_key_wire),
+        [CTO_A],
+      );
+      assert.deepEqual(second.listRolesWithExpiredHolder(998), []);
+    } finally {
+      second.close();
+    }
+  });
+
+  it("upserts candidate reachability and cascades deletes", () => {
+    const store = createStore(tempDbPath());
+    try {
+      reserve(store);
+      const candidate = store.upsertRoleCandidate({
+        role_key_wire: CTO_A,
+        agent_id: "candidate-1",
+        source: "standup",
+        priority: 10,
+        transport_locators: [{ kind: "pipe", path: "/tmp/agent-1" }],
+        updated_at_ms: 100,
+      });
+      assert.deepEqual(candidate.transport_locators, [
+        { kind: "pipe", path: "/tmp/agent-1" },
+      ]);
+
+      const failed = store.updateCandidateReachability({
+        role_key_wire: CTO_A,
+        agent_id: "candidate-1",
+        probe_failed: true,
+        excluded_until_ms: 5000,
+        last_probe_ms: 200,
+        last_probe_code: "ECONNREFUSED",
+        updated_at_ms: 201,
+      });
+      assert.equal(failed.ok, true);
+      assert.equal(failed.candidate.consecutive_probe_failures, 1);
+      assert.equal(failed.candidate.excluded_until_ms, 5000);
+      assert.deepEqual(store.listRoleCandidates(CTO_A), [failed.candidate]);
+
+      store.db
+        .prepare("DELETE FROM role_registry WHERE role_key_wire=?")
+        .run(CTO_A);
+      assert.deepEqual(store.listRoleCandidates(CTO_A), []);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("lists durable pending messages and fences persisted activations on recovery", () => {
+    const store = createStore(tempDbPath());
+    try {
+      reserve(store, { holder_lease_expires_ms: 50 });
+      store.auditLog({
+        type: "event",
+        from: "agent-1",
+        to: `topic:role:${CTO_A}`,
+        topic: "role.work",
+        ttl_ms: 1000,
+        role_key_wire: CTO_A,
+      });
+      assert.equal(store.listPendingRoleMessages(CTO_A, Date.now()).length, 1);
+
+      const recovered = store.recoverRoleRegistry(100);
+      assert.equal(recovered.roles[0].state, "electable");
+      assert.equal(recovered.roles[0].holder_agent_id, null);
+      assert.equal(recovered.roles[0].epoch, 1);
+      assert.equal(recovered.pending_messages.length, 1);
+
+      reserve(store, {
+        role_key_wire: CTO_B,
+        holder_agent_id: null,
+        state: "electable",
+      });
+      reserve(store, {
+        role_key_wire: LEAD_A,
+        holder_agent_id: null,
+        state: "electable",
+      });
+      assert.deepEqual(store.listRoleKeys({ role_kind: "lead" }), [LEAD_A]);
+    } finally {
+      store.close();
+    }
+  });
+});


### PR DESCRIPTION
## 요약

C6a-2 슬라이스 — hub store에 role registry 영속화(schema v6) + CAS/recovery API. 계약 정본 `.triflux/plans/0011a-c6a-contracts.md`의 계약 4(동시성)·계약 5(durability)·P1 보정을 구현. **inert** — router/dispatch/production 경로 무변경, store 함수만 존재하고 아직 아무도 호출하지 않음.

- schema.sql: `role_registry` + `role_candidates` CREATE TABLE IF NOT EXISTS + `idx_messages_role_key`
- store.mjs: SCHEMA_VERSION 5→6, 신규 컬럼은 raw ALTER 금지 → `ensureColumn` (버전 분기 앞 호출 — v6 인덱스가 참조하는 컬럼 seam 선행), store API 10종 (getRole / upsertRoleReservation / compareAndSetRole / listRoleKeys / listRolesWithExpiredHolder / listRoleCandidates 등)
- CAS: version 단조증가 + epoch·activation_seq·activation_id·version 4중 WHERE, `BEGIN IMMEDIATE`, stale은 `{ok:false, reason}` 반환, `activation_id IS @…` NULL-safe
- 테스트 2종 신규: v5 실 DB → v6 마이그레이션 조회 보존(실제 createStore 경로, 모킹 없음) + CAS/재시작 durability/CASCADE
- 미러: packages/triflux byte-identical, packages/remote import 변환 보존(Edit)

## 검증

- 신규 테스트 8/8, store·router 회귀 55/55 pass
- `diff -q` root↔triflux IDENTICAL, remote import `@triflux/core/hub/role-contract.mjs` 보존
- opus 교차 리뷰: **APPROVE-with-P3** (P1/P2 0건)

## P3 후속 (비차단, C6a-3에서 정리)

1. `roleFailureReason` 일치 시 `"cas_conflict"` 반환 — `null`로 의미 정상화
2. `compareAndSetRole` 트랜잭션 비대칭 (`reserveRole`과 일관성)
3. `recoverRegistry`의 active+holder NULL 조합 방어 CHECK 검토
4. 스펙 5-4/5-5 transport locator 판정은 activator 계층(C6a-3)으로 이월 — 추적 필요

## 관련

- 계약: `.triflux/plans/0011a-c6a-contracts.md` / 순서: `.triflux/plans/0011-active-cto-lead-role-system.md` "eng-review 반영"
- 선행: PR #483 (C6a-1 inert kernel)
