### PR TITLE
feat(core): register role contract kernel in pack CORE_FILES (C6a-1 follow-up)

### DIFF
--- a/packages/triflux/scripts/pack.mjs
+++ b/packages/triflux/scripts/pack.mjs
@@ -34,6 +34,8 @@ const CORE_FILES = [
   "hub/intent.mjs",
   "hub/token-mode.mjs",
   "hub/router.mjs",
+  "hub/role-contract.mjs",
+  "hub/role-control-events.mjs",
   "hub/hitl.mjs",
   "hub/assign-callbacks.mjs",
   "hub/fullcycle.mjs",

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -34,6 +34,8 @@ const CORE_FILES = [
   "hub/intent.mjs",
   "hub/token-mode.mjs",
   "hub/router.mjs",
+  "hub/role-contract.mjs",
+  "hub/role-control-events.mjs",
   "hub/hitl.mjs",
   "hub/assign-callbacks.mjs",
   "hub/fullcycle.mjs",


### PR DESCRIPTION
## 요약

C6a-1 후속 — PR #483이 추가한 `hub/role-contract.mjs` / `hub/role-control-events.mjs`를 `scripts/pack.mjs` CORE_FILES에 등록 (2줄 × root/triflux 미러 2파일). 당시 메인 체크아웃 pack.mjs가 별개 작업과 얽혀 있어 보류됐던 건을 격리 worktree에서 수행.

## 검증

- `diff -q scripts/pack.mjs packages/triflux/scripts/pack.mjs` BYTE-IDENTICAL
- `tests/unit/pack-remote.test.mjs` pass
- opus 교차 리뷰: **APPROVE** (결함 없음)

## 관련

- 선행: PR #483 (C6a-1 inert kernel) / 정책: `.claude/rules/tfx-mirror-policy.md`
