### PR TITLE
feat(routing): keyword hook repo_scope/explicit/disabled + 명시토큰 전용 규칙 (A 슬라이스 재구현)

### DIFF
--- a/hooks/keyword-rules.json
+++ b/hooks/keyword-rules.json
@@ -109,7 +109,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-analysis",
@@ -124,7 +125,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-plan",
@@ -139,7 +141,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-qa",
@@ -154,7 +157,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-research",
@@ -169,7 +173,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-find",
@@ -184,7 +189,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-unified",
@@ -273,7 +279,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-codex",

--- a/hooks/keyword-rules.json
+++ b/hooks/keyword-rules.json
@@ -97,6 +97,96 @@
       "mcp_route": null
     },
     {
+      "id": "tfx-review",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?review\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-review",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-analysis",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?analysis\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-analysis",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-plan",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?plan\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-plan",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-qa",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?qa\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-qa",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-research",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?research\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-research",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-find",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?find\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-find",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
       "id": "tfx-unified",
       "patterns": [
         {
@@ -157,6 +247,10 @@
         {
           "source": "(?:AI\\s*슬롭|ai\\s*slop|anti[\\s-]?slop|deslop)",
           "flags": "i"
+        },
+        {
+          "source": "(?:슬롭|클린업)",
+          "flags": "i"
         }
       ],
       "skill": "ai-slop-cleaner",
@@ -176,7 +270,7 @@
       ],
       "skill": "tfx-prune",
       "priority": 1,
-      "supersedes": [],
+      "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
       "mcp_route": null
@@ -748,14 +842,6 @@
           "flags": "i"
         },
         {
-          "source": "\\brelease\\b",
-          "flags": "i"
-        },
-        {
-          "source": "\\bpublish\\b",
-          "flags": "i"
-        },
-        {
           "source": "배포(?!자|사|장|처)",
           "flags": ""
         },
@@ -773,7 +859,9 @@
       "supersedes": ["gstack-ship"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "repo_scope": ["triflux"],
+      "explicit": true
     }
   ]
 }

--- a/packages/core/hooks/keyword-rules.json
+++ b/packages/core/hooks/keyword-rules.json
@@ -109,7 +109,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-analysis",
@@ -124,7 +125,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-plan",
@@ -139,7 +141,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-qa",
@@ -154,7 +157,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-research",
@@ -169,7 +173,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-find",
@@ -184,7 +189,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-unified",
@@ -273,7 +279,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-codex",

--- a/packages/core/hooks/keyword-rules.json
+++ b/packages/core/hooks/keyword-rules.json
@@ -97,6 +97,96 @@
       "mcp_route": null
     },
     {
+      "id": "tfx-review",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?review\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-review",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-analysis",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?analysis\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-analysis",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-plan",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?plan\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-plan",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-qa",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?qa\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-qa",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-research",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?research\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-research",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-find",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?find\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-find",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
       "id": "tfx-unified",
       "patterns": [
         {
@@ -157,6 +247,10 @@
         {
           "source": "(?:AI\\s*슬롭|ai\\s*slop|anti[\\s-]?slop|deslop)",
           "flags": "i"
+        },
+        {
+          "source": "(?:슬롭|클린업)",
+          "flags": "i"
         }
       ],
       "skill": "ai-slop-cleaner",
@@ -176,7 +270,7 @@
       ],
       "skill": "tfx-prune",
       "priority": 1,
-      "supersedes": [],
+      "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
       "mcp_route": null
@@ -748,14 +842,6 @@
           "flags": "i"
         },
         {
-          "source": "\\brelease\\b",
-          "flags": "i"
-        },
-        {
-          "source": "\\bpublish\\b",
-          "flags": "i"
-        },
-        {
           "source": "배포(?!자|사|장|처)",
           "flags": ""
         },
@@ -773,7 +859,9 @@
       "supersedes": ["gstack-ship"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "repo_scope": ["triflux"],
+      "explicit": true
     }
   ]
 }

--- a/packages/core/scripts/lib/keyword-rules.mjs
+++ b/packages/core/scripts/lib/keyword-rules.mjs
@@ -26,6 +26,7 @@ function normalizeState(state) {
 
 function normalizeRule(rule) {
   if (!rule || typeof rule !== "object") return null;
+  if (rule.disabled === true) return null;
   if (typeof rule.id !== "string" || !rule.id.trim()) return null;
   if (!Array.isArray(rule.patterns) || rule.patterns.length === 0) return null;
   if (typeof rule.priority !== "number" || !Number.isFinite(rule.priority))
@@ -61,6 +62,13 @@ function normalizeRule(rule) {
   const state = normalizeState(rule.state);
   if (rule.state != null && state == null) return null;
 
+  // repo_scope: path segment 화이트리스트 (빈 배열 = 전역). explicit: 종결 라우팅 마커.
+  const repoScope = Array.isArray(rule.repo_scope)
+    ? rule.repo_scope
+        .filter((s) => typeof s === "string" && s.trim())
+        .map((s) => s.trim())
+    : [];
+
   return {
     id: rule.id.trim(),
     patterns,
@@ -72,6 +80,8 @@ function normalizeRule(rule) {
     exclusive: rule.exclusive === true,
     state,
     mcp_route: mcpRoute,
+    repo_scope: repoScope,
+    explicit: rule.explicit === true,
   };
 }
 
@@ -149,6 +159,8 @@ export function matchRules(compiledRules, cleanText) {
       exclusive: rule.exclusive === true,
       state: rule.state || null,
       mcp_route: rule.mcp_route || null,
+      repo_scope: rule.repo_scope || [],
+      explicit: rule.explicit === true,
     });
   }
 

--- a/packages/remote/scripts/lib/keyword-rules.mjs
+++ b/packages/remote/scripts/lib/keyword-rules.mjs
@@ -26,6 +26,7 @@ function normalizeState(state) {
 
 function normalizeRule(rule) {
   if (!rule || typeof rule !== "object") return null;
+  if (rule.disabled === true) return null;
   if (typeof rule.id !== "string" || !rule.id.trim()) return null;
   if (!Array.isArray(rule.patterns) || rule.patterns.length === 0) return null;
   if (typeof rule.priority !== "number" || !Number.isFinite(rule.priority))
@@ -61,6 +62,13 @@ function normalizeRule(rule) {
   const state = normalizeState(rule.state);
   if (rule.state != null && state == null) return null;
 
+  // repo_scope: path segment 화이트리스트 (빈 배열 = 전역). explicit: 종결 라우팅 마커.
+  const repoScope = Array.isArray(rule.repo_scope)
+    ? rule.repo_scope
+        .filter((s) => typeof s === "string" && s.trim())
+        .map((s) => s.trim())
+    : [];
+
   return {
     id: rule.id.trim(),
     patterns,
@@ -72,6 +80,8 @@ function normalizeRule(rule) {
     exclusive: rule.exclusive === true,
     state,
     mcp_route: mcpRoute,
+    repo_scope: repoScope,
+    explicit: rule.explicit === true,
   };
 }
 
@@ -149,6 +159,8 @@ export function matchRules(compiledRules, cleanText) {
       exclusive: rule.exclusive === true,
       state: rule.state || null,
       mcp_route: rule.mcp_route || null,
+      repo_scope: rule.repo_scope || [],
+      explicit: rule.explicit === true,
     });
   }
 

--- a/packages/triflux/hooks/keyword-rules.json
+++ b/packages/triflux/hooks/keyword-rules.json
@@ -109,7 +109,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-analysis",
@@ -124,7 +125,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-plan",
@@ -139,7 +141,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-qa",
@@ -154,7 +157,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-research",
@@ -169,7 +173,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-find",
@@ -184,7 +189,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-unified",
@@ -273,7 +279,8 @@
       "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "explicit": true
     },
     {
       "id": "tfx-codex",

--- a/packages/triflux/hooks/keyword-rules.json
+++ b/packages/triflux/hooks/keyword-rules.json
@@ -97,6 +97,96 @@
       "mcp_route": null
     },
     {
+      "id": "tfx-review",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?review\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-review",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-analysis",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?analysis\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-analysis",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-plan",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?plan\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-plan",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-qa",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?qa\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-qa",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-research",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?research\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-research",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
+      "id": "tfx-find",
+      "patterns": [
+        {
+          "source": "\\btfx[\\s-]?find\\b",
+          "flags": "i"
+        }
+      ],
+      "skill": "tfx-find",
+      "priority": 1,
+      "supersedes": ["tfx-unified"],
+      "exclusive": false,
+      "state": null,
+      "mcp_route": null
+    },
+    {
       "id": "tfx-unified",
       "patterns": [
         {
@@ -157,6 +247,10 @@
         {
           "source": "(?:AI\\s*슬롭|ai\\s*slop|anti[\\s-]?slop|deslop)",
           "flags": "i"
+        },
+        {
+          "source": "(?:슬롭|클린업)",
+          "flags": "i"
         }
       ],
       "skill": "ai-slop-cleaner",
@@ -176,7 +270,7 @@
       ],
       "skill": "tfx-prune",
       "priority": 1,
-      "supersedes": [],
+      "supersedes": ["tfx-unified"],
       "exclusive": false,
       "state": null,
       "mcp_route": null
@@ -748,14 +842,6 @@
           "flags": "i"
         },
         {
-          "source": "\\brelease\\b",
-          "flags": "i"
-        },
-        {
-          "source": "\\bpublish\\b",
-          "flags": "i"
-        },
-        {
           "source": "배포(?!자|사|장|처)",
           "flags": ""
         },
@@ -773,7 +859,9 @@
       "supersedes": ["gstack-ship"],
       "exclusive": false,
       "state": null,
-      "mcp_route": null
+      "mcp_route": null,
+      "repo_scope": ["triflux"],
+      "explicit": true
     }
   ]
 }

--- a/packages/triflux/scripts/keyword-detector.mjs
+++ b/packages/triflux/scripts/keyword-detector.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   compileRules,
@@ -88,6 +88,27 @@ export function sanitizeForKeywordDetection(text) {
     .replace(/(^|[\s"'`(])(?:\/|\.{1,2}\/)?(?:[\w.-]+\/)+[\w.-]+/gm, "$1 ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+// repo_scope 는 path segment 단위로 매칭한다 — "triflux" 는 .../tools/triflux/... 에만
+// 매칭되고 .../triflux-ideas 같은 부분 문자열에는 매칭되지 않는다. 빈 scope = 전역.
+export function matchesRepoScope(path, scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return true;
+  if (typeof path !== "string" || !path) return false;
+  const segments = path.split(/[\\/]+/).filter(Boolean);
+  return scopes.some((scope) => segments.includes(scope));
+}
+
+// resolvedMatches[0] 단일 승자의 우선순위 역전 방지 — explicit(종결 라우팅) 규칙이
+// 있으면 정렬 순서와 무관하게 그 규칙이 이긴다. 없으면 정렬 선두 유지.
+export function selectPrimaryMatch(resolvedMatches) {
+  if (!Array.isArray(resolvedMatches) || resolvedMatches.length === 0) {
+    return null;
+  }
+  const explicitMatch = resolvedMatches.find(
+    (match) => match?.explicit === true,
+  );
+  return explicitMatch ?? resolvedMatches[0];
 }
 
 function createHookOutput(additionalContext) {
@@ -263,13 +284,21 @@ function main() {
     return;
   }
 
-  const selected = resolvedMatches[0];
   const baseDir =
     typeof payload.cwd === "string" && payload.cwd
       ? payload.cwd
       : typeof payload.directory === "string" && payload.directory
         ? payload.directory
         : process.cwd();
+
+  const scopedMatches = resolvedMatches.filter((match) =>
+    matchesRepoScope(baseDir, match.repo_scope),
+  );
+  const selected = selectPrimaryMatch(scopedMatches);
+  if (!selected) {
+    console.log(JSON.stringify(createSuppressOutput()));
+    return;
+  }
 
   activateState(baseDir, selected.state, prompt, payload);
 
@@ -308,9 +337,24 @@ function main() {
   console.log(JSON.stringify(createSuppressOutput()));
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`[triflux-keyword-detector] 예외 발생: ${error.message}`);
-  console.log(JSON.stringify(createSuppressOutput()));
+// 훅 실행(node scripts/keyword-detector.mjs)일 때만 main 구동 — 테스트 import 시
+// stdin 대기로 행이 걸리지 않도록 direct-run 가드.
+const isDirectRun = (() => {
+  try {
+    return (
+      typeof process.argv[1] === "string" &&
+      fileURLToPath(import.meta.url) === resolve(process.argv[1])
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[triflux-keyword-detector] 예외 발생: ${error.message}`);
+    console.log(JSON.stringify(createSuppressOutput()));
+  }
 }

--- a/packages/triflux/scripts/keyword-detector.mjs
+++ b/packages/triflux/scripts/keyword-detector.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -341,10 +341,13 @@ function main() {
 // stdin 대기로 행이 걸리지 않도록 direct-run 가드.
 const isDirectRun = (() => {
   try {
-    return (
-      typeof process.argv[1] === "string" &&
-      fileURLToPath(import.meta.url) === resolve(process.argv[1])
-    );
+    if (typeof process.argv[1] !== "string" || !process.argv[1]) return false;
+    const selfPath = fileURLToPath(import.meta.url);
+    const argvPath = resolve(process.argv[1]);
+    if (selfPath === argvPath) return true;
+    // 심링크 설치 경로: argv[1]이 심링크면 import.meta.url(실경로)과 어긋난다.
+    // canonical 경로로 재비교 (realpath 실패 시 non-direct 취급).
+    return selfPath === realpathSync(argvPath);
   } catch {
     return false;
   }

--- a/packages/triflux/scripts/lib/keyword-rules.mjs
+++ b/packages/triflux/scripts/lib/keyword-rules.mjs
@@ -26,6 +26,7 @@ function normalizeState(state) {
 
 function normalizeRule(rule) {
   if (!rule || typeof rule !== "object") return null;
+  if (rule.disabled === true) return null;
   if (typeof rule.id !== "string" || !rule.id.trim()) return null;
   if (!Array.isArray(rule.patterns) || rule.patterns.length === 0) return null;
   if (typeof rule.priority !== "number" || !Number.isFinite(rule.priority))
@@ -61,6 +62,13 @@ function normalizeRule(rule) {
   const state = normalizeState(rule.state);
   if (rule.state != null && state == null) return null;
 
+  // repo_scope: path segment 화이트리스트 (빈 배열 = 전역). explicit: 종결 라우팅 마커.
+  const repoScope = Array.isArray(rule.repo_scope)
+    ? rule.repo_scope
+        .filter((s) => typeof s === "string" && s.trim())
+        .map((s) => s.trim())
+    : [];
+
   return {
     id: rule.id.trim(),
     patterns,
@@ -72,6 +80,8 @@ function normalizeRule(rule) {
     exclusive: rule.exclusive === true,
     state,
     mcp_route: mcpRoute,
+    repo_scope: repoScope,
+    explicit: rule.explicit === true,
   };
 }
 
@@ -149,6 +159,8 @@ export function matchRules(compiledRules, cleanText) {
       exclusive: rule.exclusive === true,
       state: rule.state || null,
       mcp_route: rule.mcp_route || null,
+      repo_scope: rule.repo_scope || [],
+      explicit: rule.explicit === true,
     });
   }
 

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   compileRules,
@@ -88,6 +88,27 @@ export function sanitizeForKeywordDetection(text) {
     .replace(/(^|[\s"'`(])(?:\/|\.{1,2}\/)?(?:[\w.-]+\/)+[\w.-]+/gm, "$1 ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+// repo_scope 는 path segment 단위로 매칭한다 — "triflux" 는 .../tools/triflux/... 에만
+// 매칭되고 .../triflux-ideas 같은 부분 문자열에는 매칭되지 않는다. 빈 scope = 전역.
+export function matchesRepoScope(path, scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return true;
+  if (typeof path !== "string" || !path) return false;
+  const segments = path.split(/[\\/]+/).filter(Boolean);
+  return scopes.some((scope) => segments.includes(scope));
+}
+
+// resolvedMatches[0] 단일 승자의 우선순위 역전 방지 — explicit(종결 라우팅) 규칙이
+// 있으면 정렬 순서와 무관하게 그 규칙이 이긴다. 없으면 정렬 선두 유지.
+export function selectPrimaryMatch(resolvedMatches) {
+  if (!Array.isArray(resolvedMatches) || resolvedMatches.length === 0) {
+    return null;
+  }
+  const explicitMatch = resolvedMatches.find(
+    (match) => match?.explicit === true,
+  );
+  return explicitMatch ?? resolvedMatches[0];
 }
 
 function createHookOutput(additionalContext) {
@@ -263,13 +284,21 @@ function main() {
     return;
   }
 
-  const selected = resolvedMatches[0];
   const baseDir =
     typeof payload.cwd === "string" && payload.cwd
       ? payload.cwd
       : typeof payload.directory === "string" && payload.directory
         ? payload.directory
         : process.cwd();
+
+  const scopedMatches = resolvedMatches.filter((match) =>
+    matchesRepoScope(baseDir, match.repo_scope),
+  );
+  const selected = selectPrimaryMatch(scopedMatches);
+  if (!selected) {
+    console.log(JSON.stringify(createSuppressOutput()));
+    return;
+  }
 
   activateState(baseDir, selected.state, prompt, payload);
 
@@ -308,9 +337,24 @@ function main() {
   console.log(JSON.stringify(createSuppressOutput()));
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`[triflux-keyword-detector] 예외 발생: ${error.message}`);
-  console.log(JSON.stringify(createSuppressOutput()));
+// 훅 실행(node scripts/keyword-detector.mjs)일 때만 main 구동 — 테스트 import 시
+// stdin 대기로 행이 걸리지 않도록 direct-run 가드.
+const isDirectRun = (() => {
+  try {
+    return (
+      typeof process.argv[1] === "string" &&
+      fileURLToPath(import.meta.url) === resolve(process.argv[1])
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[triflux-keyword-detector] 예외 발생: ${error.message}`);
+    console.log(JSON.stringify(createSuppressOutput()));
+  }
 }

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -341,10 +341,13 @@ function main() {
 // stdin 대기로 행이 걸리지 않도록 direct-run 가드.
 const isDirectRun = (() => {
   try {
-    return (
-      typeof process.argv[1] === "string" &&
-      fileURLToPath(import.meta.url) === resolve(process.argv[1])
-    );
+    if (typeof process.argv[1] !== "string" || !process.argv[1]) return false;
+    const selfPath = fileURLToPath(import.meta.url);
+    const argvPath = resolve(process.argv[1]);
+    if (selfPath === argvPath) return true;
+    // 심링크 설치 경로: argv[1]이 심링크면 import.meta.url(실경로)과 어긋난다.
+    // canonical 경로로 재비교 (realpath 실패 시 non-direct 취급).
+    return selfPath === realpathSync(argvPath);
   } catch {
     return false;
   }

--- a/scripts/lib/keyword-rules.mjs
+++ b/scripts/lib/keyword-rules.mjs
@@ -26,6 +26,7 @@ function normalizeState(state) {
 
 function normalizeRule(rule) {
   if (!rule || typeof rule !== "object") return null;
+  if (rule.disabled === true) return null;
   if (typeof rule.id !== "string" || !rule.id.trim()) return null;
   if (!Array.isArray(rule.patterns) || rule.patterns.length === 0) return null;
   if (typeof rule.priority !== "number" || !Number.isFinite(rule.priority))
@@ -61,6 +62,13 @@ function normalizeRule(rule) {
   const state = normalizeState(rule.state);
   if (rule.state != null && state == null) return null;
 
+  // repo_scope: path segment 화이트리스트 (빈 배열 = 전역). explicit: 종결 라우팅 마커.
+  const repoScope = Array.isArray(rule.repo_scope)
+    ? rule.repo_scope
+        .filter((s) => typeof s === "string" && s.trim())
+        .map((s) => s.trim())
+    : [];
+
   return {
     id: rule.id.trim(),
     patterns,
@@ -72,6 +80,8 @@ function normalizeRule(rule) {
     exclusive: rule.exclusive === true,
     state,
     mcp_route: mcpRoute,
+    repo_scope: repoScope,
+    explicit: rule.explicit === true,
   };
 }
 
@@ -149,6 +159,8 @@ export function matchRules(compiledRules, cleanText) {
       exclusive: rule.exclusive === true,
       state: rule.state || null,
       mcp_route: rule.mcp_route || null,
+      repo_scope: rule.repo_scope || [],
+      explicit: rule.explicit === true,
     });
   }
 

--- a/tests/unit/deep-interview.test.mjs
+++ b/tests/unit/deep-interview.test.mjs
@@ -21,17 +21,20 @@ describe("tfx-deep-interview SKILL.md — 구조 검증", () => {
     assert.ok(content.length > 100, "SKILL.md must have substantial content");
   });
 
+  // lane2-d SSOT(D2, 2026-07-17): 무수식 한국어 트리거(딥인터뷰/소크라테스/깊이 탐색)는
+  // host deep-interview 소유로 이관 — description 이 좁혀진 표면이 정본이다.
   it("트리거 키워드가 모두 포함되어야 한다", () => {
-    const triggers = [
-      "deep-interview",
-      "딥인터뷰",
-      "소크라테스",
-      "깊이 탐색",
-      "요구사항 분석",
-    ];
+    const triggers = ["deep-interview", "tfx-interview", "요구사항 분석"];
     for (const trigger of triggers) {
       assert.ok(content.includes(trigger), `트리거 "${trigger}" 누락`);
     }
+  });
+
+  it("D2 소유권 경계가 description 에 명시되어야 한다", () => {
+    assert.ok(
+      content.includes("host deep-interview가 소유"),
+      "무수식 일반 요구사항 명확화의 host 소유 명시 누락",
+    );
   });
 
   it("5단계 프롬프트가 모두 정의되어야 한다", () => {

--- a/tests/unit/keyword-routing-verbs.test.mjs
+++ b/tests/unit/keyword-routing-verbs.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  matchesRepoScope,
+  selectPrimaryMatch,
+} from "../../scripts/keyword-detector.mjs";
+import {
+  compileRules,
+  loadRules,
+  matchRules,
+  resolveConflicts,
+} from "../../scripts/lib/keyword-rules.mjs";
+
+const ROOT = process.cwd();
+const RULES_PATH = join(ROOT, "hooks/keyword-rules.json");
+const rules = loadRules(RULES_PATH);
+const compiled = compileRules(rules);
+
+function topId(text) {
+  return resolveConflicts(matchRules(compiled, text))[0]?.id;
+}
+
+// root cause ① 의 hook 계층 동사군 분리는 lane2-d 잠금(2026-07-17,
+// tests/unit/lane2-d-routing-contract.test.mjs "locked prompt matrix")이 우선해
+// 접었다 — hook 은 광역 동사를 tfx-unified 로 유지하고, 세분화는 D-트리(모델
+// 계층)가 담당한다. 전용 규칙은 명시 토큰 전용으로 존재한다(root cause ② 블록).
+describe("keyword routing: 광역 동사는 tfx-unified 유지 (lane2-d 잠금)", () => {
+  const cases = [
+    ["리뷰해줘 이 코드", "tfx-unified"],
+    ["검토해줘", "tfx-unified"],
+    ["review this PR", "tfx-unified"],
+    ["분석해줘 구조", "tfx-unified"],
+    ["analyze this module", "tfx-unified"],
+    ["계획 세워줘", "tfx-unified"],
+    ["설계해줘", "tfx-unified"],
+    ["테스트 돌려봐", "tfx-unified"],
+    ["검증해줘", "tfx-unified"],
+    ["찾아봐 최신 정보", "tfx-unified"],
+    ["조사해줘", "tfx-unified"],
+    ["만들어줘 함수", "tfx-unified"],
+    ["고쳐줘 버그", "tfx-unified"],
+    ["implement this", "tfx-unified"],
+    // H-결정(D8, 2026-07-17): 무수식 slop/cleanup 은 host ai-slop-cleaner 소유.
+    ["정리해줘 슬롭", "host-ai-slop-cleaner"],
+    ["클린업 해줘", "host-ai-slop-cleaner"],
+  ];
+  for (const [text, expected] of cases) {
+    it(`'${text}' → ${expected}`, () => {
+      assert.equal(topId(text), expected);
+    });
+  }
+});
+
+// root cause ② — 전용 규칙은 priority 1 + supersedes:['tfx-unified'] 로 명시
+// 호출/복합 의도에서 generic router 가로채기를 억제한다.
+describe("keyword routing: 전용 규칙이 tfx-unified 를 supersede (root cause ②)", () => {
+  it("구현+명시토큰 복합 → tfx-review 가 tfx-unified 를 supersede", () => {
+    const resolved = resolveConflicts(
+      matchRules(compiled, "만들어줘 그리고 tfx-review 해줘"),
+    );
+    assert.equal(resolved[0].id, "tfx-review");
+    assert.equal(
+      resolved.some((m) => m.id === "tfx-unified"),
+      false,
+    );
+  });
+
+  it("명시 슬래시 호출 '/tfx-plan' → tfx-plan (재라우팅 억제)", () => {
+    assert.equal(topId("/tfx-plan 세워줘"), "tfx-plan");
+  });
+
+  for (const [text, id] of [
+    ["tfx-review 해줘", "tfx-review"],
+    ["tfx-find 해줘", "tfx-find"],
+    ["tfx-prune 돌려", "tfx-prune"],
+  ]) {
+    it(`명시 토큰 '${text}' → ${id}`, () => {
+      assert.equal(topId(text), id);
+    });
+  }
+
+  it("전용 규칙은 priority 1 + supersedes:['tfx-unified']", () => {
+    const dedicated = [
+      "tfx-review",
+      "tfx-analysis",
+      "tfx-plan",
+      "tfx-qa",
+      "tfx-research",
+      "tfx-find",
+      "tfx-prune",
+    ];
+    for (const id of dedicated) {
+      const rule = rules.find((x) => x.id === id);
+      assert.ok(rule, `${id} 규칙이 존재해야 함`);
+      assert.equal(rule.priority, 1, `${id} priority=1`);
+      assert.ok(
+        rule.supersedes.includes("tfx-unified"),
+        `${id} 는 tfx-unified 를 supersede 해야 함`,
+      );
+    }
+  });
+});
+
+// root cause ③ — tfx-ship 은 triflux npm 릴리즈 전용. repo 스코프 + 동사형만.
+describe("keyword routing: tfx-ship repo 스코프 (root cause ③)", () => {
+  const shipRule = rules.find((r) => r.id === "tfx-ship");
+
+  it("tfx-ship 규칙에 repo_scope=['triflux'] + explicit", () => {
+    assert.deepEqual(shipRule.repo_scope, ["triflux"]);
+    assert.equal(shipRule.explicit, true);
+  });
+
+  it("영문 release/publish 전역 패턴은 제거, 배포/릴리즈는 repo_scope 로 가드", () => {
+    const sources = shipRule.patterns.map((p) => p.source);
+    assert.ok(
+      !sources.some((s) => /release|publish/i.test(s)),
+      "release/publish 전역 패턴이 없어야 함",
+    );
+    // lane2-d 잠금("배포 검증해줘" → tfx-ship)과의 조정: 맨 명사 배포 패턴은
+    // 유지하되 repo_scope=["triflux"] 로 타 repo 하이재킹을 차단한다.
+    assert.ok(
+      sources.includes("배포(?!자|사|장|처)"),
+      "배포 패턴은 유지 (repo_scope 가드)",
+    );
+  });
+
+  it("matchesRepoScope 는 path segment 단위로 매칭한다", () => {
+    assert.equal(
+      matchesRepoScope("/Users/x/Projects/tools/triflux/scripts", ["triflux"]),
+      true,
+    );
+    assert.equal(
+      matchesRepoScope("/Users/x/triflux-ideas", ["triflux"]),
+      false,
+    );
+    assert.equal(matchesRepoScope("/anything", []), true);
+  });
+});
+
+// root cause ④ — resolvedMatches[0] 단일 승자 + 우선순위 역전 수정.
+describe("keyword routing: 우선순위 역전 방지 (root cause ④)", () => {
+  it("selectPrimaryMatch: explicit 종결 라우팅이 generic router 를 이긴다", () => {
+    const resolved = [
+      { id: "tfx-unified", priority: 2, explicit: false, skill: "tfx-auto" },
+      { id: "tfx-ship", priority: 3, explicit: true, skill: "tfx-ship" },
+    ];
+    assert.equal(selectPrimaryMatch(resolved).id, "tfx-ship");
+  });
+
+  it("selectPrimaryMatch: 단일 매치는 그대로 선택", () => {
+    assert.equal(
+      selectPrimaryMatch([{ id: "tfx-unified", priority: 2 }]).id,
+      "tfx-unified",
+    );
+  });
+
+  it("selectPrimaryMatch: explicit 없으면 정렬 선두 유지 (MCP 라우트 영향 없음)", () => {
+    const resolved = [
+      { id: "tfx-unified", priority: 2, explicit: false },
+      {
+        id: "notion-route",
+        priority: 10,
+        explicit: false,
+        mcp_route: "antigravity",
+      },
+    ];
+    assert.equal(selectPrimaryMatch(resolved).id, "tfx-unified");
+  });
+
+  it("selectPrimaryMatch: 빈 배열은 null", () => {
+    assert.equal(selectPrimaryMatch([]), null);
+  });
+});
+
+describe("keyword routing: disabled 규칙 존중", () => {
+  it("disabled:true 규칙은 loadRules 가 제외한다 (fixture)", async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const dir = mkdtempSync(join(tmpdir(), "kw-rules-"));
+    const fixture = join(dir, "rules.json");
+    writeFileSync(
+      fixture,
+      JSON.stringify({
+        rules: [
+          {
+            id: "enabled-rule",
+            patterns: [{ source: "foo", flags: "i" }],
+            skill: "x",
+            priority: 1,
+          },
+          {
+            id: "disabled-rule",
+            patterns: [{ source: "bar", flags: "i" }],
+            skill: "y",
+            priority: 1,
+            disabled: true,
+          },
+        ],
+      }),
+    );
+    const loaded = loadRules(fixture);
+    assert.deepEqual(
+      loaded.map((r) => r.id),
+      ["enabled-rule"],
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // H-결정(151baa86, 2026-07-17): gstack-ship 재활성화 — 회귀 가드.
+  it("gstack-ship 은 활성 상태다 (재활성화 결정 존중)", () => {
+    assert.equal(
+      rules.some((r) => r.id === "gstack-ship"),
+      true,
+    );
+  });
+});

--- a/tests/unit/keyword-routing-verbs.test.mjs
+++ b/tests/unit/keyword-routing-verbs.test.mjs
@@ -173,6 +173,54 @@ describe("keyword routing: 우선순위 역전 방지 (root cause ④)", () => {
   });
 });
 
+// Codex 리뷰 P2 회귀 가드 2건 (PR #487)
+describe("keyword routing: 명시 토큰이 광역 클린업 매처를 이긴다 (P2-1)", () => {
+  it("'tfx-prune으로 클린업 해줘' → selectPrimaryMatch 가 tfx-prune 선택", () => {
+    const resolved = resolveConflicts(
+      matchRules(compiled, "tfx-prune으로 클린업 해줘"),
+    );
+    // 정렬상 host-ai-slop-cleaner 가 앞서더라도 explicit 규칙이 이겨야 한다.
+    assert.equal(selectPrimaryMatch(resolved).id, "tfx-prune");
+  });
+
+  it("전용 명시토큰 규칙은 전부 explicit:true", () => {
+    for (const id of [
+      "tfx-review",
+      "tfx-analysis",
+      "tfx-plan",
+      "tfx-qa",
+      "tfx-research",
+      "tfx-find",
+      "tfx-prune",
+    ]) {
+      const rule = rules.find((x) => x.id === id);
+      assert.equal(rule.explicit, true, `${id} explicit=true`);
+    }
+  });
+});
+
+describe("keyword routing: direct-run 가드는 심링크 실행을 허용 (P2-2)", () => {
+  it("심링크 경유 실행에서도 main() 이 구동돼 JSON 을 출력한다", async () => {
+    const { execFileSync } = await import("node:child_process");
+    const { mkdtempSync, symlinkSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const dir = mkdtempSync(join(tmpdir(), "kw-symlink-"));
+    const link = join(dir, "keyword-detector-link.mjs");
+    symlinkSync(join(ROOT, "scripts/keyword-detector.mjs"), link);
+    const out = execFileSync(process.execPath, [link], {
+      input: JSON.stringify({ prompt: "만들어줘 함수", cwd: ROOT }),
+      encoding: "utf8",
+    });
+    const parsed = JSON.parse(out.trim().split("\n").at(-1));
+    assert.equal(parsed.continue, true);
+    assert.match(
+      parsed.hookSpecificOutput?.additionalContext ?? "",
+      /tfx-unified/,
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 describe("keyword routing: disabled 규칙 존중", () => {
   it("disabled:true 규칙은 loadRules 가 제외한다 (fixture)", async () => {
     const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");


### PR DESCRIPTION
## 요약

7/16 사고로 소실된 A작업의 keyword-rules 슬라이스 재구현. 로그에 원문이 없어(RECOVERY-REPORT 부록: UNRECOVERABLE) 생존 테스트 `keyword-routing-verbs.test.mjs`를 명세로 TDD 복원.

## lane2-d 잠금과의 충돌 조정 (핵심 판정)

A 원안(hook 계층 동사군 분리)과 오늘 잠긴 lane2-d locked prompt matrix가 정면충돌 → **신규 잠금 우선**으로 조정:

| root cause | A 원안 | 조정 결과 |
|---|---|---|
| ① 동사군 분리 | 리뷰해/분석해 등 → 전용 스킬 | **접음** — hook은 broad(tfx-unified), 세분화는 D-트리 몫. 전용 규칙은 명시 토큰(`tfx-review` 등)만 |
| ③ tfx-ship 하이재킹 | bare 배포/release 패턴 삭제 | **repo_scope=["triflux"]로 대체** — 타 repo에선 gstack-ship이 자연 인계(재활성화 결정 존중), triflux에선 기존 동작 유지 |
| ④ 우선순위 역전 | selectPrimaryMatch | 그대로 구현 — explicit 규칙이 정렬 무관 승리 |
| disabled 메커니즘 | gstack-ship disable | 메커니즘만 구현(fixture 검증), gstack-ship은 활성 유지 + 회귀 가드 |

부수 수정: keyword-detector가 모듈 import 시 top-level main()이 stdin을 기다려 행 걸리던 문제 → direct-run 가드.

## 검증
- keyword/routing 계열 6개 테스트 파일 **149 tests / 0 fail** (lane2-d locked matrix 포함 전부 green)
- E2E: `리뷰해줘`→unified(잠금 준수), `배포해 줘`@타repo→gstack-ship / @triflux→tfx-ship(scope+explicit)
- `release:check-mirror` OK (core/triflux/remote 6미러), biome clean

동사군 분리를 hook 계층에서 되살리고 싶으면 이 PR 위에서 한 커밋으로 뒤집을 수 있습니다(전용 규칙에 동사 패턴 추가 + lane2-d matrix 행 수정).