### PR TITLE
fix(hub): resolve P3 follow-ups

### DIFF
--- a/docs/codex-conventions.md
+++ b/docs/codex-conventions.md
@@ -72,6 +72,10 @@ psmux send-keys -t "codex-swarm-{id}" \
 | 정리 | 머지 완료 후 `git worktree remove` + `git worktree prune` |
 | 충돌 | 브랜치 존재 시 재사용, 경로 존재 시 `-v{timestamp}` suffix |
 
+`swarm/<runId>/merge` integration branch가 다른 worktree에 이미 checkout된 경우,
+integration branch를 강제로 reset하거나 checkout하지 않는다. 해당 swarm run은
+NO-GO로 실패하며, 기존 worktree와 branch는 그대로 유지한다.
+
 ## 4. MCP tool approval
 
 - **증상**: `codex exec`가 시작된 뒤 끝나지 않고 멈춘다. 특히 MCP tool 호출이 필요한 프롬프트에서 무응답 stall로 보인다.

--- a/hub/role-contract.mjs
+++ b/hub/role-contract.mjs
@@ -1,4 +1,7 @@
-const PROJECT_ID_RE = /^prj_[A-Za-z0-9_-]{22}$/u;
+export const PROJECT_ID_PATTERN = "^prj_[A-Za-z0-9_-]{22}$";
+export const HOST_ID_PATTERN = "^hst_[A-Za-z0-9_-]+$";
+
+const PROJECT_ID_RE = new RegExp(PROJECT_ID_PATTERN, "u");
 const SCOPE_ID_RE = /^scp_[A-Za-z0-9_-]{22}$/u;
 const BASE64URL_RE = /^[A-Za-z0-9_-]+$/u;
 

--- a/hub/schema.sql
+++ b/hub/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS role_registry (
     (role_kind = 'cto' AND scope_id = '') OR
     (role_kind = 'lead' AND scope_id <> '')
   ),
+  CHECK (state <> 'active' OR holder_agent_id IS NOT NULL),
   UNIQUE(project_id, role_kind, scope_id)
 );
 

--- a/hub/store.mjs
+++ b/hub/store.mjs
@@ -131,6 +131,26 @@ function ensureV7Columns(db) {
   }
 }
 
+// schema.sql의 CHECK는 CREATE TABLE IF NOT EXISTS 특성상 기존 테이블에 소급되지
+// 않는다. 매 부팅 실행되는 이 트리거가 legacy DB의 유일한 방어선이므로, 신규 DB
+// (CHECK)와 legacy DB(트리거)의 오류 문구를 의도적으로 동일하게 맞춘다.
+function ensureRoleRegistryIntegrityGuards(db) {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_insert
+    BEFORE INSERT ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_update
+    BEFORE UPDATE OF state, holder_agent_id ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+  `);
+}
+
 function storeFingerprint(dbPath) {
   return `sqlite:${createHash("sha256").update(String(dbPath)).digest("hex")}`;
 }
@@ -165,7 +185,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "7";
+  const SCHEMA_VERSION = "8";
   const curVer = (() => {
     try {
       return db
@@ -198,6 +218,7 @@ export function createStore(dbPath, options = {}) {
   // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
   ensureV6Columns(db);
   ensureV7Columns(db);
+  ensureRoleRegistryIntegrityGuards(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -606,8 +627,16 @@ export function createStore(dbPath, options = {}) {
     if (current.activation_id !== expected.activation_id) {
       return "stale_activation_id";
     }
-    return "cas_conflict";
+    return null;
   }
+
+  // db.transaction()은 DEFERRED BEGIN이라 read→write 승격 시점에
+  // SQLITE_BUSY_SNAPSHOT을 낼 수 있다. 역할 레지스트리 쓰기는 reserveRole /
+  // recoverRegistry와 동일하게 BEGIN IMMEDIATE로 쓰기 락을 선점한다.
+  const immediateTx = (fn) => {
+    const tx = db.transaction(fn);
+    return (input) => tx.immediate(input);
+  };
 
   const reserveRole = db.transaction((input) => {
     const identity = roleIdentity(input);
@@ -685,12 +714,15 @@ export function createStore(dbPath, options = {}) {
       const latest = S.getRole.get(identity.role_key_wire) ?? null;
       return {
         ok: false,
-        reason: roleFailureReason(latest, {
-          version: current.version,
-          epoch: current.epoch,
-          activation_seq: current.activation_seq,
-          activation_id: current.activation_id,
-        }),
+        // 쓰기가 0행을 건드렸는데 재조회가 기대값과 일치하면 원인을 특정할 수
+        // 없다. reason이 null로 새지 않도록 cas_conflict를 catch-all로 둔다.
+        reason:
+          roleFailureReason(latest, {
+            version: current.version,
+            epoch: current.epoch,
+            activation_seq: current.activation_seq,
+            activation_id: current.activation_id,
+          }) ?? "cas_conflict",
         role: latest,
       };
     }
@@ -713,7 +745,13 @@ export function createStore(dbPath, options = {}) {
         S.recoverExpiredRole.run(guard);
       } else if (role.holder_agent_id) {
         S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
-      } else if (role.activation_id || role.state === "elected-probing") {
+      } else if (
+        role.activation_id ||
+        role.state === "elected-probing" ||
+        // holder 없는 active는 v7 이전 DB가 남길 수 있는 phantom authority다.
+        // 트리거는 신규 유입만 막으므로 기존 행은 여기서 electable로 되돌린다.
+        role.state === "active"
+      ) {
         S.recoverOrphanedActivation.run(guard);
       }
     }
@@ -874,7 +912,7 @@ export function createStore(dbPath, options = {}) {
       return reserveRole.immediate(input);
     },
 
-    compareAndSetRole(input) {
+    compareAndSetRole: immediateTx((input) => {
       const identity = roleIdentity(input);
       const current = S.getRole.get(identity.role_key_wire) ?? null;
       if (!current) return { ok: false, reason: "not_found", role: null };
@@ -911,7 +949,7 @@ export function createStore(dbPath, options = {}) {
       }
 
       const reason = roleFailureReason(current, expected);
-      if (reason !== "cas_conflict") {
+      if (reason !== null) {
         return { ok: false, reason, role: current };
       }
 
@@ -971,12 +1009,12 @@ export function createStore(dbPath, options = {}) {
         const latest = S.getRole.get(identity.role_key_wire) ?? null;
         return {
           ok: false,
-          reason: roleFailureReason(latest, expected),
+          reason: roleFailureReason(latest, expected) ?? "cas_conflict",
           role: latest,
         };
       }
       return { ok: true, role: S.getRole.get(identity.role_key_wire) };
-    },
+    }),
 
     listRoleKeys(filter = {}) {
       const clauses = [];

--- a/hub/team/synapse-http.mjs
+++ b/hub/team/synapse-http.mjs
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import { dirname, join } from "node:path";
-import { normalizeRoleKey } from "../role-contract.mjs";
+import { HOST_ID_PATTERN, normalizeRoleKey } from "../role-contract.mjs";
+
+const HOST_ID_RE = new RegExp(HOST_ID_PATTERN, "u");
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -101,11 +103,12 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
   if (!sessionId) return meta;
   const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
   const cli = inferSessionCli(meta, opts);
-  const hostId = String(
-    meta.host_id ||
-      process.env.TFX_HOST_ID ||
-      opaqueId("hst", opts.hostname?.() || hostname()),
+  const configuredHostId = String(
+    meta.host_id || process.env.TFX_HOST_ID || opts.hostname?.() || hostname(),
   ).trim();
+  const hostId = HOST_ID_RE.test(configuredHostId)
+    ? configuredHostId
+    : opaqueId("hst", configuredHostId);
   const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
   const transportLocators = [];
   if (cli === "claude") {
@@ -146,6 +149,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
     });
   }
   const directAgentId = `session:${sessionId}`;
+  const projectId = resolveProjectId(cwd, meta, opts);
   return {
     ...meta,
     agent_id:
@@ -154,7 +158,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
         ? directAgentId
         : opaqueId("session", sessionId)),
     cli,
-    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    ...(projectId ? { project_id: projectId } : {}),
     session_id: meta.session_id || sessionId,
     host_id: hostId,
     transport_locators_json:

--- a/hub/team/worktree-lifecycle.mjs
+++ b/hub/team/worktree-lifecycle.mjs
@@ -273,6 +273,8 @@ export async function ensureWorktree({
  * @param {string} opts.baseBranch
  * @param {string} [opts.rootDir=process.cwd()]
  * @returns {Promise<{ integrationBranch: string, baseCommit: string }>}
+ * @throws {Error} when the integration branch is checked out by another
+ * worktree; this is an intentional NO-GO and leaves that worktree untouched.
  */
 export async function prepareIntegrationBranch({
   runId,
@@ -458,6 +460,11 @@ export async function rebaseShardOntoIntegration({
       }
     } else {
       await rm(integrationWorktree, { recursive: true, force: true });
+      try {
+        await git(["worktree", "prune"], rootDir);
+      } catch {
+        /* best-effort metadata cleanup after a partial worktree add */
+      }
     }
   }
 }

--- a/hub/tools.mjs
+++ b/hub/tools.mjs
@@ -13,6 +13,7 @@ import {
   listPipelineStates,
   readPipelineState,
 } from "./pipeline/state.mjs";
+import { HOST_ID_PATTERN, PROJECT_ID_PATTERN } from "./role-contract.mjs";
 import { sendInputToConductorSession } from "./team/conductor-registry.mjs";
 import { getTeamBridge } from "./team-bridge.mjs";
 
@@ -153,9 +154,9 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
-          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          project_id: { type: "string", pattern: PROJECT_ID_PATTERN },
           session_id: { type: "string", minLength: 1, maxLength: 256 },
-          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          host_id: { type: "string", pattern: HOST_ID_PATTERN },
           transport_locators_json: {
             description:
               "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",

--- a/packages/core/hub/role-contract.mjs
+++ b/packages/core/hub/role-contract.mjs
@@ -1,4 +1,7 @@
-const PROJECT_ID_RE = /^prj_[A-Za-z0-9_-]{22}$/u;
+export const PROJECT_ID_PATTERN = "^prj_[A-Za-z0-9_-]{22}$";
+export const HOST_ID_PATTERN = "^hst_[A-Za-z0-9_-]+$";
+
+const PROJECT_ID_RE = new RegExp(PROJECT_ID_PATTERN, "u");
 const SCOPE_ID_RE = /^scp_[A-Za-z0-9_-]{22}$/u;
 const BASE64URL_RE = /^[A-Za-z0-9_-]+$/u;
 

--- a/packages/core/hub/team/synapse-http.mjs
+++ b/packages/core/hub/team/synapse-http.mjs
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import { dirname, join } from "node:path";
-import { normalizeRoleKey } from "../role-contract.mjs";
+import { HOST_ID_PATTERN, normalizeRoleKey } from "../role-contract.mjs";
+
+const HOST_ID_RE = new RegExp(HOST_ID_PATTERN, "u");
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -101,11 +103,12 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
   if (!sessionId) return meta;
   const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
   const cli = inferSessionCli(meta, opts);
-  const hostId = String(
-    meta.host_id ||
-      process.env.TFX_HOST_ID ||
-      opaqueId("hst", opts.hostname?.() || hostname()),
+  const configuredHostId = String(
+    meta.host_id || process.env.TFX_HOST_ID || opts.hostname?.() || hostname(),
   ).trim();
+  const hostId = HOST_ID_RE.test(configuredHostId)
+    ? configuredHostId
+    : opaqueId("hst", configuredHostId);
   const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
   const transportLocators = [];
   if (cli === "claude") {
@@ -146,6 +149,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
     });
   }
   const directAgentId = `session:${sessionId}`;
+  const projectId = resolveProjectId(cwd, meta, opts);
   return {
     ...meta,
     agent_id:
@@ -154,7 +158,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
         ? directAgentId
         : opaqueId("session", sessionId)),
     cli,
-    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    ...(projectId ? { project_id: projectId } : {}),
     session_id: meta.session_id || sessionId,
     host_id: hostId,
     transport_locators_json:

--- a/packages/remote/hub/schema.sql
+++ b/packages/remote/hub/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS role_registry (
     (role_kind = 'cto' AND scope_id = '') OR
     (role_kind = 'lead' AND scope_id <> '')
   ),
+  CHECK (state <> 'active' OR holder_agent_id IS NOT NULL),
   UNIQUE(project_id, role_kind, scope_id)
 );
 

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -134,6 +134,26 @@ function ensureV7Columns(db) {
   }
 }
 
+// schema.sql의 CHECK는 CREATE TABLE IF NOT EXISTS 특성상 기존 테이블에 소급되지
+// 않는다. 매 부팅 실행되는 이 트리거가 legacy DB의 유일한 방어선이므로, 신규 DB
+// (CHECK)와 legacy DB(트리거)의 오류 문구를 의도적으로 동일하게 맞춘다.
+function ensureRoleRegistryIntegrityGuards(db) {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_insert
+    BEFORE INSERT ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_update
+    BEFORE UPDATE OF state, holder_agent_id ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+  `);
+}
+
 function storeFingerprint(dbPath) {
   return `sqlite:${createHash("sha256")
     .update(String(dbPath))
@@ -170,7 +190,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "7";
+  const SCHEMA_VERSION = "8";
   const curVer = (() => {
     try {
       return db
@@ -203,6 +223,7 @@ export function createStore(dbPath, options = {}) {
   // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
   ensureV6Columns(db);
   ensureV7Columns(db);
+  ensureRoleRegistryIntegrityGuards(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -609,8 +630,16 @@ export function createStore(dbPath, options = {}) {
     if (current.activation_id !== expected.activation_id) {
       return "stale_activation_id";
     }
-    return "cas_conflict";
+    return null;
   }
+
+  // db.transaction()은 DEFERRED BEGIN이라 read→write 승격 시점에
+  // SQLITE_BUSY_SNAPSHOT을 낼 수 있다. 역할 레지스트리 쓰기는 reserveRole /
+  // recoverRegistry와 동일하게 BEGIN IMMEDIATE로 쓰기 락을 선점한다.
+  const immediateTx = (fn) => {
+    const tx = db.transaction(fn);
+    return (input) => tx.immediate(input);
+  };
 
   const reserveRole = db.transaction((input) => {
     const identity = roleIdentity(input);
@@ -687,12 +716,15 @@ export function createStore(dbPath, options = {}) {
       const latest = S.getRole.get(identity.role_key_wire) ?? null;
       return {
         ok: false,
-        reason: roleFailureReason(latest, {
-          version: current.version,
-          epoch: current.epoch,
-          activation_seq: current.activation_seq,
-          activation_id: current.activation_id,
-        }),
+        // 쓰기가 0행을 건드렸는데 재조회가 기대값과 일치하면 원인을 특정할 수
+        // 없다. reason이 null로 새지 않도록 cas_conflict를 catch-all로 둔다.
+        reason:
+          roleFailureReason(latest, {
+            version: current.version,
+            epoch: current.epoch,
+            activation_seq: current.activation_seq,
+            activation_id: current.activation_id,
+          }) ?? "cas_conflict",
         role: latest,
       };
     }
@@ -715,7 +747,13 @@ export function createStore(dbPath, options = {}) {
         S.recoverExpiredRole.run(guard);
       } else if (role.holder_agent_id) {
         S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
-      } else if (role.activation_id || role.state === "elected-probing") {
+      } else if (
+        role.activation_id ||
+        role.state === "elected-probing" ||
+        // holder 없는 active는 v7 이전 DB가 남길 수 있는 phantom authority다.
+        // 트리거는 신규 유입만 막으므로 기존 행은 여기서 electable로 되돌린다.
+        role.state === "active"
+      ) {
         S.recoverOrphanedActivation.run(guard);
       }
     }
@@ -877,7 +915,7 @@ export function createStore(dbPath, options = {}) {
       return reserveRole.immediate(input);
     },
 
-    compareAndSetRole(input) {
+    compareAndSetRole: immediateTx((input) => {
       const identity = roleIdentity(input);
       const current = S.getRole.get(identity.role_key_wire) ?? null;
       if (!current) return { ok: false, reason: "not_found", role: null };
@@ -913,7 +951,7 @@ export function createStore(dbPath, options = {}) {
       }
 
       const reason = roleFailureReason(current, expected);
-      if (reason !== "cas_conflict") {
+      if (reason !== null) {
         return { ok: false, reason, role: current };
       }
 
@@ -973,12 +1011,12 @@ export function createStore(dbPath, options = {}) {
         const latest = S.getRole.get(identity.role_key_wire) ?? null;
         return {
           ok: false,
-          reason: roleFailureReason(latest, expected),
+          reason: roleFailureReason(latest, expected) ?? "cas_conflict",
           role: latest,
         };
       }
       return { ok: true, role: S.getRole.get(identity.role_key_wire) };
-    },
+    }),
 
     listRoleKeys(filter = {}) {
       const clauses = [];

--- a/packages/remote/hub/team/worktree-lifecycle.mjs
+++ b/packages/remote/hub/team/worktree-lifecycle.mjs
@@ -273,6 +273,8 @@ export async function ensureWorktree({
  * @param {string} opts.baseBranch
  * @param {string} [opts.rootDir=process.cwd()]
  * @returns {Promise<{ integrationBranch: string, baseCommit: string }>}
+ * @throws {Error} when the integration branch is checked out by another
+ * worktree; this is an intentional NO-GO and leaves that worktree untouched.
  */
 export async function prepareIntegrationBranch({
   runId,
@@ -458,6 +460,11 @@ export async function rebaseShardOntoIntegration({
       }
     } else {
       await rm(integrationWorktree, { recursive: true, force: true });
+      try {
+        await git(["worktree", "prune"], rootDir);
+      } catch {
+        /* best-effort metadata cleanup after a partial worktree add */
+      }
     }
   }
 }

--- a/packages/remote/hub/tools.mjs
+++ b/packages/remote/hub/tools.mjs
@@ -13,6 +13,10 @@ import {
   listPipelineStates,
   readPipelineState,
 } from "@triflux/core/hub/pipeline/state.mjs";
+import {
+  HOST_ID_PATTERN,
+  PROJECT_ID_PATTERN,
+} from "@triflux/core/hub/role-contract.mjs";
 import { sendInputToConductorSession } from "./team/conductor-registry.mjs";
 import { getTeamBridge } from "@triflux/core/hub/team-bridge.mjs";
 
@@ -153,9 +157,9 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
-          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          project_id: { type: "string", pattern: PROJECT_ID_PATTERN },
           session_id: { type: "string", minLength: 1, maxLength: 256 },
-          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          host_id: { type: "string", pattern: HOST_ID_PATTERN },
           transport_locators_json: {
             description:
               "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",

--- a/packages/triflux/hub/role-contract.mjs
+++ b/packages/triflux/hub/role-contract.mjs
@@ -1,4 +1,7 @@
-const PROJECT_ID_RE = /^prj_[A-Za-z0-9_-]{22}$/u;
+export const PROJECT_ID_PATTERN = "^prj_[A-Za-z0-9_-]{22}$";
+export const HOST_ID_PATTERN = "^hst_[A-Za-z0-9_-]+$";
+
+const PROJECT_ID_RE = new RegExp(PROJECT_ID_PATTERN, "u");
 const SCOPE_ID_RE = /^scp_[A-Za-z0-9_-]{22}$/u;
 const BASE64URL_RE = /^[A-Za-z0-9_-]+$/u;
 

--- a/packages/triflux/hub/schema.sql
+++ b/packages/triflux/hub/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS role_registry (
     (role_kind = 'cto' AND scope_id = '') OR
     (role_kind = 'lead' AND scope_id <> '')
   ),
+  CHECK (state <> 'active' OR holder_agent_id IS NOT NULL),
   UNIQUE(project_id, role_kind, scope_id)
 );
 

--- a/packages/triflux/hub/store.mjs
+++ b/packages/triflux/hub/store.mjs
@@ -131,6 +131,26 @@ function ensureV7Columns(db) {
   }
 }
 
+// schema.sql의 CHECK는 CREATE TABLE IF NOT EXISTS 특성상 기존 테이블에 소급되지
+// 않는다. 매 부팅 실행되는 이 트리거가 legacy DB의 유일한 방어선이므로, 신규 DB
+// (CHECK)와 legacy DB(트리거)의 오류 문구를 의도적으로 동일하게 맞춘다.
+function ensureRoleRegistryIntegrityGuards(db) {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_insert
+    BEFORE INSERT ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+    CREATE TRIGGER IF NOT EXISTS role_registry_active_holder_update
+    BEFORE UPDATE OF state, holder_agent_id ON role_registry
+    WHEN NEW.state = 'active' AND NEW.holder_agent_id IS NULL
+    BEGIN
+      SELECT RAISE(ABORT, 'CHECK constraint failed: active role requires holder_agent_id');
+    END;
+  `);
+}
+
 function storeFingerprint(dbPath) {
   return `sqlite:${createHash("sha256").update(String(dbPath)).digest("hex")}`;
 }
@@ -165,7 +185,7 @@ export function createStore(dbPath, options = {}) {
   db.exec(
     "CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)",
   );
-  const SCHEMA_VERSION = "7";
+  const SCHEMA_VERSION = "8";
   const curVer = (() => {
     try {
       return db
@@ -198,6 +218,7 @@ export function createStore(dbPath, options = {}) {
   // 매 부팅 실행해 부분 적용된 마이그레이션도 안전하게 복구한다.
   ensureV6Columns(db);
   ensureV7Columns(db);
+  ensureRoleRegistryIntegrityGuards(db);
   ensureColumn(
     db,
     "reflexion_entries",
@@ -606,8 +627,16 @@ export function createStore(dbPath, options = {}) {
     if (current.activation_id !== expected.activation_id) {
       return "stale_activation_id";
     }
-    return "cas_conflict";
+    return null;
   }
+
+  // db.transaction()은 DEFERRED BEGIN이라 read→write 승격 시점에
+  // SQLITE_BUSY_SNAPSHOT을 낼 수 있다. 역할 레지스트리 쓰기는 reserveRole /
+  // recoverRegistry와 동일하게 BEGIN IMMEDIATE로 쓰기 락을 선점한다.
+  const immediateTx = (fn) => {
+    const tx = db.transaction(fn);
+    return (input) => tx.immediate(input);
+  };
 
   const reserveRole = db.transaction((input) => {
     const identity = roleIdentity(input);
@@ -685,12 +714,15 @@ export function createStore(dbPath, options = {}) {
       const latest = S.getRole.get(identity.role_key_wire) ?? null;
       return {
         ok: false,
-        reason: roleFailureReason(latest, {
-          version: current.version,
-          epoch: current.epoch,
-          activation_seq: current.activation_seq,
-          activation_id: current.activation_id,
-        }),
+        // 쓰기가 0행을 건드렸는데 재조회가 기대값과 일치하면 원인을 특정할 수
+        // 없다. reason이 null로 새지 않도록 cas_conflict를 catch-all로 둔다.
+        reason:
+          roleFailureReason(latest, {
+            version: current.version,
+            epoch: current.epoch,
+            activation_seq: current.activation_seq,
+            activation_id: current.activation_id,
+          }) ?? "cas_conflict",
         role: latest,
       };
     }
@@ -713,7 +745,13 @@ export function createStore(dbPath, options = {}) {
         S.recoverExpiredRole.run(guard);
       } else if (role.holder_agent_id) {
         S.recoverLiveRole.run({ ...guard, activation_id: uuidv7() });
-      } else if (role.activation_id || role.state === "elected-probing") {
+      } else if (
+        role.activation_id ||
+        role.state === "elected-probing" ||
+        // holder 없는 active는 v7 이전 DB가 남길 수 있는 phantom authority다.
+        // 트리거는 신규 유입만 막으므로 기존 행은 여기서 electable로 되돌린다.
+        role.state === "active"
+      ) {
         S.recoverOrphanedActivation.run(guard);
       }
     }
@@ -874,7 +912,7 @@ export function createStore(dbPath, options = {}) {
       return reserveRole.immediate(input);
     },
 
-    compareAndSetRole(input) {
+    compareAndSetRole: immediateTx((input) => {
       const identity = roleIdentity(input);
       const current = S.getRole.get(identity.role_key_wire) ?? null;
       if (!current) return { ok: false, reason: "not_found", role: null };
@@ -911,7 +949,7 @@ export function createStore(dbPath, options = {}) {
       }
 
       const reason = roleFailureReason(current, expected);
-      if (reason !== "cas_conflict") {
+      if (reason !== null) {
         return { ok: false, reason, role: current };
       }
 
@@ -971,12 +1009,12 @@ export function createStore(dbPath, options = {}) {
         const latest = S.getRole.get(identity.role_key_wire) ?? null;
         return {
           ok: false,
-          reason: roleFailureReason(latest, expected),
+          reason: roleFailureReason(latest, expected) ?? "cas_conflict",
           role: latest,
         };
       }
       return { ok: true, role: S.getRole.get(identity.role_key_wire) };
-    },
+    }),
 
     listRoleKeys(filter = {}) {
       const clauses = [];

--- a/packages/triflux/hub/team/synapse-http.mjs
+++ b/packages/triflux/hub/team/synapse-http.mjs
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import { dirname, join } from "node:path";
-import { normalizeRoleKey } from "../role-contract.mjs";
+import { HOST_ID_PATTERN, normalizeRoleKey } from "../role-contract.mjs";
+
+const HOST_ID_RE = new RegExp(HOST_ID_PATTERN, "u");
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -101,11 +103,12 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
   if (!sessionId) return meta;
   const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
   const cli = inferSessionCli(meta, opts);
-  const hostId = String(
-    meta.host_id ||
-      process.env.TFX_HOST_ID ||
-      opaqueId("hst", opts.hostname?.() || hostname()),
+  const configuredHostId = String(
+    meta.host_id || process.env.TFX_HOST_ID || opts.hostname?.() || hostname(),
   ).trim();
+  const hostId = HOST_ID_RE.test(configuredHostId)
+    ? configuredHostId
+    : opaqueId("hst", configuredHostId);
   const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
   const transportLocators = [];
   if (cli === "claude") {
@@ -146,6 +149,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
     });
   }
   const directAgentId = `session:${sessionId}`;
+  const projectId = resolveProjectId(cwd, meta, opts);
   return {
     ...meta,
     agent_id:
@@ -154,7 +158,7 @@ export function buildSynapseRegistrationMeta(meta, opts = {}) {
         ? directAgentId
         : opaqueId("session", sessionId)),
     cli,
-    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    ...(projectId ? { project_id: projectId } : {}),
     session_id: meta.session_id || sessionId,
     host_id: hostId,
     transport_locators_json:

--- a/packages/triflux/hub/team/worktree-lifecycle.mjs
+++ b/packages/triflux/hub/team/worktree-lifecycle.mjs
@@ -273,6 +273,8 @@ export async function ensureWorktree({
  * @param {string} opts.baseBranch
  * @param {string} [opts.rootDir=process.cwd()]
  * @returns {Promise<{ integrationBranch: string, baseCommit: string }>}
+ * @throws {Error} when the integration branch is checked out by another
+ * worktree; this is an intentional NO-GO and leaves that worktree untouched.
  */
 export async function prepareIntegrationBranch({
   runId,
@@ -458,6 +460,11 @@ export async function rebaseShardOntoIntegration({
       }
     } else {
       await rm(integrationWorktree, { recursive: true, force: true });
+      try {
+        await git(["worktree", "prune"], rootDir);
+      } catch {
+        /* best-effort metadata cleanup after a partial worktree add */
+      }
     }
   }
 }

--- a/packages/triflux/hub/tools.mjs
+++ b/packages/triflux/hub/tools.mjs
@@ -13,6 +13,7 @@ import {
   listPipelineStates,
   readPipelineState,
 } from "./pipeline/state.mjs";
+import { HOST_ID_PATTERN, PROJECT_ID_PATTERN } from "./role-contract.mjs";
 import { sendInputToConductorSession } from "./team/conductor-registry.mjs";
 import { getTeamBridge } from "./team-bridge.mjs";
 
@@ -153,9 +154,9 @@ export function createTools(store, router, hitl, pipe = null) {
           },
           topics: { type: "array", items: { type: "string" }, maxItems: 64 },
           metadata: { type: "object" },
-          project_id: { type: "string", pattern: "^prj_[A-Za-z0-9_-]{22}$" },
+          project_id: { type: "string", pattern: PROJECT_ID_PATTERN },
           session_id: { type: "string", minLength: 1, maxLength: 256 },
-          host_id: { type: "string", pattern: "^hst_[A-Za-z0-9_-]+$" },
+          host_id: { type: "string", pattern: HOST_ID_PATTERN },
           transport_locators_json: {
             description:
               "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",

--- a/tests/unit/registration-plumbing.test.mjs
+++ b/tests/unit/registration-plumbing.test.mjs
@@ -168,6 +168,27 @@ describe("registration scoped identity plumbing", { skip: SQLITE_SKIP }, () => {
 });
 
 describe("SessionStart scoped registration metadata", () => {
+  it("normalizes a raw TFX_HOST_ID into a valid opaque locator identity", () => {
+    const previous = process.env.TFX_HOST_ID;
+    process.env.TFX_HOST_ID = "MacBook Pro / raw host";
+    try {
+      const identity = buildSynapseRegistrationMeta(
+        { sessionKind: "interactive", sessionId: "host-normalization" },
+        { nowMs: () => 1000 },
+      );
+      assert.match(identity.host_id, /^hst_[A-Za-z0-9_-]{22}$/u);
+      assert.equal(identity.project_id, undefined);
+      assert.equal(Object.hasOwn(identity, "project_id"), false);
+      assert.equal(
+        JSON.parse(identity.transport_locators_json)[0].host_id,
+        identity.host_id,
+      );
+    } finally {
+      if (previous === undefined) delete process.env.TFX_HOST_ID;
+      else process.env.TFX_HOST_ID = previous;
+    }
+  });
+
   it("loads tracked project identity and emits only detectable Codex tmux locator", () => {
     const root = mkdtempSync(join(tmpdir(), "tfx-session-registration-"));
     TEMP_DIRS.push(root);

--- a/tests/unit/store-migration-v6.test.mjs
+++ b/tests/unit/store-migration-v6.test.mjs
@@ -95,7 +95,7 @@ afterEach(() => {
   }
 });
 
-describe("hub store schema v7 migration", { skip: SQLITE_SKIP }, () => {
+describe("hub store schema v8 migration", { skip: SQLITE_SKIP }, () => {
   it("migrates a real v5 database without losing agents or messages", () => {
     const dbPath = makeV5Database();
     const first = createStore(dbPath);
@@ -105,7 +105,7 @@ describe("hub store schema v7 migration", { skip: SQLITE_SKIP }, () => {
         .prepare("SELECT value FROM _meta WHERE key='schema_version'")
         .pluck()
         .get(),
-      "7",
+      "8",
     );
     assert.deepEqual(first.getAgent("legacy-agent"), {
       agent_id: "legacy-agent",
@@ -170,6 +170,99 @@ describe("hub store schema v7 migration", { skip: SQLITE_SKIP }, () => {
       assert.equal(renewed.data.presence_generation, 1);
     } finally {
       router.stopSweeper();
+      store.close();
+    }
+  });
+});
+
+function makeLegacyRoleRegistryDatabase() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-store-role-legacy-"));
+  TEMP_DIRS.push(dir);
+  const dbPath = join(dir, "hub.db");
+  const Database = loadBetterSqlite3ForTest();
+  const db = new Database(dbPath);
+  // v8 이전 role_registry에는 active + holder NULL을 막는 CHECK가 없다.
+  db.exec(`
+    CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT);
+    INSERT INTO _meta (key, value) VALUES ('schema_version', '6');
+
+    CREATE TABLE role_registry (
+      role_key_wire TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      role_kind TEXT NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT '',
+      state TEXT NOT NULL,
+      holder_agent_id TEXT,
+      previous_holder_agent_id TEXT,
+      epoch INTEGER NOT NULL DEFAULT 0,
+      activation_seq INTEGER NOT NULL DEFAULT 0,
+      activation_id TEXT,
+      activation_deadline_ms INTEGER,
+      holder_lease_expires_ms INTEGER,
+      charter_version TEXT,
+      charter_acked_epoch INTEGER,
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      next_probe_ms INTEGER,
+      blocked_reason TEXT,
+      last_transition_ms INTEGER NOT NULL DEFAULT 0,
+      last_reason TEXT,
+      version INTEGER NOT NULL DEFAULT 0,
+      UNIQUE(project_id, role_kind, scope_id)
+    );
+
+    INSERT INTO role_registry (role_key_wire, project_id, role_kind, scope_id, state)
+    VALUES ('legacy-phantom-cto', 'prj_AAAAAAAAAAAAAAAAAAAAAA', 'cto', '', 'active');
+  `);
+  db.close();
+  return dbPath;
+}
+
+describe("hub store role registry legacy integrity guards", {
+  skip: SQLITE_SKIP,
+}, () => {
+  it("CHECK가 없는 legacy 테이블을 트리거로 방어하고 기존 phantom active를 electable로 되돌린다", () => {
+    const store = createStore(makeLegacyRoleRegistryDatabase());
+    try {
+      // CREATE TABLE IF NOT EXISTS는 기존 테이블에 CHECK를 소급하지 못한다.
+      // 따라서 매 부팅 실행되는 트리거가 legacy DB의 유일한 방어선이다.
+      const tableSql = store.db
+        .prepare("SELECT sql FROM sqlite_master WHERE name='role_registry'")
+        .pluck()
+        .get();
+      assert.equal(/holder_agent_id IS NOT NULL/u.test(tableSql), false);
+
+      assert.throws(
+        () =>
+          store.db
+            .prepare(
+              `INSERT INTO role_registry (role_key_wire, project_id, role_kind, scope_id, state)
+               VALUES ('new-phantom-cto', 'prj_BBBBBBBBBBBBBBBBBBBBBB', 'cto', '', 'active')`,
+            )
+            .run(),
+        /CHECK constraint failed/u,
+      );
+
+      // 트리거는 신규 유입만 막으므로, 이미 들어와 있던 행은 복구가 처리해야 한다.
+      assert.deepEqual(
+        store.db
+          .prepare(
+            "SELECT state, holder_agent_id FROM role_registry WHERE role_key_wire='legacy-phantom-cto'",
+          )
+          .get(),
+        { state: "active", holder_agent_id: null },
+      );
+
+      store.recoverRoleRegistry(Date.now());
+
+      assert.deepEqual(
+        store.db
+          .prepare(
+            "SELECT state, holder_agent_id FROM role_registry WHERE role_key_wire='legacy-phantom-cto'",
+          )
+          .get(),
+        { state: "electable", holder_agent_id: null },
+      );
+    } finally {
       store.close();
     }
   });

--- a/tests/unit/store-role-registry.test.mjs
+++ b/tests/unit/store-role-registry.test.mjs
@@ -161,6 +161,13 @@ describe("hub store role registry", { skip: SQLITE_SKIP }, () => {
           state: "electable",
         },
         {
+          role_key_wire: "invalid-active-without-holder",
+          project_id: PROJECT_A,
+          role_kind: "cto",
+          scope_id: "",
+          state: "active",
+        },
+        {
           role_key_wire: "invalid-state",
           project_id: PROJECT_A,
           role_kind: "cto",

--- a/tests/unit/worktree-lifecycle.test.mjs
+++ b/tests/unit/worktree-lifecycle.test.mjs
@@ -128,6 +128,44 @@ describe("worktree-lifecycle", () => {
     assert.equal(result2.integrationBranch, result.integrationBranch);
   });
 
+  it("W-02a: refuses to reset an integration branch checked out elsewhere", async () => {
+    const first = await prepareIntegrationBranch({
+      runId: "checked-out-integration",
+      baseBranch: "main",
+      rootDir: repoDir,
+    });
+    const checkout = join(repoDir, ".codex-swarm", "integration-holder");
+    execFileSync(
+      "git",
+      ["worktree", "add", checkout, first.integrationBranch],
+      {
+        cwd: repoDir,
+        windowsHide: true,
+      },
+    );
+    const before = execFileSync("git", ["rev-parse", first.integrationBranch], {
+      cwd: repoDir,
+      encoding: "utf8",
+      windowsHide: true,
+    }).trim();
+
+    await assert.rejects(
+      prepareIntegrationBranch({
+        runId: "checked-out-integration",
+        baseBranch: "main",
+        rootDir: repoDir,
+      }),
+    );
+    assert.equal(
+      execFileSync("git", ["rev-parse", first.integrationBranch], {
+        cwd: repoDir,
+        encoding: "utf8",
+        windowsHide: true,
+      }).trim(),
+      before,
+    );
+  });
+
   it("W-03: pruneWorktree — worktree + 브랜치 정리", async () => {
     // 먼저 worktree 생성
     const wt = await ensureWorktree({


### PR DESCRIPTION
이월 P3 8개 항목 수정 + 교차리뷰 지적 반영.

## 배경

Codex 워커가 P3 8개 항목을 구현 → Claude 교차리뷰에서 **P1 1건 / P2 4건 / P3 4건** 적발 → 지적 반영 후 Codex 교차검토 **APPROVE**.

## 변경

| 항목 | 내용 |
|---|---|
| host_id | 유효하지 않은 `TFX_HOST_ID`/`meta.host_id`를 opaque locator로 정규화. 이미 `hst_` 형식이면 무변경 통과(기존 유효 host_id 하위호환 유지) |
| project_id | 미검출 시 `undefined` 키를 만들지 않음 |
| SSOT | `prj_`/`hst_` 정규식을 `role-contract`의 `PROJECT_ID_PATTERN`/`HOST_ID_PATTERN`으로 단일화 |
| roleFailureReason | 전 필드 일치 시 `null`(사전검사용). 사후 경로 2곳은 `?? "cas_conflict"`로 닫음 |
| compareAndSetRole | 트랜잭션 래핑 + `reserveRole`/`recoverRegistry`와 동일하게 **BEGIN IMMEDIATE** 통일 |
| role_registry 무결성 | CHECK(신규 DB) + 매 부팅 트리거(legacy DB) + `recoverRegistry`의 phantom active 복구 **3중화** |
| swarm | integration branch가 타 worktree에 checkout돼 있으면 NO-GO |
| worktree | 정리 실패 경로에 `prune` 보강 |

## SCHEMA_VERSION 6→8 (rebase 중 발견)

main의 lane2-e가 **v7(`presence_generation`)** 을 이미 쓰는데 본 브랜치도 v7을 주장했다. 두 변경이 같은 `"6"→"7"` 라인을 건드려 **git이 충돌 없이 자동병합**하므로, 방치하면 `"7"`이 두 스키마를 뜻하게 되고 한쪽 seam이 조용히 사라진다.

→ `ensureV7Columns`(presence_generation)와 `ensureRoleRegistryIntegrityGuards`(트리거)를 **모두 보존**하고 `"8"`로 승격.

## 교차리뷰 지적 반영 (Claude → 본 커밋)

- **P1** `npm run lint` 실패 3건(format ×2, organizeImports ×1) → CI 차단이었음. 해소
- **P2-1** `recoverRegistry`가 기존 `active`+holder NULL 행을 방어 못 해 **영구 phantom authority** 잔존 → `role.state === "active"` 분기 추가
- **P2-2** `compareAndSetRole`만 DEFERRED 트랜잭션 → `immediateTx` 헬퍼로 통일
- **P2-3** 정규화 코드가 단일화 대상 정규식을 하드코딩 → `HOST_ID_PATTERN` import
- **P2-4** 표 중간 문단 삽입으로 `| 충돌 |` 행 파손 → 표 아래로 이동
- **P3-1** `reason: null` 누수 차단, **P3-2** legacy v6 회귀 테스트 추가, **P3-4** 트리거 의도 주석

## 검증

- `npm test`: **4,723 tests / 4,706 pass / 0 fail / 17 skip**, `lint:skills` PASS(44 skills)
- `npm run lint`: 클린(836 files)
- 미러: core/triflux **IDENTICAL**, remote `@triflux/core` 변환 보존(상대경로 revert 0)
- **P2-1 실증**: 버그를 드러낸 프로브 before/after → `["legacy-bad","active",null]` → `["legacy-bad","electable",null]`
- **Codex 교차검토 APPROVE**: v7 실사용형 DB(`_meta='7'`)를 직접 만들어 v8 재진입 반증, 정상 active holder 복구·`immediateTx` 중첩·3-layer 미러 검증, 전체 스위트 독립 실행. finding 0건