### PR TITLE
docs(adr): ADR-0011 accepted 승격

### DIFF
--- a/docs/adr/0011-active-role-system-cto-scoped-lead.md
+++ b/docs/adr/0011-active-role-system-cto-scoped-lead.md
@@ -1,13 +1,13 @@
 ---
 id: 0011
 title: 능동 역할 시스템 — CTO + scoped lead (C+A 하이브리드)
-status: proposed
+status: accepted
 date: 2026-07-16
 deciders: [tellang]
 supersedes: []
 superseded_by: null
 relates: [0010]
-pr: null
+pr: "#483, #484, #485"
 ---
 
 # ADR-0011: 능동 역할 시스템 — CTO + scoped lead (C+A 하이브리드)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,7 +17,7 @@ triflux의 아키텍처·정책·횡단 결정을 ADR(Architecture Decision Reco
 | [0008](0008-native-bridge-ui-default-on.md) | headless 워커 native-bridge 기본 노출 | Accepted | 0002 |
 | [0009](0009-stack-coexistence-three-layer.md) | gstack·sp·triflux 단방향 3-layer 공존 | Accepted | 0002 |
 | [0010](0010-cto-lake-hub-role-boundary.md) | CTO lake ↔ Hub role 경계 — liveness/history 평면 분리 | Proposed | 0005, 0007 |
-| [0011](0011-active-role-system-cto-scoped-lead.md) | 능동 역할 시스템 — CTO + scoped lead (C+A 하이브리드) | Proposed | 0010 |
+| [0011](0011-active-role-system-cto-scoped-lead.md) | 능동 역할 시스템 — CTO + scoped lead (C+A 하이브리드) | Accepted | 0010 |
 
 상태 범례: **Proposed**(제안) · **Accepted**(확정, 불변) · **Superseded**(대체됨 → `_archive/`) · **Deprecated**/**Rejected**/**Withdrawn**(무효화 → `_archive/`).
 


### PR DESCRIPTION
## 요약

ADR-0011(능동 역할 시스템 — CTO + scoped lead) status를 proposed → accepted로 승격.

근거: C6a 10계약 스펙 확정(`.triflux/plans/0011a-c6a-contracts.md`, Codex 초안 + Claude opus 적대적 교차검증) + 계약 기반 구현 2슬라이스 랜딩 — C6a-1 inert kernel(#483), C6a-2 schema v6 + store CAS/recovery(#484, opus 리뷰 APPROVE) + pack 등록(#485).

변경: frontmatter status/pr 필드 + README 상태보드 행. CONVENTIONS 상태머신(proposed→accepted) 준수, docs-adr-structure 테스트 0 fail.