### PR TITLE
fix(release): prepare 테스트 출력 실시간 스트리밍 — 실패 로그 절단 제거

### DIFF
--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -407,8 +407,50 @@ describe("release governance scripts", () => {
           call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
-      assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);
+      assert.equal(testCall.options.stdio, "inherit");
       assert.equal(testCall.options.timeout, 10 * 60 * 1000);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepareRelease reports a failed step without captured test output", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const largeOutput = "failing test output\n".repeat(10_000);
+      const execStub = (command, args) => {
+        if (command === "git" && args[0] === "status") return "";
+        if (command === "git" && args[0] === "describe") return "v1.2.2";
+        if (command === "git" && args[0] === "log")
+          return "abc1234 feat: sample\n";
+        if (args[0]?.endsWith("test-lock.mjs")) {
+          const error = new Error("test command failed");
+          error.status = 17;
+          error.stdout = largeOutput;
+          error.stderr = largeOutput;
+          throw error;
+        }
+        return "";
+      };
+
+      await assert.rejects(
+        prepareRelease({
+          rootDir: root,
+          version: "1.2.3",
+          allowDirty: true,
+          dryRun: false,
+          execFileSyncFn: execStub,
+        }),
+        (error) => {
+          assert.equal(
+            error.message,
+            "[prepare] step=npm-test failed (exit code=17)",
+          );
+          assert.doesNotMatch(error.message, /failing test output/);
+          return true;
+        },
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/triflux/scripts/__tests__/release-governance.test.mjs
+++ b/packages/triflux/scripts/__tests__/release-governance.test.mjs
@@ -407,7 +407,11 @@ describe("release governance scripts", () => {
           call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
-      assert.equal(testCall.options.stdio, "inherit");
+      assert.deepEqual(testCall.options.stdio, [
+        "ignore",
+        "inherit",
+        "inherit",
+      ]);
       assert.equal(testCall.options.timeout, 10 * 60 * 1000);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -447,10 +451,53 @@ describe("release governance scripts", () => {
             error.message,
             "[prepare] step=npm-test failed (exit code=17)",
           );
+          assert.equal(error.cause.message, "test command failed");
           assert.doesNotMatch(error.message, /failing test output/);
           return true;
         },
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepareRelease preserves timeout and signal diagnostics", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      for (const failure of [
+        { code: "ETIMEDOUT", expected: "timeout after 600000ms" },
+        { signal: "SIGKILL", expected: "signal=SIGKILL" },
+      ]) {
+        const execStub = (command, args) => {
+          if (command === "git" && args[0] === "status") return "";
+          if (command === "git" && args[0] === "describe") return "v1.2.2";
+          if (command === "git" && args[0] === "log")
+            return "abc1234 feat: sample\n";
+          if (args[0]?.endsWith("test-lock.mjs")) {
+            const error = new Error("test command failed");
+            Object.assign(error, failure);
+            throw error;
+          }
+          return "";
+        };
+
+        await assert.rejects(
+          prepareRelease({
+            rootDir: root,
+            version: "1.2.3",
+            allowDirty: true,
+            dryRun: false,
+            execFileSyncFn: execStub,
+          }),
+          (error) => {
+            assert.match(error.message, new RegExp(failure.expected));
+            assert.equal(error.cause.code, failure.code);
+            assert.equal(error.cause.signal, failure.signal);
+            return true;
+          },
+        );
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/triflux/scripts/release/lib.mjs
+++ b/packages/triflux/scripts/release/lib.mjs
@@ -335,8 +335,7 @@ export function runCommand(
     // execFileSync default maxBuffer is 1 MiB. With stdio=pipe the parent
     // captures all stdout/stderr; piped npm/test/build runs easily overflow
     // that and surface as opaque ENOBUFS-shaped failures. 64 MiB is the
-    // generic floor; callers can override per-step (prepare.mjs npm-test
-    // sets 128 MiB). Defense-in-depth — not a fix for any specific bug.
+    // generic floor. Defense-in-depth — not a fix for any specific bug.
     opts.maxBuffer = maxBuffer ?? 64 * 1024 * 1024;
   }
 

--- a/packages/triflux/scripts/release/prepare.mjs
+++ b/packages/triflux/scripts/release/prepare.mjs
@@ -86,12 +86,12 @@ export async function prepareRelease({
         "scripts/__tests__/**/*.test.mjs",
       ],
       skip: skipTests,
-      // maxBuffer: 1 MiB default is too small for piped node --test verbose
-      // output. 128 MiB matches the prior npm-test ceiling.
+      // Stream test output directly so GitHub Actions preserves the failing
+      // test name and assertion details instead of truncating a captured
+      // execFileSync error object.
       options: {
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: "inherit",
         timeoutMs: TEST_TIMEOUT_MS,
-        maxBuffer: 128 * 1024 * 1024,
         shell: false,
       },
     },
@@ -114,11 +114,20 @@ export async function prepareRelease({
         continue;
       }
       logStep(step.name);
-      runCommand(step.command, step.args, {
-        cwd: rootDir,
-        execFileSyncFn,
-        ...step.options,
-      });
+      try {
+        runCommand(step.command, step.args, {
+          cwd: rootDir,
+          execFileSyncFn,
+          ...step.options,
+        });
+      } catch (error) {
+        const exitCode = Number.isInteger(error?.status)
+          ? error.status
+          : "unknown";
+        throw new Error(
+          `[prepare] step=${step.name} failed (exit code=${exitCode})`,
+        );
+      }
     }
   } else {
     for (const step of steps) {

--- a/packages/triflux/scripts/release/prepare.mjs
+++ b/packages/triflux/scripts/release/prepare.mjs
@@ -90,7 +90,7 @@ export async function prepareRelease({
       // test name and assertion details instead of truncating a captured
       // execFileSync error object.
       options: {
-        stdio: "inherit",
+        stdio: ["ignore", "inherit", "inherit"],
         timeoutMs: TEST_TIMEOUT_MS,
         shell: false,
       },
@@ -124,8 +124,14 @@ export async function prepareRelease({
         const exitCode = Number.isInteger(error?.status)
           ? error.status
           : "unknown";
+        const signal = error?.signal ? `, signal=${error.signal}` : "";
+        const timeout =
+          error?.code === "ETIMEDOUT"
+            ? `, timeout after ${step.options?.timeoutMs ?? "unknown"}ms`
+            : "";
         throw new Error(
-          `[prepare] step=${step.name} failed (exit code=${exitCode})`,
+          `[prepare] step=${step.name} failed (exit code=${exitCode}${signal}${timeout})`,
+          { cause: error },
         );
       }
     }

--- a/packages/triflux/scripts/test-lock.mjs
+++ b/packages/triflux/scripts/test-lock.mjs
@@ -386,7 +386,7 @@ export function main(argv = process.argv.slice(2)) {
   // forward args after -- to node --test
   const args = preserveForceExitFailures(expandTestArgs(argv));
   // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
-  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
+  // ["ignore","inherit","inherit"], full inherit cascades the parent stdin=ignore
   // to grand-child node --test, breaking ConPTY assumptions on Windows and
   // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
   // inherited so the grand-child still streams to whoever attached to us.

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -407,8 +407,50 @@ describe("release governance scripts", () => {
           call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
-      assert.deepEqual(testCall.options.stdio, ["ignore", "pipe", "pipe"]);
+      assert.equal(testCall.options.stdio, "inherit");
       assert.equal(testCall.options.timeout, 10 * 60 * 1000);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepareRelease reports a failed step without captured test output", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      const largeOutput = "failing test output\n".repeat(10_000);
+      const execStub = (command, args) => {
+        if (command === "git" && args[0] === "status") return "";
+        if (command === "git" && args[0] === "describe") return "v1.2.2";
+        if (command === "git" && args[0] === "log")
+          return "abc1234 feat: sample\n";
+        if (args[0]?.endsWith("test-lock.mjs")) {
+          const error = new Error("test command failed");
+          error.status = 17;
+          error.stdout = largeOutput;
+          error.stderr = largeOutput;
+          throw error;
+        }
+        return "";
+      };
+
+      await assert.rejects(
+        prepareRelease({
+          rootDir: root,
+          version: "1.2.3",
+          allowDirty: true,
+          dryRun: false,
+          execFileSyncFn: execStub,
+        }),
+        (error) => {
+          assert.equal(
+            error.message,
+            "[prepare] step=npm-test failed (exit code=17)",
+          );
+          assert.doesNotMatch(error.message, /failing test output/);
+          return true;
+        },
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/__tests__/release-governance.test.mjs
+++ b/scripts/__tests__/release-governance.test.mjs
@@ -407,7 +407,11 @@ describe("release governance scripts", () => {
           call.args[0]?.endsWith("test-lock.mjs"),
       );
       assert.ok(testCall);
-      assert.equal(testCall.options.stdio, "inherit");
+      assert.deepEqual(testCall.options.stdio, [
+        "ignore",
+        "inherit",
+        "inherit",
+      ]);
       assert.equal(testCall.options.timeout, 10 * 60 * 1000);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -447,10 +451,53 @@ describe("release governance scripts", () => {
             error.message,
             "[prepare] step=npm-test failed (exit code=17)",
           );
+          assert.equal(error.cause.message, "test command failed");
           assert.doesNotMatch(error.message, /failing test output/);
           return true;
         },
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prepareRelease preserves timeout and signal diagnostics", async () => {
+    const root = makeRepo();
+    try {
+      assertVersionSync({ rootDir: root, fix: true });
+      for (const failure of [
+        { code: "ETIMEDOUT", expected: "timeout after 600000ms" },
+        { signal: "SIGKILL", expected: "signal=SIGKILL" },
+      ]) {
+        const execStub = (command, args) => {
+          if (command === "git" && args[0] === "status") return "";
+          if (command === "git" && args[0] === "describe") return "v1.2.2";
+          if (command === "git" && args[0] === "log")
+            return "abc1234 feat: sample\n";
+          if (args[0]?.endsWith("test-lock.mjs")) {
+            const error = new Error("test command failed");
+            Object.assign(error, failure);
+            throw error;
+          }
+          return "";
+        };
+
+        await assert.rejects(
+          prepareRelease({
+            rootDir: root,
+            version: "1.2.3",
+            allowDirty: true,
+            dryRun: false,
+            execFileSyncFn: execStub,
+          }),
+          (error) => {
+            assert.match(error.message, new RegExp(failure.expected));
+            assert.equal(error.cause.code, failure.code);
+            assert.equal(error.cause.signal, failure.signal);
+            return true;
+          },
+        );
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -335,8 +335,7 @@ export function runCommand(
     // execFileSync default maxBuffer is 1 MiB. With stdio=pipe the parent
     // captures all stdout/stderr; piped npm/test/build runs easily overflow
     // that and surface as opaque ENOBUFS-shaped failures. 64 MiB is the
-    // generic floor; callers can override per-step (prepare.mjs npm-test
-    // sets 128 MiB). Defense-in-depth — not a fix for any specific bug.
+    // generic floor. Defense-in-depth — not a fix for any specific bug.
     opts.maxBuffer = maxBuffer ?? 64 * 1024 * 1024;
   }
 

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -86,12 +86,12 @@ export async function prepareRelease({
         "scripts/__tests__/**/*.test.mjs",
       ],
       skip: skipTests,
-      // maxBuffer: 1 MiB default is too small for piped node --test verbose
-      // output. 128 MiB matches the prior npm-test ceiling.
+      // Stream test output directly so GitHub Actions preserves the failing
+      // test name and assertion details instead of truncating a captured
+      // execFileSync error object.
       options: {
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: "inherit",
         timeoutMs: TEST_TIMEOUT_MS,
-        maxBuffer: 128 * 1024 * 1024,
         shell: false,
       },
     },
@@ -114,11 +114,20 @@ export async function prepareRelease({
         continue;
       }
       logStep(step.name);
-      runCommand(step.command, step.args, {
-        cwd: rootDir,
-        execFileSyncFn,
-        ...step.options,
-      });
+      try {
+        runCommand(step.command, step.args, {
+          cwd: rootDir,
+          execFileSyncFn,
+          ...step.options,
+        });
+      } catch (error) {
+        const exitCode = Number.isInteger(error?.status)
+          ? error.status
+          : "unknown";
+        throw new Error(
+          `[prepare] step=${step.name} failed (exit code=${exitCode})`,
+        );
+      }
     }
   } else {
     for (const step of steps) {

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -90,7 +90,7 @@ export async function prepareRelease({
       // test name and assertion details instead of truncating a captured
       // execFileSync error object.
       options: {
-        stdio: "inherit",
+        stdio: ["ignore", "inherit", "inherit"],
         timeoutMs: TEST_TIMEOUT_MS,
         shell: false,
       },
@@ -124,8 +124,14 @@ export async function prepareRelease({
         const exitCode = Number.isInteger(error?.status)
           ? error.status
           : "unknown";
+        const signal = error?.signal ? `, signal=${error.signal}` : "";
+        const timeout =
+          error?.code === "ETIMEDOUT"
+            ? `, timeout after ${step.options?.timeoutMs ?? "unknown"}ms`
+            : "";
         throw new Error(
-          `[prepare] step=${step.name} failed (exit code=${exitCode})`,
+          `[prepare] step=${step.name} failed (exit code=${exitCode}${signal}${timeout})`,
+          { cause: error },
         );
       }
     }

--- a/scripts/test-lock.mjs
+++ b/scripts/test-lock.mjs
@@ -386,7 +386,7 @@ export function main(argv = process.argv.slice(2)) {
   // forward args after -- to node --test
   const args = preserveForceExitFailures(expandTestArgs(argv));
   // stdio split (issue #192 F1): when prepare.mjs spawns this lock with
-  // ["ignore","pipe","pipe"], full inherit cascades the parent stdin=ignore
+  // ["ignore","inherit","inherit"], full inherit cascades the parent stdin=ignore
   // to grand-child node --test, breaking ConPTY assumptions on Windows and
   // surfacing as EXIT=1 (false-failed). Pipe stdin only — stdout/stderr stay
   // inherited so the grand-child still streams to whoever attached to us.

--- a/tests/regression/release-prepare-completes-all-steps.test.mjs
+++ b/tests/regression/release-prepare-completes-all-steps.test.mjs
@@ -174,7 +174,7 @@ describe("release:prepare regression — step sequence completeness", () => {
         dryRun: false,
         execFileSyncFn: fn,
       }),
-      /test step failed/,
+      /\[prepare\] step=npm-test failed/,
     );
 
     // 단락 검증: test 만 호출됐고, lint/pack 은 호출 안 됨


### PR DESCRIPTION
## 배경

release.yml Prepare 스텝이 3연속 flake(#482 2회 + v10.44.0 run 29563214290)인데 실패 테스트명이 매번 유실됐다. 조사 결과 로그 절단의 직접 원인은 prepare.mjs가 테스트 출력을 pipe로 캡처한 뒤 execFileSync 오류 객체를 그대로 던져 Node inspect 직렬화가 앞부분만 남기는 구조.

## 변경

- npm-test 스텝 `stdio: ["ignore", "inherit", "inherit"]` — GH Actions가 실패 테스트명·assertion을 실시간 보존 (stdin은 기존대로 ignore)
- 실패 시 대용량 output 객체 재던지기 제거 — 스텝명 + exit code + timeout/signal 정보 + `{ cause }` 보존
- 대용량 캡처가 오류 메시지에 포함되지 않는 회귀 테스트 추가
- packages/triflux 미러 byte-identical 동기

## 리뷰

opus 크로스리뷰 FIX_FIRST → P1(tests/regression 기존 테스트 파손) + P2 3건(ETIMEDOUT/signal 진단 소실, stdin 확장) 전부 반영(b07dbf2c). 회귀 6/6·거버넌스 9/9·미러 diff 일치.

## 관측 계획

이 PR은 관측성만 수정. flake 자체(Node 24 vs 20, 8-way 병렬 hub state 경합 가설)는 다음 릴리즈에서 실제 실패 테스트명 확보 후 후속.