### PR TITLE
fix(swarm): rootDir 통합 제거 — 임시 worktree 통합 + preflight lease-dirty NO-GO (데이터손실 재발 방지)

### DIFF
--- a/hub/team/swarm-preflight.mjs
+++ b/hub/team/swarm-preflight.mjs
@@ -1,6 +1,7 @@
 // hub/team/swarm-preflight.mjs — PRD swarm preflight report/gate (#188)
 // Predicts launch-time blockers before any worker session or worktree spawn.
 
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { readHosts, resolveHost } from "../lib/hosts-compat.mjs";
 import { whichCommand } from "../platform.mjs";
@@ -81,6 +82,44 @@ function checkSensitive(plan, sensitiveDeny) {
     }
   }
   return makeCheck("sensitiveDeny", true, { matches });
+}
+
+function parseTrackedStatus(rawStatus) {
+  const files = [];
+  const records = String(rawStatus || "").split("\0");
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (record.length < 4) continue;
+    const status = record.slice(0, 2);
+    files.push(normalizePath(record.slice(3)));
+    if (/[RC]/u.test(status) && records[index + 1]) {
+      files.push(normalizePath(records[++index]));
+    }
+  }
+  return unique(files);
+}
+
+function checkRootDirtyLease(plan, repoRoot, deps = {}) {
+  const gitStatus =
+    deps.gitStatus ||
+    ((cwd) =>
+      execFileSync(
+        "git",
+        ["status", "--porcelain=v1", "-z", "--untracked-files=no"],
+        { cwd, encoding: "utf8", windowsHide: true },
+      ));
+  const dirtyFiles = parseTrackedStatus(gitStatus(repoRoot));
+  const leasedFiles = unique(
+    [...plan.leaseMap.values()].flat().map(normalizePath),
+  );
+  const leaseSet = new Set(leasedFiles);
+  const overlappingFiles = dirtyFiles.filter((file) => leaseSet.has(file));
+
+  return makeCheck("rootDirtyLease", overlappingFiles.length === 0, {
+    dirtyFiles,
+    leasedFiles,
+    overlappingFiles,
+  });
 }
 
 function checkHosts(plan, repoRoot) {
@@ -216,6 +255,13 @@ function collectMessages(checks) {
     );
   }
 
+  const rootDirtyLease = checks.rootDirtyLease;
+  if (rootDirtyLease && !rootDirtyLease.ok) {
+    errors.push(
+      `rootDir tracked changes overlap shard leases: ${rootDirtyLease.overlappingFiles.join(", ")}`,
+    );
+  }
+
   return { errors: unique(errors), warnings: unique(warnings) };
 }
 
@@ -258,6 +304,7 @@ export function runSwarmPreflight(prdPath, opts = {}) {
     leases: makeCheck("leases", plan.conflicts.length === 0, {
       conflicts: [...plan.conflicts],
     }),
+    rootDirtyLease: checkRootDirtyLease(plan, repoRoot, opts.deps),
     sensitiveDeny: checkSensitive(plan, sensitiveDeny),
     hosts: checkHosts(plan, repoRoot),
     workerCli: checkLocalWorkerClis(plan, opts.deps),

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -4,8 +4,16 @@
 // Remote support: host option → SSH-based git operations via remote-session.mjs.
 
 import { execFile } from "node:child_process";
-import { access, mkdir, readdir, realpath, rm } from "node:fs/promises";
-import { normalize, relative, resolve } from "node:path";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, normalize, relative, resolve } from "node:path";
 import { remoteGit, validateHost } from "./remote-session.mjs";
 
 const SWARM_ROOT = ".codex-swarm";
@@ -327,24 +335,23 @@ export async function rebaseShardOntoIntegration({
     }
   }
 
-  // #127 BUG-E: capture caller's branch BEFORE any checkout. Without
-  // restoring it in finally, this function leaks main repo HEAD onto
-  // integrationBranch and every subsequent Edit/commit lands on the swarm
-  // temp branch silently (observed 2026-04-20: probe + edits + commits all
-  // ended up on swarm/.../merge while user thought they were on main).
-  let originalBranch = null;
-  try {
-    const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-    if (head && head !== "HEAD") originalBranch = head;
-  } catch {
-    /* detached HEAD or unknown — skip restore */
-  }
-
-  // Backup integration HEAD for rollback
+  // #127 BUG-E accident history: this function used to checkout the
+  // integration branch in rootDir, leak rootDir HEAD, and redirect later user
+  // edits/commits into swarm/.../merge. Integration now happens exclusively in
+  // a disposable worktree, so rootDir HEAD never moves and needs no restore.
+  //
+  // #129 BUG-J accident history: checkout failure was followed by a blind
+  // reset --hard (or branch -f rollback) against rootDir, which rewound the
+  // caller branch. Rollback now resets only the disposable worktree; there is
+  // no rootDir reset path and therefore no stash-create last-resort path.
   const backupCommit = await git(["rev-parse", integrationBranch], rootDir);
 
   let shaList = [];
   let ffError = null;
+  let integrationWorktreeAdded = false;
+  const integrationWorktree = await mkdtemp(
+    join(tmpdir(), "tfx-swarm-integration-"),
+  );
 
   try {
     const log = await git(
@@ -361,11 +368,15 @@ export async function rebaseShardOntoIntegration({
       .map((s) => s.trim())
       .filter(Boolean);
 
-    await git(["checkout", integrationBranch], rootDir);
+    await git(
+      ["worktree", "add", "--quiet", integrationWorktree, integrationBranch],
+      rootDir,
+    );
+    integrationWorktreeAdded = true;
 
     try {
-      await git(["merge", "--ff-only", shardBranch], rootDir);
-      const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+      await git(["merge", "--ff-only", shardBranch], integrationWorktree);
+      const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
       return {
         ok: true,
         headCommit,
@@ -376,12 +387,15 @@ export async function rebaseShardOntoIntegration({
     } catch (err) {
       ffError = err;
       try {
-        await git(["merge", "--abort"], rootDir);
+        await git(["merge", "--abort"], integrationWorktree);
       } catch {
         /* ff-only usually leaves no merge state */
       }
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        // Safe destructive operation: this cwd is the disposable integration
+        // worktree, never rootDir. It restores the integration ref before the
+        // cherry-pick fallback without touching user files.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* fallback below will report if cherry-pick also fails */
       }
@@ -391,10 +405,10 @@ export async function rebaseShardOntoIntegration({
     // fail when histories diverge or a shard branch is checked out by a swarm
     // worktree. Cherry-pick reads commits without moving the shard branch ref.
     for (const sha of shaList) {
-      await git(["cherry-pick", sha], rootDir);
+      await git(["cherry-pick", sha], integrationWorktree);
     }
 
-    const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+    const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
     return {
       ok: true,
       headCommit,
@@ -406,42 +420,17 @@ export async function rebaseShardOntoIntegration({
         : "cherry-pick fallback",
     };
   } catch (err) {
-    try {
-      await git(["cherry-pick", "--abort"], rootDir);
-    } catch {
-      /* already clean */
-    }
-
-    // #129 BUG-J: Roll back integrationBranch without mutating whatever
-    // branch HEAD currently points at. The previous implementation did a
-    // blind `reset --hard backupCommit` on current HEAD — if the earlier
-    // `git checkout integrationBranch` inside the try block failed (e.g.
-    // integrationBranch was already checked out by a swarm worktree) the
-    // caller's branch silently rewound to integrationBranch's backup commit.
-    // Observed 2026-04-20: fix branch tree lost to main HEAD during swarm
-    // probe, requiring `git merge --ff-only origin/<branch>` recovery.
-    let currentBranch = null;
-    try {
-      const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-      if (head && head !== "HEAD") currentBranch = head;
-    } catch {
-      /* detached — fall through to ref-only update */
-    }
-
-    if (currentBranch === integrationBranch) {
-      // HEAD is on integrationBranch — reset advances this branch only.
+    if (integrationWorktreeAdded) {
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        await git(["cherry-pick", "--abort"], integrationWorktree);
+      } catch {
+        /* already clean */
+      }
+      try {
+        // #129 rollback is now local to the disposable integration worktree.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* best-effort */
-      }
-    } else {
-      // HEAD is elsewhere (originalBranch, detached, or another branch).
-      // Update the integrationBranch ref directly; never touch current HEAD.
-      try {
-        await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
-      } catch {
-        /* best-effort: branch may be checked out in another worktree */
       }
     }
 
@@ -453,14 +442,22 @@ export async function rebaseShardOntoIntegration({
       fallbackReason: ffError?.message || null,
     };
   } finally {
-    // Always restore caller's branch. Skip if originalBranch is null
-    // (detached HEAD case) or already on target.
-    if (originalBranch) {
+    if (integrationWorktreeAdded) {
       try {
-        await git(["checkout", originalBranch], rootDir);
+        await git(
+          ["worktree", "remove", "--force", integrationWorktree],
+          rootDir,
+        );
       } catch {
-        /* best-effort — caller will see HEAD on integrationBranch */
+        await rm(integrationWorktree, { recursive: true, force: true });
+        try {
+          await git(["worktree", "prune"], rootDir);
+        } catch {
+          /* best-effort metadata cleanup */
+        }
       }
+    } else {
+      await rm(integrationWorktree, { recursive: true, force: true });
     }
   }
 }

--- a/packages/remote/hub/team/swarm-preflight.mjs
+++ b/packages/remote/hub/team/swarm-preflight.mjs
@@ -1,6 +1,7 @@
 // hub/team/swarm-preflight.mjs — PRD swarm preflight report/gate (#188)
 // Predicts launch-time blockers before any worker session or worktree spawn.
 
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { readHosts, resolveHost } from "@triflux/core/hub/lib/hosts-compat.mjs";
 import { whichCommand } from "@triflux/core/hub/platform.mjs";
@@ -81,6 +82,44 @@ function checkSensitive(plan, sensitiveDeny) {
     }
   }
   return makeCheck("sensitiveDeny", true, { matches });
+}
+
+function parseTrackedStatus(rawStatus) {
+  const files = [];
+  const records = String(rawStatus || "").split("\0");
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (record.length < 4) continue;
+    const status = record.slice(0, 2);
+    files.push(normalizePath(record.slice(3)));
+    if (/[RC]/u.test(status) && records[index + 1]) {
+      files.push(normalizePath(records[++index]));
+    }
+  }
+  return unique(files);
+}
+
+function checkRootDirtyLease(plan, repoRoot, deps = {}) {
+  const gitStatus =
+    deps.gitStatus ||
+    ((cwd) =>
+      execFileSync(
+        "git",
+        ["status", "--porcelain=v1", "-z", "--untracked-files=no"],
+        { cwd, encoding: "utf8", windowsHide: true },
+      ));
+  const dirtyFiles = parseTrackedStatus(gitStatus(repoRoot));
+  const leasedFiles = unique(
+    [...plan.leaseMap.values()].flat().map(normalizePath),
+  );
+  const leaseSet = new Set(leasedFiles);
+  const overlappingFiles = dirtyFiles.filter((file) => leaseSet.has(file));
+
+  return makeCheck("rootDirtyLease", overlappingFiles.length === 0, {
+    dirtyFiles,
+    leasedFiles,
+    overlappingFiles,
+  });
 }
 
 function checkHosts(plan, repoRoot) {
@@ -216,6 +255,13 @@ function collectMessages(checks) {
     );
   }
 
+  const rootDirtyLease = checks.rootDirtyLease;
+  if (rootDirtyLease && !rootDirtyLease.ok) {
+    errors.push(
+      `rootDir tracked changes overlap shard leases: ${rootDirtyLease.overlappingFiles.join(", ")}`,
+    );
+  }
+
   return { errors: unique(errors), warnings: unique(warnings) };
 }
 
@@ -258,6 +304,7 @@ export function runSwarmPreflight(prdPath, opts = {}) {
     leases: makeCheck("leases", plan.conflicts.length === 0, {
       conflicts: [...plan.conflicts],
     }),
+    rootDirtyLease: checkRootDirtyLease(plan, repoRoot, opts.deps),
     sensitiveDeny: checkSensitive(plan, sensitiveDeny),
     hosts: checkHosts(plan, repoRoot),
     workerCli: checkLocalWorkerClis(plan, opts.deps),

--- a/packages/remote/hub/team/worktree-lifecycle.mjs
+++ b/packages/remote/hub/team/worktree-lifecycle.mjs
@@ -4,8 +4,16 @@
 // Remote support: host option → SSH-based git operations via remote-session.mjs.
 
 import { execFile } from "node:child_process";
-import { access, mkdir, readdir, realpath, rm } from "node:fs/promises";
-import { normalize, relative, resolve } from "node:path";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, normalize, relative, resolve } from "node:path";
 import { remoteGit, validateHost } from "./remote-session.mjs";
 
 const SWARM_ROOT = ".codex-swarm";
@@ -327,24 +335,23 @@ export async function rebaseShardOntoIntegration({
     }
   }
 
-  // #127 BUG-E: capture caller's branch BEFORE any checkout. Without
-  // restoring it in finally, this function leaks main repo HEAD onto
-  // integrationBranch and every subsequent Edit/commit lands on the swarm
-  // temp branch silently (observed 2026-04-20: probe + edits + commits all
-  // ended up on swarm/.../merge while user thought they were on main).
-  let originalBranch = null;
-  try {
-    const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-    if (head && head !== "HEAD") originalBranch = head;
-  } catch {
-    /* detached HEAD or unknown — skip restore */
-  }
-
-  // Backup integration HEAD for rollback
+  // #127 BUG-E accident history: this function used to checkout the
+  // integration branch in rootDir, leak rootDir HEAD, and redirect later user
+  // edits/commits into swarm/.../merge. Integration now happens exclusively in
+  // a disposable worktree, so rootDir HEAD never moves and needs no restore.
+  //
+  // #129 BUG-J accident history: checkout failure was followed by a blind
+  // reset --hard (or branch -f rollback) against rootDir, which rewound the
+  // caller branch. Rollback now resets only the disposable worktree; there is
+  // no rootDir reset path and therefore no stash-create last-resort path.
   const backupCommit = await git(["rev-parse", integrationBranch], rootDir);
 
   let shaList = [];
   let ffError = null;
+  let integrationWorktreeAdded = false;
+  const integrationWorktree = await mkdtemp(
+    join(tmpdir(), "tfx-swarm-integration-"),
+  );
 
   try {
     const log = await git(
@@ -361,11 +368,15 @@ export async function rebaseShardOntoIntegration({
       .map((s) => s.trim())
       .filter(Boolean);
 
-    await git(["checkout", integrationBranch], rootDir);
+    await git(
+      ["worktree", "add", "--quiet", integrationWorktree, integrationBranch],
+      rootDir,
+    );
+    integrationWorktreeAdded = true;
 
     try {
-      await git(["merge", "--ff-only", shardBranch], rootDir);
-      const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+      await git(["merge", "--ff-only", shardBranch], integrationWorktree);
+      const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
       return {
         ok: true,
         headCommit,
@@ -376,12 +387,15 @@ export async function rebaseShardOntoIntegration({
     } catch (err) {
       ffError = err;
       try {
-        await git(["merge", "--abort"], rootDir);
+        await git(["merge", "--abort"], integrationWorktree);
       } catch {
         /* ff-only usually leaves no merge state */
       }
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        // Safe destructive operation: this cwd is the disposable integration
+        // worktree, never rootDir. It restores the integration ref before the
+        // cherry-pick fallback without touching user files.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* fallback below will report if cherry-pick also fails */
       }
@@ -391,10 +405,10 @@ export async function rebaseShardOntoIntegration({
     // fail when histories diverge or a shard branch is checked out by a swarm
     // worktree. Cherry-pick reads commits without moving the shard branch ref.
     for (const sha of shaList) {
-      await git(["cherry-pick", sha], rootDir);
+      await git(["cherry-pick", sha], integrationWorktree);
     }
 
-    const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+    const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
     return {
       ok: true,
       headCommit,
@@ -406,42 +420,17 @@ export async function rebaseShardOntoIntegration({
         : "cherry-pick fallback",
     };
   } catch (err) {
-    try {
-      await git(["cherry-pick", "--abort"], rootDir);
-    } catch {
-      /* already clean */
-    }
-
-    // #129 BUG-J: Roll back integrationBranch without mutating whatever
-    // branch HEAD currently points at. The previous implementation did a
-    // blind `reset --hard backupCommit` on current HEAD — if the earlier
-    // `git checkout integrationBranch` inside the try block failed (e.g.
-    // integrationBranch was already checked out by a swarm worktree) the
-    // caller's branch silently rewound to integrationBranch's backup commit.
-    // Observed 2026-04-20: fix branch tree lost to main HEAD during swarm
-    // probe, requiring `git merge --ff-only origin/<branch>` recovery.
-    let currentBranch = null;
-    try {
-      const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-      if (head && head !== "HEAD") currentBranch = head;
-    } catch {
-      /* detached — fall through to ref-only update */
-    }
-
-    if (currentBranch === integrationBranch) {
-      // HEAD is on integrationBranch — reset advances this branch only.
+    if (integrationWorktreeAdded) {
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        await git(["cherry-pick", "--abort"], integrationWorktree);
+      } catch {
+        /* already clean */
+      }
+      try {
+        // #129 rollback is now local to the disposable integration worktree.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* best-effort */
-      }
-    } else {
-      // HEAD is elsewhere (originalBranch, detached, or another branch).
-      // Update the integrationBranch ref directly; never touch current HEAD.
-      try {
-        await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
-      } catch {
-        /* best-effort: branch may be checked out in another worktree */
       }
     }
 
@@ -453,14 +442,22 @@ export async function rebaseShardOntoIntegration({
       fallbackReason: ffError?.message || null,
     };
   } finally {
-    // Always restore caller's branch. Skip if originalBranch is null
-    // (detached HEAD case) or already on target.
-    if (originalBranch) {
+    if (integrationWorktreeAdded) {
       try {
-        await git(["checkout", originalBranch], rootDir);
+        await git(
+          ["worktree", "remove", "--force", integrationWorktree],
+          rootDir,
+        );
       } catch {
-        /* best-effort — caller will see HEAD on integrationBranch */
+        await rm(integrationWorktree, { recursive: true, force: true });
+        try {
+          await git(["worktree", "prune"], rootDir);
+        } catch {
+          /* best-effort metadata cleanup */
+        }
       }
+    } else {
+      await rm(integrationWorktree, { recursive: true, force: true });
     }
   }
 }

--- a/packages/triflux/hub/team/swarm-preflight.mjs
+++ b/packages/triflux/hub/team/swarm-preflight.mjs
@@ -1,6 +1,7 @@
 // hub/team/swarm-preflight.mjs — PRD swarm preflight report/gate (#188)
 // Predicts launch-time blockers before any worker session or worktree spawn.
 
+import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { readHosts, resolveHost } from "../lib/hosts-compat.mjs";
 import { whichCommand } from "../platform.mjs";
@@ -81,6 +82,44 @@ function checkSensitive(plan, sensitiveDeny) {
     }
   }
   return makeCheck("sensitiveDeny", true, { matches });
+}
+
+function parseTrackedStatus(rawStatus) {
+  const files = [];
+  const records = String(rawStatus || "").split("\0");
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (record.length < 4) continue;
+    const status = record.slice(0, 2);
+    files.push(normalizePath(record.slice(3)));
+    if (/[RC]/u.test(status) && records[index + 1]) {
+      files.push(normalizePath(records[++index]));
+    }
+  }
+  return unique(files);
+}
+
+function checkRootDirtyLease(plan, repoRoot, deps = {}) {
+  const gitStatus =
+    deps.gitStatus ||
+    ((cwd) =>
+      execFileSync(
+        "git",
+        ["status", "--porcelain=v1", "-z", "--untracked-files=no"],
+        { cwd, encoding: "utf8", windowsHide: true },
+      ));
+  const dirtyFiles = parseTrackedStatus(gitStatus(repoRoot));
+  const leasedFiles = unique(
+    [...plan.leaseMap.values()].flat().map(normalizePath),
+  );
+  const leaseSet = new Set(leasedFiles);
+  const overlappingFiles = dirtyFiles.filter((file) => leaseSet.has(file));
+
+  return makeCheck("rootDirtyLease", overlappingFiles.length === 0, {
+    dirtyFiles,
+    leasedFiles,
+    overlappingFiles,
+  });
 }
 
 function checkHosts(plan, repoRoot) {
@@ -216,6 +255,13 @@ function collectMessages(checks) {
     );
   }
 
+  const rootDirtyLease = checks.rootDirtyLease;
+  if (rootDirtyLease && !rootDirtyLease.ok) {
+    errors.push(
+      `rootDir tracked changes overlap shard leases: ${rootDirtyLease.overlappingFiles.join(", ")}`,
+    );
+  }
+
   return { errors: unique(errors), warnings: unique(warnings) };
 }
 
@@ -258,6 +304,7 @@ export function runSwarmPreflight(prdPath, opts = {}) {
     leases: makeCheck("leases", plan.conflicts.length === 0, {
       conflicts: [...plan.conflicts],
     }),
+    rootDirtyLease: checkRootDirtyLease(plan, repoRoot, opts.deps),
     sensitiveDeny: checkSensitive(plan, sensitiveDeny),
     hosts: checkHosts(plan, repoRoot),
     workerCli: checkLocalWorkerClis(plan, opts.deps),

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -4,8 +4,16 @@
 // Remote support: host option → SSH-based git operations via remote-session.mjs.
 
 import { execFile } from "node:child_process";
-import { access, mkdir, readdir, realpath, rm } from "node:fs/promises";
-import { normalize, relative, resolve } from "node:path";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, normalize, relative, resolve } from "node:path";
 import { remoteGit, validateHost } from "./remote-session.mjs";
 
 const SWARM_ROOT = ".codex-swarm";
@@ -327,24 +335,23 @@ export async function rebaseShardOntoIntegration({
     }
   }
 
-  // #127 BUG-E: capture caller's branch BEFORE any checkout. Without
-  // restoring it in finally, this function leaks main repo HEAD onto
-  // integrationBranch and every subsequent Edit/commit lands on the swarm
-  // temp branch silently (observed 2026-04-20: probe + edits + commits all
-  // ended up on swarm/.../merge while user thought they were on main).
-  let originalBranch = null;
-  try {
-    const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-    if (head && head !== "HEAD") originalBranch = head;
-  } catch {
-    /* detached HEAD or unknown — skip restore */
-  }
-
-  // Backup integration HEAD for rollback
+  // #127 BUG-E accident history: this function used to checkout the
+  // integration branch in rootDir, leak rootDir HEAD, and redirect later user
+  // edits/commits into swarm/.../merge. Integration now happens exclusively in
+  // a disposable worktree, so rootDir HEAD never moves and needs no restore.
+  //
+  // #129 BUG-J accident history: checkout failure was followed by a blind
+  // reset --hard (or branch -f rollback) against rootDir, which rewound the
+  // caller branch. Rollback now resets only the disposable worktree; there is
+  // no rootDir reset path and therefore no stash-create last-resort path.
   const backupCommit = await git(["rev-parse", integrationBranch], rootDir);
 
   let shaList = [];
   let ffError = null;
+  let integrationWorktreeAdded = false;
+  const integrationWorktree = await mkdtemp(
+    join(tmpdir(), "tfx-swarm-integration-"),
+  );
 
   try {
     const log = await git(
@@ -361,11 +368,15 @@ export async function rebaseShardOntoIntegration({
       .map((s) => s.trim())
       .filter(Boolean);
 
-    await git(["checkout", integrationBranch], rootDir);
+    await git(
+      ["worktree", "add", "--quiet", integrationWorktree, integrationBranch],
+      rootDir,
+    );
+    integrationWorktreeAdded = true;
 
     try {
-      await git(["merge", "--ff-only", shardBranch], rootDir);
-      const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+      await git(["merge", "--ff-only", shardBranch], integrationWorktree);
+      const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
       return {
         ok: true,
         headCommit,
@@ -376,12 +387,15 @@ export async function rebaseShardOntoIntegration({
     } catch (err) {
       ffError = err;
       try {
-        await git(["merge", "--abort"], rootDir);
+        await git(["merge", "--abort"], integrationWorktree);
       } catch {
         /* ff-only usually leaves no merge state */
       }
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        // Safe destructive operation: this cwd is the disposable integration
+        // worktree, never rootDir. It restores the integration ref before the
+        // cherry-pick fallback without touching user files.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* fallback below will report if cherry-pick also fails */
       }
@@ -391,10 +405,10 @@ export async function rebaseShardOntoIntegration({
     // fail when histories diverge or a shard branch is checked out by a swarm
     // worktree. Cherry-pick reads commits without moving the shard branch ref.
     for (const sha of shaList) {
-      await git(["cherry-pick", sha], rootDir);
+      await git(["cherry-pick", sha], integrationWorktree);
     }
 
-    const headCommit = await git(["rev-parse", "HEAD"], rootDir);
+    const headCommit = await git(["rev-parse", "HEAD"], integrationWorktree);
     return {
       ok: true,
       headCommit,
@@ -406,42 +420,17 @@ export async function rebaseShardOntoIntegration({
         : "cherry-pick fallback",
     };
   } catch (err) {
-    try {
-      await git(["cherry-pick", "--abort"], rootDir);
-    } catch {
-      /* already clean */
-    }
-
-    // #129 BUG-J: Roll back integrationBranch without mutating whatever
-    // branch HEAD currently points at. The previous implementation did a
-    // blind `reset --hard backupCommit` on current HEAD — if the earlier
-    // `git checkout integrationBranch` inside the try block failed (e.g.
-    // integrationBranch was already checked out by a swarm worktree) the
-    // caller's branch silently rewound to integrationBranch's backup commit.
-    // Observed 2026-04-20: fix branch tree lost to main HEAD during swarm
-    // probe, requiring `git merge --ff-only origin/<branch>` recovery.
-    let currentBranch = null;
-    try {
-      const head = await git(["rev-parse", "--abbrev-ref", "HEAD"], rootDir);
-      if (head && head !== "HEAD") currentBranch = head;
-    } catch {
-      /* detached — fall through to ref-only update */
-    }
-
-    if (currentBranch === integrationBranch) {
-      // HEAD is on integrationBranch — reset advances this branch only.
+    if (integrationWorktreeAdded) {
       try {
-        await git(["reset", "--hard", backupCommit], rootDir);
+        await git(["cherry-pick", "--abort"], integrationWorktree);
+      } catch {
+        /* already clean */
+      }
+      try {
+        // #129 rollback is now local to the disposable integration worktree.
+        await git(["reset", "--hard", backupCommit], integrationWorktree);
       } catch {
         /* best-effort */
-      }
-    } else {
-      // HEAD is elsewhere (originalBranch, detached, or another branch).
-      // Update the integrationBranch ref directly; never touch current HEAD.
-      try {
-        await git(["branch", "-f", integrationBranch, backupCommit], rootDir);
-      } catch {
-        /* best-effort: branch may be checked out in another worktree */
       }
     }
 
@@ -453,14 +442,22 @@ export async function rebaseShardOntoIntegration({
       fallbackReason: ffError?.message || null,
     };
   } finally {
-    // Always restore caller's branch. Skip if originalBranch is null
-    // (detached HEAD case) or already on target.
-    if (originalBranch) {
+    if (integrationWorktreeAdded) {
       try {
-        await git(["checkout", originalBranch], rootDir);
+        await git(
+          ["worktree", "remove", "--force", integrationWorktree],
+          rootDir,
+        );
       } catch {
-        /* best-effort — caller will see HEAD on integrationBranch */
+        await rm(integrationWorktree, { recursive: true, force: true });
+        try {
+          await git(["worktree", "prune"], rootDir);
+        } catch {
+          /* best-effort metadata cleanup */
+        }
       }
+    } else {
+      await rm(integrationWorktree, { recursive: true, force: true });
     }
   }
 }

--- a/tests/unit/swarm-preflight.test.mjs
+++ b/tests/unit/swarm-preflight.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -10,7 +11,21 @@ import {
 } from "../../hub/team/swarm-preflight.mjs";
 
 function makeTmpDir() {
-  return mkdtempSync(join(tmpdir(), `tfx-swarm-preflight-${process.pid}-`));
+  const repoRoot = mkdtempSync(
+    join(tmpdir(), `tfx-swarm-preflight-${process.pid}-`),
+  );
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });
+  execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "base"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Triflux Test",
+      GIT_AUTHOR_EMAIL: "test@triflux.local",
+      GIT_COMMITTER_NAME: "Triflux Test",
+      GIT_COMMITTER_EMAIL: "test@triflux.local",
+    },
+  });
+  return repoRoot;
 }
 
 function writePrd(dir, content) {
@@ -79,6 +94,83 @@ describe("swarm-preflight", () => {
       shards: ["a", "b"],
     });
     assert.match(report.errors.join("\n"), /lease conflict/u);
+  });
+
+  it("returns NO-GO with file names when tracked rootDir changes overlap leases", () => {
+    const repoRoot = makeTmpDir();
+    const leasedFile = join(repoRoot, "src", "api.mjs");
+    mkdirSync(join(repoRoot, "src"), { recursive: true });
+    writeFileSync(leasedFile, "export const value = 1;\n");
+    execFileSync("git", ["add", "src/api.mjs"], { cwd: repoRoot });
+    execFileSync("git", ["commit", "-q", "-m", "add api"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Triflux Test",
+        GIT_AUTHOR_EMAIL: "test@triflux.local",
+        GIT_COMMITTER_NAME: "Triflux Test",
+        GIT_COMMITTER_EMAIL: "test@triflux.local",
+      },
+    });
+    writeFileSync(leasedFile, "export const value = 2;\n");
+    const prdPath = writePrd(
+      repoRoot,
+      `
+## Shard: api
+- agent: codex
+- files: src/api.mjs
+- prompt: Update API.
+`,
+    );
+
+    const report = runSwarmPreflight(prdPath, {
+      repoRoot,
+      deps: { whichCommand: () => "/usr/bin/true" },
+    });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.verdict, "no-go");
+    assert.deepEqual(report.checks.rootDirtyLease.overlappingFiles, [
+      "src/api.mjs",
+    ]);
+    assert.match(report.errors.join("\n"), /src\/api\.mjs/u);
+    assert.match(formatPreflightReport(report), /src\/api\.mjs/u);
+  });
+
+  it("keeps GO when tracked rootDir changes do not overlap leases", () => {
+    const repoRoot = makeTmpDir();
+    writeFileSync(join(repoRoot, "notes.md"), "base\n");
+    execFileSync("git", ["add", "notes.md"], { cwd: repoRoot });
+    execFileSync("git", ["commit", "-q", "-m", "add notes"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "Triflux Test",
+        GIT_AUTHOR_EMAIL: "test@triflux.local",
+        GIT_COMMITTER_NAME: "Triflux Test",
+        GIT_COMMITTER_EMAIL: "test@triflux.local",
+      },
+    });
+    writeFileSync(join(repoRoot, "notes.md"), "dirty but unrelated\n");
+    const prdPath = writePrd(
+      repoRoot,
+      `
+## Shard: api
+- agent: codex
+- files: src/api.mjs
+- prompt: Update API.
+`,
+    );
+
+    const report = runSwarmPreflight(prdPath, {
+      repoRoot,
+      deps: { whichCommand: () => "/usr/bin/true" },
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.verdict, "go");
+    assert.deepEqual(report.checks.rootDirtyLease.dirtyFiles, ["notes.md"]);
+    assert.deepEqual(report.checks.rootDirtyLease.overlappingFiles, []);
   });
 
   it("returns NO-GO for explicit missing hosts", () => {

--- a/tests/unit/worktree-lifecycle-integration-safety.test.mjs
+++ b/tests/unit/worktree-lifecycle-integration-safety.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { rebaseShardOntoIntegration } from "../../hub/team/worktree-lifecycle.mjs";
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    windowsHide: true,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Triflux Test",
+      GIT_AUTHOR_EMAIL: "test@triflux.local",
+      GIT_COMMITTER_NAME: "Triflux Test",
+      GIT_COMMITTER_EMAIL: "test@triflux.local",
+    },
+  }).trim();
+}
+
+function makeRepo() {
+  const repo = mkdtempSync(
+    join(tmpdir(), `tfx-integration-safety-${process.pid}-`),
+  );
+  git(repo, ["init", "-q", "-b", "main"]);
+  writeFileSync(join(repo, "shared.txt"), "base\n");
+  git(repo, ["add", "shared.txt"]);
+  git(repo, ["commit", "-q", "-m", "base"]);
+  return repo;
+}
+
+function removeRepo(repo) {
+  rmSync(repo, { recursive: true, force: true });
+}
+
+test("dirty leased rootDir file survives the historical ff-failure path", async () => {
+  const repo = makeRepo();
+  try {
+    git(repo, ["checkout", "-q", "-b", "swarm/run/merge", "main"]);
+    writeFileSync(join(repo, "integration.txt"), "integration content\n");
+    git(repo, ["add", "integration.txt"]);
+    git(repo, ["commit", "-q", "-m", "diverge integration"]);
+
+    git(repo, ["checkout", "-q", "-b", "swarm/run/shard", "main"]);
+    writeFileSync(join(repo, "shared.txt"), "shard\n");
+    git(repo, ["commit", "-q", "-am", "shard change"]);
+
+    git(repo, ["checkout", "-q", "main"]);
+    // shared.txt represents a rootDir tracked change that is also leased by
+    // the shard. The old rootDir merge failed here, then reset --hard erased it.
+    writeFileSync(join(repo, "shared.txt"), "root dirty lease overlap\n");
+    const headBefore = git(repo, ["rev-parse", "HEAD"]);
+    const statusBefore = git(repo, ["status", "--porcelain"]);
+
+    const result = await rebaseShardOntoIntegration({
+      shardBranch: "swarm/run/shard",
+      integrationBranch: "swarm/run/merge",
+      rootDir: repo,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.strategy, "cherry-pick");
+    assert.equal(
+      readFileSync(join(repo, "shared.txt"), "utf8"),
+      "root dirty lease overlap\n",
+    );
+    assert.equal(git(repo, ["status", "--porcelain"]), statusBefore);
+    assert.equal(git(repo, ["rev-parse", "HEAD"]), headBefore);
+    assert.equal(git(repo, ["rev-parse", "--abbrev-ref", "HEAD"]), "main");
+    assert.equal(git(repo, ["show", "swarm/run/merge:shared.txt"]), "shard");
+  } finally {
+    removeRepo(repo);
+  }
+});
+
+test("fast-forward updates only the integration ref", async () => {
+  const repo = makeRepo();
+  try {
+    git(repo, ["checkout", "-q", "-b", "swarm/run/shard"]);
+    writeFileSync(join(repo, "shard.txt"), "shard content\n");
+    git(repo, ["add", "shard.txt"]);
+    git(repo, ["commit", "-q", "-m", "shard feature"]);
+    const shardCommit = git(repo, ["rev-parse", "HEAD"]);
+
+    git(repo, ["checkout", "-q", "main"]);
+    git(repo, ["branch", "swarm/run/merge", "main"]);
+    const headBefore = git(repo, ["rev-parse", "HEAD"]);
+    const indexBefore = git(repo, ["write-tree"]);
+    const statusBefore = git(repo, ["status", "--porcelain"]);
+
+    const result = await rebaseShardOntoIntegration({
+      shardBranch: "swarm/run/shard",
+      integrationBranch: "swarm/run/merge",
+      rootDir: repo,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.strategy, "auto-ff");
+    assert.equal(git(repo, ["rev-parse", "swarm/run/merge"]), shardCommit);
+    assert.equal(git(repo, ["rev-parse", "HEAD"]), headBefore);
+    assert.equal(git(repo, ["write-tree"]), indexBefore);
+    assert.equal(git(repo, ["status", "--porcelain"]), statusBefore);
+    assert.equal(readFileSync(join(repo, "shared.txt"), "utf8"), "base\n");
+  } finally {
+    removeRepo(repo);
+  }
+});
+
+test("cherry-pick fallback leaves rootDir HEAD, index, and working tree untouched", async () => {
+  const repo = makeRepo();
+  try {
+    git(repo, ["checkout", "-q", "-b", "swarm/run/merge"]);
+    writeFileSync(join(repo, "integration.txt"), "integration content\n");
+    git(repo, ["add", "integration.txt"]);
+    git(repo, ["commit", "-q", "-m", "integration base"]);
+
+    git(repo, ["checkout", "-q", "-b", "swarm/run/shard", "main"]);
+    writeFileSync(join(repo, "shard.txt"), "shard content\n");
+    git(repo, ["add", "shard.txt"]);
+    git(repo, ["commit", "-q", "-m", "shard feature"]);
+
+    git(repo, ["checkout", "-q", "main"]);
+    writeFileSync(join(repo, "shared.txt"), "root remains dirty\n");
+    const headBefore = git(repo, ["rev-parse", "HEAD"]);
+    const indexBefore = git(repo, ["write-tree"]);
+    const statusBefore = git(repo, ["status", "--porcelain"]);
+
+    const result = await rebaseShardOntoIntegration({
+      shardBranch: "swarm/run/shard",
+      integrationBranch: "swarm/run/merge",
+      rootDir: repo,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.strategy, "cherry-pick");
+    assert.equal(
+      git(repo, ["show", "swarm/run/merge:integration.txt"]),
+      "integration content",
+    );
+    assert.equal(
+      git(repo, ["show", "swarm/run/merge:shard.txt"]),
+      "shard content",
+    );
+    assert.equal(git(repo, ["rev-parse", "HEAD"]), headBefore);
+    assert.equal(git(repo, ["write-tree"]), indexBefore);
+    assert.equal(git(repo, ["status", "--porcelain"]), statusBefore);
+    assert.equal(
+      readFileSync(join(repo, "shared.txt"), "utf8"),
+      "root remains dirty\n",
+    );
+  } finally {
+    removeRepo(repo);
+  }
+});


### PR DESCRIPTION
## 요약

2026-07-16 실사고(미커밋 92파일 소거)의 근본수정. `rebaseShardOntoIntegrationImpl`의 모든 변조 연산(merge/reset/cherry-pick/abort)을 **임시 worktree**로 이동 — rootDir 대상 git 호출은 읽기+worktree add/remove/prune만 남음. 성공/ff실패/cherry-pick실패 전 경로에서 rootDir HEAD·인덱스·워킹트리 불변. preflight에 rootDir dirty × shard lease 교집합 NO-GO 추가.

## 리뷰 (opus 교차, APPROVE)

- **회귀 가드 실증**: 신규 테스트를 사고 당시(부모) 구현에 물리면 정확히 사고 시그니처로 실패(미커밋 변경 소거 재현), 신 구현에선 통과 — 실제 git repo + 파일 내용 assert.
- BUG-E/BUG-J는 패치가 아닌 **구조적 제거** (checkout/reset 경로 자체 소멸).
- 미러 IDENTICAL(triflux)/변환 보존(remote), swarm 범위 59/59 pass.
- P3 후속 2건(비차단): ① integrationBranch가 타 worktree에 체크아웃된 경우 이제 안전 NO-GO(동작 변화 문서화 권장) ② worktree add 부분실패 시 prune 생략 가능성 — else 분기 prune 추가.

## 관련
- 사고 포렌식·이슈 초안: `~/.gstack/.../recovery/20260716-a-work/swarm-dataloss-issue-draft.md`