### PR TITLE
feat(hub): registration plumbing — scoped role 신원/transport locator 배관 (C6a-3)

### DIFF
--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -9,6 +9,7 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
+import { normalizeRoleKey } from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -16,6 +17,258 @@ const ROLE_SOURCE_RANK = Object.freeze({
   explicit: 2,
   "topic-fallback": 1,
 });
+const TRANSPORT_LOCATOR_SCHEMA_VERSION = "tfx.transport-locator.v1";
+const TRANSPORT_KINDS = new Set(["claude-uds", "tmux"]);
+const TRANSPORT_CAPABILITIES = new Set([
+  "probe",
+  "wake",
+  "activate",
+  "interrupt",
+]);
+const HOST_ID_RE = /^hst_[A-Za-z0-9_-]+$/u;
+
+function registrationError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function registrationString(value, code, { maxLength = 256 } = {}) {
+  if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
+    throw registrationError(code);
+  }
+  return value.trim();
+}
+
+function registrationLogicalRef(value, code, { maxLength = 128 } = {}) {
+  const normalized = registrationString(value, code, { maxLength });
+  if (!/^[A-Za-z0-9._:-]+$/u.test(normalized)) {
+    throw registrationError(code);
+  }
+  return normalized;
+}
+
+function assertExactFields(value, allowed, code) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.keys(value).some((field) => !allowed.has(field))
+  ) {
+    throw registrationError(code);
+  }
+}
+
+function normalizeTransportLocator(
+  value,
+  { cli, hostId, now, leaseExpiresMs },
+) {
+  assertExactFields(
+    value,
+    new Set([
+      "schema_version",
+      "transport_id",
+      "kind",
+      "host_id",
+      "capabilities",
+      "priority",
+      "expires_at_ms",
+      "locator",
+    ]),
+    "TRANSPORT_LOCATOR_INVALID",
+  );
+  if (value.schema_version !== TRANSPORT_LOCATOR_SCHEMA_VERSION) {
+    throw registrationError("TRANSPORT_LOCATOR_SCHEMA_UNSUPPORTED");
+  }
+  const transportId = registrationLogicalRef(
+    value.transport_id,
+    "TRANSPORT_ID_INVALID",
+    { maxLength: 128 },
+  );
+  if (!TRANSPORT_KINDS.has(value.kind)) {
+    throw registrationError("TRANSPORT_KIND_UNSUPPORTED");
+  }
+  if (cli === "codex" && value.kind !== "tmux") {
+    throw registrationError("CODEX_TRANSPORT_UNSUPPORTED");
+  }
+  const locatorHostId = registrationString(value.host_id, "HOST_ID_INVALID", {
+    maxLength: 128,
+  });
+  if (!HOST_ID_RE.test(locatorHostId) || (hostId && locatorHostId !== hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+  if (!Array.isArray(value.capabilities)) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  const capabilities = uniqueStrings(value.capabilities);
+  if (
+    capabilities.length !== value.capabilities.length ||
+    capabilities.some((capability) => !TRANSPORT_CAPABILITIES.has(capability))
+  ) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  if (!Number.isSafeInteger(value.priority)) {
+    throw registrationError("TRANSPORT_PRIORITY_INVALID");
+  }
+  if (
+    !Number.isSafeInteger(value.expires_at_ms) ||
+    value.expires_at_ms <= now ||
+    value.expires_at_ms > leaseExpiresMs
+  ) {
+    throw registrationError("TRANSPORT_EXPIRY_INVALID");
+  }
+
+  let locator;
+  if (value.kind === "claude-uds") {
+    assertExactFields(
+      value.locator,
+      new Set(["session_id", "short", "bridge_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    const sessionId = value.locator.session_id;
+    const short = value.locator.short;
+    if (!sessionId && !short) {
+      throw registrationError("CLAUDE_UDS_SESSION_REQUIRED");
+    }
+    locator = {
+      ...(sessionId
+        ? {
+            session_id: registrationLogicalRef(
+              sessionId,
+              "CLAUDE_UDS_SESSION_INVALID",
+            ),
+          }
+        : {}),
+      ...(short
+        ? {
+            short: registrationLogicalRef(short, "CLAUDE_UDS_SHORT_INVALID", {
+              maxLength: 128,
+            }),
+          }
+        : {}),
+      bridge_id: registrationLogicalRef(
+        value.locator.bridge_id,
+        "CLAUDE_UDS_BRIDGE_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  } else {
+    assertExactFields(
+      value.locator,
+      new Set(["session_name", "mux_server_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    locator = {
+      session_name: registrationLogicalRef(
+        value.locator.session_name,
+        "TMUX_SESSION_INVALID",
+        { maxLength: 128 },
+      ),
+      mux_server_id: registrationLogicalRef(
+        value.locator.mux_server_id,
+        "TMUX_SERVER_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  }
+
+  return {
+    schema_version: TRANSPORT_LOCATOR_SCHEMA_VERSION,
+    transport_id: transportId,
+    kind: value.kind,
+    host_id: locatorHostId,
+    capabilities,
+    priority: value.priority,
+    expires_at_ms: value.expires_at_ms,
+    locator,
+  };
+}
+
+export function normalizeRegistrationIdentity(args = {}, now = Date.now()) {
+  const hasProjectId = Object.hasOwn(args, "project_id");
+  const hasSessionId = Object.hasOwn(args, "session_id");
+  const hasHostId = Object.hasOwn(args, "host_id");
+  const hasLocatorJson = Object.hasOwn(args, "transport_locators_json");
+  const hasLocators = Object.hasOwn(args, "transport_locators");
+  if (
+    !hasProjectId &&
+    !hasSessionId &&
+    !hasHostId &&
+    !hasLocatorJson &&
+    !hasLocators
+  ) {
+    return null;
+  }
+
+  const projectId = hasProjectId
+    ? normalizeRoleKey({ project_id: args.project_id, role_kind: "cto" })
+        .project_id
+    : null;
+  const sessionId = hasSessionId
+    ? registrationString(args.session_id, "SESSION_ID_INVALID")
+    : null;
+  const hostId = hasHostId
+    ? registrationString(args.host_id, "HOST_ID_INVALID", { maxLength: 128 })
+    : null;
+  if (hostId && !HOST_ID_RE.test(hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  let rawLocators = [];
+  if (hasLocatorJson) {
+    if (Array.isArray(args.transport_locators_json)) {
+      rawLocators = args.transport_locators_json;
+    } else if (typeof args.transport_locators_json === "string") {
+      try {
+        rawLocators = JSON.parse(args.transport_locators_json);
+      } catch {
+        throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+      }
+    } else {
+      throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+    }
+  } else if (hasLocators) {
+    rawLocators = args.transport_locators;
+  }
+  if (!Array.isArray(rawLocators)) {
+    throw registrationError("TRANSPORT_LOCATORS_INVALID");
+  }
+
+  const ttlMs = Number(args.heartbeat_ttl_ms ?? 30000);
+  if (rawLocators.length > 0 && (!Number.isFinite(ttlMs) || ttlMs <= 0)) {
+    throw registrationError("HEARTBEAT_TTL_INVALID");
+  }
+  const leaseExpiresMs = now + ttlMs;
+  const normalizedLocators = rawLocators
+    .map((locator) =>
+      normalizeTransportLocator(locator, {
+        cli: args.cli,
+        hostId,
+        now,
+        leaseExpiresMs,
+      }),
+    )
+    .sort(
+      (left, right) =>
+        right.priority - left.priority ||
+        left.transport_id.localeCompare(right.transport_id),
+    );
+  const resolvedHostId = hostId || normalizedLocators[0]?.host_id || null;
+  if (
+    resolvedHostId &&
+    normalizedLocators.some((locator) => locator.host_id !== resolvedHostId)
+  ) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  return {
+    project_id: projectId,
+    session_id: sessionId,
+    host_id: resolvedHostId,
+    transport_locators_json:
+      hasLocatorJson || hasLocators ? JSON.stringify(normalizedLocators) : null,
+  };
+}
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -123,6 +376,18 @@ export function createRouter(store) {
   const queuesByAgent = new Map();
   const liveMessages = new Map();
   const roleStates = new Map();
+  const updateRegistrationIdentity = store.db?.prepare
+    ? store.db.prepare(`
+        UPDATE agents SET
+          project_id=COALESCE(@project_id, project_id),
+          session_id=COALESCE(@session_id, session_id),
+          host_id=COALESCE(@host_id, host_id),
+          transport_locators_json=COALESCE(
+            @transport_locators_json,
+            transport_locators_json
+          )
+        WHERE agent_id=@agent_id`)
+    : null;
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -855,9 +1120,16 @@ export function createRouter(store) {
     deliveryEmitter,
 
     registerAgent(args) {
+      const identity = normalizeRegistrationIdentity(args);
       const result = store.registerAgent(args);
       if (!registerPresenceIsEffective(result)) {
         return registerPresenceFailure(args.agent_id, result);
+      }
+      if (identity && updateRegistrationIdentity) {
+        updateRegistrationIdentity.run({
+          agent_id: args.agent_id,
+          ...identity,
+        });
       }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -1558,6 +1558,38 @@ export async function startHub({
         try {
           const body = await parseBody(req);
           const { sessionId } = body || {};
+          if (body?.agent_id && body?.cli) {
+            const registered = router.registerAgent({
+              agent_id: body.agent_id,
+              cli: body.cli,
+              capabilities: Array.isArray(body.capabilities)
+                ? body.capabilities
+                : [],
+              topics: Array.isArray(body.topics) ? body.topics : [],
+              heartbeat_ttl_ms: body.heartbeat_ttl_ms ?? 300000,
+              metadata:
+                body.metadata && typeof body.metadata === "object"
+                  ? body.metadata
+                  : { source: "session_start" },
+              ...(Object.hasOwn(body, "project_id")
+                ? { project_id: body.project_id }
+                : {}),
+              ...(Object.hasOwn(body, "session_id")
+                ? { session_id: body.session_id }
+                : {}),
+              ...(Object.hasOwn(body, "host_id")
+                ? { host_id: body.host_id }
+                : {}),
+              ...(Object.hasOwn(body, "transport_locators_json")
+                ? { transport_locators_json: body.transport_locators_json }
+                : {}),
+            });
+            if (!registered?.ok) {
+              throw new Error(
+                registered?.error?.message || "hub agent register failed",
+              );
+            }
+          }
           const result = synapseRegistry.register(sessionId, body);
           if (!result?.ok) {
             throw new Error(result?.reason || "register failed");
@@ -1712,6 +1744,10 @@ export async function startHub({
               topics = [],
               capabilities = [],
               metadata = {},
+              project_id,
+              session_id,
+              host_id,
+              transport_locators_json,
             } = body;
             if (!agent_id || !cli) {
               return writeJson(res, 400, {
@@ -1740,6 +1776,12 @@ export async function startHub({
               topics,
               heartbeat_ttl_ms,
               metadata,
+              ...(project_id === undefined ? {} : { project_id }),
+              ...(session_id === undefined ? {} : { session_id }),
+              ...(host_id === undefined ? {} : { host_id }),
+              ...(transport_locators_json === undefined
+                ? {}
+                : { transport_locators_json }),
             });
             if (result.ok) {
               workerSpans.set(agent_id, {

--- a/hub/team/synapse-http.mjs
+++ b/hub/team/synapse-http.mjs
@@ -1,6 +1,9 @@
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { normalizeRoleKey } from "../role-contract.mjs";
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -19,6 +22,144 @@ function normalizeToken(raw) {
   if (raw == null) return null;
   const token = String(raw).trim();
   return token || null;
+}
+
+function opaqueId(prefix, value) {
+  return `${prefix}_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function normalizedProjectId(value) {
+  try {
+    return normalizeRoleKey({ project_id: value, role_kind: "cto" }).project_id;
+  } catch {
+    return "";
+  }
+}
+
+function resolveProjectId(cwd, meta, opts = {}) {
+  const explicit = meta?.project_id || process.env.TFX_PROJECT_ID;
+  if (explicit) return normalizedProjectId(explicit);
+  if (typeof opts.resolveProjectId === "function") {
+    return normalizedProjectId(opts.resolveProjectId(cwd));
+  }
+  let current = cwd;
+  while (current) {
+    const manifest = join(current, ".triflux", "project.json");
+    if (existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(readFileSync(manifest, "utf8"));
+        if (parsed?.schema_version !== "tfx.project.v1") return "";
+        return normalizedProjectId(parsed.project_id);
+      } catch {
+        return "";
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return "";
+}
+
+function inferSessionCli(meta, opts = {}) {
+  const explicit = String(meta?.cli || meta?.actor_cli || "")
+    .trim()
+    .toLowerCase();
+  if (explicit === "codex" || explicit === "claude") return explicit;
+  const entrypoint = String(opts.entrypoint ?? process.argv[1] ?? "");
+  if (entrypoint.includes("codex-session-hook")) return "codex";
+  if (entrypoint.includes("agy-session-hook")) return "other";
+  return "claude";
+}
+
+function resolveTmuxSession(meta, opts = {}) {
+  const explicit =
+    meta?.tmux_session || meta?.session_name || process.env.TFX_TMUX_SESSION;
+  if (explicit) return String(explicit).trim();
+  if (!process.env.TMUX) return "";
+  try {
+    const run =
+      opts.tmuxSessionName ||
+      (() =>
+        execFileSync("tmux", ["display-message", "-p", "#{session_name}"], {
+          encoding: "utf8",
+          timeout: 200,
+          windowsHide: true,
+        }));
+    return String(run() || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function buildSynapseRegistrationMeta(meta, opts = {}) {
+  if (!meta || meta.sessionKind !== "interactive") return meta;
+  const sessionId = String(meta.sessionId || "").trim();
+  if (!sessionId) return meta;
+  const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
+  const cli = inferSessionCli(meta, opts);
+  const hostId = String(
+    meta.host_id ||
+      process.env.TFX_HOST_ID ||
+      opaqueId("hst", opts.hostname?.() || hostname()),
+  ).trim();
+  const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
+  const transportLocators = [];
+  if (cli === "claude") {
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `claude-uds:${hostId}:${sessionId}`),
+      kind: "claude-uds",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_id: sessionId,
+        bridge_id: String(
+          meta.bridge_id || process.env.TFX_BRIDGE_ID || "local-hub",
+        ),
+      },
+    });
+  }
+  const tmuxSession = resolveTmuxSession(meta, opts);
+  if (tmuxSession) {
+    const muxServerSource =
+      meta.mux_server_id ||
+      process.env.TFX_MUX_SERVER_ID ||
+      String(process.env.TMUX || "default").split(",", 1)[0];
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `tmux:${hostId}:${tmuxSession}`),
+      kind: "tmux",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: cli === "codex" ? 100 : 50,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_name: tmuxSession,
+        mux_server_id: opaqueId("mux", muxServerSource),
+      },
+    });
+  }
+  const directAgentId = `session:${sessionId}`;
+  return {
+    ...meta,
+    agent_id:
+      meta.agent_id ||
+      (directAgentId.length <= 64 && /^[a-zA-Z0-9._:-]+$/u.test(directAgentId)
+        ? directAgentId
+        : opaqueId("session", sessionId)),
+    cli,
+    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    session_id: meta.session_id || sessionId,
+    host_id: hostId,
+    transport_locators_json:
+      meta.transport_locators_json ?? JSON.stringify(transportLocators),
+  };
 }
 
 // Mirrors hub/bridge.mjs:readHubToken — env override first, then the token file.
@@ -139,7 +280,11 @@ export function drainPendingSynapse(timeoutMs = 1000) {
 }
 
 export function registerSynapseSession(meta, opts = {}) {
-  return fireAndForgetSynapse("/synapse/register", meta, opts);
+  return fireAndForgetSynapse(
+    "/synapse/register",
+    buildSynapseRegistrationMeta(meta, opts),
+    opts,
+  );
 }
 
 export function heartbeatSynapseSession(

--- a/hub/tools.mjs
+++ b/hub/tools.mjs
@@ -153,6 +153,17 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
+          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          session_id: { type: "string", minLength: 1, maxLength: 256 },
+          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          transport_locators_json: {
+            description:
+              "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",
+            oneOf: [
+              { type: "array", items: { type: "object" } },
+              { type: "string" },
+            ],
+          },
           heartbeat_ttl_ms: {
             type: "integer",
             minimum: 10000,

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -9,6 +9,7 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
+import { normalizeRoleKey } from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -16,6 +17,258 @@ const ROLE_SOURCE_RANK = Object.freeze({
   explicit: 2,
   "topic-fallback": 1,
 });
+const TRANSPORT_LOCATOR_SCHEMA_VERSION = "tfx.transport-locator.v1";
+const TRANSPORT_KINDS = new Set(["claude-uds", "tmux"]);
+const TRANSPORT_CAPABILITIES = new Set([
+  "probe",
+  "wake",
+  "activate",
+  "interrupt",
+]);
+const HOST_ID_RE = /^hst_[A-Za-z0-9_-]+$/u;
+
+function registrationError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function registrationString(value, code, { maxLength = 256 } = {}) {
+  if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
+    throw registrationError(code);
+  }
+  return value.trim();
+}
+
+function registrationLogicalRef(value, code, { maxLength = 128 } = {}) {
+  const normalized = registrationString(value, code, { maxLength });
+  if (!/^[A-Za-z0-9._:-]+$/u.test(normalized)) {
+    throw registrationError(code);
+  }
+  return normalized;
+}
+
+function assertExactFields(value, allowed, code) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.keys(value).some((field) => !allowed.has(field))
+  ) {
+    throw registrationError(code);
+  }
+}
+
+function normalizeTransportLocator(
+  value,
+  { cli, hostId, now, leaseExpiresMs },
+) {
+  assertExactFields(
+    value,
+    new Set([
+      "schema_version",
+      "transport_id",
+      "kind",
+      "host_id",
+      "capabilities",
+      "priority",
+      "expires_at_ms",
+      "locator",
+    ]),
+    "TRANSPORT_LOCATOR_INVALID",
+  );
+  if (value.schema_version !== TRANSPORT_LOCATOR_SCHEMA_VERSION) {
+    throw registrationError("TRANSPORT_LOCATOR_SCHEMA_UNSUPPORTED");
+  }
+  const transportId = registrationLogicalRef(
+    value.transport_id,
+    "TRANSPORT_ID_INVALID",
+    { maxLength: 128 },
+  );
+  if (!TRANSPORT_KINDS.has(value.kind)) {
+    throw registrationError("TRANSPORT_KIND_UNSUPPORTED");
+  }
+  if (cli === "codex" && value.kind !== "tmux") {
+    throw registrationError("CODEX_TRANSPORT_UNSUPPORTED");
+  }
+  const locatorHostId = registrationString(value.host_id, "HOST_ID_INVALID", {
+    maxLength: 128,
+  });
+  if (!HOST_ID_RE.test(locatorHostId) || (hostId && locatorHostId !== hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+  if (!Array.isArray(value.capabilities)) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  const capabilities = uniqueStrings(value.capabilities);
+  if (
+    capabilities.length !== value.capabilities.length ||
+    capabilities.some((capability) => !TRANSPORT_CAPABILITIES.has(capability))
+  ) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  if (!Number.isSafeInteger(value.priority)) {
+    throw registrationError("TRANSPORT_PRIORITY_INVALID");
+  }
+  if (
+    !Number.isSafeInteger(value.expires_at_ms) ||
+    value.expires_at_ms <= now ||
+    value.expires_at_ms > leaseExpiresMs
+  ) {
+    throw registrationError("TRANSPORT_EXPIRY_INVALID");
+  }
+
+  let locator;
+  if (value.kind === "claude-uds") {
+    assertExactFields(
+      value.locator,
+      new Set(["session_id", "short", "bridge_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    const sessionId = value.locator.session_id;
+    const short = value.locator.short;
+    if (!sessionId && !short) {
+      throw registrationError("CLAUDE_UDS_SESSION_REQUIRED");
+    }
+    locator = {
+      ...(sessionId
+        ? {
+            session_id: registrationLogicalRef(
+              sessionId,
+              "CLAUDE_UDS_SESSION_INVALID",
+            ),
+          }
+        : {}),
+      ...(short
+        ? {
+            short: registrationLogicalRef(short, "CLAUDE_UDS_SHORT_INVALID", {
+              maxLength: 128,
+            }),
+          }
+        : {}),
+      bridge_id: registrationLogicalRef(
+        value.locator.bridge_id,
+        "CLAUDE_UDS_BRIDGE_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  } else {
+    assertExactFields(
+      value.locator,
+      new Set(["session_name", "mux_server_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    locator = {
+      session_name: registrationLogicalRef(
+        value.locator.session_name,
+        "TMUX_SESSION_INVALID",
+        { maxLength: 128 },
+      ),
+      mux_server_id: registrationLogicalRef(
+        value.locator.mux_server_id,
+        "TMUX_SERVER_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  }
+
+  return {
+    schema_version: TRANSPORT_LOCATOR_SCHEMA_VERSION,
+    transport_id: transportId,
+    kind: value.kind,
+    host_id: locatorHostId,
+    capabilities,
+    priority: value.priority,
+    expires_at_ms: value.expires_at_ms,
+    locator,
+  };
+}
+
+export function normalizeRegistrationIdentity(args = {}, now = Date.now()) {
+  const hasProjectId = Object.hasOwn(args, "project_id");
+  const hasSessionId = Object.hasOwn(args, "session_id");
+  const hasHostId = Object.hasOwn(args, "host_id");
+  const hasLocatorJson = Object.hasOwn(args, "transport_locators_json");
+  const hasLocators = Object.hasOwn(args, "transport_locators");
+  if (
+    !hasProjectId &&
+    !hasSessionId &&
+    !hasHostId &&
+    !hasLocatorJson &&
+    !hasLocators
+  ) {
+    return null;
+  }
+
+  const projectId = hasProjectId
+    ? normalizeRoleKey({ project_id: args.project_id, role_kind: "cto" })
+        .project_id
+    : null;
+  const sessionId = hasSessionId
+    ? registrationString(args.session_id, "SESSION_ID_INVALID")
+    : null;
+  const hostId = hasHostId
+    ? registrationString(args.host_id, "HOST_ID_INVALID", { maxLength: 128 })
+    : null;
+  if (hostId && !HOST_ID_RE.test(hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  let rawLocators = [];
+  if (hasLocatorJson) {
+    if (Array.isArray(args.transport_locators_json)) {
+      rawLocators = args.transport_locators_json;
+    } else if (typeof args.transport_locators_json === "string") {
+      try {
+        rawLocators = JSON.parse(args.transport_locators_json);
+      } catch {
+        throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+      }
+    } else {
+      throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+    }
+  } else if (hasLocators) {
+    rawLocators = args.transport_locators;
+  }
+  if (!Array.isArray(rawLocators)) {
+    throw registrationError("TRANSPORT_LOCATORS_INVALID");
+  }
+
+  const ttlMs = Number(args.heartbeat_ttl_ms ?? 30000);
+  if (rawLocators.length > 0 && (!Number.isFinite(ttlMs) || ttlMs <= 0)) {
+    throw registrationError("HEARTBEAT_TTL_INVALID");
+  }
+  const leaseExpiresMs = now + ttlMs;
+  const normalizedLocators = rawLocators
+    .map((locator) =>
+      normalizeTransportLocator(locator, {
+        cli: args.cli,
+        hostId,
+        now,
+        leaseExpiresMs,
+      }),
+    )
+    .sort(
+      (left, right) =>
+        right.priority - left.priority ||
+        left.transport_id.localeCompare(right.transport_id),
+    );
+  const resolvedHostId = hostId || normalizedLocators[0]?.host_id || null;
+  if (
+    resolvedHostId &&
+    normalizedLocators.some((locator) => locator.host_id !== resolvedHostId)
+  ) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  return {
+    project_id: projectId,
+    session_id: sessionId,
+    host_id: resolvedHostId,
+    transport_locators_json:
+      hasLocatorJson || hasLocators ? JSON.stringify(normalizedLocators) : null,
+  };
+}
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -123,6 +376,18 @@ export function createRouter(store) {
   const queuesByAgent = new Map();
   const liveMessages = new Map();
   const roleStates = new Map();
+  const updateRegistrationIdentity = store.db?.prepare
+    ? store.db.prepare(`
+        UPDATE agents SET
+          project_id=COALESCE(@project_id, project_id),
+          session_id=COALESCE(@session_id, session_id),
+          host_id=COALESCE(@host_id, host_id),
+          transport_locators_json=COALESCE(
+            @transport_locators_json,
+            transport_locators_json
+          )
+        WHERE agent_id=@agent_id`)
+    : null;
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -855,9 +1120,16 @@ export function createRouter(store) {
     deliveryEmitter,
 
     registerAgent(args) {
+      const identity = normalizeRegistrationIdentity(args);
       const result = store.registerAgent(args);
       if (!registerPresenceIsEffective(result)) {
         return registerPresenceFailure(args.agent_id, result);
+      }
+      if (identity && updateRegistrationIdentity) {
+        updateRegistrationIdentity.run({
+          agent_id: args.agent_id,
+          ...identity,
+        });
       }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);

--- a/packages/core/hub/team/synapse-http.mjs
+++ b/packages/core/hub/team/synapse-http.mjs
@@ -1,6 +1,9 @@
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { normalizeRoleKey } from "../role-contract.mjs";
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -19,6 +22,144 @@ function normalizeToken(raw) {
   if (raw == null) return null;
   const token = String(raw).trim();
   return token || null;
+}
+
+function opaqueId(prefix, value) {
+  return `${prefix}_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function normalizedProjectId(value) {
+  try {
+    return normalizeRoleKey({ project_id: value, role_kind: "cto" }).project_id;
+  } catch {
+    return "";
+  }
+}
+
+function resolveProjectId(cwd, meta, opts = {}) {
+  const explicit = meta?.project_id || process.env.TFX_PROJECT_ID;
+  if (explicit) return normalizedProjectId(explicit);
+  if (typeof opts.resolveProjectId === "function") {
+    return normalizedProjectId(opts.resolveProjectId(cwd));
+  }
+  let current = cwd;
+  while (current) {
+    const manifest = join(current, ".triflux", "project.json");
+    if (existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(readFileSync(manifest, "utf8"));
+        if (parsed?.schema_version !== "tfx.project.v1") return "";
+        return normalizedProjectId(parsed.project_id);
+      } catch {
+        return "";
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return "";
+}
+
+function inferSessionCli(meta, opts = {}) {
+  const explicit = String(meta?.cli || meta?.actor_cli || "")
+    .trim()
+    .toLowerCase();
+  if (explicit === "codex" || explicit === "claude") return explicit;
+  const entrypoint = String(opts.entrypoint ?? process.argv[1] ?? "");
+  if (entrypoint.includes("codex-session-hook")) return "codex";
+  if (entrypoint.includes("agy-session-hook")) return "other";
+  return "claude";
+}
+
+function resolveTmuxSession(meta, opts = {}) {
+  const explicit =
+    meta?.tmux_session || meta?.session_name || process.env.TFX_TMUX_SESSION;
+  if (explicit) return String(explicit).trim();
+  if (!process.env.TMUX) return "";
+  try {
+    const run =
+      opts.tmuxSessionName ||
+      (() =>
+        execFileSync("tmux", ["display-message", "-p", "#{session_name}"], {
+          encoding: "utf8",
+          timeout: 200,
+          windowsHide: true,
+        }));
+    return String(run() || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function buildSynapseRegistrationMeta(meta, opts = {}) {
+  if (!meta || meta.sessionKind !== "interactive") return meta;
+  const sessionId = String(meta.sessionId || "").trim();
+  if (!sessionId) return meta;
+  const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
+  const cli = inferSessionCli(meta, opts);
+  const hostId = String(
+    meta.host_id ||
+      process.env.TFX_HOST_ID ||
+      opaqueId("hst", opts.hostname?.() || hostname()),
+  ).trim();
+  const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
+  const transportLocators = [];
+  if (cli === "claude") {
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `claude-uds:${hostId}:${sessionId}`),
+      kind: "claude-uds",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_id: sessionId,
+        bridge_id: String(
+          meta.bridge_id || process.env.TFX_BRIDGE_ID || "local-hub",
+        ),
+      },
+    });
+  }
+  const tmuxSession = resolveTmuxSession(meta, opts);
+  if (tmuxSession) {
+    const muxServerSource =
+      meta.mux_server_id ||
+      process.env.TFX_MUX_SERVER_ID ||
+      String(process.env.TMUX || "default").split(",", 1)[0];
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `tmux:${hostId}:${tmuxSession}`),
+      kind: "tmux",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: cli === "codex" ? 100 : 50,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_name: tmuxSession,
+        mux_server_id: opaqueId("mux", muxServerSource),
+      },
+    });
+  }
+  const directAgentId = `session:${sessionId}`;
+  return {
+    ...meta,
+    agent_id:
+      meta.agent_id ||
+      (directAgentId.length <= 64 && /^[a-zA-Z0-9._:-]+$/u.test(directAgentId)
+        ? directAgentId
+        : opaqueId("session", sessionId)),
+    cli,
+    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    session_id: meta.session_id || sessionId,
+    host_id: hostId,
+    transport_locators_json:
+      meta.transport_locators_json ?? JSON.stringify(transportLocators),
+  };
 }
 
 // Mirrors hub/bridge.mjs:readHubToken — env override first, then the token file.
@@ -139,7 +280,11 @@ export function drainPendingSynapse(timeoutMs = 1000) {
 }
 
 export function registerSynapseSession(meta, opts = {}) {
-  return fireAndForgetSynapse("/synapse/register", meta, opts);
+  return fireAndForgetSynapse(
+    "/synapse/register",
+    buildSynapseRegistrationMeta(meta, opts),
+    opts,
+  );
 }
 
 export function heartbeatSynapseSession(

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -1545,6 +1545,38 @@ export async function startHub({
         try {
           const body = await parseBody(req);
           const { sessionId } = body || {};
+          if (body?.agent_id && body?.cli) {
+            const registered = router.registerAgent({
+              agent_id: body.agent_id,
+              cli: body.cli,
+              capabilities: Array.isArray(body.capabilities)
+                ? body.capabilities
+                : [],
+              topics: Array.isArray(body.topics) ? body.topics : [],
+              heartbeat_ttl_ms: body.heartbeat_ttl_ms ?? 300000,
+              metadata:
+                body.metadata && typeof body.metadata === "object"
+                  ? body.metadata
+                  : { source: "session_start" },
+              ...(Object.hasOwn(body, "project_id")
+                ? { project_id: body.project_id }
+                : {}),
+              ...(Object.hasOwn(body, "session_id")
+                ? { session_id: body.session_id }
+                : {}),
+              ...(Object.hasOwn(body, "host_id")
+                ? { host_id: body.host_id }
+                : {}),
+              ...(Object.hasOwn(body, "transport_locators_json")
+                ? { transport_locators_json: body.transport_locators_json }
+                : {}),
+            });
+            if (!registered?.ok) {
+              throw new Error(
+                registered?.error?.message || "hub agent register failed",
+              );
+            }
+          }
           const result = synapseRegistry.register(sessionId, body);
           if (!result?.ok) {
             throw new Error(result?.reason || "register failed");
@@ -1699,6 +1731,10 @@ export async function startHub({
               topics = [],
               capabilities = [],
               metadata = {},
+              project_id,
+              session_id,
+              host_id,
+              transport_locators_json,
             } = body;
             if (!agent_id || !cli) {
               return writeJson(res, 400, {
@@ -1725,6 +1761,12 @@ export async function startHub({
               topics,
               heartbeat_ttl_ms,
               metadata,
+              ...(project_id === undefined ? {} : { project_id }),
+              ...(session_id === undefined ? {} : { session_id }),
+              ...(host_id === undefined ? {} : { host_id }),
+              ...(transport_locators_json === undefined
+                ? {}
+                : { transport_locators_json }),
             });
             if (result.ok) {
               workerSpans.set(agent_id, {

--- a/packages/remote/hub/tools.mjs
+++ b/packages/remote/hub/tools.mjs
@@ -149,6 +149,14 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
+          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          session_id: { type: "string", minLength: 1, maxLength: 256 },
+          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          transport_locators_json: {
+            description:
+              "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",
+            oneOf: [{ type: "array", items: { type: "object" } }, { type: "string" }],
+          },
           heartbeat_ttl_ms: {
             type: "integer",
             minimum: 10000,

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -9,6 +9,7 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
+import { normalizeRoleKey } from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -16,6 +17,258 @@ const ROLE_SOURCE_RANK = Object.freeze({
   explicit: 2,
   "topic-fallback": 1,
 });
+const TRANSPORT_LOCATOR_SCHEMA_VERSION = "tfx.transport-locator.v1";
+const TRANSPORT_KINDS = new Set(["claude-uds", "tmux"]);
+const TRANSPORT_CAPABILITIES = new Set([
+  "probe",
+  "wake",
+  "activate",
+  "interrupt",
+]);
+const HOST_ID_RE = /^hst_[A-Za-z0-9_-]+$/u;
+
+function registrationError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function registrationString(value, code, { maxLength = 256 } = {}) {
+  if (typeof value !== "string" || !value.trim() || value.length > maxLength) {
+    throw registrationError(code);
+  }
+  return value.trim();
+}
+
+function registrationLogicalRef(value, code, { maxLength = 128 } = {}) {
+  const normalized = registrationString(value, code, { maxLength });
+  if (!/^[A-Za-z0-9._:-]+$/u.test(normalized)) {
+    throw registrationError(code);
+  }
+  return normalized;
+}
+
+function assertExactFields(value, allowed, code) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.keys(value).some((field) => !allowed.has(field))
+  ) {
+    throw registrationError(code);
+  }
+}
+
+function normalizeTransportLocator(
+  value,
+  { cli, hostId, now, leaseExpiresMs },
+) {
+  assertExactFields(
+    value,
+    new Set([
+      "schema_version",
+      "transport_id",
+      "kind",
+      "host_id",
+      "capabilities",
+      "priority",
+      "expires_at_ms",
+      "locator",
+    ]),
+    "TRANSPORT_LOCATOR_INVALID",
+  );
+  if (value.schema_version !== TRANSPORT_LOCATOR_SCHEMA_VERSION) {
+    throw registrationError("TRANSPORT_LOCATOR_SCHEMA_UNSUPPORTED");
+  }
+  const transportId = registrationLogicalRef(
+    value.transport_id,
+    "TRANSPORT_ID_INVALID",
+    { maxLength: 128 },
+  );
+  if (!TRANSPORT_KINDS.has(value.kind)) {
+    throw registrationError("TRANSPORT_KIND_UNSUPPORTED");
+  }
+  if (cli === "codex" && value.kind !== "tmux") {
+    throw registrationError("CODEX_TRANSPORT_UNSUPPORTED");
+  }
+  const locatorHostId = registrationString(value.host_id, "HOST_ID_INVALID", {
+    maxLength: 128,
+  });
+  if (!HOST_ID_RE.test(locatorHostId) || (hostId && locatorHostId !== hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+  if (!Array.isArray(value.capabilities)) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  const capabilities = uniqueStrings(value.capabilities);
+  if (
+    capabilities.length !== value.capabilities.length ||
+    capabilities.some((capability) => !TRANSPORT_CAPABILITIES.has(capability))
+  ) {
+    throw registrationError("TRANSPORT_CAPABILITIES_INVALID");
+  }
+  if (!Number.isSafeInteger(value.priority)) {
+    throw registrationError("TRANSPORT_PRIORITY_INVALID");
+  }
+  if (
+    !Number.isSafeInteger(value.expires_at_ms) ||
+    value.expires_at_ms <= now ||
+    value.expires_at_ms > leaseExpiresMs
+  ) {
+    throw registrationError("TRANSPORT_EXPIRY_INVALID");
+  }
+
+  let locator;
+  if (value.kind === "claude-uds") {
+    assertExactFields(
+      value.locator,
+      new Set(["session_id", "short", "bridge_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    const sessionId = value.locator.session_id;
+    const short = value.locator.short;
+    if (!sessionId && !short) {
+      throw registrationError("CLAUDE_UDS_SESSION_REQUIRED");
+    }
+    locator = {
+      ...(sessionId
+        ? {
+            session_id: registrationLogicalRef(
+              sessionId,
+              "CLAUDE_UDS_SESSION_INVALID",
+            ),
+          }
+        : {}),
+      ...(short
+        ? {
+            short: registrationLogicalRef(short, "CLAUDE_UDS_SHORT_INVALID", {
+              maxLength: 128,
+            }),
+          }
+        : {}),
+      bridge_id: registrationLogicalRef(
+        value.locator.bridge_id,
+        "CLAUDE_UDS_BRIDGE_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  } else {
+    assertExactFields(
+      value.locator,
+      new Set(["session_name", "mux_server_id"]),
+      "TRANSPORT_LOCATOR_INVALID",
+    );
+    locator = {
+      session_name: registrationLogicalRef(
+        value.locator.session_name,
+        "TMUX_SESSION_INVALID",
+        { maxLength: 128 },
+      ),
+      mux_server_id: registrationLogicalRef(
+        value.locator.mux_server_id,
+        "TMUX_SERVER_INVALID",
+        { maxLength: 128 },
+      ),
+    };
+  }
+
+  return {
+    schema_version: TRANSPORT_LOCATOR_SCHEMA_VERSION,
+    transport_id: transportId,
+    kind: value.kind,
+    host_id: locatorHostId,
+    capabilities,
+    priority: value.priority,
+    expires_at_ms: value.expires_at_ms,
+    locator,
+  };
+}
+
+export function normalizeRegistrationIdentity(args = {}, now = Date.now()) {
+  const hasProjectId = Object.hasOwn(args, "project_id");
+  const hasSessionId = Object.hasOwn(args, "session_id");
+  const hasHostId = Object.hasOwn(args, "host_id");
+  const hasLocatorJson = Object.hasOwn(args, "transport_locators_json");
+  const hasLocators = Object.hasOwn(args, "transport_locators");
+  if (
+    !hasProjectId &&
+    !hasSessionId &&
+    !hasHostId &&
+    !hasLocatorJson &&
+    !hasLocators
+  ) {
+    return null;
+  }
+
+  const projectId = hasProjectId
+    ? normalizeRoleKey({ project_id: args.project_id, role_kind: "cto" })
+        .project_id
+    : null;
+  const sessionId = hasSessionId
+    ? registrationString(args.session_id, "SESSION_ID_INVALID")
+    : null;
+  const hostId = hasHostId
+    ? registrationString(args.host_id, "HOST_ID_INVALID", { maxLength: 128 })
+    : null;
+  if (hostId && !HOST_ID_RE.test(hostId)) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  let rawLocators = [];
+  if (hasLocatorJson) {
+    if (Array.isArray(args.transport_locators_json)) {
+      rawLocators = args.transport_locators_json;
+    } else if (typeof args.transport_locators_json === "string") {
+      try {
+        rawLocators = JSON.parse(args.transport_locators_json);
+      } catch {
+        throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+      }
+    } else {
+      throw registrationError("TRANSPORT_LOCATORS_JSON_INVALID");
+    }
+  } else if (hasLocators) {
+    rawLocators = args.transport_locators;
+  }
+  if (!Array.isArray(rawLocators)) {
+    throw registrationError("TRANSPORT_LOCATORS_INVALID");
+  }
+
+  const ttlMs = Number(args.heartbeat_ttl_ms ?? 30000);
+  if (rawLocators.length > 0 && (!Number.isFinite(ttlMs) || ttlMs <= 0)) {
+    throw registrationError("HEARTBEAT_TTL_INVALID");
+  }
+  const leaseExpiresMs = now + ttlMs;
+  const normalizedLocators = rawLocators
+    .map((locator) =>
+      normalizeTransportLocator(locator, {
+        cli: args.cli,
+        hostId,
+        now,
+        leaseExpiresMs,
+      }),
+    )
+    .sort(
+      (left, right) =>
+        right.priority - left.priority ||
+        left.transport_id.localeCompare(right.transport_id),
+    );
+  const resolvedHostId = hostId || normalizedLocators[0]?.host_id || null;
+  if (
+    resolvedHostId &&
+    normalizedLocators.some((locator) => locator.host_id !== resolvedHostId)
+  ) {
+    throw registrationError("HOST_ID_INVALID");
+  }
+
+  return {
+    project_id: projectId,
+    session_id: sessionId,
+    host_id: resolvedHostId,
+    transport_locators_json:
+      hasLocatorJson || hasLocators ? JSON.stringify(normalizedLocators) : null,
+  };
+}
 
 function uniqueStrings(values = []) {
   return Array.from(
@@ -123,6 +376,18 @@ export function createRouter(store) {
   const queuesByAgent = new Map();
   const liveMessages = new Map();
   const roleStates = new Map();
+  const updateRegistrationIdentity = store.db?.prepare
+    ? store.db.prepare(`
+        UPDATE agents SET
+          project_id=COALESCE(@project_id, project_id),
+          session_id=COALESCE(@session_id, session_id),
+          host_id=COALESCE(@host_id, host_id),
+          transport_locators_json=COALESCE(
+            @transport_locators_json,
+            transport_locators_json
+          )
+        WHERE agent_id=@agent_id`)
+    : null;
   const MAX_LATENCY_SAMPLES = 100;
   let latencyIdx = 0;
   const deliveryLatencies = new Array(MAX_LATENCY_SAMPLES).fill(0);
@@ -855,9 +1120,16 @@ export function createRouter(store) {
     deliveryEmitter,
 
     registerAgent(args) {
+      const identity = normalizeRegistrationIdentity(args);
       const result = store.registerAgent(args);
       if (!registerPresenceIsEffective(result)) {
         return registerPresenceFailure(args.agent_id, result);
+      }
+      if (identity && updateRegistrationIdentity) {
+        updateRegistrationIdentity.run({
+          agent_id: args.agent_id,
+          ...identity,
+        });
       }
       upsertRuntimeTopics(args.agent_id, args.topics || [], { replace: true });
       refreshRoleCandidateForAgent(args.agent_id);

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -1558,6 +1558,38 @@ export async function startHub({
         try {
           const body = await parseBody(req);
           const { sessionId } = body || {};
+          if (body?.agent_id && body?.cli) {
+            const registered = router.registerAgent({
+              agent_id: body.agent_id,
+              cli: body.cli,
+              capabilities: Array.isArray(body.capabilities)
+                ? body.capabilities
+                : [],
+              topics: Array.isArray(body.topics) ? body.topics : [],
+              heartbeat_ttl_ms: body.heartbeat_ttl_ms ?? 300000,
+              metadata:
+                body.metadata && typeof body.metadata === "object"
+                  ? body.metadata
+                  : { source: "session_start" },
+              ...(Object.hasOwn(body, "project_id")
+                ? { project_id: body.project_id }
+                : {}),
+              ...(Object.hasOwn(body, "session_id")
+                ? { session_id: body.session_id }
+                : {}),
+              ...(Object.hasOwn(body, "host_id")
+                ? { host_id: body.host_id }
+                : {}),
+              ...(Object.hasOwn(body, "transport_locators_json")
+                ? { transport_locators_json: body.transport_locators_json }
+                : {}),
+            });
+            if (!registered?.ok) {
+              throw new Error(
+                registered?.error?.message || "hub agent register failed",
+              );
+            }
+          }
           const result = synapseRegistry.register(sessionId, body);
           if (!result?.ok) {
             throw new Error(result?.reason || "register failed");
@@ -1712,6 +1744,10 @@ export async function startHub({
               topics = [],
               capabilities = [],
               metadata = {},
+              project_id,
+              session_id,
+              host_id,
+              transport_locators_json,
             } = body;
             if (!agent_id || !cli) {
               return writeJson(res, 400, {
@@ -1740,6 +1776,12 @@ export async function startHub({
               topics,
               heartbeat_ttl_ms,
               metadata,
+              ...(project_id === undefined ? {} : { project_id }),
+              ...(session_id === undefined ? {} : { session_id }),
+              ...(host_id === undefined ? {} : { host_id }),
+              ...(transport_locators_json === undefined
+                ? {}
+                : { transport_locators_json }),
             });
             if (result.ok) {
               workerSpans.set(agent_id, {

--- a/packages/triflux/hub/team/synapse-http.mjs
+++ b/packages/triflux/hub/team/synapse-http.mjs
@@ -1,6 +1,9 @@
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { normalizeRoleKey } from "../role-contract.mjs";
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -19,6 +22,144 @@ function normalizeToken(raw) {
   if (raw == null) return null;
   const token = String(raw).trim();
   return token || null;
+}
+
+function opaqueId(prefix, value) {
+  return `${prefix}_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function normalizedProjectId(value) {
+  try {
+    return normalizeRoleKey({ project_id: value, role_kind: "cto" }).project_id;
+  } catch {
+    return "";
+  }
+}
+
+function resolveProjectId(cwd, meta, opts = {}) {
+  const explicit = meta?.project_id || process.env.TFX_PROJECT_ID;
+  if (explicit) return normalizedProjectId(explicit);
+  if (typeof opts.resolveProjectId === "function") {
+    return normalizedProjectId(opts.resolveProjectId(cwd));
+  }
+  let current = cwd;
+  while (current) {
+    const manifest = join(current, ".triflux", "project.json");
+    if (existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(readFileSync(manifest, "utf8"));
+        if (parsed?.schema_version !== "tfx.project.v1") return "";
+        return normalizedProjectId(parsed.project_id);
+      } catch {
+        return "";
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return "";
+}
+
+function inferSessionCli(meta, opts = {}) {
+  const explicit = String(meta?.cli || meta?.actor_cli || "")
+    .trim()
+    .toLowerCase();
+  if (explicit === "codex" || explicit === "claude") return explicit;
+  const entrypoint = String(opts.entrypoint ?? process.argv[1] ?? "");
+  if (entrypoint.includes("codex-session-hook")) return "codex";
+  if (entrypoint.includes("agy-session-hook")) return "other";
+  return "claude";
+}
+
+function resolveTmuxSession(meta, opts = {}) {
+  const explicit =
+    meta?.tmux_session || meta?.session_name || process.env.TFX_TMUX_SESSION;
+  if (explicit) return String(explicit).trim();
+  if (!process.env.TMUX) return "";
+  try {
+    const run =
+      opts.tmuxSessionName ||
+      (() =>
+        execFileSync("tmux", ["display-message", "-p", "#{session_name}"], {
+          encoding: "utf8",
+          timeout: 200,
+          windowsHide: true,
+        }));
+    return String(run() || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function buildSynapseRegistrationMeta(meta, opts = {}) {
+  if (!meta || meta.sessionKind !== "interactive") return meta;
+  const sessionId = String(meta.sessionId || "").trim();
+  if (!sessionId) return meta;
+  const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
+  const cli = inferSessionCli(meta, opts);
+  const hostId = String(
+    meta.host_id ||
+      process.env.TFX_HOST_ID ||
+      opaqueId("hst", opts.hostname?.() || hostname()),
+  ).trim();
+  const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
+  const transportLocators = [];
+  if (cli === "claude") {
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `claude-uds:${hostId}:${sessionId}`),
+      kind: "claude-uds",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_id: sessionId,
+        bridge_id: String(
+          meta.bridge_id || process.env.TFX_BRIDGE_ID || "local-hub",
+        ),
+      },
+    });
+  }
+  const tmuxSession = resolveTmuxSession(meta, opts);
+  if (tmuxSession) {
+    const muxServerSource =
+      meta.mux_server_id ||
+      process.env.TFX_MUX_SERVER_ID ||
+      String(process.env.TMUX || "default").split(",", 1)[0];
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `tmux:${hostId}:${tmuxSession}`),
+      kind: "tmux",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: cli === "codex" ? 100 : 50,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_name: tmuxSession,
+        mux_server_id: opaqueId("mux", muxServerSource),
+      },
+    });
+  }
+  const directAgentId = `session:${sessionId}`;
+  return {
+    ...meta,
+    agent_id:
+      meta.agent_id ||
+      (directAgentId.length <= 64 && /^[a-zA-Z0-9._:-]+$/u.test(directAgentId)
+        ? directAgentId
+        : opaqueId("session", sessionId)),
+    cli,
+    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    session_id: meta.session_id || sessionId,
+    host_id: hostId,
+    transport_locators_json:
+      meta.transport_locators_json ?? JSON.stringify(transportLocators),
+  };
 }
 
 // Mirrors hub/bridge.mjs:readHubToken — env override first, then the token file.
@@ -139,7 +280,11 @@ export function drainPendingSynapse(timeoutMs = 1000) {
 }
 
 export function registerSynapseSession(meta, opts = {}) {
-  return fireAndForgetSynapse("/synapse/register", meta, opts);
+  return fireAndForgetSynapse(
+    "/synapse/register",
+    buildSynapseRegistrationMeta(meta, opts),
+    opts,
+  );
 }
 
 export function heartbeatSynapseSession(

--- a/packages/triflux/hub/tools.mjs
+++ b/packages/triflux/hub/tools.mjs
@@ -153,6 +153,17 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
+          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          session_id: { type: "string", minLength: 1, maxLength: 256 },
+          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          transport_locators_json: {
+            description:
+              "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",
+            oneOf: [
+              { type: "array", items: { type: "object" } },
+              { type: "string" },
+            ],
+          },
           heartbeat_ttl_ms: {
             type: "integer",
             minimum: 10000,

--- a/packages/triflux/scripts/release/check-packages-mirror.mjs
+++ b/packages/triflux/scripts/release/check-packages-mirror.mjs
@@ -40,6 +40,10 @@ const CORE_FILE_MIRRORS = [
     target: "packages/core/hub/bridge.mjs",
   },
   {
+    source: "hub/router.mjs",
+    target: "packages/core/hub/router.mjs",
+  },
+  {
     source: "hub/team/retry-state-machine.mjs",
     target: "packages/core/hub/team/retry-state-machine.mjs",
   },

--- a/scripts/release/check-packages-mirror.mjs
+++ b/scripts/release/check-packages-mirror.mjs
@@ -40,6 +40,10 @@ const CORE_FILE_MIRRORS = [
     target: "packages/core/hub/bridge.mjs",
   },
   {
+    source: "hub/router.mjs",
+    target: "packages/core/hub/router.mjs",
+  },
+  {
     source: "hub/team/retry-state-machine.mjs",
     target: "packages/core/hub/team/retry-state-machine.mjs",
   },

--- a/tests/unit/check-packages-mirror-core.test.mjs
+++ b/tests/unit/check-packages-mirror-core.test.mjs
@@ -13,6 +13,7 @@ import { compareMirror } from "../../scripts/release/check-packages-mirror.mjs";
 
 const CORE_MIRRORS = new Map([
   ["hub/bridge.mjs", "packages/core/hub/bridge.mjs"],
+  ["hub/router.mjs", "packages/core/hub/router.mjs"],
   [
     "hub/team/retry-state-machine.mjs",
     "packages/core/hub/team/retry-state-machine.mjs",

--- a/tests/unit/registration-plumbing.test.mjs
+++ b/tests/unit/registration-plumbing.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { decodeRoleKey, encodeRoleKey } from "../../hub/role-contract.mjs";
+import { createRouter } from "../../hub/router.mjs";
+import { createStore } from "../../hub/store.mjs";
+import { buildSynapseRegistrationMeta } from "../../hub/team/synapse-http.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const PROJECT_ID = `prj_${"A".repeat(22)}`;
+const HOST_ID = `hst_${"B".repeat(22)}`;
+const TEMP_DIRS = [];
+
+function tempStore() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-registration-plumbing-"));
+  TEMP_DIRS.push(dir);
+  const store = createStore(join(dir, "hub.db"));
+  return { store, router: createRouter(store) };
+}
+
+function tmuxLocator(expiresAtMs = Date.now() + 60000) {
+  return {
+    schema_version: "tfx.transport-locator.v1",
+    transport_id: "trn_codex_tmux",
+    kind: "tmux",
+    host_id: HOST_ID,
+    capabilities: ["probe", "wake", "activate", "interrupt"],
+    priority: 100,
+    expires_at_ms: expiresAtMs,
+    locator: {
+      session_name: "codex-worker",
+      mux_server_id: "mux_local",
+    },
+  };
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("registration scoped identity plumbing", { skip: SQLITE_SKIP }, () => {
+  it("stores scoped identity and normalized transport locators round-trip", () => {
+    const { store, router } = tempStore();
+    try {
+      const locator = tmuxLocator();
+      const result = router.registerAgent({
+        agent_id: "codex-registration-roundtrip",
+        cli: "codex",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 120000,
+        project_id: PROJECT_ID,
+        session_id: "session-registration-roundtrip",
+        host_id: HOST_ID,
+        transport_locators_json: JSON.stringify([locator]),
+      });
+
+      assert.equal(result.ok, true);
+      const row = store.db
+        .prepare(
+          "SELECT project_id, session_id, host_id, transport_locators_json FROM agents WHERE agent_id = ?",
+        )
+        .get("codex-registration-roundtrip");
+      assert.equal(row.project_id, PROJECT_ID);
+      assert.equal(row.session_id, "session-registration-roundtrip");
+      assert.equal(row.host_id, HOST_ID);
+      assert.deepEqual(JSON.parse(row.transport_locators_json), [locator]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("keeps legacy registration successful with v6 defaults", () => {
+    const { store, router } = tempStore();
+    try {
+      const result = router.registerAgent({
+        agent_id: "legacy-registration",
+        cli: "claude",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 30000,
+      });
+
+      assert.equal(result.ok, true);
+      const row = store.db
+        .prepare(
+          "SELECT project_id, session_id, host_id, transport_locators_json FROM agents WHERE agent_id = ?",
+        )
+        .get("legacy-registration");
+      assert.equal(row.project_id, null);
+      assert.equal(row.session_id, null);
+      assert.equal(row.host_id, null);
+      assert.equal(row.transport_locators_json, "[]");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rejects non-normalized locator shapes and unsupported Codex UDS", () => {
+    const { store, router } = tempStore();
+    try {
+      assert.throws(
+        () =>
+          router.registerAgent({
+            agent_id: "invalid-locator-path",
+            cli: "codex",
+            capabilities: ["code"],
+            topics: [],
+            heartbeat_ttl_ms: 120000,
+            host_id: HOST_ID,
+            transport_locators_json: JSON.stringify([
+              {
+                ...tmuxLocator(),
+                locator: {
+                  ...tmuxLocator().locator,
+                  cwd: "/private/project",
+                },
+              },
+            ]),
+          }),
+        { code: "TRANSPORT_LOCATOR_INVALID" },
+      );
+      assert.throws(
+        () =>
+          router.registerAgent({
+            agent_id: "invalid-codex-uds",
+            cli: "codex",
+            capabilities: ["code"],
+            topics: [],
+            heartbeat_ttl_ms: 120000,
+            host_id: HOST_ID,
+            transport_locators_json: [
+              {
+                schema_version: "tfx.transport-locator.v1",
+                transport_id: "trn_codex_uds",
+                kind: "claude-uds",
+                host_id: HOST_ID,
+                capabilities: ["probe"],
+                priority: 100,
+                expires_at_ms: Date.now() + 60000,
+                locator: {
+                  session_id: "codex-session",
+                  bridge_id: "local-hub",
+                },
+              },
+            ],
+          }),
+        { code: "CODEX_TRANSPORT_UNSUPPORTED" },
+      );
+      assert.equal(store.getAgent("invalid-locator-path"), null);
+      assert.equal(store.getAgent("invalid-codex-uds"), null);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("round-trips stable opaque project identity through RoleKey wire encoding", () => {
+    const roleKey = { project_id: PROJECT_ID, role_kind: "cto" };
+    const wire = encodeRoleKey(roleKey);
+    assert.deepEqual(decodeRoleKey(wire), roleKey);
+    assert.equal(wire.includes(process.cwd()), false);
+  });
+});
+
+describe("SessionStart scoped registration metadata", () => {
+  it("loads tracked project identity and emits only detectable Codex tmux locator", () => {
+    const root = mkdtempSync(join(tmpdir(), "tfx-session-registration-"));
+    TEMP_DIRS.push(root);
+    mkdirSync(join(root, ".triflux"), { recursive: true });
+    writeFileSync(
+      join(root, ".triflux", "project.json"),
+      JSON.stringify({
+        schema_version: "tfx.project.v1",
+        project_id: PROJECT_ID,
+      }),
+    );
+
+    const identity = buildSynapseRegistrationMeta(
+      {
+        sessionKind: "interactive",
+        sessionId: "codex-session",
+        cwd: join(root, "nested"),
+        host_id: HOST_ID,
+        tmux_session: "codex-worker",
+        mux_server_id: "mux-explicit",
+      },
+      { nowMs: () => 1000, entrypoint: "hooks/codex-session-hook.mjs" },
+    );
+
+    assert.equal(identity.project_id, PROJECT_ID);
+    assert.equal(identity.session_id, "codex-session");
+    assert.equal(identity.host_id, HOST_ID);
+    const locators = JSON.parse(identity.transport_locators_json);
+    assert.equal(locators.length, 1);
+    assert.equal(locators[0].kind, "tmux");
+    assert.deepEqual(locators[0].locator, {
+      session_name: "codex-worker",
+      mux_server_id: locators[0].locator.mux_server_id,
+    });
+    assert.equal(JSON.stringify(locators).includes(root), false);
+  });
+});


### PR DESCRIPTION
## 요약

C6a-3 슬라이스 — 세션 등록 경로(SessionStart→synapse, hub register 표면)에 `project_id`/`session_id`/`host_id`/`transport_locators_json` 배관. **inert** — 선출/activator/dispatch 무접촉(삭제줄 0, 순수 삽입), 필드 전부 optional로 legacy 등록 하위호환(실 router+store 테스트로 실증).

- 계약 7: transport locator normalized schema + expiry≤lease 강제 + 미등록 필드 거부 + tmux 소켓 경로 opaque 해싱
- 계약 10: project_id는 해석만(자동 재생성 금지), 검증은 role-contract.mjs 단일 위임

## 리뷰 (opus 교차)

1차 REQUEST CHANGES → **P2 반영 완료** (`cd6e569e`): core router 미러 드리프트 — published `@triflux/remote`가 core router를 import하는데 root만 갱신돼 신원 필드가 조용히 소실(실측: ok:true + null/null/[])되던 것을 cp 동기 + `check-mirror CORE_FILE_MIRRORS`에 router 등록으로 봉합(사각지대 재발 차단).

P3 후속 3건(비차단, C6a-4에서 정리):
1. `TFX_HOST_ID` 원문 통과 시 HOST_ID_INVALID로 presence 전체 소실 — env 값 opaqueId 정규화 또는 warn+무시
2. `{project_id: undefined}` in-process throw — builder 조건부 spread
3. prj_/hst_ 정규식이 tools.mjs 스키마에 중복 — role-contract SSOT로 단일화

## 관련
- 계약: `.triflux/plans/0011a-c6a-contracts.md` / 선행: #483(C6a-1), #484(C6a-2)