### PR TITLE
feat(hub): implement scoped role activator

### DIFF
--- a/hub/pipe.mjs
+++ b/hub/pipe.mjs
@@ -220,6 +220,35 @@ export function createPipeServer({
 
   async function processCommand(client, action, payload = {}) {
     switch (action) {
+      case "ensure_role": {
+        if (client && !client.agentId) {
+          return {
+            ok: false,
+            error: {
+              code: "PRINCIPAL_REQUIRED",
+              message: "agent registration required before ensure_role",
+            },
+          };
+        }
+        return router.requestEnsureRole(payload, {
+          principal: client?.agentId
+            ? { type: "agent", agent_id: client.agentId }
+            : {
+                type: "system",
+                service: "team-pipeline",
+                project_id: payload?.role_key?.project_id,
+              },
+        });
+      }
+
+      case "ack_role_activation":
+        return router.ackRoleActivation(payload, {
+          principal: {
+            type: "agent",
+            agent_id: client?.agentId,
+          },
+        });
+
       case "register": {
         const result = router.registerAgent(payload);
         if (!result?.ok) return result;
@@ -814,8 +843,12 @@ export function createPipeServer({
       };
     },
 
-    async executeCommand(action, payload) {
-      return await processCommand(null, action, payload);
+    async executeCommand(action, payload, context = {}) {
+      const client =
+        context.connection_bound || context.agent_id
+          ? { agentId: context.agent_id ?? null }
+          : null;
+      return await processCommand(client, action, payload);
     },
 
     async executeQuery(action, payload) {

--- a/hub/role-activator-tfx-live.mjs
+++ b/hub/role-activator-tfx-live.mjs
@@ -1,0 +1,292 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = dirname(MODULE_DIR);
+const REQUIRED_CAPABILITIES = ["probe", "wake", "activate"];
+
+function opaqueHostId(value) {
+  return `hst_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    const lines = text.split(/\r?\n/u);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      try {
+        return JSON.parse(lines[index]);
+      } catch {}
+    }
+    return {};
+  }
+}
+
+function seconds(timeoutMs, fallbackMs) {
+  const value = Number(timeoutMs);
+  return String(
+    Math.max(1, Math.ceil((value > 0 ? value : fallbackMs) / 1000)),
+  );
+}
+
+function reasonFromError(error) {
+  if (error?.name === "AbortError") return "timeout";
+  if (error?.code === "ETIMEDOUT" || error?.killed) return "timeout";
+  if (error?.code === "EACCES" || error?.code === "EPERM") {
+    return "permission_denied";
+  }
+  if (error?.code === "ENOENT") return "adapter_unavailable";
+  if (Number(error?.code) === 1) return "target_not_found";
+  return "transport_error";
+}
+
+function probeResult(locator, startedAt, observedAt, patch) {
+  return {
+    schema_version: "tfx-live.transport-probe.v1",
+    ok: false,
+    reachable: false,
+    wakeable: false,
+    transport_selected: locator?.kind ?? null,
+    transport_id: locator?.transport_id ?? "unknown",
+    host_id: locator?.host_id ?? "unknown",
+    latency_ms: Math.max(0, observedAt - startedAt),
+    observed_at_ms: observedAt,
+    reason_code: "transport_error",
+    ...patch,
+  };
+}
+
+function defaultSessionName(roleKey) {
+  const suffix = globalThis.crypto.randomUUID().slice(0, 8);
+  return `tfx-role-${roleKey.role_kind}-${suffix}`;
+}
+
+function activationPrompt(activation) {
+  return JSON.stringify(activation);
+}
+
+export function createTfxLiveRoleAdapter(options = {}) {
+  const projectRoot = options.projectRoot || DEFAULT_ROOT;
+  const defaultTfxLivePath = join(projectRoot, "bin", "tfx-live.mjs");
+  const tfxLivePath = options.tfxLivePath || defaultTfxLivePath;
+  const tfxLiveCommand =
+    options.tfxLiveCommand ||
+    (!options.tfxLivePath && !existsSync(defaultTfxLivePath)
+      ? "tfx-live"
+      : null);
+  const bridgePath =
+    options.bridgePath || join(projectRoot, "hub", "bridge.mjs");
+  const nodePath = options.nodePath || process.execPath;
+  const tmuxPath = options.tmuxPath || "tmux";
+  const localHostId =
+    options.localHostId || opaqueHostId(options.hostname?.() || hostname());
+  const muxServerId = options.muxServerId || "mux_local";
+  const now = options.now || Date.now;
+  const sessionName = options.sessionName || defaultSessionName;
+  const runProcess =
+    options.runProcess ||
+    (async (command, args, processOptions = {}) =>
+      await execFileAsync(command, args, {
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+        ...processOptions,
+      }));
+  const active = new Map();
+
+  function runTfxLive(args, processOptions) {
+    return tfxLiveCommand
+      ? runProcess(tfxLiveCommand, args, processOptions)
+      : runProcess(nodePath, [tfxLivePath, ...args], processOptions);
+  }
+
+  function supports(locator) {
+    return (
+      locator?.schema_version === "tfx.transport-locator.v1" &&
+      locator.host_id === localHostId &&
+      (locator.kind === "claude-uds" || locator.kind === "tmux") &&
+      Array.isArray(locator.capabilities) &&
+      REQUIRED_CAPABILITIES.every((capability) =>
+        locator.capabilities.includes(capability),
+      )
+    );
+  }
+
+  async function probe(locator, probeOptions = {}) {
+    const startedAt = now();
+    if (!supports(locator)) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: "adapter_unavailable",
+      });
+    }
+    try {
+      if (locator.kind === "tmux") {
+        await runProcess(
+          tmuxPath,
+          ["has-session", "-t", locator.locator.session_name],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+      } else {
+        const refArgs = locator.locator.session_id
+          ? ["--session-id", locator.locator.session_id]
+          : ["--short", locator.locator.short];
+        const result = await runTfxLive(
+          [
+            "probe",
+            ...refArgs,
+            "--bridge",
+            bridgePath,
+            "--timeout",
+            seconds(probeOptions.timeout_ms, 10_000),
+          ],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+        const payload = parseJsonOutput(result.stdout);
+        if (payload.ok !== true) {
+          return probeResult(locator, startedAt, now(), {
+            reason_code:
+              payload.reason_code || payload.reason || "target_not_found",
+          });
+        }
+      }
+      return probeResult(locator, startedAt, now(), {
+        ok: true,
+        reachable: true,
+        wakeable: true,
+        reason_code: "ok",
+      });
+    } catch (error) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: reasonFromError(error),
+      });
+    }
+  }
+
+  function liveArgs(locator, cli, verb) {
+    if (locator.kind === "tmux") {
+      return [
+        verb,
+        "--cli",
+        cli,
+        "--transport",
+        "tmux",
+        "--session",
+        locator.locator.session_name,
+      ];
+    }
+    const refArgs = locator.locator.session_id
+      ? ["--session-id", locator.locator.session_id]
+      : ["--short", locator.locator.short];
+    return [
+      verb,
+      "--cli",
+      "claude",
+      "--transport",
+      "uds",
+      ...refArgs,
+      "--bridge",
+      bridgePath,
+    ];
+  }
+
+  async function wake(locator, activation, wakeOptions = {}) {
+    if (!supports(locator)) {
+      return { ok: false, reason_code: "adapter_unavailable" };
+    }
+    const cli = activation?.holder_cli === "codex" ? "codex" : "claude";
+    const args = [
+      ...liveArgs(locator, cli, "ask"),
+      "--prompt",
+      activationPrompt(activation),
+      "--timeout",
+      seconds(wakeOptions.timeout_ms, 10_000),
+    ];
+    try {
+      const result = await runTfxLive(args, {
+        timeout: wakeOptions.timeout_ms,
+        signal: wakeOptions.signal,
+      });
+      const payload = parseJsonOutput(result.stdout);
+      if (payload.ok === false) {
+        return {
+          ok: false,
+          reason_code: payload.reason_code || "transport_error",
+        };
+      }
+      active.set(activation.activation_id, { locator, cli });
+      return { ok: true, transport_id: locator.transport_id };
+    } catch (error) {
+      return { ok: false, reason_code: reasonFromError(error) };
+    }
+  }
+
+  async function standup(roleKey, cli, standupOptions = {}) {
+    const name = sessionName(roleKey);
+    await runTfxLive(
+      [
+        "start",
+        "--session",
+        name,
+        "--cli",
+        cli,
+        "--cwd",
+        projectRoot,
+        "--ready-timeout",
+        seconds(standupOptions.timeout_ms, 60_000),
+      ],
+      {
+        timeout: standupOptions.timeout_ms,
+        signal: standupOptions.signal,
+      },
+    );
+    return {
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: `standup:${name}`,
+      kind: "tmux",
+      host_id: localHostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: now() + 300_000,
+      locator: { session_name: name, mux_server_id: muxServerId },
+    };
+  }
+
+  async function cancel(activationId) {
+    const target = active.get(activationId);
+    if (!target) return false;
+    active.delete(activationId);
+    try {
+      await runTfxLive(
+        [
+          ...liveArgs(target.locator, target.cli, "interrupt"),
+          "--timeout",
+          "5",
+        ],
+        { timeout: 5_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return { supports, probe, wake, standup, cancel };
+}

--- a/hub/role-activator.mjs
+++ b/hub/role-activator.mjs
@@ -375,14 +375,18 @@ export function createRoleActivator(options = {}) {
     ) {
       return { receipt: receipt("joined", roleKeyWire, current) };
     }
+    let candidates;
     if (
       ["unreachable", "quarantined"].includes(current?.state) &&
       Number(current.next_probe_ms) > now()
     ) {
-      return { receipt: receipt("joined", roleKeyWire, current) };
+      candidates = eligibleCandidates(roleKey, roleKeyWire);
+      if (!candidates.length) {
+        return { receipt: receipt("joined", roleKeyWire, current) };
+      }
     }
 
-    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    candidates ??= eligibleCandidates(roleKey, roleKeyWire);
     const holder = candidates[0] || null;
     const plan = reserve(roleKey, current, holder, normalized.trigger);
     return { plan, candidates };
@@ -791,12 +795,9 @@ export function createRoleActivator(options = {}) {
         },
       );
     } catch (error) {
-      const reasonCode = error?.code || "standup_wake_failed";
-      const deferred = deferStandupRetry(plan, reasonCode);
-      return {
-        status: deferred.role?.state || "unreachable",
-        reason_code: reasonCode,
-        role: deferred.role,
+      wake = {
+        ok: false,
+        reason_code: error?.code || "standup_wake_failed",
       };
     }
     const afterWake = await gate(plan);

--- a/hub/role-activator.mjs
+++ b/hub/role-activator.mjs
@@ -1,0 +1,1195 @@
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
+import {
+  buildCapabilityDegradedEvent,
+  emitRoleControlEvent,
+} from "./role-control-events.mjs";
+
+export const ENSURE_ROLE_SCHEMA_VERSION = "tfx.ensure-role.v1";
+export const ROLE_ACTIVATION_ACK_SCHEMA_VERSION = "tfx.role-activation-ack.v1";
+
+const ENSURE_ROLE_TRIGGERS = new Set([
+  "session_start",
+  "publish_no_holder",
+  "lease_expired",
+  "restart_recovery",
+  "hygiene_changed",
+  "charter_issued",
+  "manual",
+]);
+const REQUIRED_LOCATOR_CAPABILITIES = ["probe", "wake", "activate"];
+const DEFAULTS = Object.freeze({
+  probe_timeout_ms: 10_000,
+  activation_ack_timeout_ms: 45_000,
+  standup_timeout_ms: 60_000,
+  max_probe_failures: 3,
+  backoff_base_ms: 1_000,
+  backoff_factor: 2,
+  backoff_max_ms: 30_000,
+  backoff_jitter_ratio: 0.2,
+  candidate_quarantine_ms: 120_000,
+});
+
+function activatorError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeEnsureRequest(request, now) {
+  if (
+    !isRecord(request) ||
+    request.schema_version !== ENSURE_ROLE_SCHEMA_VERSION ||
+    !ENSURE_ROLE_TRIGGERS.has(request.trigger) ||
+    typeof request.cause_id !== "string" ||
+    !request.cause_id.trim()
+  ) {
+    throw activatorError("ENSURE_ROLE_REQUEST_INVALID");
+  }
+  const roleKey = normalizeRoleKey(request.role_key);
+  return {
+    schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+    role_key: roleKey,
+    role_key_wire: encodeRoleKey(roleKey),
+    trigger: request.trigger,
+    cause_id: request.cause_id.trim(),
+    requested_at_ms: now(),
+  };
+}
+
+function managerEnabled(control, roleKind) {
+  if (!control?.master_enabled) return false;
+  return roleKind === "cto"
+    ? control.cto_manager_enabled === true
+    : control.lead_manager_enabled === true;
+}
+
+function blockedReason(control) {
+  return control?.master_enabled ? "manager_disabled" : "master_off";
+}
+
+function receipt(disposition, roleKeyWire, role, extra = {}) {
+  return {
+    accepted: !["manager_disabled", "scope_closed"].includes(disposition),
+    disposition,
+    role_key_wire: roleKeyWire,
+    state: role?.state ?? "electable",
+    epoch: role?.epoch ?? 0,
+    ...(role?.activation_id ? { activation_id: role.activation_id } : {}),
+    ...extra,
+  };
+}
+
+function activationGuard(role) {
+  return {
+    role_key_wire: role.role_key_wire,
+    expected_version: role.version,
+    expected_epoch: role.epoch,
+    expected_activation_seq: role.activation_seq,
+    expected_activation_id: role.activation_id,
+  };
+}
+
+function locatorUsable(locator, adapter, disabledAdapters, now) {
+  return (
+    isRecord(locator) &&
+    locator.schema_version === "tfx.transport-locator.v1" &&
+    typeof locator.kind === "string" &&
+    !disabledAdapters.has(locator.kind) &&
+    Number(locator.expires_at_ms) > now &&
+    Array.isArray(locator.capabilities) &&
+    REQUIRED_LOCATOR_CAPABILITIES.every((capability) =>
+      locator.capabilities.includes(capability),
+    ) &&
+    adapter.supports(locator) === true
+  );
+}
+
+function candidateLive(candidate, store, roleKey, now) {
+  const agent = store.getAgent(candidate.agent_id);
+  if (
+    !agent ||
+    agent.status !== "online" ||
+    Number(agent.lease_expires_ms) <= now
+  ) {
+    return null;
+  }
+  if (agent.project_id && agent.project_id !== roleKey.project_id) return null;
+  const capabilities = Array.isArray(agent.capabilities)
+    ? agent.capabilities
+    : [];
+  if (!capabilities.includes(`role:${roleKey.role_kind}:candidate`))
+    return null;
+  return agent;
+}
+
+function normalizeProbeResult(result, locator) {
+  if (
+    !isRecord(result) ||
+    result.schema_version !== "tfx-live.transport-probe.v1"
+  ) {
+    return {
+      ok: false,
+      reachable: false,
+      wakeable: false,
+      reason_code: "protocol_mismatch",
+      transport_id: locator.transport_id,
+    };
+  }
+  return result;
+}
+
+export function computeRoleBackoffMs(
+  failureCount,
+  config = {},
+  rng = Math.random,
+) {
+  const options = { ...DEFAULTS, ...config };
+  const count = Math.max(1, Number(failureCount) || 1);
+  const base = Math.min(
+    options.backoff_base_ms * options.backoff_factor ** (count - 1),
+    options.backoff_max_ms,
+  );
+  const unit = Math.max(0, Math.min(1, Number(rng()) || 0));
+  const jitter = (unit * 2 - 1) * options.backoff_jitter_ratio;
+  return Math.round(base * (1 + jitter));
+}
+
+export function createRoleActivator(options = {}) {
+  const {
+    store,
+    adapter,
+    getControlSnapshot = () => ({
+      generation: 0,
+      master_enabled: false,
+      cto_manager_enabled: false,
+      lead_manager_enabled: false,
+    }),
+    getCharterVersion = () => null,
+    isScopeClosed = () => false,
+    runCoreCanary = () => ({ ok: true }),
+    uuid = () => globalThis.crypto.randomUUID(),
+    now = Date.now,
+    rng = Math.random,
+    logger = null,
+    onControlEvent = null,
+    onRoleActive = null,
+    scheduleTimeout = setTimeout,
+    clearScheduledTimeout = clearTimeout,
+    writeFallback = (line) => process.stderr.write(line),
+  } = options;
+  const config = { ...DEFAULTS, ...(options.config || {}) };
+  if (!store || !adapter)
+    throw activatorError("ROLE_ACTIVATOR_DEPENDENCY_INVALID");
+
+  const flights = new Map();
+  const ackTimers = new Map();
+  const disabledAdapters = new Set();
+  let controlOverride = null;
+  let managerCircuitReason = null;
+
+  function controlSnapshot() {
+    return controlOverride || getControlSnapshot();
+  }
+
+  function emitDegraded(input) {
+    let event = null;
+    try {
+      event = buildCapabilityDegradedEvent({
+        module: "role-activator",
+        dur_ms: 0,
+        ...input,
+      });
+      if (typeof onControlEvent === "function") onControlEvent(event);
+      if (logger) emitRoleControlEvent(logger, event);
+      return event;
+    } catch {
+      managerCircuitReason = "logger_event_shape_failed";
+      try {
+        writeFallback(
+          `${JSON.stringify({
+            service: "triflux",
+            env: process.env.NODE_ENV || "development",
+            module: "role-activator",
+            event: "capability.degraded",
+            event_id:
+              event?.event_id ??
+              globalThis.crypto?.randomUUID?.() ??
+              "evt_fallback",
+            dur_ms: 0,
+            control_action: "manager_disable",
+            reason_code: managerCircuitReason,
+            level: "error",
+            time: new Date(now()).toISOString(),
+            msg: "capability.degraded",
+          })}\n`,
+        );
+      } catch {}
+      return null;
+    }
+  }
+
+  function runCanary(roleKeyWire) {
+    if (managerCircuitReason) return false;
+    let result;
+    try {
+      result = runCoreCanary({ store, adapter });
+    } catch (error) {
+      result = { ok: false, reason_code: error?.code || "core_canary_failed" };
+    }
+    if (result?.ok !== false) return true;
+    managerCircuitReason = result.reason_code || "core_canary_failed";
+    emitDegraded({
+      control_action: "manager_disable",
+      reason_code: managerCircuitReason,
+      role_key_wire: roleKeyWire,
+    });
+    return false;
+  }
+
+  function eligibleCandidates(roleKey, roleKeyWire, excluded = new Set()) {
+    const currentTime = now();
+    return store
+      .listRoleCandidates(roleKeyWire)
+      .filter((candidate) => !excluded.has(candidate.agent_id))
+      .filter(
+        (candidate) =>
+          candidate.excluded_until_ms == null ||
+          Number(candidate.excluded_until_ms) <= currentTime,
+      )
+      .map((candidate) => {
+        const agent = candidateLive(candidate, store, roleKey, currentTime);
+        if (!agent) return null;
+        const locators = (candidate.transport_locators || [])
+          .filter((locator) =>
+            locatorUsable(locator, adapter, disabledAdapters, currentTime),
+          )
+          .sort(
+            (left, right) =>
+              Number(right.priority || 0) - Number(left.priority || 0) ||
+              String(left.transport_id).localeCompare(
+                String(right.transport_id),
+              ),
+          );
+        return locators.length ? { candidate, agent, locators } : null;
+      })
+      .filter(Boolean);
+  }
+
+  function reserve(roleKey, current, holder, trigger, activationId = uuid()) {
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const result = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      ...(current
+        ? {
+            expected_version: current.version,
+            expected_epoch: current.epoch,
+          }
+        : {}),
+      holder_agent_id: holder?.candidate.agent_id ?? null,
+      holder_lease_expires_ms: holder?.agent.lease_expires_ms ?? null,
+      state: "elected-probing",
+      activation_id: activationId,
+      activation_deadline_ms:
+        now() +
+        (holder ? config.activation_ack_timeout_ms : config.standup_timeout_ms),
+      charter_version: getCharterVersion(roleKey.role_kind),
+      charter_acked_epoch: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: holder ? "candidate_selected" : "standup_reserved",
+    });
+    if (!result.ok) {
+      throw activatorError("ROLE_RESERVATION_CONFLICT", result.reason);
+    }
+    return {
+      roleKey,
+      roleKeyWire,
+      role: result.role,
+      holder,
+      trigger,
+      controlGeneration: controlSnapshot()?.generation ?? 0,
+    };
+  }
+
+  function prepare(normalized) {
+    const { role_key: roleKey, role_key_wire: roleKeyWire } = normalized;
+    const control = controlSnapshot();
+    if (
+      !managerEnabled(control, roleKey.role_kind) ||
+      !runCanary(roleKeyWire)
+    ) {
+      const reasonCode = managerCircuitReason || blockedReason(control);
+      let current = store.getRole(roleKeyWire);
+      if (
+        current &&
+        (current.holder_agent_id ||
+          current.activation_id ||
+          current.state === "active" ||
+          current.state === "elected-probing")
+      ) {
+        current = fencePlan({ roleKeyWire }, reasonCode).role;
+      }
+      return {
+        receipt: receipt("manager_disabled", roleKeyWire, current, {
+          blocked_reason: reasonCode,
+        }),
+      };
+    }
+    if (roleKey.role_kind === "lead" && isScopeClosed(roleKey)) {
+      return {
+        receipt: receipt(
+          "scope_closed",
+          roleKeyWire,
+          store.getRole(roleKeyWire),
+        ),
+      };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    const charterVersion = getCharterVersion(roleKey.role_kind);
+    if (
+      current?.state === "active" &&
+      current.holder_agent_id &&
+      Number(current.holder_lease_expires_ms) > now() &&
+      current.charter_acked_epoch === current.epoch &&
+      current.charter_version === charterVersion &&
+      normalized.trigger !== "charter_issued"
+    ) {
+      return {
+        receipt: receipt("already_active", roleKeyWire, current),
+      };
+    }
+
+    if (
+      current?.state === "elected-probing" &&
+      current.activation_id &&
+      Number(current.activation_deadline_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+    if (
+      ["unreachable", "quarantined"].includes(current?.state) &&
+      Number(current.next_probe_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+
+    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    const holder = candidates[0] || null;
+    const plan = reserve(roleKey, current, holder, normalized.trigger);
+    return { plan, candidates };
+  }
+
+  function cas(plan, patch) {
+    return store.compareAndSetRole({
+      ...activationGuard(plan.role),
+      patch: {
+        last_transition_ms: now(),
+        ...patch,
+      },
+    });
+  }
+
+  function fencePlan(plan, reasonCode) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (!current) return { ok: false, reason: "not_found", role: null };
+    return store.upsertRoleReservation({
+      role_key_wire: plan.roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      blocked_reason: reasonCode,
+      last_transition_ms: now(),
+      last_reason: reasonCode,
+    });
+  }
+
+  async function cancelPlan(plan, reasonCode) {
+    const entry = flights.get(plan.roleKeyWire);
+    if (entry?.cancelledOutcome) return entry.cancelledOutcome;
+    try {
+      await adapter.cancel(plan.role.activation_id);
+    } catch {}
+    const result = fencePlan(plan, reasonCode);
+    return {
+      status: "cancelled",
+      reason_code: reasonCode,
+      role: result.role,
+    };
+  }
+
+  async function gate(plan) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (
+      !current ||
+      current.version !== plan.role.version ||
+      current.epoch !== plan.role.epoch ||
+      current.activation_seq !== plan.role.activation_seq ||
+      current.activation_id !== plan.role.activation_id
+    ) {
+      return { status: "stale", reason_code: "cas_conflict", role: current };
+    }
+    const control = controlSnapshot();
+    if (
+      managerCircuitReason ||
+      !managerEnabled(control, plan.roleKey.role_kind) ||
+      Number(control?.generation ?? 0) !== Number(plan.controlGeneration)
+    ) {
+      return await cancelPlan(
+        plan,
+        managerCircuitReason || blockedReason(control),
+      );
+    }
+    return null;
+  }
+
+  function markCandidateFailure(plan, holder, reasonCode) {
+    const failures =
+      Number(holder.candidate.consecutive_probe_failures || 0) + 1;
+    const delay =
+      failures >= config.max_probe_failures
+        ? config.candidate_quarantine_ms
+        : computeRoleBackoffMs(failures, config, rng);
+    const excludedUntil = now() + delay;
+    store.updateCandidateReachability({
+      role_key_wire: plan.roleKeyWire,
+      agent_id: holder.candidate.agent_id,
+      consecutive_probe_failures: failures,
+      excluded_until_ms: excludedUntil,
+      last_probe_ms: now(),
+      last_probe_code: reasonCode,
+      updated_at_ms: now(),
+    });
+    const failed = cas(plan, {
+      state: "unreachable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      next_probe_ms: excludedUntil,
+      retry_count: Number(plan.role.retry_count || 0) + 1,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "candidate_exclude",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      candidate_agent_id: holder.candidate.agent_id,
+    });
+    return { ...failed, failures, excludedUntil };
+  }
+
+  function scheduleAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      store.compareAndSetRole({
+        ...activationGuard(current),
+        patch: {
+          state: "unreachable",
+          activation_deadline_ms: null,
+          next_probe_ms: now(),
+          last_transition_ms: now(),
+          last_reason: "ack_timeout",
+        },
+      });
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  function deferStandupRetry(plan, reasonCode) {
+    const failures = Number(plan.role.retry_count || 0) + 1;
+    const exhausted = failures >= config.max_probe_failures;
+    const delay = exhausted
+      ? config.candidate_quarantine_ms
+      : computeRoleBackoffMs(failures, config, rng);
+    const result = cas(plan, {
+      state: exhausted ? "quarantined" : "unreachable",
+      holder_agent_id: null,
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: failures,
+      next_probe_ms: now() + delay,
+      blocked_reason: null,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "dispatch_block",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      capability: "standup_activation",
+    });
+    return result;
+  }
+
+  function scheduleStandupAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.holder_agent_id !== null ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      deferStandupRetry({ ...plan, role: current }, "standup_ack_timeout");
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  async function runCandidatePlan(initialPlan, initialCandidates) {
+    let plan = initialPlan;
+    let remaining = initialCandidates;
+    const attempted = new Set();
+
+    while (plan.holder) {
+      const holder = plan.holder;
+      attempted.add(holder.candidate.agent_id);
+      let lastReason = "transport_error";
+
+      for (const locator of holder.locators) {
+        const beforeProbe = await gate(plan);
+        if (beforeProbe) return beforeProbe;
+
+        let rawProbe;
+        try {
+          rawProbe = await adapter.probe(locator, {
+            timeout_ms: config.probe_timeout_ms,
+            signal: flights.get(plan.roleKeyWire)?.controller.signal,
+          });
+        } catch (error) {
+          rawProbe = {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: false,
+            reachable: false,
+            wakeable: false,
+            reason_code: error?.code || "transport_error",
+            transport_id: locator.transport_id,
+          };
+        }
+        const probe = normalizeProbeResult(rawProbe, locator);
+        const afterProbe = await gate(plan);
+        if (afterProbe) return afterProbe;
+
+        if (!probe.ok || !probe.reachable || !probe.wakeable) {
+          lastReason = probe.reason_code || "transport_error";
+          if (lastReason === "adapter_unavailable") {
+            disabledAdapters.add(locator.kind);
+            emitDegraded({
+              control_action: "adapter_disable",
+              reason_code: lastReason,
+              project_id: plan.roleKey.project_id,
+              role_key_wire: plan.roleKeyWire,
+              candidate_agent_id: holder.candidate.agent_id,
+              transport_id: locator.transport_id,
+            });
+          }
+          continue;
+        }
+
+        store.updateCandidateReachability({
+          role_key_wire: plan.roleKeyWire,
+          agent_id: holder.candidate.agent_id,
+          probe_succeeded: true,
+          excluded_until_ms: null,
+          last_probe_ms: now(),
+          last_probe_code: "ok",
+          updated_at_ms: now(),
+        });
+
+        const beforeWake = await gate(plan);
+        if (beforeWake) return beforeWake;
+        let wake;
+        try {
+          wake = await adapter.wake(
+            locator,
+            {
+              schema_version: "tfx.role-activation.v1",
+              role_key: plan.roleKey,
+              role_key_wire: plan.roleKeyWire,
+              epoch: plan.role.epoch,
+              activation_seq: plan.role.activation_seq,
+              activation_id: plan.role.activation_id,
+              charter_version: plan.role.charter_version,
+              holder_cli: holder.agent.cli,
+            },
+            {
+              timeout_ms: config.probe_timeout_ms,
+              signal: flights.get(plan.roleKeyWire)?.controller.signal,
+            },
+          );
+        } catch (error) {
+          wake = { ok: false, reason_code: error?.code || "transport_error" };
+        }
+        const afterWake = await gate(plan);
+        if (afterWake) return afterWake;
+        if (wake?.ok === false) {
+          lastReason = wake.reason_code || "wake_failed";
+          continue;
+        }
+
+        scheduleAckTimeout(plan);
+        return {
+          status: "awaiting_ack",
+          role: store.getRole(plan.roleKeyWire),
+          activation_id: plan.role.activation_id,
+          holder_agent_id: holder.candidate.agent_id,
+          transport_id: locator.transport_id,
+        };
+      }
+
+      const failed = markCandidateFailure(plan, holder, lastReason);
+      if (!failed.ok) {
+        return {
+          status: "stale",
+          reason_code: failed.reason,
+          role: failed.role,
+        };
+      }
+      remaining = eligibleCandidates(plan.roleKey, plan.roleKeyWire, attempted);
+      if (!remaining.length) {
+        if (failed.failures < config.max_probe_failures) {
+          return {
+            status: "unreachable",
+            role: failed.role,
+            reason_code: lastReason,
+          };
+        }
+        const quarantined = store.compareAndSetRole({
+          ...activationGuard(failed.role),
+          patch: {
+            state: "quarantined",
+            activation_id: null,
+            activation_deadline_ms: null,
+            holder_lease_expires_ms: null,
+            last_transition_ms: now(),
+            last_reason: "candidates_excluded",
+          },
+        });
+        return {
+          status: "quarantined",
+          role: quarantined.role,
+          reason_code: lastReason,
+        };
+      }
+      plan = reserve(plan.roleKey, failed.role, remaining[0], plan.trigger);
+    }
+
+    return await runStandupPlan(plan);
+  }
+
+  async function runStandupPlan(plan) {
+    const before = await gate(plan);
+    if (before) return before;
+
+    function blockStandup(reasonCode) {
+      const blocked = cas(plan, {
+        state: "electable",
+        holder_agent_id: null,
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        blocked_reason: "no_candidate",
+        last_reason: reasonCode,
+      });
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: reasonCode,
+        project_id: plan.roleKey.project_id,
+        role_key_wire: plan.roleKeyWire,
+        capability: "standup",
+      });
+      return {
+        status: "blocked",
+        reason_code: reasonCode,
+        role: blocked.role,
+      };
+    }
+
+    if (typeof adapter.standup !== "function") {
+      return blockStandup("standup_unavailable");
+    }
+
+    let locator;
+    try {
+      locator = await adapter.standup(plan.roleKey, "claude", {
+        timeout_ms: config.standup_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        activation: {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+        },
+      });
+    } catch (error) {
+      const afterFailure = await gate(plan);
+      if (afterFailure) return afterFailure;
+      return blockStandup(error?.code || "standup_failed");
+    }
+    const after = await gate(plan);
+    if (after) return after;
+    let supported = false;
+    try {
+      supported = locatorUsable(locator, adapter, disabledAdapters, now());
+    } catch {}
+    if (!supported) return blockStandup("standup_locator_invalid");
+    // C3 binds the stood-up session identity/grant and delivers its charter
+    // ACK. C6a-4 still sends the activation now and bounds retries until that
+    // binding exists, so a missing C3 hook cannot create a tight orphan loop.
+    const wake = await adapter.wake(
+      locator,
+      {
+        schema_version: "tfx.role-activation.v1",
+        role_key: plan.roleKey,
+        role_key_wire: plan.roleKeyWire,
+        epoch: plan.role.epoch,
+        activation_seq: plan.role.activation_seq,
+        activation_id: plan.role.activation_id,
+        charter_version: plan.role.charter_version,
+        holder_cli: "claude",
+      },
+      {
+        timeout_ms: config.probe_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+      },
+    );
+    const afterWake = await gate(plan);
+    if (afterWake) return afterWake;
+    if (wake?.ok !== true) {
+      const reasonCode = wake?.reason_code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
+    scheduleStandupAckTimeout(plan);
+    return {
+      status: "standup_started",
+      role: store.getRole(plan.roleKeyWire),
+      activation_id: plan.role.activation_id,
+      locator,
+    };
+  }
+
+  function startFlight(plan, candidates = []) {
+    const controller = new AbortController();
+    const entry = { controller, plan, promise: null };
+    entry.promise = Promise.resolve()
+      .then(() =>
+        plan.holder ? runCandidatePlan(plan, candidates) : runStandupPlan(plan),
+      )
+      .catch((error) => {
+        const reasonCode = error?.code || "activation_dispatch_failed";
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: reasonCode,
+          project_id: plan.roleKey.project_id,
+          role_key_wire: plan.roleKeyWire,
+        });
+        return {
+          status: "error",
+          reason_code: reasonCode,
+          role: store.getRole(plan.roleKeyWire),
+        };
+      })
+      .finally(() => {
+        if (flights.get(plan.roleKeyWire) === entry) {
+          flights.delete(plan.roleKeyWire);
+        }
+      });
+    flights.set(plan.roleKeyWire, entry);
+    return entry;
+  }
+
+  function requestEnsureRole(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) {
+      return receipt(
+        "joined",
+        normalized.role_key_wire,
+        store.getRole(normalized.role_key_wire),
+      );
+    }
+
+    let prepared;
+    try {
+      prepared = prepare(normalized, context);
+    } catch (error) {
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: error?.code || "activation_reservation_failed",
+        project_id: normalized.role_key.project_id,
+        role_key_wire: normalized.role_key_wire,
+      });
+      throw error;
+    }
+    if (prepared.receipt) return prepared.receipt;
+    startFlight(prepared.plan, prepared.candidates);
+    return receipt("started", normalized.role_key_wire, prepared.plan.role);
+  }
+
+  async function ensureRoleAwake(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) return await currentFlight.promise;
+    const result = requestEnsureRole(request, context);
+    const started = flights.get(normalized.role_key_wire);
+    return started ? await started.promise : result;
+  }
+
+  function ackActivation(input, context = {}) {
+    if (
+      !isRecord(input) ||
+      input.schema_version !== ROLE_ACTIVATION_ACK_SCHEMA_VERSION ||
+      input.reachable !== true ||
+      !isRecord(input.charter_ack)
+    ) {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+    let roleKey;
+    let roleKeyWire;
+    try {
+      roleKey = normalizeRoleKey(input.role_key);
+      roleKeyWire = encodeRoleKey(roleKey);
+      if (encodeRoleKey(input.charter_ack.role_key) !== roleKeyWire) {
+        return { ok: false, code: "STALE_EPOCH" };
+      }
+    } catch {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    if (!current) return { ok: false, code: "STALE_EPOCH" };
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      const fenced = fencePlan(
+        { roleKeyWire },
+        managerCircuitReason || blockedReason(control),
+      );
+      return { ok: false, code: "STALE_EPOCH", role: fenced.role };
+    }
+    if (
+      input.epoch !== current.epoch ||
+      input.activation_seq !== current.activation_seq ||
+      input.activation_id !== current.activation_id ||
+      input.charter_ack.epoch !== current.epoch
+    ) {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+    const principalAgentId = context?.principal?.agent_id;
+    if (
+      input.holder_agent_id !== current.holder_agent_id ||
+      principalAgentId !== current.holder_agent_id
+    ) {
+      return { ok: false, code: "HOLDER_MISMATCH", role: current };
+    }
+    if (
+      input.charter_ack.charter_version !== current.charter_version ||
+      input.charter_ack.charter_version !== getCharterVersion(roleKey.role_kind)
+    ) {
+      return { ok: false, code: "CHARTER_VERSION_MISMATCH", role: current };
+    }
+    const holder = store.getAgent(current.holder_agent_id);
+    if (
+      !holder ||
+      holder.status !== "online" ||
+      Number(holder.lease_expires_ms) <= now() ||
+      Number(current.holder_lease_expires_ms) <= now()
+    ) {
+      return { ok: false, code: "HOLDER_LEASE_EXPIRED", role: current };
+    }
+    if (
+      current.state === "active" &&
+      current.charter_acked_epoch === current.epoch
+    ) {
+      return { ok: true, idempotent: true, role: current, ack: input };
+    }
+    if (current.state !== "elected-probing") {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+
+    const activated = store.compareAndSetRole({
+      ...activationGuard(current),
+      patch: {
+        state: "active",
+        charter_acked_epoch: current.epoch,
+        activation_deadline_ms: null,
+        blocked_reason: null,
+        last_transition_ms: now(),
+        last_reason: "activation_acked",
+      },
+    });
+    if (!activated.ok) {
+      return { ok: false, code: "STALE_EPOCH", role: activated.role };
+    }
+    const timer = ackTimers.get(current.activation_id);
+    if (timer) clearScheduledTimeout(timer);
+    ackTimers.delete(current.activation_id);
+    if (typeof onRoleActive === "function") {
+      try {
+        onRoleActive({ role: activated.role, ack: input });
+      } catch (error) {
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: error?.code || "backlog_transfer_failed",
+          project_id: roleKey.project_id,
+          role_key_wire: roleKeyWire,
+        });
+      }
+    }
+    return { ok: true, idempotent: false, role: activated.role, ack: input };
+  }
+
+  async function drain() {
+    await Promise.allSettled(
+      [...flights.values()].map((entry) => entry.promise),
+    );
+  }
+
+  function close() {
+    for (const entry of flights.values()) entry.controller.abort();
+    for (const timer of ackTimers.values()) clearScheduledTimeout(timer);
+    ackTimers.clear();
+  }
+
+  function updateControlSnapshot(snapshot) {
+    const previousGeneration = Number(controlSnapshot()?.generation ?? 0);
+    controlOverride = snapshot;
+    if (Number(snapshot?.generation ?? 0) !== previousGeneration) {
+      disabledAdapters.clear();
+    }
+    for (const entry of flights.values()) {
+      if (managerEnabled(snapshot, entry.plan.roleKey.role_kind)) continue;
+      entry.controller.abort();
+      Promise.resolve(adapter.cancel(entry.plan.role.activation_id)).catch(
+        () => {},
+      );
+      const result = fencePlan(entry.plan, blockedReason(snapshot));
+      entry.cancelledOutcome = {
+        status: "cancelled",
+        reason_code: blockedReason(snapshot),
+        role: result.role,
+      };
+    }
+    return snapshot;
+  }
+
+  function notifyCandidateChanged(
+    roleKeyInput,
+    agentId,
+    reason = "candidate_registered",
+  ) {
+    const roleKey = normalizeRoleKey(roleKeyInput);
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const candidateResult = store.updateCandidateReachability({
+      role_key_wire: roleKeyWire,
+      agent_id: agentId,
+      probe_succeeded: true,
+      excluded_until_ms: null,
+      last_probe_ms: now(),
+      last_probe_code: reason,
+      updated_at_ms: now(),
+    });
+    if (!candidateResult.ok) return candidateResult;
+
+    const current = store.getRole(roleKeyWire);
+    if (!current || current.state !== "quarantined") {
+      return { ok: true, candidate: candidateResult.candidate, role: current };
+    }
+    const restored = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: 0,
+      next_probe_ms: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: reason,
+    });
+    return {
+      ok: restored.ok,
+      candidate: candidateResult.candidate,
+      role: restored.role,
+      ...(restored.ok ? {} : { reason: restored.reason }),
+    };
+  }
+
+  function ensureExpiredRoles(sweepNow = now()) {
+    const receipts = [];
+    for (const expired of store.listRolesWithExpiredHolder(sweepNow)) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(expired.role_key_wire);
+      } catch {
+        continue;
+      }
+      const current = store.getRole(expired.role_key_wire);
+      if (
+        !current ||
+        current.holder_agent_id == null ||
+        Number(current.holder_lease_expires_ms) > sweepNow
+      ) {
+        continue;
+      }
+      const flight = flights.get(expired.role_key_wire);
+      if (flight) {
+        flight.controller.abort();
+        Promise.resolve(adapter.cancel(flight.plan.role.activation_id)).catch(
+          () => {},
+        );
+        flight.cancelledOutcome = {
+          status: "cancelled",
+          reason_code: "holder_lease_expired",
+          role: current,
+        };
+        flights.delete(expired.role_key_wire);
+      }
+      const fenced = store.upsertRoleReservation({
+        role_key_wire: expired.role_key_wire,
+        expected_version: current.version,
+        expected_epoch: current.epoch,
+        holder_agent_id: null,
+        previous_holder_agent_id: current.holder_agent_id,
+        state: "electable",
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        charter_acked_epoch: null,
+        blocked_reason: null,
+        last_transition_ms: sweepNow,
+        last_reason: "holder_lease_expired",
+      });
+      if (!fenced.ok) continue;
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "lease_expired",
+            cause_id: `lease:${expired.role_key_wire}:${sweepNow}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "sweeper",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  function ensureRecoveredRoles(recovery) {
+    const receipts = [];
+    for (const recovered of recovery?.roles || []) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(recovered.role_key_wire);
+      } catch {
+        continue;
+      }
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "restart_recovery",
+            cause_id: `restart:${recovered.role_key_wire}:${recovered.epoch}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "hub-recovery",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  return {
+    requestEnsureRole,
+    ensureRole: ensureRoleAwake,
+    ensureRoleAwake,
+    ackActivation,
+    updateControlSnapshot,
+    notifyCandidateChanged,
+    ensureExpiredRoles,
+    ensureRecoveredRoles,
+    drain,
+    close,
+    isRoleManaged(roleKeyInput) {
+      const roleKey = normalizeRoleKey(roleKeyInput);
+      return (
+        !managerCircuitReason &&
+        managerEnabled(controlSnapshot(), roleKey.role_kind) &&
+        !(roleKey.role_kind === "lead" && isScopeClosed(roleKey))
+      );
+    },
+    getRoleSnapshot(roleKey) {
+      return store.getRole(encodeRoleKey(roleKey));
+    },
+  };
+}
+
+export async function ensureRoleAwake(activator, request, context = {}) {
+  if (!activator || typeof activator.ensureRoleAwake !== "function") {
+    throw activatorError("ROLE_ACTIVATOR_INVALID");
+  }
+  return await activator.ensureRoleAwake(request, context);
+}

--- a/hub/role-activator.mjs
+++ b/hub/role-activator.mjs
@@ -776,23 +776,34 @@ export function createRoleActivator(options = {}) {
     // C3 binds the stood-up session identity/grant and delivers its charter
     // ACK. C6a-4 still sends the activation now and bounds retries until that
     // binding exists, so a missing C3 hook cannot create a tight orphan loop.
-    const wake = await adapter.wake(
-      locator,
-      {
-        schema_version: "tfx.role-activation.v1",
-        role_key: plan.roleKey,
-        role_key_wire: plan.roleKeyWire,
-        epoch: plan.role.epoch,
-        activation_seq: plan.role.activation_seq,
-        activation_id: plan.role.activation_id,
-        charter_version: plan.role.charter_version,
-        holder_cli: "claude",
-      },
-      {
-        timeout_ms: config.probe_timeout_ms,
-        signal: flights.get(plan.roleKeyWire)?.controller.signal,
-      },
-    );
+    let wake;
+    try {
+      wake = await adapter.wake(
+        locator,
+        {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+          holder_cli: "claude",
+        },
+        {
+          timeout_ms: config.probe_timeout_ms,
+          signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        },
+      );
+    } catch (error) {
+      const reasonCode = error?.code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
     const afterWake = await gate(plan);
     if (afterWake) return afterWake;
     if (wake?.ok !== true) {

--- a/hub/role-activator.mjs
+++ b/hub/role-activator.mjs
@@ -509,16 +509,11 @@ export function createRoleActivator(options = {}) {
       ) {
         return;
       }
-      store.compareAndSetRole({
-        ...activationGuard(current),
-        patch: {
-          state: "unreachable",
-          activation_deadline_ms: null,
-          next_probe_ms: now(),
-          last_transition_ms: now(),
-          last_reason: "ack_timeout",
-        },
-      });
+      markCandidateFailure(
+        { ...plan, role: current },
+        plan.holder,
+        "ack_timeout",
+      );
     }, delay);
     timer?.unref?.();
     ackTimers.set(plan.role.activation_id, timer);

--- a/hub/role-activator.mjs
+++ b/hub/role-activator.mjs
@@ -963,6 +963,7 @@ export function createRoleActivator(options = {}) {
         state: "active",
         charter_acked_epoch: current.epoch,
         activation_deadline_ms: null,
+        retry_count: 0,
         blocked_reason: null,
         last_transition_ms: now(),
         last_reason: "activation_acked",
@@ -1029,6 +1030,13 @@ export function createRoleActivator(options = {}) {
     reason = "candidate_registered",
   ) {
     const roleKey = normalizeRoleKey(roleKeyInput);
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      return {
+        ok: false,
+        reason_code: managerCircuitReason || blockedReason(control),
+      };
+    }
     const roleKeyWire = encodeRoleKey(roleKey);
     const candidateResult = store.updateCandidateReachability({
       role_key_wire: roleKeyWire,

--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -370,6 +370,7 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  */
 export function createRouter(store, options = {}) {
   const roleActivator = options.roleActivator || null;
+  const hubLog = options.logger || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -2039,7 +2040,11 @@ export function createRouter(store, options = {}) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
-      roleActivator?.ensureExpiredRoles?.(Date.now());
+      try {
+        roleActivator?.ensureExpiredRoles?.(Date.now());
+      } catch (err) {
+        hubLog?.warn?.({ err }, "role_activator.expiry_sweep_degraded");
+      }
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/hub/router.mjs
+++ b/hub/router.mjs
@@ -9,7 +9,11 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
-import { normalizeRoleKey } from "./role-contract.mjs";
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -364,7 +368,8 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  * 라우터 생성
  * @param {object} store
  */
-export function createRouter(store) {
+export function createRouter(store, options = {}) {
+  const roleActivator = options.roleActivator || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -486,6 +491,57 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function scopedRoleForMessage(message = {}) {
+    const to = String(message.to_agent ?? message.to ?? "");
+    const prefix = "topic:role:";
+    if (to.startsWith(prefix)) {
+      const roleKeyWire = to.slice(prefix.length);
+      try {
+        return { roleKey: decodeRoleKey(roleKeyWire), roleKeyWire };
+      } catch {
+        return null;
+      }
+    }
+    if (to !== "topic:cto") return null;
+    const from = message.from_agent ?? message.from;
+    const projectId = message.project_id ?? store.getAgent(from)?.project_id;
+    if (!projectId) return null;
+    try {
+      const roleKey = normalizeRoleKey({
+        project_id: projectId,
+        role_kind: "cto",
+      });
+      return { roleKey, roleKeyWire: encodeRoleKey(roleKey) };
+    } catch {
+      return null;
+    }
+  }
+
+  function requestRoleActivation(message, trigger = "publish_no_holder") {
+    if (!roleActivator?.requestEnsureRole) return undefined;
+    const scoped = scopedRoleForMessage(message);
+    if (!scoped) return undefined;
+    try {
+      return roleActivator.requestEnsureRole(
+        {
+          schema_version: "tfx.ensure-role.v1",
+          role_key: scoped.roleKey,
+          trigger,
+          cause_id: String(message.id || message.correlation_id || uuidv7()),
+        },
+        {
+          principal: {
+            type: "system",
+            service: trigger === "session_start" ? "session-hook" : "router",
+            project_id: scoped.roleKey.project_id,
+          },
+        },
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   function ensureRoleState(roleName) {
@@ -655,6 +711,7 @@ export function createRouter(store) {
   }
 
   function shouldTrackWithoutRecipients(message) {
+    if (roleActivator && scopedRoleForMessage(message)) return true;
     const to = message?.to_agent ?? message?.to;
     if (!String(to || "").startsWith("topic:")) return false;
     return ROLE_TOPICS.has(String(to).slice(6));
@@ -874,10 +931,69 @@ export function createRouter(store) {
     deliveryEmitter.emit("message", agentId, message);
   }
 
+  function activateScopedRoleHolder(role) {
+    if (!role?.role_key_wire || !role.holder_agent_id) return 0;
+    const current = store.getRole(role.role_key_wire);
+    if (
+      !current ||
+      current.state !== "active" ||
+      current.charter_acked_epoch !== current.epoch ||
+      current.holder_agent_id !== role.holder_agent_id ||
+      current.epoch !== role.epoch ||
+      current.activation_seq !== role.activation_seq ||
+      current.activation_id !== role.activation_id ||
+      current.version !== role.version
+    ) {
+      return 0;
+    }
+
+    let transferred = 0;
+    for (const message of store.listPendingRoleMessages(
+      role.role_key_wire,
+      Date.now(),
+    )) {
+      let record = getMessageRecord(message.id);
+      if (!record) {
+        trackMessage(message, [current.holder_agent_id]);
+        record = getMessageRecord(message.id);
+      } else {
+        record.recipients.add(current.holder_agent_id);
+      }
+      if (!queuesByAgent.get(current.holder_agent_id)?.has(message.id)) {
+        queueMessage(current.holder_agent_id, record.message);
+        transferred += 1;
+      }
+      record.message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+    return transferred;
+  }
+
   function resolveRecipients(msg) {
     const to = msg.to_agent ?? msg.to;
     if (!to?.startsWith("topic:")) {
       return [to];
+    }
+
+    if (roleActivator) {
+      const scoped = scopedRoleForMessage(msg);
+      if (scoped) {
+        const role = store.getRole(scoped.roleKeyWire);
+        const managed = roleActivator.isRoleManaged?.(scoped.roleKey) !== false;
+        if (role && managed) {
+          const holder = role.holder_agent_id
+            ? store.getAgent(role.holder_agent_id)
+            : null;
+          const active =
+            role.state === "active" &&
+            role.charter_acked_epoch === role.epoch &&
+            Number(role.holder_lease_expires_ms) > Date.now() &&
+            holder?.status === "online" &&
+            Number(holder.lease_expires_ms) > Date.now();
+          return active ? [role.holder_agent_id] : [];
+        }
+        if (to !== "topic:cto") return [];
+      }
     }
 
     const topic = to.slice(6);
@@ -993,6 +1109,8 @@ export function createRouter(store) {
     trace_id,
     correlation_id,
   }) {
+    const messageIdentity = { from, to, project_id: payload?.project_id };
+    const scoped = scopedRoleForMessage(messageIdentity);
     const msg = store.auditLog({
       type,
       from,
@@ -1003,6 +1121,7 @@ export function createRouter(store) {
       payload,
       trace_id,
       correlation_id,
+      role_key_wire: scoped?.roleKeyWire ?? null,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
     if (recipients.length || shouldTrackWithoutRecipients(msg)) {
@@ -1018,7 +1137,11 @@ export function createRouter(store) {
     if (msg.type === "response") {
       responseEmitter.emit(msg.correlation_id, msg.payload);
     }
-    return { msg, recipients };
+    const activation =
+      recipients.length === 0
+        ? requestRoleActivation(msg, "publish_no_holder")
+        : undefined;
+    return { msg, recipients, activation };
   }
 
   function buildAssignSnapshot(job, extra = {}) {
@@ -1186,6 +1309,29 @@ export function createRouter(store) {
     responseEmitter,
     deliveryEmitter,
 
+    activateScopedRoleHolder,
+
+    requestEnsureRole(request, context = {}) {
+      if (!roleActivator?.requestEnsureRole) {
+        return {
+          accepted: false,
+          disposition: "manager_disabled",
+          role_key_wire: encodeRoleKey(request.role_key),
+          state: "electable",
+          epoch: 0,
+          blocked_reason: "activator_unavailable",
+        };
+      }
+      return roleActivator.requestEnsureRole(request, context);
+    },
+
+    ackRoleActivation(ack, context = {}) {
+      if (!roleActivator?.ackActivation) {
+        return { ok: false, code: "ROLE_ACTIVATOR_UNAVAILABLE" };
+      }
+      return roleActivator.ackActivation(ack, context);
+    },
+
     registerAgent(args) {
       const identityFailure = validateCallerIdentity(args);
       if (identityFailure) return identityFailure;
@@ -1217,6 +1363,17 @@ export function createRouter(store) {
           reason: "register",
           transferBacklog: true,
         });
+      }
+      if (roleActivator && identity?.project_id && identity?.session_id) {
+        requestRoleActivation(
+          {
+            id: identity.session_id,
+            from_agent: args.agent_id,
+            to_agent: "topic:cto",
+            project_id: identity.project_id,
+          },
+          "session_start",
+        );
       }
       return {
         ok: true,
@@ -1319,6 +1476,7 @@ export function createRouter(store) {
         if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
           trackMessage(msg, []);
         }
+        requestRoleActivation(msg, "publish_no_holder");
         return 0;
       }
       if (!getMessageRecord(msg.id)) {
@@ -1470,7 +1628,7 @@ export function createRouter(store) {
       message_type,
     }) {
       const type = message_type || (correlation_id ? "response" : "event");
-      const { msg, recipients } = dispatchMessage({
+      const { msg, recipients, activation } = dispatchMessage({
         type,
         from,
         to,
@@ -1487,7 +1645,13 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
-          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+          role:
+            roleActivator && scopedRoleForMessage(msg)
+              ? roleActivator.getRoleSnapshot(scopedRoleForMessage(msg).roleKey)
+              : to === "topic:cto"
+                ? getRoleSnapshot("cto")
+                : undefined,
+          activation,
         },
       };
     },
@@ -1875,6 +2039,7 @@ export function createRouter(store) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
+      roleActivator?.ensureExpiredRoles?.(Date.now());
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -38,6 +38,7 @@ import {
   reapExistingHubProcesses,
   resolveHubPortForContext,
 } from "./hub-lifecycle.mjs";
+import { resolveRoleControlSnapshot } from "./lib/cto-env.mjs";
 import {
   cleanupOrphanNodeProcesses,
   cleanupOrphanRuntimeProcesses,
@@ -60,6 +61,8 @@ import { focusSessionOnMac } from "./mac-focus.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
+import { createRoleActivator } from "./role-activator.mjs";
+import { createTfxLiveRoleAdapter } from "./role-activator-tfx-live.mjs";
 import { createRouter } from "./router.mjs";
 import { createAdaptiveFingerprintService } from "./session-fingerprint.mjs";
 import {
@@ -1063,7 +1066,44 @@ export async function startHub({
   }
 
   const store = await createStoreAdapter(dbPath);
-  const router = createRouter(store);
+  const roleStoreMethods = [
+    "getAgent",
+    "getRole",
+    "upsertRoleReservation",
+    "compareAndSetRole",
+    "listRoleCandidates",
+    "updateCandidateReachability",
+    "listRolesWithExpiredHolder",
+    "listPendingRoleMessages",
+    "recoverRoleRegistry",
+  ];
+  const roleStoreReady = roleStoreMethods.every(
+    (method) => typeof store[method] === "function",
+  );
+  let roleControlSnapshot = resolveRoleControlSnapshot(process.env);
+  const getRoleControlSnapshot = () => {
+    roleControlSnapshot = resolveRoleControlSnapshot(process.env, {
+      previous: roleControlSnapshot,
+    });
+    return roleControlSnapshot;
+  };
+  let router;
+  const roleActivator = roleStoreReady
+    ? createRoleActivator({
+        store,
+        adapter: createTfxLiveRoleAdapter({ projectRoot: PROJECT_ROOT }),
+        getControlSnapshot: getRoleControlSnapshot,
+        getCharterVersion: (roleKind) =>
+          roleKind === "lead" ? "tfx.lead-charter.v1" : "tfx.cto-charter.v1",
+        logger: hubLog,
+        onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
+      })
+    : null;
+  router = createRouter(store, { roleActivator });
+  if (roleActivator) {
+    const recovered = store.recoverRoleRegistry(Date.now());
+    roleActivator.ensureRecoveredRoles(recovered);
+  }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 
   // Neural Memory adaptive engine 초기화
@@ -2469,6 +2509,9 @@ export async function startHub({
       await delegatorWorker.stop();
     } catch {}
     try {
+      roleActivator?.close();
+    } catch {}
+    try {
       store.close();
     } catch {}
     if (!ephemeralPort && !preserveTokenFile) {
@@ -2675,6 +2718,7 @@ export async function startHub({
               try {
                 synapseRegistry.destroy();
               } catch {}
+              roleActivator?.close();
               store.close();
               if (!ephemeralPort) {
                 cleanupOwnedPidFile();

--- a/hub/server.mjs
+++ b/hub/server.mjs
@@ -1099,10 +1099,14 @@ export async function startHub({
         onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
       })
     : null;
-  router = createRouter(store, { roleActivator });
+  router = createRouter(store, { roleActivator, logger: hubLog });
   if (roleActivator) {
     const recovered = store.recoverRoleRegistry(Date.now());
-    roleActivator.ensureRecoveredRoles(recovered);
+    try {
+      roleActivator.ensureRecoveredRoles(recovered);
+    } catch (err) {
+      hubLog.warn({ err }, "role_activator.recovery_degraded");
+    }
   }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 

--- a/hub/store.mjs
+++ b/hub/store.mjs
@@ -653,19 +653,23 @@ export function createStore(dbPath, options = {}) {
           : (current?.previous_holder_agent_id ?? null)),
       epoch: nextEpoch,
       activation_seq: nextActivationSeq,
-      activation_id:
-        input.activation_id ??
-        (input.holder_agent_id ? uuidv7() : (current?.activation_id ?? null)),
-      activation_deadline_ms:
-        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
-      holder_lease_expires_ms:
-        input.holder_lease_expires_ms ??
-        current?.holder_lease_expires_ms ??
-        null,
-      charter_version:
-        input.charter_version ?? current?.charter_version ?? null,
-      charter_acked_epoch:
-        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      activation_id: Object.hasOwn(input, "activation_id")
+        ? input.activation_id
+        : input.holder_agent_id
+          ? uuidv7()
+          : (current?.activation_id ?? null),
+      activation_deadline_ms: Object.hasOwn(input, "activation_deadline_ms")
+        ? input.activation_deadline_ms
+        : (current?.activation_deadline_ms ?? null),
+      holder_lease_expires_ms: Object.hasOwn(input, "holder_lease_expires_ms")
+        ? input.holder_lease_expires_ms
+        : (current?.holder_lease_expires_ms ?? null),
+      charter_version: Object.hasOwn(input, "charter_version")
+        ? input.charter_version
+        : (current?.charter_version ?? null),
+      charter_acked_epoch: Object.hasOwn(input, "charter_acked_epoch")
+        ? input.charter_acked_epoch
+        : (current?.charter_acked_epoch ?? null),
       retry_count: input.retry_count ?? current?.retry_count ?? 0,
       next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
       blocked_reason:

--- a/packages/core/hub/role-activator.mjs
+++ b/packages/core/hub/role-activator.mjs
@@ -375,14 +375,18 @@ export function createRoleActivator(options = {}) {
     ) {
       return { receipt: receipt("joined", roleKeyWire, current) };
     }
+    let candidates;
     if (
       ["unreachable", "quarantined"].includes(current?.state) &&
       Number(current.next_probe_ms) > now()
     ) {
-      return { receipt: receipt("joined", roleKeyWire, current) };
+      candidates = eligibleCandidates(roleKey, roleKeyWire);
+      if (!candidates.length) {
+        return { receipt: receipt("joined", roleKeyWire, current) };
+      }
     }
 
-    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    candidates ??= eligibleCandidates(roleKey, roleKeyWire);
     const holder = candidates[0] || null;
     const plan = reserve(roleKey, current, holder, normalized.trigger);
     return { plan, candidates };
@@ -791,12 +795,9 @@ export function createRoleActivator(options = {}) {
         },
       );
     } catch (error) {
-      const reasonCode = error?.code || "standup_wake_failed";
-      const deferred = deferStandupRetry(plan, reasonCode);
-      return {
-        status: deferred.role?.state || "unreachable",
-        reason_code: reasonCode,
-        role: deferred.role,
+      wake = {
+        ok: false,
+        reason_code: error?.code || "standup_wake_failed",
       };
     }
     const afterWake = await gate(plan);

--- a/packages/core/hub/role-activator.mjs
+++ b/packages/core/hub/role-activator.mjs
@@ -1,0 +1,1195 @@
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
+import {
+  buildCapabilityDegradedEvent,
+  emitRoleControlEvent,
+} from "./role-control-events.mjs";
+
+export const ENSURE_ROLE_SCHEMA_VERSION = "tfx.ensure-role.v1";
+export const ROLE_ACTIVATION_ACK_SCHEMA_VERSION = "tfx.role-activation-ack.v1";
+
+const ENSURE_ROLE_TRIGGERS = new Set([
+  "session_start",
+  "publish_no_holder",
+  "lease_expired",
+  "restart_recovery",
+  "hygiene_changed",
+  "charter_issued",
+  "manual",
+]);
+const REQUIRED_LOCATOR_CAPABILITIES = ["probe", "wake", "activate"];
+const DEFAULTS = Object.freeze({
+  probe_timeout_ms: 10_000,
+  activation_ack_timeout_ms: 45_000,
+  standup_timeout_ms: 60_000,
+  max_probe_failures: 3,
+  backoff_base_ms: 1_000,
+  backoff_factor: 2,
+  backoff_max_ms: 30_000,
+  backoff_jitter_ratio: 0.2,
+  candidate_quarantine_ms: 120_000,
+});
+
+function activatorError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeEnsureRequest(request, now) {
+  if (
+    !isRecord(request) ||
+    request.schema_version !== ENSURE_ROLE_SCHEMA_VERSION ||
+    !ENSURE_ROLE_TRIGGERS.has(request.trigger) ||
+    typeof request.cause_id !== "string" ||
+    !request.cause_id.trim()
+  ) {
+    throw activatorError("ENSURE_ROLE_REQUEST_INVALID");
+  }
+  const roleKey = normalizeRoleKey(request.role_key);
+  return {
+    schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+    role_key: roleKey,
+    role_key_wire: encodeRoleKey(roleKey),
+    trigger: request.trigger,
+    cause_id: request.cause_id.trim(),
+    requested_at_ms: now(),
+  };
+}
+
+function managerEnabled(control, roleKind) {
+  if (!control?.master_enabled) return false;
+  return roleKind === "cto"
+    ? control.cto_manager_enabled === true
+    : control.lead_manager_enabled === true;
+}
+
+function blockedReason(control) {
+  return control?.master_enabled ? "manager_disabled" : "master_off";
+}
+
+function receipt(disposition, roleKeyWire, role, extra = {}) {
+  return {
+    accepted: !["manager_disabled", "scope_closed"].includes(disposition),
+    disposition,
+    role_key_wire: roleKeyWire,
+    state: role?.state ?? "electable",
+    epoch: role?.epoch ?? 0,
+    ...(role?.activation_id ? { activation_id: role.activation_id } : {}),
+    ...extra,
+  };
+}
+
+function activationGuard(role) {
+  return {
+    role_key_wire: role.role_key_wire,
+    expected_version: role.version,
+    expected_epoch: role.epoch,
+    expected_activation_seq: role.activation_seq,
+    expected_activation_id: role.activation_id,
+  };
+}
+
+function locatorUsable(locator, adapter, disabledAdapters, now) {
+  return (
+    isRecord(locator) &&
+    locator.schema_version === "tfx.transport-locator.v1" &&
+    typeof locator.kind === "string" &&
+    !disabledAdapters.has(locator.kind) &&
+    Number(locator.expires_at_ms) > now &&
+    Array.isArray(locator.capabilities) &&
+    REQUIRED_LOCATOR_CAPABILITIES.every((capability) =>
+      locator.capabilities.includes(capability),
+    ) &&
+    adapter.supports(locator) === true
+  );
+}
+
+function candidateLive(candidate, store, roleKey, now) {
+  const agent = store.getAgent(candidate.agent_id);
+  if (
+    !agent ||
+    agent.status !== "online" ||
+    Number(agent.lease_expires_ms) <= now
+  ) {
+    return null;
+  }
+  if (agent.project_id && agent.project_id !== roleKey.project_id) return null;
+  const capabilities = Array.isArray(agent.capabilities)
+    ? agent.capabilities
+    : [];
+  if (!capabilities.includes(`role:${roleKey.role_kind}:candidate`))
+    return null;
+  return agent;
+}
+
+function normalizeProbeResult(result, locator) {
+  if (
+    !isRecord(result) ||
+    result.schema_version !== "tfx-live.transport-probe.v1"
+  ) {
+    return {
+      ok: false,
+      reachable: false,
+      wakeable: false,
+      reason_code: "protocol_mismatch",
+      transport_id: locator.transport_id,
+    };
+  }
+  return result;
+}
+
+export function computeRoleBackoffMs(
+  failureCount,
+  config = {},
+  rng = Math.random,
+) {
+  const options = { ...DEFAULTS, ...config };
+  const count = Math.max(1, Number(failureCount) || 1);
+  const base = Math.min(
+    options.backoff_base_ms * options.backoff_factor ** (count - 1),
+    options.backoff_max_ms,
+  );
+  const unit = Math.max(0, Math.min(1, Number(rng()) || 0));
+  const jitter = (unit * 2 - 1) * options.backoff_jitter_ratio;
+  return Math.round(base * (1 + jitter));
+}
+
+export function createRoleActivator(options = {}) {
+  const {
+    store,
+    adapter,
+    getControlSnapshot = () => ({
+      generation: 0,
+      master_enabled: false,
+      cto_manager_enabled: false,
+      lead_manager_enabled: false,
+    }),
+    getCharterVersion = () => null,
+    isScopeClosed = () => false,
+    runCoreCanary = () => ({ ok: true }),
+    uuid = () => globalThis.crypto.randomUUID(),
+    now = Date.now,
+    rng = Math.random,
+    logger = null,
+    onControlEvent = null,
+    onRoleActive = null,
+    scheduleTimeout = setTimeout,
+    clearScheduledTimeout = clearTimeout,
+    writeFallback = (line) => process.stderr.write(line),
+  } = options;
+  const config = { ...DEFAULTS, ...(options.config || {}) };
+  if (!store || !adapter)
+    throw activatorError("ROLE_ACTIVATOR_DEPENDENCY_INVALID");
+
+  const flights = new Map();
+  const ackTimers = new Map();
+  const disabledAdapters = new Set();
+  let controlOverride = null;
+  let managerCircuitReason = null;
+
+  function controlSnapshot() {
+    return controlOverride || getControlSnapshot();
+  }
+
+  function emitDegraded(input) {
+    let event = null;
+    try {
+      event = buildCapabilityDegradedEvent({
+        module: "role-activator",
+        dur_ms: 0,
+        ...input,
+      });
+      if (typeof onControlEvent === "function") onControlEvent(event);
+      if (logger) emitRoleControlEvent(logger, event);
+      return event;
+    } catch {
+      managerCircuitReason = "logger_event_shape_failed";
+      try {
+        writeFallback(
+          `${JSON.stringify({
+            service: "triflux",
+            env: process.env.NODE_ENV || "development",
+            module: "role-activator",
+            event: "capability.degraded",
+            event_id:
+              event?.event_id ??
+              globalThis.crypto?.randomUUID?.() ??
+              "evt_fallback",
+            dur_ms: 0,
+            control_action: "manager_disable",
+            reason_code: managerCircuitReason,
+            level: "error",
+            time: new Date(now()).toISOString(),
+            msg: "capability.degraded",
+          })}\n`,
+        );
+      } catch {}
+      return null;
+    }
+  }
+
+  function runCanary(roleKeyWire) {
+    if (managerCircuitReason) return false;
+    let result;
+    try {
+      result = runCoreCanary({ store, adapter });
+    } catch (error) {
+      result = { ok: false, reason_code: error?.code || "core_canary_failed" };
+    }
+    if (result?.ok !== false) return true;
+    managerCircuitReason = result.reason_code || "core_canary_failed";
+    emitDegraded({
+      control_action: "manager_disable",
+      reason_code: managerCircuitReason,
+      role_key_wire: roleKeyWire,
+    });
+    return false;
+  }
+
+  function eligibleCandidates(roleKey, roleKeyWire, excluded = new Set()) {
+    const currentTime = now();
+    return store
+      .listRoleCandidates(roleKeyWire)
+      .filter((candidate) => !excluded.has(candidate.agent_id))
+      .filter(
+        (candidate) =>
+          candidate.excluded_until_ms == null ||
+          Number(candidate.excluded_until_ms) <= currentTime,
+      )
+      .map((candidate) => {
+        const agent = candidateLive(candidate, store, roleKey, currentTime);
+        if (!agent) return null;
+        const locators = (candidate.transport_locators || [])
+          .filter((locator) =>
+            locatorUsable(locator, adapter, disabledAdapters, currentTime),
+          )
+          .sort(
+            (left, right) =>
+              Number(right.priority || 0) - Number(left.priority || 0) ||
+              String(left.transport_id).localeCompare(
+                String(right.transport_id),
+              ),
+          );
+        return locators.length ? { candidate, agent, locators } : null;
+      })
+      .filter(Boolean);
+  }
+
+  function reserve(roleKey, current, holder, trigger, activationId = uuid()) {
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const result = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      ...(current
+        ? {
+            expected_version: current.version,
+            expected_epoch: current.epoch,
+          }
+        : {}),
+      holder_agent_id: holder?.candidate.agent_id ?? null,
+      holder_lease_expires_ms: holder?.agent.lease_expires_ms ?? null,
+      state: "elected-probing",
+      activation_id: activationId,
+      activation_deadline_ms:
+        now() +
+        (holder ? config.activation_ack_timeout_ms : config.standup_timeout_ms),
+      charter_version: getCharterVersion(roleKey.role_kind),
+      charter_acked_epoch: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: holder ? "candidate_selected" : "standup_reserved",
+    });
+    if (!result.ok) {
+      throw activatorError("ROLE_RESERVATION_CONFLICT", result.reason);
+    }
+    return {
+      roleKey,
+      roleKeyWire,
+      role: result.role,
+      holder,
+      trigger,
+      controlGeneration: controlSnapshot()?.generation ?? 0,
+    };
+  }
+
+  function prepare(normalized) {
+    const { role_key: roleKey, role_key_wire: roleKeyWire } = normalized;
+    const control = controlSnapshot();
+    if (
+      !managerEnabled(control, roleKey.role_kind) ||
+      !runCanary(roleKeyWire)
+    ) {
+      const reasonCode = managerCircuitReason || blockedReason(control);
+      let current = store.getRole(roleKeyWire);
+      if (
+        current &&
+        (current.holder_agent_id ||
+          current.activation_id ||
+          current.state === "active" ||
+          current.state === "elected-probing")
+      ) {
+        current = fencePlan({ roleKeyWire }, reasonCode).role;
+      }
+      return {
+        receipt: receipt("manager_disabled", roleKeyWire, current, {
+          blocked_reason: reasonCode,
+        }),
+      };
+    }
+    if (roleKey.role_kind === "lead" && isScopeClosed(roleKey)) {
+      return {
+        receipt: receipt(
+          "scope_closed",
+          roleKeyWire,
+          store.getRole(roleKeyWire),
+        ),
+      };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    const charterVersion = getCharterVersion(roleKey.role_kind);
+    if (
+      current?.state === "active" &&
+      current.holder_agent_id &&
+      Number(current.holder_lease_expires_ms) > now() &&
+      current.charter_acked_epoch === current.epoch &&
+      current.charter_version === charterVersion &&
+      normalized.trigger !== "charter_issued"
+    ) {
+      return {
+        receipt: receipt("already_active", roleKeyWire, current),
+      };
+    }
+
+    if (
+      current?.state === "elected-probing" &&
+      current.activation_id &&
+      Number(current.activation_deadline_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+    if (
+      ["unreachable", "quarantined"].includes(current?.state) &&
+      Number(current.next_probe_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+
+    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    const holder = candidates[0] || null;
+    const plan = reserve(roleKey, current, holder, normalized.trigger);
+    return { plan, candidates };
+  }
+
+  function cas(plan, patch) {
+    return store.compareAndSetRole({
+      ...activationGuard(plan.role),
+      patch: {
+        last_transition_ms: now(),
+        ...patch,
+      },
+    });
+  }
+
+  function fencePlan(plan, reasonCode) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (!current) return { ok: false, reason: "not_found", role: null };
+    return store.upsertRoleReservation({
+      role_key_wire: plan.roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      blocked_reason: reasonCode,
+      last_transition_ms: now(),
+      last_reason: reasonCode,
+    });
+  }
+
+  async function cancelPlan(plan, reasonCode) {
+    const entry = flights.get(plan.roleKeyWire);
+    if (entry?.cancelledOutcome) return entry.cancelledOutcome;
+    try {
+      await adapter.cancel(plan.role.activation_id);
+    } catch {}
+    const result = fencePlan(plan, reasonCode);
+    return {
+      status: "cancelled",
+      reason_code: reasonCode,
+      role: result.role,
+    };
+  }
+
+  async function gate(plan) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (
+      !current ||
+      current.version !== plan.role.version ||
+      current.epoch !== plan.role.epoch ||
+      current.activation_seq !== plan.role.activation_seq ||
+      current.activation_id !== plan.role.activation_id
+    ) {
+      return { status: "stale", reason_code: "cas_conflict", role: current };
+    }
+    const control = controlSnapshot();
+    if (
+      managerCircuitReason ||
+      !managerEnabled(control, plan.roleKey.role_kind) ||
+      Number(control?.generation ?? 0) !== Number(plan.controlGeneration)
+    ) {
+      return await cancelPlan(
+        plan,
+        managerCircuitReason || blockedReason(control),
+      );
+    }
+    return null;
+  }
+
+  function markCandidateFailure(plan, holder, reasonCode) {
+    const failures =
+      Number(holder.candidate.consecutive_probe_failures || 0) + 1;
+    const delay =
+      failures >= config.max_probe_failures
+        ? config.candidate_quarantine_ms
+        : computeRoleBackoffMs(failures, config, rng);
+    const excludedUntil = now() + delay;
+    store.updateCandidateReachability({
+      role_key_wire: plan.roleKeyWire,
+      agent_id: holder.candidate.agent_id,
+      consecutive_probe_failures: failures,
+      excluded_until_ms: excludedUntil,
+      last_probe_ms: now(),
+      last_probe_code: reasonCode,
+      updated_at_ms: now(),
+    });
+    const failed = cas(plan, {
+      state: "unreachable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      next_probe_ms: excludedUntil,
+      retry_count: Number(plan.role.retry_count || 0) + 1,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "candidate_exclude",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      candidate_agent_id: holder.candidate.agent_id,
+    });
+    return { ...failed, failures, excludedUntil };
+  }
+
+  function scheduleAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      store.compareAndSetRole({
+        ...activationGuard(current),
+        patch: {
+          state: "unreachable",
+          activation_deadline_ms: null,
+          next_probe_ms: now(),
+          last_transition_ms: now(),
+          last_reason: "ack_timeout",
+        },
+      });
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  function deferStandupRetry(plan, reasonCode) {
+    const failures = Number(plan.role.retry_count || 0) + 1;
+    const exhausted = failures >= config.max_probe_failures;
+    const delay = exhausted
+      ? config.candidate_quarantine_ms
+      : computeRoleBackoffMs(failures, config, rng);
+    const result = cas(plan, {
+      state: exhausted ? "quarantined" : "unreachable",
+      holder_agent_id: null,
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: failures,
+      next_probe_ms: now() + delay,
+      blocked_reason: null,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "dispatch_block",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      capability: "standup_activation",
+    });
+    return result;
+  }
+
+  function scheduleStandupAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.holder_agent_id !== null ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      deferStandupRetry({ ...plan, role: current }, "standup_ack_timeout");
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  async function runCandidatePlan(initialPlan, initialCandidates) {
+    let plan = initialPlan;
+    let remaining = initialCandidates;
+    const attempted = new Set();
+
+    while (plan.holder) {
+      const holder = plan.holder;
+      attempted.add(holder.candidate.agent_id);
+      let lastReason = "transport_error";
+
+      for (const locator of holder.locators) {
+        const beforeProbe = await gate(plan);
+        if (beforeProbe) return beforeProbe;
+
+        let rawProbe;
+        try {
+          rawProbe = await adapter.probe(locator, {
+            timeout_ms: config.probe_timeout_ms,
+            signal: flights.get(plan.roleKeyWire)?.controller.signal,
+          });
+        } catch (error) {
+          rawProbe = {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: false,
+            reachable: false,
+            wakeable: false,
+            reason_code: error?.code || "transport_error",
+            transport_id: locator.transport_id,
+          };
+        }
+        const probe = normalizeProbeResult(rawProbe, locator);
+        const afterProbe = await gate(plan);
+        if (afterProbe) return afterProbe;
+
+        if (!probe.ok || !probe.reachable || !probe.wakeable) {
+          lastReason = probe.reason_code || "transport_error";
+          if (lastReason === "adapter_unavailable") {
+            disabledAdapters.add(locator.kind);
+            emitDegraded({
+              control_action: "adapter_disable",
+              reason_code: lastReason,
+              project_id: plan.roleKey.project_id,
+              role_key_wire: plan.roleKeyWire,
+              candidate_agent_id: holder.candidate.agent_id,
+              transport_id: locator.transport_id,
+            });
+          }
+          continue;
+        }
+
+        store.updateCandidateReachability({
+          role_key_wire: plan.roleKeyWire,
+          agent_id: holder.candidate.agent_id,
+          probe_succeeded: true,
+          excluded_until_ms: null,
+          last_probe_ms: now(),
+          last_probe_code: "ok",
+          updated_at_ms: now(),
+        });
+
+        const beforeWake = await gate(plan);
+        if (beforeWake) return beforeWake;
+        let wake;
+        try {
+          wake = await adapter.wake(
+            locator,
+            {
+              schema_version: "tfx.role-activation.v1",
+              role_key: plan.roleKey,
+              role_key_wire: plan.roleKeyWire,
+              epoch: plan.role.epoch,
+              activation_seq: plan.role.activation_seq,
+              activation_id: plan.role.activation_id,
+              charter_version: plan.role.charter_version,
+              holder_cli: holder.agent.cli,
+            },
+            {
+              timeout_ms: config.probe_timeout_ms,
+              signal: flights.get(plan.roleKeyWire)?.controller.signal,
+            },
+          );
+        } catch (error) {
+          wake = { ok: false, reason_code: error?.code || "transport_error" };
+        }
+        const afterWake = await gate(plan);
+        if (afterWake) return afterWake;
+        if (wake?.ok === false) {
+          lastReason = wake.reason_code || "wake_failed";
+          continue;
+        }
+
+        scheduleAckTimeout(plan);
+        return {
+          status: "awaiting_ack",
+          role: store.getRole(plan.roleKeyWire),
+          activation_id: plan.role.activation_id,
+          holder_agent_id: holder.candidate.agent_id,
+          transport_id: locator.transport_id,
+        };
+      }
+
+      const failed = markCandidateFailure(plan, holder, lastReason);
+      if (!failed.ok) {
+        return {
+          status: "stale",
+          reason_code: failed.reason,
+          role: failed.role,
+        };
+      }
+      remaining = eligibleCandidates(plan.roleKey, plan.roleKeyWire, attempted);
+      if (!remaining.length) {
+        if (failed.failures < config.max_probe_failures) {
+          return {
+            status: "unreachable",
+            role: failed.role,
+            reason_code: lastReason,
+          };
+        }
+        const quarantined = store.compareAndSetRole({
+          ...activationGuard(failed.role),
+          patch: {
+            state: "quarantined",
+            activation_id: null,
+            activation_deadline_ms: null,
+            holder_lease_expires_ms: null,
+            last_transition_ms: now(),
+            last_reason: "candidates_excluded",
+          },
+        });
+        return {
+          status: "quarantined",
+          role: quarantined.role,
+          reason_code: lastReason,
+        };
+      }
+      plan = reserve(plan.roleKey, failed.role, remaining[0], plan.trigger);
+    }
+
+    return await runStandupPlan(plan);
+  }
+
+  async function runStandupPlan(plan) {
+    const before = await gate(plan);
+    if (before) return before;
+
+    function blockStandup(reasonCode) {
+      const blocked = cas(plan, {
+        state: "electable",
+        holder_agent_id: null,
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        blocked_reason: "no_candidate",
+        last_reason: reasonCode,
+      });
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: reasonCode,
+        project_id: plan.roleKey.project_id,
+        role_key_wire: plan.roleKeyWire,
+        capability: "standup",
+      });
+      return {
+        status: "blocked",
+        reason_code: reasonCode,
+        role: blocked.role,
+      };
+    }
+
+    if (typeof adapter.standup !== "function") {
+      return blockStandup("standup_unavailable");
+    }
+
+    let locator;
+    try {
+      locator = await adapter.standup(plan.roleKey, "claude", {
+        timeout_ms: config.standup_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        activation: {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+        },
+      });
+    } catch (error) {
+      const afterFailure = await gate(plan);
+      if (afterFailure) return afterFailure;
+      return blockStandup(error?.code || "standup_failed");
+    }
+    const after = await gate(plan);
+    if (after) return after;
+    let supported = false;
+    try {
+      supported = locatorUsable(locator, adapter, disabledAdapters, now());
+    } catch {}
+    if (!supported) return blockStandup("standup_locator_invalid");
+    // C3 binds the stood-up session identity/grant and delivers its charter
+    // ACK. C6a-4 still sends the activation now and bounds retries until that
+    // binding exists, so a missing C3 hook cannot create a tight orphan loop.
+    const wake = await adapter.wake(
+      locator,
+      {
+        schema_version: "tfx.role-activation.v1",
+        role_key: plan.roleKey,
+        role_key_wire: plan.roleKeyWire,
+        epoch: plan.role.epoch,
+        activation_seq: plan.role.activation_seq,
+        activation_id: plan.role.activation_id,
+        charter_version: plan.role.charter_version,
+        holder_cli: "claude",
+      },
+      {
+        timeout_ms: config.probe_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+      },
+    );
+    const afterWake = await gate(plan);
+    if (afterWake) return afterWake;
+    if (wake?.ok !== true) {
+      const reasonCode = wake?.reason_code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
+    scheduleStandupAckTimeout(plan);
+    return {
+      status: "standup_started",
+      role: store.getRole(plan.roleKeyWire),
+      activation_id: plan.role.activation_id,
+      locator,
+    };
+  }
+
+  function startFlight(plan, candidates = []) {
+    const controller = new AbortController();
+    const entry = { controller, plan, promise: null };
+    entry.promise = Promise.resolve()
+      .then(() =>
+        plan.holder ? runCandidatePlan(plan, candidates) : runStandupPlan(plan),
+      )
+      .catch((error) => {
+        const reasonCode = error?.code || "activation_dispatch_failed";
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: reasonCode,
+          project_id: plan.roleKey.project_id,
+          role_key_wire: plan.roleKeyWire,
+        });
+        return {
+          status: "error",
+          reason_code: reasonCode,
+          role: store.getRole(plan.roleKeyWire),
+        };
+      })
+      .finally(() => {
+        if (flights.get(plan.roleKeyWire) === entry) {
+          flights.delete(plan.roleKeyWire);
+        }
+      });
+    flights.set(plan.roleKeyWire, entry);
+    return entry;
+  }
+
+  function requestEnsureRole(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) {
+      return receipt(
+        "joined",
+        normalized.role_key_wire,
+        store.getRole(normalized.role_key_wire),
+      );
+    }
+
+    let prepared;
+    try {
+      prepared = prepare(normalized, context);
+    } catch (error) {
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: error?.code || "activation_reservation_failed",
+        project_id: normalized.role_key.project_id,
+        role_key_wire: normalized.role_key_wire,
+      });
+      throw error;
+    }
+    if (prepared.receipt) return prepared.receipt;
+    startFlight(prepared.plan, prepared.candidates);
+    return receipt("started", normalized.role_key_wire, prepared.plan.role);
+  }
+
+  async function ensureRoleAwake(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) return await currentFlight.promise;
+    const result = requestEnsureRole(request, context);
+    const started = flights.get(normalized.role_key_wire);
+    return started ? await started.promise : result;
+  }
+
+  function ackActivation(input, context = {}) {
+    if (
+      !isRecord(input) ||
+      input.schema_version !== ROLE_ACTIVATION_ACK_SCHEMA_VERSION ||
+      input.reachable !== true ||
+      !isRecord(input.charter_ack)
+    ) {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+    let roleKey;
+    let roleKeyWire;
+    try {
+      roleKey = normalizeRoleKey(input.role_key);
+      roleKeyWire = encodeRoleKey(roleKey);
+      if (encodeRoleKey(input.charter_ack.role_key) !== roleKeyWire) {
+        return { ok: false, code: "STALE_EPOCH" };
+      }
+    } catch {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    if (!current) return { ok: false, code: "STALE_EPOCH" };
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      const fenced = fencePlan(
+        { roleKeyWire },
+        managerCircuitReason || blockedReason(control),
+      );
+      return { ok: false, code: "STALE_EPOCH", role: fenced.role };
+    }
+    if (
+      input.epoch !== current.epoch ||
+      input.activation_seq !== current.activation_seq ||
+      input.activation_id !== current.activation_id ||
+      input.charter_ack.epoch !== current.epoch
+    ) {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+    const principalAgentId = context?.principal?.agent_id;
+    if (
+      input.holder_agent_id !== current.holder_agent_id ||
+      principalAgentId !== current.holder_agent_id
+    ) {
+      return { ok: false, code: "HOLDER_MISMATCH", role: current };
+    }
+    if (
+      input.charter_ack.charter_version !== current.charter_version ||
+      input.charter_ack.charter_version !== getCharterVersion(roleKey.role_kind)
+    ) {
+      return { ok: false, code: "CHARTER_VERSION_MISMATCH", role: current };
+    }
+    const holder = store.getAgent(current.holder_agent_id);
+    if (
+      !holder ||
+      holder.status !== "online" ||
+      Number(holder.lease_expires_ms) <= now() ||
+      Number(current.holder_lease_expires_ms) <= now()
+    ) {
+      return { ok: false, code: "HOLDER_LEASE_EXPIRED", role: current };
+    }
+    if (
+      current.state === "active" &&
+      current.charter_acked_epoch === current.epoch
+    ) {
+      return { ok: true, idempotent: true, role: current, ack: input };
+    }
+    if (current.state !== "elected-probing") {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+
+    const activated = store.compareAndSetRole({
+      ...activationGuard(current),
+      patch: {
+        state: "active",
+        charter_acked_epoch: current.epoch,
+        activation_deadline_ms: null,
+        blocked_reason: null,
+        last_transition_ms: now(),
+        last_reason: "activation_acked",
+      },
+    });
+    if (!activated.ok) {
+      return { ok: false, code: "STALE_EPOCH", role: activated.role };
+    }
+    const timer = ackTimers.get(current.activation_id);
+    if (timer) clearScheduledTimeout(timer);
+    ackTimers.delete(current.activation_id);
+    if (typeof onRoleActive === "function") {
+      try {
+        onRoleActive({ role: activated.role, ack: input });
+      } catch (error) {
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: error?.code || "backlog_transfer_failed",
+          project_id: roleKey.project_id,
+          role_key_wire: roleKeyWire,
+        });
+      }
+    }
+    return { ok: true, idempotent: false, role: activated.role, ack: input };
+  }
+
+  async function drain() {
+    await Promise.allSettled(
+      [...flights.values()].map((entry) => entry.promise),
+    );
+  }
+
+  function close() {
+    for (const entry of flights.values()) entry.controller.abort();
+    for (const timer of ackTimers.values()) clearScheduledTimeout(timer);
+    ackTimers.clear();
+  }
+
+  function updateControlSnapshot(snapshot) {
+    const previousGeneration = Number(controlSnapshot()?.generation ?? 0);
+    controlOverride = snapshot;
+    if (Number(snapshot?.generation ?? 0) !== previousGeneration) {
+      disabledAdapters.clear();
+    }
+    for (const entry of flights.values()) {
+      if (managerEnabled(snapshot, entry.plan.roleKey.role_kind)) continue;
+      entry.controller.abort();
+      Promise.resolve(adapter.cancel(entry.plan.role.activation_id)).catch(
+        () => {},
+      );
+      const result = fencePlan(entry.plan, blockedReason(snapshot));
+      entry.cancelledOutcome = {
+        status: "cancelled",
+        reason_code: blockedReason(snapshot),
+        role: result.role,
+      };
+    }
+    return snapshot;
+  }
+
+  function notifyCandidateChanged(
+    roleKeyInput,
+    agentId,
+    reason = "candidate_registered",
+  ) {
+    const roleKey = normalizeRoleKey(roleKeyInput);
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const candidateResult = store.updateCandidateReachability({
+      role_key_wire: roleKeyWire,
+      agent_id: agentId,
+      probe_succeeded: true,
+      excluded_until_ms: null,
+      last_probe_ms: now(),
+      last_probe_code: reason,
+      updated_at_ms: now(),
+    });
+    if (!candidateResult.ok) return candidateResult;
+
+    const current = store.getRole(roleKeyWire);
+    if (!current || current.state !== "quarantined") {
+      return { ok: true, candidate: candidateResult.candidate, role: current };
+    }
+    const restored = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: 0,
+      next_probe_ms: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: reason,
+    });
+    return {
+      ok: restored.ok,
+      candidate: candidateResult.candidate,
+      role: restored.role,
+      ...(restored.ok ? {} : { reason: restored.reason }),
+    };
+  }
+
+  function ensureExpiredRoles(sweepNow = now()) {
+    const receipts = [];
+    for (const expired of store.listRolesWithExpiredHolder(sweepNow)) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(expired.role_key_wire);
+      } catch {
+        continue;
+      }
+      const current = store.getRole(expired.role_key_wire);
+      if (
+        !current ||
+        current.holder_agent_id == null ||
+        Number(current.holder_lease_expires_ms) > sweepNow
+      ) {
+        continue;
+      }
+      const flight = flights.get(expired.role_key_wire);
+      if (flight) {
+        flight.controller.abort();
+        Promise.resolve(adapter.cancel(flight.plan.role.activation_id)).catch(
+          () => {},
+        );
+        flight.cancelledOutcome = {
+          status: "cancelled",
+          reason_code: "holder_lease_expired",
+          role: current,
+        };
+        flights.delete(expired.role_key_wire);
+      }
+      const fenced = store.upsertRoleReservation({
+        role_key_wire: expired.role_key_wire,
+        expected_version: current.version,
+        expected_epoch: current.epoch,
+        holder_agent_id: null,
+        previous_holder_agent_id: current.holder_agent_id,
+        state: "electable",
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        charter_acked_epoch: null,
+        blocked_reason: null,
+        last_transition_ms: sweepNow,
+        last_reason: "holder_lease_expired",
+      });
+      if (!fenced.ok) continue;
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "lease_expired",
+            cause_id: `lease:${expired.role_key_wire}:${sweepNow}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "sweeper",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  function ensureRecoveredRoles(recovery) {
+    const receipts = [];
+    for (const recovered of recovery?.roles || []) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(recovered.role_key_wire);
+      } catch {
+        continue;
+      }
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "restart_recovery",
+            cause_id: `restart:${recovered.role_key_wire}:${recovered.epoch}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "hub-recovery",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  return {
+    requestEnsureRole,
+    ensureRole: ensureRoleAwake,
+    ensureRoleAwake,
+    ackActivation,
+    updateControlSnapshot,
+    notifyCandidateChanged,
+    ensureExpiredRoles,
+    ensureRecoveredRoles,
+    drain,
+    close,
+    isRoleManaged(roleKeyInput) {
+      const roleKey = normalizeRoleKey(roleKeyInput);
+      return (
+        !managerCircuitReason &&
+        managerEnabled(controlSnapshot(), roleKey.role_kind) &&
+        !(roleKey.role_kind === "lead" && isScopeClosed(roleKey))
+      );
+    },
+    getRoleSnapshot(roleKey) {
+      return store.getRole(encodeRoleKey(roleKey));
+    },
+  };
+}
+
+export async function ensureRoleAwake(activator, request, context = {}) {
+  if (!activator || typeof activator.ensureRoleAwake !== "function") {
+    throw activatorError("ROLE_ACTIVATOR_INVALID");
+  }
+  return await activator.ensureRoleAwake(request, context);
+}

--- a/packages/core/hub/role-activator.mjs
+++ b/packages/core/hub/role-activator.mjs
@@ -776,23 +776,34 @@ export function createRoleActivator(options = {}) {
     // C3 binds the stood-up session identity/grant and delivers its charter
     // ACK. C6a-4 still sends the activation now and bounds retries until that
     // binding exists, so a missing C3 hook cannot create a tight orphan loop.
-    const wake = await adapter.wake(
-      locator,
-      {
-        schema_version: "tfx.role-activation.v1",
-        role_key: plan.roleKey,
-        role_key_wire: plan.roleKeyWire,
-        epoch: plan.role.epoch,
-        activation_seq: plan.role.activation_seq,
-        activation_id: plan.role.activation_id,
-        charter_version: plan.role.charter_version,
-        holder_cli: "claude",
-      },
-      {
-        timeout_ms: config.probe_timeout_ms,
-        signal: flights.get(plan.roleKeyWire)?.controller.signal,
-      },
-    );
+    let wake;
+    try {
+      wake = await adapter.wake(
+        locator,
+        {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+          holder_cli: "claude",
+        },
+        {
+          timeout_ms: config.probe_timeout_ms,
+          signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        },
+      );
+    } catch (error) {
+      const reasonCode = error?.code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
     const afterWake = await gate(plan);
     if (afterWake) return afterWake;
     if (wake?.ok !== true) {

--- a/packages/core/hub/role-activator.mjs
+++ b/packages/core/hub/role-activator.mjs
@@ -509,16 +509,11 @@ export function createRoleActivator(options = {}) {
       ) {
         return;
       }
-      store.compareAndSetRole({
-        ...activationGuard(current),
-        patch: {
-          state: "unreachable",
-          activation_deadline_ms: null,
-          next_probe_ms: now(),
-          last_transition_ms: now(),
-          last_reason: "ack_timeout",
-        },
-      });
+      markCandidateFailure(
+        { ...plan, role: current },
+        plan.holder,
+        "ack_timeout",
+      );
     }, delay);
     timer?.unref?.();
     ackTimers.set(plan.role.activation_id, timer);

--- a/packages/core/hub/role-activator.mjs
+++ b/packages/core/hub/role-activator.mjs
@@ -963,6 +963,7 @@ export function createRoleActivator(options = {}) {
         state: "active",
         charter_acked_epoch: current.epoch,
         activation_deadline_ms: null,
+        retry_count: 0,
         blocked_reason: null,
         last_transition_ms: now(),
         last_reason: "activation_acked",
@@ -1029,6 +1030,13 @@ export function createRoleActivator(options = {}) {
     reason = "candidate_registered",
   ) {
     const roleKey = normalizeRoleKey(roleKeyInput);
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      return {
+        ok: false,
+        reason_code: managerCircuitReason || blockedReason(control),
+      };
+    }
     const roleKeyWire = encodeRoleKey(roleKey);
     const candidateResult = store.updateCandidateReachability({
       role_key_wire: roleKeyWire,

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -370,6 +370,7 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  */
 export function createRouter(store, options = {}) {
   const roleActivator = options.roleActivator || null;
+  const hubLog = options.logger || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -2039,7 +2040,11 @@ export function createRouter(store, options = {}) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
-      roleActivator?.ensureExpiredRoles?.(Date.now());
+      try {
+        roleActivator?.ensureExpiredRoles?.(Date.now());
+      } catch (err) {
+        hubLog?.warn?.({ err }, "role_activator.expiry_sweep_degraded");
+      }
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/packages/core/hub/router.mjs
+++ b/packages/core/hub/router.mjs
@@ -9,7 +9,11 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
-import { normalizeRoleKey } from "./role-contract.mjs";
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -364,7 +368,8 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  * 라우터 생성
  * @param {object} store
  */
-export function createRouter(store) {
+export function createRouter(store, options = {}) {
+  const roleActivator = options.roleActivator || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -486,6 +491,57 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function scopedRoleForMessage(message = {}) {
+    const to = String(message.to_agent ?? message.to ?? "");
+    const prefix = "topic:role:";
+    if (to.startsWith(prefix)) {
+      const roleKeyWire = to.slice(prefix.length);
+      try {
+        return { roleKey: decodeRoleKey(roleKeyWire), roleKeyWire };
+      } catch {
+        return null;
+      }
+    }
+    if (to !== "topic:cto") return null;
+    const from = message.from_agent ?? message.from;
+    const projectId = message.project_id ?? store.getAgent(from)?.project_id;
+    if (!projectId) return null;
+    try {
+      const roleKey = normalizeRoleKey({
+        project_id: projectId,
+        role_kind: "cto",
+      });
+      return { roleKey, roleKeyWire: encodeRoleKey(roleKey) };
+    } catch {
+      return null;
+    }
+  }
+
+  function requestRoleActivation(message, trigger = "publish_no_holder") {
+    if (!roleActivator?.requestEnsureRole) return undefined;
+    const scoped = scopedRoleForMessage(message);
+    if (!scoped) return undefined;
+    try {
+      return roleActivator.requestEnsureRole(
+        {
+          schema_version: "tfx.ensure-role.v1",
+          role_key: scoped.roleKey,
+          trigger,
+          cause_id: String(message.id || message.correlation_id || uuidv7()),
+        },
+        {
+          principal: {
+            type: "system",
+            service: trigger === "session_start" ? "session-hook" : "router",
+            project_id: scoped.roleKey.project_id,
+          },
+        },
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   function ensureRoleState(roleName) {
@@ -655,6 +711,7 @@ export function createRouter(store) {
   }
 
   function shouldTrackWithoutRecipients(message) {
+    if (roleActivator && scopedRoleForMessage(message)) return true;
     const to = message?.to_agent ?? message?.to;
     if (!String(to || "").startsWith("topic:")) return false;
     return ROLE_TOPICS.has(String(to).slice(6));
@@ -874,10 +931,69 @@ export function createRouter(store) {
     deliveryEmitter.emit("message", agentId, message);
   }
 
+  function activateScopedRoleHolder(role) {
+    if (!role?.role_key_wire || !role.holder_agent_id) return 0;
+    const current = store.getRole(role.role_key_wire);
+    if (
+      !current ||
+      current.state !== "active" ||
+      current.charter_acked_epoch !== current.epoch ||
+      current.holder_agent_id !== role.holder_agent_id ||
+      current.epoch !== role.epoch ||
+      current.activation_seq !== role.activation_seq ||
+      current.activation_id !== role.activation_id ||
+      current.version !== role.version
+    ) {
+      return 0;
+    }
+
+    let transferred = 0;
+    for (const message of store.listPendingRoleMessages(
+      role.role_key_wire,
+      Date.now(),
+    )) {
+      let record = getMessageRecord(message.id);
+      if (!record) {
+        trackMessage(message, [current.holder_agent_id]);
+        record = getMessageRecord(message.id);
+      } else {
+        record.recipients.add(current.holder_agent_id);
+      }
+      if (!queuesByAgent.get(current.holder_agent_id)?.has(message.id)) {
+        queueMessage(current.holder_agent_id, record.message);
+        transferred += 1;
+      }
+      record.message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+    return transferred;
+  }
+
   function resolveRecipients(msg) {
     const to = msg.to_agent ?? msg.to;
     if (!to?.startsWith("topic:")) {
       return [to];
+    }
+
+    if (roleActivator) {
+      const scoped = scopedRoleForMessage(msg);
+      if (scoped) {
+        const role = store.getRole(scoped.roleKeyWire);
+        const managed = roleActivator.isRoleManaged?.(scoped.roleKey) !== false;
+        if (role && managed) {
+          const holder = role.holder_agent_id
+            ? store.getAgent(role.holder_agent_id)
+            : null;
+          const active =
+            role.state === "active" &&
+            role.charter_acked_epoch === role.epoch &&
+            Number(role.holder_lease_expires_ms) > Date.now() &&
+            holder?.status === "online" &&
+            Number(holder.lease_expires_ms) > Date.now();
+          return active ? [role.holder_agent_id] : [];
+        }
+        if (to !== "topic:cto") return [];
+      }
     }
 
     const topic = to.slice(6);
@@ -993,6 +1109,8 @@ export function createRouter(store) {
     trace_id,
     correlation_id,
   }) {
+    const messageIdentity = { from, to, project_id: payload?.project_id };
+    const scoped = scopedRoleForMessage(messageIdentity);
     const msg = store.auditLog({
       type,
       from,
@@ -1003,6 +1121,7 @@ export function createRouter(store) {
       payload,
       trace_id,
       correlation_id,
+      role_key_wire: scoped?.roleKeyWire ?? null,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
     if (recipients.length || shouldTrackWithoutRecipients(msg)) {
@@ -1018,7 +1137,11 @@ export function createRouter(store) {
     if (msg.type === "response") {
       responseEmitter.emit(msg.correlation_id, msg.payload);
     }
-    return { msg, recipients };
+    const activation =
+      recipients.length === 0
+        ? requestRoleActivation(msg, "publish_no_holder")
+        : undefined;
+    return { msg, recipients, activation };
   }
 
   function buildAssignSnapshot(job, extra = {}) {
@@ -1186,6 +1309,29 @@ export function createRouter(store) {
     responseEmitter,
     deliveryEmitter,
 
+    activateScopedRoleHolder,
+
+    requestEnsureRole(request, context = {}) {
+      if (!roleActivator?.requestEnsureRole) {
+        return {
+          accepted: false,
+          disposition: "manager_disabled",
+          role_key_wire: encodeRoleKey(request.role_key),
+          state: "electable",
+          epoch: 0,
+          blocked_reason: "activator_unavailable",
+        };
+      }
+      return roleActivator.requestEnsureRole(request, context);
+    },
+
+    ackRoleActivation(ack, context = {}) {
+      if (!roleActivator?.ackActivation) {
+        return { ok: false, code: "ROLE_ACTIVATOR_UNAVAILABLE" };
+      }
+      return roleActivator.ackActivation(ack, context);
+    },
+
     registerAgent(args) {
       const identityFailure = validateCallerIdentity(args);
       if (identityFailure) return identityFailure;
@@ -1217,6 +1363,17 @@ export function createRouter(store) {
           reason: "register",
           transferBacklog: true,
         });
+      }
+      if (roleActivator && identity?.project_id && identity?.session_id) {
+        requestRoleActivation(
+          {
+            id: identity.session_id,
+            from_agent: args.agent_id,
+            to_agent: "topic:cto",
+            project_id: identity.project_id,
+          },
+          "session_start",
+        );
       }
       return {
         ok: true,
@@ -1319,6 +1476,7 @@ export function createRouter(store) {
         if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
           trackMessage(msg, []);
         }
+        requestRoleActivation(msg, "publish_no_holder");
         return 0;
       }
       if (!getMessageRecord(msg.id)) {
@@ -1470,7 +1628,7 @@ export function createRouter(store) {
       message_type,
     }) {
       const type = message_type || (correlation_id ? "response" : "event");
-      const { msg, recipients } = dispatchMessage({
+      const { msg, recipients, activation } = dispatchMessage({
         type,
         from,
         to,
@@ -1487,7 +1645,13 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
-          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+          role:
+            roleActivator && scopedRoleForMessage(msg)
+              ? roleActivator.getRoleSnapshot(scopedRoleForMessage(msg).roleKey)
+              : to === "topic:cto"
+                ? getRoleSnapshot("cto")
+                : undefined,
+          activation,
         },
       };
     },
@@ -1875,6 +2039,7 @@ export function createRouter(store) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
+      roleActivator?.ensureExpiredRoles?.(Date.now());
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/packages/remote/hub/pipe.mjs
+++ b/packages/remote/hub/pipe.mjs
@@ -220,6 +220,35 @@ export function createPipeServer({
 
   async function processCommand(client, action, payload = {}) {
     switch (action) {
+      case "ensure_role": {
+        if (client && !client.agentId) {
+          return {
+            ok: false,
+            error: {
+              code: "PRINCIPAL_REQUIRED",
+              message: "agent registration required before ensure_role",
+            },
+          };
+        }
+        return router.requestEnsureRole(payload, {
+          principal: client?.agentId
+            ? { type: "agent", agent_id: client.agentId }
+            : {
+                type: "system",
+                service: "team-pipeline",
+                project_id: payload?.role_key?.project_id,
+              },
+        });
+      }
+
+      case "ack_role_activation":
+        return router.ackRoleActivation(payload, {
+          principal: {
+            type: "agent",
+            agent_id: client?.agentId,
+          },
+        });
+
       case "register": {
         const result = router.registerAgent(payload);
         if (!result?.ok) return result;
@@ -824,8 +853,12 @@ export function createPipeServer({
       };
     },
 
-    async executeCommand(action, payload) {
-      return await processCommand(null, action, payload);
+    async executeCommand(action, payload, context = {}) {
+      const client =
+        context.connection_bound || context.agent_id
+          ? { agentId: context.agent_id ?? null }
+          : null;
+      return await processCommand(client, action, payload);
     },
 
     async executeQuery(action, payload) {

--- a/packages/remote/hub/role-activator-tfx-live.mjs
+++ b/packages/remote/hub/role-activator-tfx-live.mjs
@@ -1,0 +1,292 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = dirname(MODULE_DIR);
+const REQUIRED_CAPABILITIES = ["probe", "wake", "activate"];
+
+function opaqueHostId(value) {
+  return `hst_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    const lines = text.split(/\r?\n/u);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      try {
+        return JSON.parse(lines[index]);
+      } catch {}
+    }
+    return {};
+  }
+}
+
+function seconds(timeoutMs, fallbackMs) {
+  const value = Number(timeoutMs);
+  return String(
+    Math.max(1, Math.ceil((value > 0 ? value : fallbackMs) / 1000)),
+  );
+}
+
+function reasonFromError(error) {
+  if (error?.name === "AbortError") return "timeout";
+  if (error?.code === "ETIMEDOUT" || error?.killed) return "timeout";
+  if (error?.code === "EACCES" || error?.code === "EPERM") {
+    return "permission_denied";
+  }
+  if (error?.code === "ENOENT") return "adapter_unavailable";
+  if (Number(error?.code) === 1) return "target_not_found";
+  return "transport_error";
+}
+
+function probeResult(locator, startedAt, observedAt, patch) {
+  return {
+    schema_version: "tfx-live.transport-probe.v1",
+    ok: false,
+    reachable: false,
+    wakeable: false,
+    transport_selected: locator?.kind ?? null,
+    transport_id: locator?.transport_id ?? "unknown",
+    host_id: locator?.host_id ?? "unknown",
+    latency_ms: Math.max(0, observedAt - startedAt),
+    observed_at_ms: observedAt,
+    reason_code: "transport_error",
+    ...patch,
+  };
+}
+
+function defaultSessionName(roleKey) {
+  const suffix = globalThis.crypto.randomUUID().slice(0, 8);
+  return `tfx-role-${roleKey.role_kind}-${suffix}`;
+}
+
+function activationPrompt(activation) {
+  return JSON.stringify(activation);
+}
+
+export function createTfxLiveRoleAdapter(options = {}) {
+  const projectRoot = options.projectRoot || DEFAULT_ROOT;
+  const defaultTfxLivePath = join(projectRoot, "bin", "tfx-live.mjs");
+  const tfxLivePath = options.tfxLivePath || defaultTfxLivePath;
+  const tfxLiveCommand =
+    options.tfxLiveCommand ||
+    (!options.tfxLivePath && !existsSync(defaultTfxLivePath)
+      ? "tfx-live"
+      : null);
+  const bridgePath =
+    options.bridgePath || join(projectRoot, "hub", "bridge.mjs");
+  const nodePath = options.nodePath || process.execPath;
+  const tmuxPath = options.tmuxPath || "tmux";
+  const localHostId =
+    options.localHostId || opaqueHostId(options.hostname?.() || hostname());
+  const muxServerId = options.muxServerId || "mux_local";
+  const now = options.now || Date.now;
+  const sessionName = options.sessionName || defaultSessionName;
+  const runProcess =
+    options.runProcess ||
+    (async (command, args, processOptions = {}) =>
+      await execFileAsync(command, args, {
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+        ...processOptions,
+      }));
+  const active = new Map();
+
+  function runTfxLive(args, processOptions) {
+    return tfxLiveCommand
+      ? runProcess(tfxLiveCommand, args, processOptions)
+      : runProcess(nodePath, [tfxLivePath, ...args], processOptions);
+  }
+
+  function supports(locator) {
+    return (
+      locator?.schema_version === "tfx.transport-locator.v1" &&
+      locator.host_id === localHostId &&
+      (locator.kind === "claude-uds" || locator.kind === "tmux") &&
+      Array.isArray(locator.capabilities) &&
+      REQUIRED_CAPABILITIES.every((capability) =>
+        locator.capabilities.includes(capability),
+      )
+    );
+  }
+
+  async function probe(locator, probeOptions = {}) {
+    const startedAt = now();
+    if (!supports(locator)) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: "adapter_unavailable",
+      });
+    }
+    try {
+      if (locator.kind === "tmux") {
+        await runProcess(
+          tmuxPath,
+          ["has-session", "-t", locator.locator.session_name],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+      } else {
+        const refArgs = locator.locator.session_id
+          ? ["--session-id", locator.locator.session_id]
+          : ["--short", locator.locator.short];
+        const result = await runTfxLive(
+          [
+            "probe",
+            ...refArgs,
+            "--bridge",
+            bridgePath,
+            "--timeout",
+            seconds(probeOptions.timeout_ms, 10_000),
+          ],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+        const payload = parseJsonOutput(result.stdout);
+        if (payload.ok !== true) {
+          return probeResult(locator, startedAt, now(), {
+            reason_code:
+              payload.reason_code || payload.reason || "target_not_found",
+          });
+        }
+      }
+      return probeResult(locator, startedAt, now(), {
+        ok: true,
+        reachable: true,
+        wakeable: true,
+        reason_code: "ok",
+      });
+    } catch (error) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: reasonFromError(error),
+      });
+    }
+  }
+
+  function liveArgs(locator, cli, verb) {
+    if (locator.kind === "tmux") {
+      return [
+        verb,
+        "--cli",
+        cli,
+        "--transport",
+        "tmux",
+        "--session",
+        locator.locator.session_name,
+      ];
+    }
+    const refArgs = locator.locator.session_id
+      ? ["--session-id", locator.locator.session_id]
+      : ["--short", locator.locator.short];
+    return [
+      verb,
+      "--cli",
+      "claude",
+      "--transport",
+      "uds",
+      ...refArgs,
+      "--bridge",
+      bridgePath,
+    ];
+  }
+
+  async function wake(locator, activation, wakeOptions = {}) {
+    if (!supports(locator)) {
+      return { ok: false, reason_code: "adapter_unavailable" };
+    }
+    const cli = activation?.holder_cli === "codex" ? "codex" : "claude";
+    const args = [
+      ...liveArgs(locator, cli, "ask"),
+      "--prompt",
+      activationPrompt(activation),
+      "--timeout",
+      seconds(wakeOptions.timeout_ms, 10_000),
+    ];
+    try {
+      const result = await runTfxLive(args, {
+        timeout: wakeOptions.timeout_ms,
+        signal: wakeOptions.signal,
+      });
+      const payload = parseJsonOutput(result.stdout);
+      if (payload.ok === false) {
+        return {
+          ok: false,
+          reason_code: payload.reason_code || "transport_error",
+        };
+      }
+      active.set(activation.activation_id, { locator, cli });
+      return { ok: true, transport_id: locator.transport_id };
+    } catch (error) {
+      return { ok: false, reason_code: reasonFromError(error) };
+    }
+  }
+
+  async function standup(roleKey, cli, standupOptions = {}) {
+    const name = sessionName(roleKey);
+    await runTfxLive(
+      [
+        "start",
+        "--session",
+        name,
+        "--cli",
+        cli,
+        "--cwd",
+        projectRoot,
+        "--ready-timeout",
+        seconds(standupOptions.timeout_ms, 60_000),
+      ],
+      {
+        timeout: standupOptions.timeout_ms,
+        signal: standupOptions.signal,
+      },
+    );
+    return {
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: `standup:${name}`,
+      kind: "tmux",
+      host_id: localHostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: now() + 300_000,
+      locator: { session_name: name, mux_server_id: muxServerId },
+    };
+  }
+
+  async function cancel(activationId) {
+    const target = active.get(activationId);
+    if (!target) return false;
+    active.delete(activationId);
+    try {
+      await runTfxLive(
+        [
+          ...liveArgs(target.locator, target.cli, "interrupt"),
+          "--timeout",
+          "5",
+        ],
+        { timeout: 5_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return { supports, probe, wake, standup, cancel };
+}

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -38,6 +38,7 @@ import {
   reapExistingHubProcesses,
   resolveHubPortForContext,
 } from "./hub-lifecycle.mjs";
+import { resolveRoleControlSnapshot } from "./lib/cto-env.mjs";
 import {
   cleanupOrphanNodeProcesses,
   cleanupOrphanRuntimeProcesses,
@@ -60,6 +61,8 @@ import { focusSessionOnMac } from "./mac-focus.mjs";
 import { logQuotaRefreshFailures } from "@triflux/core/hub/middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "@triflux/core/hub/middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
+import { createRoleActivator } from "@triflux/core/hub/role-activator.mjs";
+import { createTfxLiveRoleAdapter } from "./role-activator-tfx-live.mjs";
 import { createRouter } from "@triflux/core/hub/router.mjs";
 import { createAdaptiveFingerprintService } from "@triflux/core/hub/session-fingerprint.mjs";
 import {
@@ -1063,7 +1066,44 @@ export async function startHub({
   }
 
   const store = await createStoreAdapter(dbPath);
-  const router = createRouter(store);
+  const roleStoreMethods = [
+    "getAgent",
+    "getRole",
+    "upsertRoleReservation",
+    "compareAndSetRole",
+    "listRoleCandidates",
+    "updateCandidateReachability",
+    "listRolesWithExpiredHolder",
+    "listPendingRoleMessages",
+    "recoverRoleRegistry",
+  ];
+  const roleStoreReady = roleStoreMethods.every(
+    (method) => typeof store[method] === "function",
+  );
+  let roleControlSnapshot = resolveRoleControlSnapshot(process.env);
+  const getRoleControlSnapshot = () => {
+    roleControlSnapshot = resolveRoleControlSnapshot(process.env, {
+      previous: roleControlSnapshot,
+    });
+    return roleControlSnapshot;
+  };
+  let router;
+  const roleActivator = roleStoreReady
+    ? createRoleActivator({
+        store,
+        adapter: createTfxLiveRoleAdapter({ projectRoot: PROJECT_ROOT }),
+        getControlSnapshot: getRoleControlSnapshot,
+        getCharterVersion: (roleKind) =>
+          roleKind === "lead" ? "tfx.lead-charter.v1" : "tfx.cto-charter.v1",
+        logger: hubLog,
+        onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
+      })
+    : null;
+  router = createRouter(store, { roleActivator });
+  if (roleActivator) {
+    const recovered = store.recoverRoleRegistry(Date.now());
+    roleActivator.ensureRecoveredRoles(recovered);
+  }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 
   // Neural Memory adaptive engine 초기화
@@ -2469,6 +2509,9 @@ export async function startHub({
       await delegatorWorker.stop();
     } catch {}
     try {
+      roleActivator?.close();
+    } catch {}
+    try {
       store.close();
     } catch {}
     if (!ephemeralPort && !preserveTokenFile) {
@@ -2675,6 +2718,7 @@ export async function startHub({
               try {
                 synapseRegistry.destroy();
               } catch {}
+              roleActivator?.close();
               store.close();
               if (!ephemeralPort) {
                 cleanupOwnedPidFile();

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -1099,10 +1099,14 @@ export async function startHub({
         onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
       })
     : null;
-  router = createRouter(store, { roleActivator });
+  router = createRouter(store, { roleActivator, logger: hubLog });
   if (roleActivator) {
     const recovered = store.recoverRoleRegistry(Date.now());
-    roleActivator.ensureRecoveredRoles(recovered);
+    try {
+      roleActivator.ensureRecoveredRoles(recovered);
+    } catch (err) {
+      hubLog.warn({ err }, "role_activator.recovery_degraded");
+    }
   }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -13,10 +13,7 @@ import {
 } from "@triflux/core/hub/lib/timeout-defaults.mjs";
 import { uuidv7 } from "@triflux/core/hub/lib/uuidv7.mjs";
 import { recalcConfidence } from "@triflux/core/hub/reflexion.mjs";
-import {
-  decodeRoleKey,
-  ROLE_REACHABILITY_STATES,
-} from "@triflux/core/hub/role-contract.mjs";
+import { decodeRoleKey, ROLE_REACHABILITY_STATES } from "@triflux/core/hub/role-contract.mjs";
 
 export { uuidv7 };
 
@@ -253,9 +250,7 @@ export function createStore(dbPath, options = {}) {
       "UPDATE agents SET status='offline' WHERE agent_id=? AND presence_generation=? AND status='stale' AND lease_expires_ms < ? - 300000",
     ),
 
-    getRole: db.prepare(
-      "SELECT * FROM role_registry WHERE role_key_wire = ?",
-    ),
+    getRole: db.prepare("SELECT * FROM role_registry WHERE role_key_wire = ?"),
     insertRoleReservation: db.prepare(`
       INSERT INTO role_registry (
         role_key_wire, project_id, role_kind, scope_id, state,
@@ -312,9 +307,7 @@ export function createStore(dbPath, options = {}) {
         AND activation_seq=@expected_activation_seq
         AND activation_id IS @expected_activation_id
         AND version=@expected_version`),
-    listRoles: db.prepare(
-      "SELECT * FROM role_registry ORDER BY role_key_wire",
-    ),
+    listRoles: db.prepare("SELECT * FROM role_registry ORDER BY role_key_wire"),
     expiredHolderRoles: db.prepare(`
       SELECT * FROM role_registry
       WHERE holder_agent_id IS NOT NULL
@@ -652,27 +645,32 @@ export function createStore(dbPath, options = {}) {
       previous_holder_agent_id:
         input.previous_holder_agent_id ??
         (current?.holder_agent_id !== input.holder_agent_id
-          ? current?.holder_agent_id ?? null
-          : current?.previous_holder_agent_id ?? null),
+          ? (current?.holder_agent_id ?? null)
+          : (current?.previous_holder_agent_id ?? null)),
       epoch: nextEpoch,
       activation_seq: nextActivationSeq,
-      activation_id:
-        input.activation_id ??
-        (input.holder_agent_id ? uuidv7() : current?.activation_id ?? null),
-      activation_deadline_ms:
-        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
-      holder_lease_expires_ms:
-        input.holder_lease_expires_ms ??
-        current?.holder_lease_expires_ms ??
-        null,
-      charter_version: input.charter_version ?? current?.charter_version ?? null,
-      charter_acked_epoch:
-        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      activation_id: Object.hasOwn(input, "activation_id")
+        ? input.activation_id
+        : input.holder_agent_id
+          ? uuidv7()
+          : (current?.activation_id ?? null),
+      activation_deadline_ms: Object.hasOwn(input, "activation_deadline_ms")
+        ? input.activation_deadline_ms
+        : (current?.activation_deadline_ms ?? null),
+      holder_lease_expires_ms: Object.hasOwn(input, "holder_lease_expires_ms")
+        ? input.holder_lease_expires_ms
+        : (current?.holder_lease_expires_ms ?? null),
+      charter_version: Object.hasOwn(input, "charter_version")
+        ? input.charter_version
+        : (current?.charter_version ?? null),
+      charter_acked_epoch: Object.hasOwn(input, "charter_acked_epoch")
+        ? input.charter_acked_epoch
+        : (current?.charter_acked_epoch ?? null),
       retry_count: input.retry_count ?? current?.retry_count ?? 0,
       next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
       blocked_reason:
         input.blocked_reason === undefined
-          ? current?.blocked_reason ?? null
+          ? (current?.blocked_reason ?? null)
           : input.blocked_reason,
       last_transition_ms: input.last_transition_ms ?? Date.now(),
       last_reason: input.last_reason ?? "role_reserved",
@@ -724,14 +722,10 @@ export function createStore(dbPath, options = {}) {
     return {
       roles,
       candidates: roles.flatMap((role) =>
-        S.listRoleCandidates
-          .all(role.role_key_wire)
-          .map(parseRoleCandidateRow),
+        S.listRoleCandidates.all(role.role_key_wire).map(parseRoleCandidateRow),
       ),
       pending_messages: roles.flatMap((role) =>
-        S.pendingRoleMessages
-          .all(role.role_key_wire, now)
-          .map(parseMessageRow),
+        S.pendingRoleMessages.all(role.role_key_wire, now).map(parseMessageRow),
       ),
     };
   });
@@ -891,7 +885,8 @@ export function createStore(dbPath, options = {}) {
         Object.hasOwn(input, "expectedActivationId") ||
         Object.hasOwn(input, "activation_id");
       const expected = {
-        version: input.expected_version ?? input.expectedVersion ?? input.version,
+        version:
+          input.expected_version ?? input.expectedVersion ?? input.version,
         epoch: input.expected_epoch ?? input.expectedEpoch ?? input.epoch,
         activation_seq:
           input.expected_activation_seq ??
@@ -1033,15 +1028,15 @@ export function createStore(dbPath, options = {}) {
           0,
         excluded_until_ms:
           input.excluded_until_ms === undefined
-            ? current?.excluded_until_ms ?? null
+            ? (current?.excluded_until_ms ?? null)
             : input.excluded_until_ms,
         last_probe_ms:
           input.last_probe_ms === undefined
-            ? current?.last_probe_ms ?? null
+            ? (current?.last_probe_ms ?? null)
             : input.last_probe_ms,
         last_probe_code:
           input.last_probe_code === undefined
-            ? current?.last_probe_code ?? null
+            ? (current?.last_probe_code ?? null)
             : input.last_probe_code,
         updated_at_ms: input.updated_at_ms ?? Date.now(),
       });
@@ -1056,9 +1051,11 @@ export function createStore(dbPath, options = {}) {
       if (!current) return { ok: false, reason: "not_found" };
 
       let failures =
-        input.consecutive_probe_failures ??
-        current.consecutive_probe_failures;
-      if (input.probe_failed === true || input.increment_probe_failures === true) {
+        input.consecutive_probe_failures ?? current.consecutive_probe_failures;
+      if (
+        input.probe_failed === true ||
+        input.increment_probe_failures === true
+      ) {
         failures = current.consecutive_probe_failures + 1;
       } else if (input.probe_succeeded === true) {
         failures = 0;

--- a/packages/triflux/hub/pipe.mjs
+++ b/packages/triflux/hub/pipe.mjs
@@ -220,6 +220,35 @@ export function createPipeServer({
 
   async function processCommand(client, action, payload = {}) {
     switch (action) {
+      case "ensure_role": {
+        if (client && !client.agentId) {
+          return {
+            ok: false,
+            error: {
+              code: "PRINCIPAL_REQUIRED",
+              message: "agent registration required before ensure_role",
+            },
+          };
+        }
+        return router.requestEnsureRole(payload, {
+          principal: client?.agentId
+            ? { type: "agent", agent_id: client.agentId }
+            : {
+                type: "system",
+                service: "team-pipeline",
+                project_id: payload?.role_key?.project_id,
+              },
+        });
+      }
+
+      case "ack_role_activation":
+        return router.ackRoleActivation(payload, {
+          principal: {
+            type: "agent",
+            agent_id: client?.agentId,
+          },
+        });
+
       case "register": {
         const result = router.registerAgent(payload);
         if (!result?.ok) return result;
@@ -814,8 +843,12 @@ export function createPipeServer({
       };
     },
 
-    async executeCommand(action, payload) {
-      return await processCommand(null, action, payload);
+    async executeCommand(action, payload, context = {}) {
+      const client =
+        context.connection_bound || context.agent_id
+          ? { agentId: context.agent_id ?? null }
+          : null;
+      return await processCommand(client, action, payload);
     },
 
     async executeQuery(action, payload) {

--- a/packages/triflux/hub/role-activator-tfx-live.mjs
+++ b/packages/triflux/hub/role-activator-tfx-live.mjs
@@ -1,0 +1,292 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = dirname(MODULE_DIR);
+const REQUIRED_CAPABILITIES = ["probe", "wake", "activate"];
+
+function opaqueHostId(value) {
+  return `hst_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    const lines = text.split(/\r?\n/u);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      try {
+        return JSON.parse(lines[index]);
+      } catch {}
+    }
+    return {};
+  }
+}
+
+function seconds(timeoutMs, fallbackMs) {
+  const value = Number(timeoutMs);
+  return String(
+    Math.max(1, Math.ceil((value > 0 ? value : fallbackMs) / 1000)),
+  );
+}
+
+function reasonFromError(error) {
+  if (error?.name === "AbortError") return "timeout";
+  if (error?.code === "ETIMEDOUT" || error?.killed) return "timeout";
+  if (error?.code === "EACCES" || error?.code === "EPERM") {
+    return "permission_denied";
+  }
+  if (error?.code === "ENOENT") return "adapter_unavailable";
+  if (Number(error?.code) === 1) return "target_not_found";
+  return "transport_error";
+}
+
+function probeResult(locator, startedAt, observedAt, patch) {
+  return {
+    schema_version: "tfx-live.transport-probe.v1",
+    ok: false,
+    reachable: false,
+    wakeable: false,
+    transport_selected: locator?.kind ?? null,
+    transport_id: locator?.transport_id ?? "unknown",
+    host_id: locator?.host_id ?? "unknown",
+    latency_ms: Math.max(0, observedAt - startedAt),
+    observed_at_ms: observedAt,
+    reason_code: "transport_error",
+    ...patch,
+  };
+}
+
+function defaultSessionName(roleKey) {
+  const suffix = globalThis.crypto.randomUUID().slice(0, 8);
+  return `tfx-role-${roleKey.role_kind}-${suffix}`;
+}
+
+function activationPrompt(activation) {
+  return JSON.stringify(activation);
+}
+
+export function createTfxLiveRoleAdapter(options = {}) {
+  const projectRoot = options.projectRoot || DEFAULT_ROOT;
+  const defaultTfxLivePath = join(projectRoot, "bin", "tfx-live.mjs");
+  const tfxLivePath = options.tfxLivePath || defaultTfxLivePath;
+  const tfxLiveCommand =
+    options.tfxLiveCommand ||
+    (!options.tfxLivePath && !existsSync(defaultTfxLivePath)
+      ? "tfx-live"
+      : null);
+  const bridgePath =
+    options.bridgePath || join(projectRoot, "hub", "bridge.mjs");
+  const nodePath = options.nodePath || process.execPath;
+  const tmuxPath = options.tmuxPath || "tmux";
+  const localHostId =
+    options.localHostId || opaqueHostId(options.hostname?.() || hostname());
+  const muxServerId = options.muxServerId || "mux_local";
+  const now = options.now || Date.now;
+  const sessionName = options.sessionName || defaultSessionName;
+  const runProcess =
+    options.runProcess ||
+    (async (command, args, processOptions = {}) =>
+      await execFileAsync(command, args, {
+        encoding: "utf8",
+        windowsHide: true,
+        maxBuffer: 1024 * 1024,
+        ...processOptions,
+      }));
+  const active = new Map();
+
+  function runTfxLive(args, processOptions) {
+    return tfxLiveCommand
+      ? runProcess(tfxLiveCommand, args, processOptions)
+      : runProcess(nodePath, [tfxLivePath, ...args], processOptions);
+  }
+
+  function supports(locator) {
+    return (
+      locator?.schema_version === "tfx.transport-locator.v1" &&
+      locator.host_id === localHostId &&
+      (locator.kind === "claude-uds" || locator.kind === "tmux") &&
+      Array.isArray(locator.capabilities) &&
+      REQUIRED_CAPABILITIES.every((capability) =>
+        locator.capabilities.includes(capability),
+      )
+    );
+  }
+
+  async function probe(locator, probeOptions = {}) {
+    const startedAt = now();
+    if (!supports(locator)) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: "adapter_unavailable",
+      });
+    }
+    try {
+      if (locator.kind === "tmux") {
+        await runProcess(
+          tmuxPath,
+          ["has-session", "-t", locator.locator.session_name],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+      } else {
+        const refArgs = locator.locator.session_id
+          ? ["--session-id", locator.locator.session_id]
+          : ["--short", locator.locator.short];
+        const result = await runTfxLive(
+          [
+            "probe",
+            ...refArgs,
+            "--bridge",
+            bridgePath,
+            "--timeout",
+            seconds(probeOptions.timeout_ms, 10_000),
+          ],
+          {
+            timeout: probeOptions.timeout_ms,
+            signal: probeOptions.signal,
+          },
+        );
+        const payload = parseJsonOutput(result.stdout);
+        if (payload.ok !== true) {
+          return probeResult(locator, startedAt, now(), {
+            reason_code:
+              payload.reason_code || payload.reason || "target_not_found",
+          });
+        }
+      }
+      return probeResult(locator, startedAt, now(), {
+        ok: true,
+        reachable: true,
+        wakeable: true,
+        reason_code: "ok",
+      });
+    } catch (error) {
+      return probeResult(locator, startedAt, now(), {
+        reason_code: reasonFromError(error),
+      });
+    }
+  }
+
+  function liveArgs(locator, cli, verb) {
+    if (locator.kind === "tmux") {
+      return [
+        verb,
+        "--cli",
+        cli,
+        "--transport",
+        "tmux",
+        "--session",
+        locator.locator.session_name,
+      ];
+    }
+    const refArgs = locator.locator.session_id
+      ? ["--session-id", locator.locator.session_id]
+      : ["--short", locator.locator.short];
+    return [
+      verb,
+      "--cli",
+      "claude",
+      "--transport",
+      "uds",
+      ...refArgs,
+      "--bridge",
+      bridgePath,
+    ];
+  }
+
+  async function wake(locator, activation, wakeOptions = {}) {
+    if (!supports(locator)) {
+      return { ok: false, reason_code: "adapter_unavailable" };
+    }
+    const cli = activation?.holder_cli === "codex" ? "codex" : "claude";
+    const args = [
+      ...liveArgs(locator, cli, "ask"),
+      "--prompt",
+      activationPrompt(activation),
+      "--timeout",
+      seconds(wakeOptions.timeout_ms, 10_000),
+    ];
+    try {
+      const result = await runTfxLive(args, {
+        timeout: wakeOptions.timeout_ms,
+        signal: wakeOptions.signal,
+      });
+      const payload = parseJsonOutput(result.stdout);
+      if (payload.ok === false) {
+        return {
+          ok: false,
+          reason_code: payload.reason_code || "transport_error",
+        };
+      }
+      active.set(activation.activation_id, { locator, cli });
+      return { ok: true, transport_id: locator.transport_id };
+    } catch (error) {
+      return { ok: false, reason_code: reasonFromError(error) };
+    }
+  }
+
+  async function standup(roleKey, cli, standupOptions = {}) {
+    const name = sessionName(roleKey);
+    await runTfxLive(
+      [
+        "start",
+        "--session",
+        name,
+        "--cli",
+        cli,
+        "--cwd",
+        projectRoot,
+        "--ready-timeout",
+        seconds(standupOptions.timeout_ms, 60_000),
+      ],
+      {
+        timeout: standupOptions.timeout_ms,
+        signal: standupOptions.signal,
+      },
+    );
+    return {
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: `standup:${name}`,
+      kind: "tmux",
+      host_id: localHostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: now() + 300_000,
+      locator: { session_name: name, mux_server_id: muxServerId },
+    };
+  }
+
+  async function cancel(activationId) {
+    const target = active.get(activationId);
+    if (!target) return false;
+    active.delete(activationId);
+    try {
+      await runTfxLive(
+        [
+          ...liveArgs(target.locator, target.cli, "interrupt"),
+          "--timeout",
+          "5",
+        ],
+        { timeout: 5_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return { supports, probe, wake, standup, cancel };
+}

--- a/packages/triflux/hub/role-activator.mjs
+++ b/packages/triflux/hub/role-activator.mjs
@@ -375,14 +375,18 @@ export function createRoleActivator(options = {}) {
     ) {
       return { receipt: receipt("joined", roleKeyWire, current) };
     }
+    let candidates;
     if (
       ["unreachable", "quarantined"].includes(current?.state) &&
       Number(current.next_probe_ms) > now()
     ) {
-      return { receipt: receipt("joined", roleKeyWire, current) };
+      candidates = eligibleCandidates(roleKey, roleKeyWire);
+      if (!candidates.length) {
+        return { receipt: receipt("joined", roleKeyWire, current) };
+      }
     }
 
-    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    candidates ??= eligibleCandidates(roleKey, roleKeyWire);
     const holder = candidates[0] || null;
     const plan = reserve(roleKey, current, holder, normalized.trigger);
     return { plan, candidates };
@@ -791,12 +795,9 @@ export function createRoleActivator(options = {}) {
         },
       );
     } catch (error) {
-      const reasonCode = error?.code || "standup_wake_failed";
-      const deferred = deferStandupRetry(plan, reasonCode);
-      return {
-        status: deferred.role?.state || "unreachable",
-        reason_code: reasonCode,
-        role: deferred.role,
+      wake = {
+        ok: false,
+        reason_code: error?.code || "standup_wake_failed",
       };
     }
     const afterWake = await gate(plan);

--- a/packages/triflux/hub/role-activator.mjs
+++ b/packages/triflux/hub/role-activator.mjs
@@ -1,0 +1,1195 @@
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
+import {
+  buildCapabilityDegradedEvent,
+  emitRoleControlEvent,
+} from "./role-control-events.mjs";
+
+export const ENSURE_ROLE_SCHEMA_VERSION = "tfx.ensure-role.v1";
+export const ROLE_ACTIVATION_ACK_SCHEMA_VERSION = "tfx.role-activation-ack.v1";
+
+const ENSURE_ROLE_TRIGGERS = new Set([
+  "session_start",
+  "publish_no_holder",
+  "lease_expired",
+  "restart_recovery",
+  "hygiene_changed",
+  "charter_issued",
+  "manual",
+]);
+const REQUIRED_LOCATOR_CAPABILITIES = ["probe", "wake", "activate"];
+const DEFAULTS = Object.freeze({
+  probe_timeout_ms: 10_000,
+  activation_ack_timeout_ms: 45_000,
+  standup_timeout_ms: 60_000,
+  max_probe_failures: 3,
+  backoff_base_ms: 1_000,
+  backoff_factor: 2,
+  backoff_max_ms: 30_000,
+  backoff_jitter_ratio: 0.2,
+  candidate_quarantine_ms: 120_000,
+});
+
+function activatorError(code, message = code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeEnsureRequest(request, now) {
+  if (
+    !isRecord(request) ||
+    request.schema_version !== ENSURE_ROLE_SCHEMA_VERSION ||
+    !ENSURE_ROLE_TRIGGERS.has(request.trigger) ||
+    typeof request.cause_id !== "string" ||
+    !request.cause_id.trim()
+  ) {
+    throw activatorError("ENSURE_ROLE_REQUEST_INVALID");
+  }
+  const roleKey = normalizeRoleKey(request.role_key);
+  return {
+    schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+    role_key: roleKey,
+    role_key_wire: encodeRoleKey(roleKey),
+    trigger: request.trigger,
+    cause_id: request.cause_id.trim(),
+    requested_at_ms: now(),
+  };
+}
+
+function managerEnabled(control, roleKind) {
+  if (!control?.master_enabled) return false;
+  return roleKind === "cto"
+    ? control.cto_manager_enabled === true
+    : control.lead_manager_enabled === true;
+}
+
+function blockedReason(control) {
+  return control?.master_enabled ? "manager_disabled" : "master_off";
+}
+
+function receipt(disposition, roleKeyWire, role, extra = {}) {
+  return {
+    accepted: !["manager_disabled", "scope_closed"].includes(disposition),
+    disposition,
+    role_key_wire: roleKeyWire,
+    state: role?.state ?? "electable",
+    epoch: role?.epoch ?? 0,
+    ...(role?.activation_id ? { activation_id: role.activation_id } : {}),
+    ...extra,
+  };
+}
+
+function activationGuard(role) {
+  return {
+    role_key_wire: role.role_key_wire,
+    expected_version: role.version,
+    expected_epoch: role.epoch,
+    expected_activation_seq: role.activation_seq,
+    expected_activation_id: role.activation_id,
+  };
+}
+
+function locatorUsable(locator, adapter, disabledAdapters, now) {
+  return (
+    isRecord(locator) &&
+    locator.schema_version === "tfx.transport-locator.v1" &&
+    typeof locator.kind === "string" &&
+    !disabledAdapters.has(locator.kind) &&
+    Number(locator.expires_at_ms) > now &&
+    Array.isArray(locator.capabilities) &&
+    REQUIRED_LOCATOR_CAPABILITIES.every((capability) =>
+      locator.capabilities.includes(capability),
+    ) &&
+    adapter.supports(locator) === true
+  );
+}
+
+function candidateLive(candidate, store, roleKey, now) {
+  const agent = store.getAgent(candidate.agent_id);
+  if (
+    !agent ||
+    agent.status !== "online" ||
+    Number(agent.lease_expires_ms) <= now
+  ) {
+    return null;
+  }
+  if (agent.project_id && agent.project_id !== roleKey.project_id) return null;
+  const capabilities = Array.isArray(agent.capabilities)
+    ? agent.capabilities
+    : [];
+  if (!capabilities.includes(`role:${roleKey.role_kind}:candidate`))
+    return null;
+  return agent;
+}
+
+function normalizeProbeResult(result, locator) {
+  if (
+    !isRecord(result) ||
+    result.schema_version !== "tfx-live.transport-probe.v1"
+  ) {
+    return {
+      ok: false,
+      reachable: false,
+      wakeable: false,
+      reason_code: "protocol_mismatch",
+      transport_id: locator.transport_id,
+    };
+  }
+  return result;
+}
+
+export function computeRoleBackoffMs(
+  failureCount,
+  config = {},
+  rng = Math.random,
+) {
+  const options = { ...DEFAULTS, ...config };
+  const count = Math.max(1, Number(failureCount) || 1);
+  const base = Math.min(
+    options.backoff_base_ms * options.backoff_factor ** (count - 1),
+    options.backoff_max_ms,
+  );
+  const unit = Math.max(0, Math.min(1, Number(rng()) || 0));
+  const jitter = (unit * 2 - 1) * options.backoff_jitter_ratio;
+  return Math.round(base * (1 + jitter));
+}
+
+export function createRoleActivator(options = {}) {
+  const {
+    store,
+    adapter,
+    getControlSnapshot = () => ({
+      generation: 0,
+      master_enabled: false,
+      cto_manager_enabled: false,
+      lead_manager_enabled: false,
+    }),
+    getCharterVersion = () => null,
+    isScopeClosed = () => false,
+    runCoreCanary = () => ({ ok: true }),
+    uuid = () => globalThis.crypto.randomUUID(),
+    now = Date.now,
+    rng = Math.random,
+    logger = null,
+    onControlEvent = null,
+    onRoleActive = null,
+    scheduleTimeout = setTimeout,
+    clearScheduledTimeout = clearTimeout,
+    writeFallback = (line) => process.stderr.write(line),
+  } = options;
+  const config = { ...DEFAULTS, ...(options.config || {}) };
+  if (!store || !adapter)
+    throw activatorError("ROLE_ACTIVATOR_DEPENDENCY_INVALID");
+
+  const flights = new Map();
+  const ackTimers = new Map();
+  const disabledAdapters = new Set();
+  let controlOverride = null;
+  let managerCircuitReason = null;
+
+  function controlSnapshot() {
+    return controlOverride || getControlSnapshot();
+  }
+
+  function emitDegraded(input) {
+    let event = null;
+    try {
+      event = buildCapabilityDegradedEvent({
+        module: "role-activator",
+        dur_ms: 0,
+        ...input,
+      });
+      if (typeof onControlEvent === "function") onControlEvent(event);
+      if (logger) emitRoleControlEvent(logger, event);
+      return event;
+    } catch {
+      managerCircuitReason = "logger_event_shape_failed";
+      try {
+        writeFallback(
+          `${JSON.stringify({
+            service: "triflux",
+            env: process.env.NODE_ENV || "development",
+            module: "role-activator",
+            event: "capability.degraded",
+            event_id:
+              event?.event_id ??
+              globalThis.crypto?.randomUUID?.() ??
+              "evt_fallback",
+            dur_ms: 0,
+            control_action: "manager_disable",
+            reason_code: managerCircuitReason,
+            level: "error",
+            time: new Date(now()).toISOString(),
+            msg: "capability.degraded",
+          })}\n`,
+        );
+      } catch {}
+      return null;
+    }
+  }
+
+  function runCanary(roleKeyWire) {
+    if (managerCircuitReason) return false;
+    let result;
+    try {
+      result = runCoreCanary({ store, adapter });
+    } catch (error) {
+      result = { ok: false, reason_code: error?.code || "core_canary_failed" };
+    }
+    if (result?.ok !== false) return true;
+    managerCircuitReason = result.reason_code || "core_canary_failed";
+    emitDegraded({
+      control_action: "manager_disable",
+      reason_code: managerCircuitReason,
+      role_key_wire: roleKeyWire,
+    });
+    return false;
+  }
+
+  function eligibleCandidates(roleKey, roleKeyWire, excluded = new Set()) {
+    const currentTime = now();
+    return store
+      .listRoleCandidates(roleKeyWire)
+      .filter((candidate) => !excluded.has(candidate.agent_id))
+      .filter(
+        (candidate) =>
+          candidate.excluded_until_ms == null ||
+          Number(candidate.excluded_until_ms) <= currentTime,
+      )
+      .map((candidate) => {
+        const agent = candidateLive(candidate, store, roleKey, currentTime);
+        if (!agent) return null;
+        const locators = (candidate.transport_locators || [])
+          .filter((locator) =>
+            locatorUsable(locator, adapter, disabledAdapters, currentTime),
+          )
+          .sort(
+            (left, right) =>
+              Number(right.priority || 0) - Number(left.priority || 0) ||
+              String(left.transport_id).localeCompare(
+                String(right.transport_id),
+              ),
+          );
+        return locators.length ? { candidate, agent, locators } : null;
+      })
+      .filter(Boolean);
+  }
+
+  function reserve(roleKey, current, holder, trigger, activationId = uuid()) {
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const result = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      ...(current
+        ? {
+            expected_version: current.version,
+            expected_epoch: current.epoch,
+          }
+        : {}),
+      holder_agent_id: holder?.candidate.agent_id ?? null,
+      holder_lease_expires_ms: holder?.agent.lease_expires_ms ?? null,
+      state: "elected-probing",
+      activation_id: activationId,
+      activation_deadline_ms:
+        now() +
+        (holder ? config.activation_ack_timeout_ms : config.standup_timeout_ms),
+      charter_version: getCharterVersion(roleKey.role_kind),
+      charter_acked_epoch: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: holder ? "candidate_selected" : "standup_reserved",
+    });
+    if (!result.ok) {
+      throw activatorError("ROLE_RESERVATION_CONFLICT", result.reason);
+    }
+    return {
+      roleKey,
+      roleKeyWire,
+      role: result.role,
+      holder,
+      trigger,
+      controlGeneration: controlSnapshot()?.generation ?? 0,
+    };
+  }
+
+  function prepare(normalized) {
+    const { role_key: roleKey, role_key_wire: roleKeyWire } = normalized;
+    const control = controlSnapshot();
+    if (
+      !managerEnabled(control, roleKey.role_kind) ||
+      !runCanary(roleKeyWire)
+    ) {
+      const reasonCode = managerCircuitReason || blockedReason(control);
+      let current = store.getRole(roleKeyWire);
+      if (
+        current &&
+        (current.holder_agent_id ||
+          current.activation_id ||
+          current.state === "active" ||
+          current.state === "elected-probing")
+      ) {
+        current = fencePlan({ roleKeyWire }, reasonCode).role;
+      }
+      return {
+        receipt: receipt("manager_disabled", roleKeyWire, current, {
+          blocked_reason: reasonCode,
+        }),
+      };
+    }
+    if (roleKey.role_kind === "lead" && isScopeClosed(roleKey)) {
+      return {
+        receipt: receipt(
+          "scope_closed",
+          roleKeyWire,
+          store.getRole(roleKeyWire),
+        ),
+      };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    const charterVersion = getCharterVersion(roleKey.role_kind);
+    if (
+      current?.state === "active" &&
+      current.holder_agent_id &&
+      Number(current.holder_lease_expires_ms) > now() &&
+      current.charter_acked_epoch === current.epoch &&
+      current.charter_version === charterVersion &&
+      normalized.trigger !== "charter_issued"
+    ) {
+      return {
+        receipt: receipt("already_active", roleKeyWire, current),
+      };
+    }
+
+    if (
+      current?.state === "elected-probing" &&
+      current.activation_id &&
+      Number(current.activation_deadline_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+    if (
+      ["unreachable", "quarantined"].includes(current?.state) &&
+      Number(current.next_probe_ms) > now()
+    ) {
+      return { receipt: receipt("joined", roleKeyWire, current) };
+    }
+
+    const candidates = eligibleCandidates(roleKey, roleKeyWire);
+    const holder = candidates[0] || null;
+    const plan = reserve(roleKey, current, holder, normalized.trigger);
+    return { plan, candidates };
+  }
+
+  function cas(plan, patch) {
+    return store.compareAndSetRole({
+      ...activationGuard(plan.role),
+      patch: {
+        last_transition_ms: now(),
+        ...patch,
+      },
+    });
+  }
+
+  function fencePlan(plan, reasonCode) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (!current) return { ok: false, reason: "not_found", role: null };
+    return store.upsertRoleReservation({
+      role_key_wire: plan.roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      blocked_reason: reasonCode,
+      last_transition_ms: now(),
+      last_reason: reasonCode,
+    });
+  }
+
+  async function cancelPlan(plan, reasonCode) {
+    const entry = flights.get(plan.roleKeyWire);
+    if (entry?.cancelledOutcome) return entry.cancelledOutcome;
+    try {
+      await adapter.cancel(plan.role.activation_id);
+    } catch {}
+    const result = fencePlan(plan, reasonCode);
+    return {
+      status: "cancelled",
+      reason_code: reasonCode,
+      role: result.role,
+    };
+  }
+
+  async function gate(plan) {
+    const current = store.getRole(plan.roleKeyWire);
+    if (
+      !current ||
+      current.version !== plan.role.version ||
+      current.epoch !== plan.role.epoch ||
+      current.activation_seq !== plan.role.activation_seq ||
+      current.activation_id !== plan.role.activation_id
+    ) {
+      return { status: "stale", reason_code: "cas_conflict", role: current };
+    }
+    const control = controlSnapshot();
+    if (
+      managerCircuitReason ||
+      !managerEnabled(control, plan.roleKey.role_kind) ||
+      Number(control?.generation ?? 0) !== Number(plan.controlGeneration)
+    ) {
+      return await cancelPlan(
+        plan,
+        managerCircuitReason || blockedReason(control),
+      );
+    }
+    return null;
+  }
+
+  function markCandidateFailure(plan, holder, reasonCode) {
+    const failures =
+      Number(holder.candidate.consecutive_probe_failures || 0) + 1;
+    const delay =
+      failures >= config.max_probe_failures
+        ? config.candidate_quarantine_ms
+        : computeRoleBackoffMs(failures, config, rng);
+    const excludedUntil = now() + delay;
+    store.updateCandidateReachability({
+      role_key_wire: plan.roleKeyWire,
+      agent_id: holder.candidate.agent_id,
+      consecutive_probe_failures: failures,
+      excluded_until_ms: excludedUntil,
+      last_probe_ms: now(),
+      last_probe_code: reasonCode,
+      updated_at_ms: now(),
+    });
+    const failed = cas(plan, {
+      state: "unreachable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      next_probe_ms: excludedUntil,
+      retry_count: Number(plan.role.retry_count || 0) + 1,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "candidate_exclude",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      candidate_agent_id: holder.candidate.agent_id,
+    });
+    return { ...failed, failures, excludedUntil };
+  }
+
+  function scheduleAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      store.compareAndSetRole({
+        ...activationGuard(current),
+        patch: {
+          state: "unreachable",
+          activation_deadline_ms: null,
+          next_probe_ms: now(),
+          last_transition_ms: now(),
+          last_reason: "ack_timeout",
+        },
+      });
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  function deferStandupRetry(plan, reasonCode) {
+    const failures = Number(plan.role.retry_count || 0) + 1;
+    const exhausted = failures >= config.max_probe_failures;
+    const delay = exhausted
+      ? config.candidate_quarantine_ms
+      : computeRoleBackoffMs(failures, config, rng);
+    const result = cas(plan, {
+      state: exhausted ? "quarantined" : "unreachable",
+      holder_agent_id: null,
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: failures,
+      next_probe_ms: now() + delay,
+      blocked_reason: null,
+      last_reason: reasonCode,
+    });
+    emitDegraded({
+      control_action: "dispatch_block",
+      reason_code: reasonCode,
+      project_id: plan.roleKey.project_id,
+      role_key_wire: plan.roleKeyWire,
+      capability: "standup_activation",
+    });
+    return result;
+  }
+
+  function scheduleStandupAckTimeout(plan) {
+    const delay = Math.max(0, Number(plan.role.activation_deadline_ms) - now());
+    const timer = scheduleTimeout(() => {
+      ackTimers.delete(plan.role.activation_id);
+      const current = store.getRole(plan.roleKeyWire);
+      if (
+        !current ||
+        current.state !== "elected-probing" ||
+        current.holder_agent_id !== null ||
+        current.epoch !== plan.role.epoch ||
+        current.activation_seq !== plan.role.activation_seq ||
+        current.activation_id !== plan.role.activation_id
+      ) {
+        return;
+      }
+      deferStandupRetry({ ...plan, role: current }, "standup_ack_timeout");
+    }, delay);
+    timer?.unref?.();
+    ackTimers.set(plan.role.activation_id, timer);
+  }
+
+  async function runCandidatePlan(initialPlan, initialCandidates) {
+    let plan = initialPlan;
+    let remaining = initialCandidates;
+    const attempted = new Set();
+
+    while (plan.holder) {
+      const holder = plan.holder;
+      attempted.add(holder.candidate.agent_id);
+      let lastReason = "transport_error";
+
+      for (const locator of holder.locators) {
+        const beforeProbe = await gate(plan);
+        if (beforeProbe) return beforeProbe;
+
+        let rawProbe;
+        try {
+          rawProbe = await adapter.probe(locator, {
+            timeout_ms: config.probe_timeout_ms,
+            signal: flights.get(plan.roleKeyWire)?.controller.signal,
+          });
+        } catch (error) {
+          rawProbe = {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: false,
+            reachable: false,
+            wakeable: false,
+            reason_code: error?.code || "transport_error",
+            transport_id: locator.transport_id,
+          };
+        }
+        const probe = normalizeProbeResult(rawProbe, locator);
+        const afterProbe = await gate(plan);
+        if (afterProbe) return afterProbe;
+
+        if (!probe.ok || !probe.reachable || !probe.wakeable) {
+          lastReason = probe.reason_code || "transport_error";
+          if (lastReason === "adapter_unavailable") {
+            disabledAdapters.add(locator.kind);
+            emitDegraded({
+              control_action: "adapter_disable",
+              reason_code: lastReason,
+              project_id: plan.roleKey.project_id,
+              role_key_wire: plan.roleKeyWire,
+              candidate_agent_id: holder.candidate.agent_id,
+              transport_id: locator.transport_id,
+            });
+          }
+          continue;
+        }
+
+        store.updateCandidateReachability({
+          role_key_wire: plan.roleKeyWire,
+          agent_id: holder.candidate.agent_id,
+          probe_succeeded: true,
+          excluded_until_ms: null,
+          last_probe_ms: now(),
+          last_probe_code: "ok",
+          updated_at_ms: now(),
+        });
+
+        const beforeWake = await gate(plan);
+        if (beforeWake) return beforeWake;
+        let wake;
+        try {
+          wake = await adapter.wake(
+            locator,
+            {
+              schema_version: "tfx.role-activation.v1",
+              role_key: plan.roleKey,
+              role_key_wire: plan.roleKeyWire,
+              epoch: plan.role.epoch,
+              activation_seq: plan.role.activation_seq,
+              activation_id: plan.role.activation_id,
+              charter_version: plan.role.charter_version,
+              holder_cli: holder.agent.cli,
+            },
+            {
+              timeout_ms: config.probe_timeout_ms,
+              signal: flights.get(plan.roleKeyWire)?.controller.signal,
+            },
+          );
+        } catch (error) {
+          wake = { ok: false, reason_code: error?.code || "transport_error" };
+        }
+        const afterWake = await gate(plan);
+        if (afterWake) return afterWake;
+        if (wake?.ok === false) {
+          lastReason = wake.reason_code || "wake_failed";
+          continue;
+        }
+
+        scheduleAckTimeout(plan);
+        return {
+          status: "awaiting_ack",
+          role: store.getRole(plan.roleKeyWire),
+          activation_id: plan.role.activation_id,
+          holder_agent_id: holder.candidate.agent_id,
+          transport_id: locator.transport_id,
+        };
+      }
+
+      const failed = markCandidateFailure(plan, holder, lastReason);
+      if (!failed.ok) {
+        return {
+          status: "stale",
+          reason_code: failed.reason,
+          role: failed.role,
+        };
+      }
+      remaining = eligibleCandidates(plan.roleKey, plan.roleKeyWire, attempted);
+      if (!remaining.length) {
+        if (failed.failures < config.max_probe_failures) {
+          return {
+            status: "unreachable",
+            role: failed.role,
+            reason_code: lastReason,
+          };
+        }
+        const quarantined = store.compareAndSetRole({
+          ...activationGuard(failed.role),
+          patch: {
+            state: "quarantined",
+            activation_id: null,
+            activation_deadline_ms: null,
+            holder_lease_expires_ms: null,
+            last_transition_ms: now(),
+            last_reason: "candidates_excluded",
+          },
+        });
+        return {
+          status: "quarantined",
+          role: quarantined.role,
+          reason_code: lastReason,
+        };
+      }
+      plan = reserve(plan.roleKey, failed.role, remaining[0], plan.trigger);
+    }
+
+    return await runStandupPlan(plan);
+  }
+
+  async function runStandupPlan(plan) {
+    const before = await gate(plan);
+    if (before) return before;
+
+    function blockStandup(reasonCode) {
+      const blocked = cas(plan, {
+        state: "electable",
+        holder_agent_id: null,
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        blocked_reason: "no_candidate",
+        last_reason: reasonCode,
+      });
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: reasonCode,
+        project_id: plan.roleKey.project_id,
+        role_key_wire: plan.roleKeyWire,
+        capability: "standup",
+      });
+      return {
+        status: "blocked",
+        reason_code: reasonCode,
+        role: blocked.role,
+      };
+    }
+
+    if (typeof adapter.standup !== "function") {
+      return blockStandup("standup_unavailable");
+    }
+
+    let locator;
+    try {
+      locator = await adapter.standup(plan.roleKey, "claude", {
+        timeout_ms: config.standup_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        activation: {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+        },
+      });
+    } catch (error) {
+      const afterFailure = await gate(plan);
+      if (afterFailure) return afterFailure;
+      return blockStandup(error?.code || "standup_failed");
+    }
+    const after = await gate(plan);
+    if (after) return after;
+    let supported = false;
+    try {
+      supported = locatorUsable(locator, adapter, disabledAdapters, now());
+    } catch {}
+    if (!supported) return blockStandup("standup_locator_invalid");
+    // C3 binds the stood-up session identity/grant and delivers its charter
+    // ACK. C6a-4 still sends the activation now and bounds retries until that
+    // binding exists, so a missing C3 hook cannot create a tight orphan loop.
+    const wake = await adapter.wake(
+      locator,
+      {
+        schema_version: "tfx.role-activation.v1",
+        role_key: plan.roleKey,
+        role_key_wire: plan.roleKeyWire,
+        epoch: plan.role.epoch,
+        activation_seq: plan.role.activation_seq,
+        activation_id: plan.role.activation_id,
+        charter_version: plan.role.charter_version,
+        holder_cli: "claude",
+      },
+      {
+        timeout_ms: config.probe_timeout_ms,
+        signal: flights.get(plan.roleKeyWire)?.controller.signal,
+      },
+    );
+    const afterWake = await gate(plan);
+    if (afterWake) return afterWake;
+    if (wake?.ok !== true) {
+      const reasonCode = wake?.reason_code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
+    scheduleStandupAckTimeout(plan);
+    return {
+      status: "standup_started",
+      role: store.getRole(plan.roleKeyWire),
+      activation_id: plan.role.activation_id,
+      locator,
+    };
+  }
+
+  function startFlight(plan, candidates = []) {
+    const controller = new AbortController();
+    const entry = { controller, plan, promise: null };
+    entry.promise = Promise.resolve()
+      .then(() =>
+        plan.holder ? runCandidatePlan(plan, candidates) : runStandupPlan(plan),
+      )
+      .catch((error) => {
+        const reasonCode = error?.code || "activation_dispatch_failed";
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: reasonCode,
+          project_id: plan.roleKey.project_id,
+          role_key_wire: plan.roleKeyWire,
+        });
+        return {
+          status: "error",
+          reason_code: reasonCode,
+          role: store.getRole(plan.roleKeyWire),
+        };
+      })
+      .finally(() => {
+        if (flights.get(plan.roleKeyWire) === entry) {
+          flights.delete(plan.roleKeyWire);
+        }
+      });
+    flights.set(plan.roleKeyWire, entry);
+    return entry;
+  }
+
+  function requestEnsureRole(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) {
+      return receipt(
+        "joined",
+        normalized.role_key_wire,
+        store.getRole(normalized.role_key_wire),
+      );
+    }
+
+    let prepared;
+    try {
+      prepared = prepare(normalized, context);
+    } catch (error) {
+      emitDegraded({
+        control_action: "dispatch_block",
+        reason_code: error?.code || "activation_reservation_failed",
+        project_id: normalized.role_key.project_id,
+        role_key_wire: normalized.role_key_wire,
+      });
+      throw error;
+    }
+    if (prepared.receipt) return prepared.receipt;
+    startFlight(prepared.plan, prepared.candidates);
+    return receipt("started", normalized.role_key_wire, prepared.plan.role);
+  }
+
+  async function ensureRoleAwake(request, context = {}) {
+    const normalized = normalizeEnsureRequest(request, now);
+    const currentFlight = flights.get(normalized.role_key_wire);
+    if (currentFlight) return await currentFlight.promise;
+    const result = requestEnsureRole(request, context);
+    const started = flights.get(normalized.role_key_wire);
+    return started ? await started.promise : result;
+  }
+
+  function ackActivation(input, context = {}) {
+    if (
+      !isRecord(input) ||
+      input.schema_version !== ROLE_ACTIVATION_ACK_SCHEMA_VERSION ||
+      input.reachable !== true ||
+      !isRecord(input.charter_ack)
+    ) {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+    let roleKey;
+    let roleKeyWire;
+    try {
+      roleKey = normalizeRoleKey(input.role_key);
+      roleKeyWire = encodeRoleKey(roleKey);
+      if (encodeRoleKey(input.charter_ack.role_key) !== roleKeyWire) {
+        return { ok: false, code: "STALE_EPOCH" };
+      }
+    } catch {
+      return { ok: false, code: "ACTIVATION_ACK_INVALID" };
+    }
+
+    const current = store.getRole(roleKeyWire);
+    if (!current) return { ok: false, code: "STALE_EPOCH" };
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      const fenced = fencePlan(
+        { roleKeyWire },
+        managerCircuitReason || blockedReason(control),
+      );
+      return { ok: false, code: "STALE_EPOCH", role: fenced.role };
+    }
+    if (
+      input.epoch !== current.epoch ||
+      input.activation_seq !== current.activation_seq ||
+      input.activation_id !== current.activation_id ||
+      input.charter_ack.epoch !== current.epoch
+    ) {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+    const principalAgentId = context?.principal?.agent_id;
+    if (
+      input.holder_agent_id !== current.holder_agent_id ||
+      principalAgentId !== current.holder_agent_id
+    ) {
+      return { ok: false, code: "HOLDER_MISMATCH", role: current };
+    }
+    if (
+      input.charter_ack.charter_version !== current.charter_version ||
+      input.charter_ack.charter_version !== getCharterVersion(roleKey.role_kind)
+    ) {
+      return { ok: false, code: "CHARTER_VERSION_MISMATCH", role: current };
+    }
+    const holder = store.getAgent(current.holder_agent_id);
+    if (
+      !holder ||
+      holder.status !== "online" ||
+      Number(holder.lease_expires_ms) <= now() ||
+      Number(current.holder_lease_expires_ms) <= now()
+    ) {
+      return { ok: false, code: "HOLDER_LEASE_EXPIRED", role: current };
+    }
+    if (
+      current.state === "active" &&
+      current.charter_acked_epoch === current.epoch
+    ) {
+      return { ok: true, idempotent: true, role: current, ack: input };
+    }
+    if (current.state !== "elected-probing") {
+      return { ok: false, code: "STALE_EPOCH", role: current };
+    }
+
+    const activated = store.compareAndSetRole({
+      ...activationGuard(current),
+      patch: {
+        state: "active",
+        charter_acked_epoch: current.epoch,
+        activation_deadline_ms: null,
+        blocked_reason: null,
+        last_transition_ms: now(),
+        last_reason: "activation_acked",
+      },
+    });
+    if (!activated.ok) {
+      return { ok: false, code: "STALE_EPOCH", role: activated.role };
+    }
+    const timer = ackTimers.get(current.activation_id);
+    if (timer) clearScheduledTimeout(timer);
+    ackTimers.delete(current.activation_id);
+    if (typeof onRoleActive === "function") {
+      try {
+        onRoleActive({ role: activated.role, ack: input });
+      } catch (error) {
+        emitDegraded({
+          control_action: "dispatch_block",
+          reason_code: error?.code || "backlog_transfer_failed",
+          project_id: roleKey.project_id,
+          role_key_wire: roleKeyWire,
+        });
+      }
+    }
+    return { ok: true, idempotent: false, role: activated.role, ack: input };
+  }
+
+  async function drain() {
+    await Promise.allSettled(
+      [...flights.values()].map((entry) => entry.promise),
+    );
+  }
+
+  function close() {
+    for (const entry of flights.values()) entry.controller.abort();
+    for (const timer of ackTimers.values()) clearScheduledTimeout(timer);
+    ackTimers.clear();
+  }
+
+  function updateControlSnapshot(snapshot) {
+    const previousGeneration = Number(controlSnapshot()?.generation ?? 0);
+    controlOverride = snapshot;
+    if (Number(snapshot?.generation ?? 0) !== previousGeneration) {
+      disabledAdapters.clear();
+    }
+    for (const entry of flights.values()) {
+      if (managerEnabled(snapshot, entry.plan.roleKey.role_kind)) continue;
+      entry.controller.abort();
+      Promise.resolve(adapter.cancel(entry.plan.role.activation_id)).catch(
+        () => {},
+      );
+      const result = fencePlan(entry.plan, blockedReason(snapshot));
+      entry.cancelledOutcome = {
+        status: "cancelled",
+        reason_code: blockedReason(snapshot),
+        role: result.role,
+      };
+    }
+    return snapshot;
+  }
+
+  function notifyCandidateChanged(
+    roleKeyInput,
+    agentId,
+    reason = "candidate_registered",
+  ) {
+    const roleKey = normalizeRoleKey(roleKeyInput);
+    const roleKeyWire = encodeRoleKey(roleKey);
+    const candidateResult = store.updateCandidateReachability({
+      role_key_wire: roleKeyWire,
+      agent_id: agentId,
+      probe_succeeded: true,
+      excluded_until_ms: null,
+      last_probe_ms: now(),
+      last_probe_code: reason,
+      updated_at_ms: now(),
+    });
+    if (!candidateResult.ok) return candidateResult;
+
+    const current = store.getRole(roleKeyWire);
+    if (!current || current.state !== "quarantined") {
+      return { ok: true, candidate: candidateResult.candidate, role: current };
+    }
+    const restored = store.upsertRoleReservation({
+      role_key_wire: roleKeyWire,
+      expected_version: current.version,
+      expected_epoch: current.epoch,
+      holder_agent_id: null,
+      previous_holder_agent_id:
+        current.holder_agent_id ?? current.previous_holder_agent_id,
+      state: "electable",
+      activation_id: null,
+      activation_deadline_ms: null,
+      holder_lease_expires_ms: null,
+      charter_acked_epoch: null,
+      retry_count: 0,
+      next_probe_ms: null,
+      blocked_reason: null,
+      last_transition_ms: now(),
+      last_reason: reason,
+    });
+    return {
+      ok: restored.ok,
+      candidate: candidateResult.candidate,
+      role: restored.role,
+      ...(restored.ok ? {} : { reason: restored.reason }),
+    };
+  }
+
+  function ensureExpiredRoles(sweepNow = now()) {
+    const receipts = [];
+    for (const expired of store.listRolesWithExpiredHolder(sweepNow)) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(expired.role_key_wire);
+      } catch {
+        continue;
+      }
+      const current = store.getRole(expired.role_key_wire);
+      if (
+        !current ||
+        current.holder_agent_id == null ||
+        Number(current.holder_lease_expires_ms) > sweepNow
+      ) {
+        continue;
+      }
+      const flight = flights.get(expired.role_key_wire);
+      if (flight) {
+        flight.controller.abort();
+        Promise.resolve(adapter.cancel(flight.plan.role.activation_id)).catch(
+          () => {},
+        );
+        flight.cancelledOutcome = {
+          status: "cancelled",
+          reason_code: "holder_lease_expired",
+          role: current,
+        };
+        flights.delete(expired.role_key_wire);
+      }
+      const fenced = store.upsertRoleReservation({
+        role_key_wire: expired.role_key_wire,
+        expected_version: current.version,
+        expected_epoch: current.epoch,
+        holder_agent_id: null,
+        previous_holder_agent_id: current.holder_agent_id,
+        state: "electable",
+        activation_id: null,
+        activation_deadline_ms: null,
+        holder_lease_expires_ms: null,
+        charter_acked_epoch: null,
+        blocked_reason: null,
+        last_transition_ms: sweepNow,
+        last_reason: "holder_lease_expired",
+      });
+      if (!fenced.ok) continue;
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "lease_expired",
+            cause_id: `lease:${expired.role_key_wire}:${sweepNow}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "sweeper",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  function ensureRecoveredRoles(recovery) {
+    const receipts = [];
+    for (const recovered of recovery?.roles || []) {
+      let roleKey;
+      try {
+        roleKey = decodeRoleKey(recovered.role_key_wire);
+      } catch {
+        continue;
+      }
+      receipts.push(
+        requestEnsureRole(
+          {
+            schema_version: ENSURE_ROLE_SCHEMA_VERSION,
+            role_key: roleKey,
+            trigger: "restart_recovery",
+            cause_id: `restart:${recovered.role_key_wire}:${recovered.epoch}`,
+          },
+          {
+            principal: {
+              type: "system",
+              service: "hub-recovery",
+              project_id: roleKey.project_id,
+            },
+          },
+        ),
+      );
+    }
+    return receipts;
+  }
+
+  return {
+    requestEnsureRole,
+    ensureRole: ensureRoleAwake,
+    ensureRoleAwake,
+    ackActivation,
+    updateControlSnapshot,
+    notifyCandidateChanged,
+    ensureExpiredRoles,
+    ensureRecoveredRoles,
+    drain,
+    close,
+    isRoleManaged(roleKeyInput) {
+      const roleKey = normalizeRoleKey(roleKeyInput);
+      return (
+        !managerCircuitReason &&
+        managerEnabled(controlSnapshot(), roleKey.role_kind) &&
+        !(roleKey.role_kind === "lead" && isScopeClosed(roleKey))
+      );
+    },
+    getRoleSnapshot(roleKey) {
+      return store.getRole(encodeRoleKey(roleKey));
+    },
+  };
+}
+
+export async function ensureRoleAwake(activator, request, context = {}) {
+  if (!activator || typeof activator.ensureRoleAwake !== "function") {
+    throw activatorError("ROLE_ACTIVATOR_INVALID");
+  }
+  return await activator.ensureRoleAwake(request, context);
+}

--- a/packages/triflux/hub/role-activator.mjs
+++ b/packages/triflux/hub/role-activator.mjs
@@ -776,23 +776,34 @@ export function createRoleActivator(options = {}) {
     // C3 binds the stood-up session identity/grant and delivers its charter
     // ACK. C6a-4 still sends the activation now and bounds retries until that
     // binding exists, so a missing C3 hook cannot create a tight orphan loop.
-    const wake = await adapter.wake(
-      locator,
-      {
-        schema_version: "tfx.role-activation.v1",
-        role_key: plan.roleKey,
-        role_key_wire: plan.roleKeyWire,
-        epoch: plan.role.epoch,
-        activation_seq: plan.role.activation_seq,
-        activation_id: plan.role.activation_id,
-        charter_version: plan.role.charter_version,
-        holder_cli: "claude",
-      },
-      {
-        timeout_ms: config.probe_timeout_ms,
-        signal: flights.get(plan.roleKeyWire)?.controller.signal,
-      },
-    );
+    let wake;
+    try {
+      wake = await adapter.wake(
+        locator,
+        {
+          schema_version: "tfx.role-activation.v1",
+          role_key: plan.roleKey,
+          role_key_wire: plan.roleKeyWire,
+          epoch: plan.role.epoch,
+          activation_seq: plan.role.activation_seq,
+          activation_id: plan.role.activation_id,
+          charter_version: plan.role.charter_version,
+          holder_cli: "claude",
+        },
+        {
+          timeout_ms: config.probe_timeout_ms,
+          signal: flights.get(plan.roleKeyWire)?.controller.signal,
+        },
+      );
+    } catch (error) {
+      const reasonCode = error?.code || "standup_wake_failed";
+      const deferred = deferStandupRetry(plan, reasonCode);
+      return {
+        status: deferred.role?.state || "unreachable",
+        reason_code: reasonCode,
+        role: deferred.role,
+      };
+    }
     const afterWake = await gate(plan);
     if (afterWake) return afterWake;
     if (wake?.ok !== true) {

--- a/packages/triflux/hub/role-activator.mjs
+++ b/packages/triflux/hub/role-activator.mjs
@@ -509,16 +509,11 @@ export function createRoleActivator(options = {}) {
       ) {
         return;
       }
-      store.compareAndSetRole({
-        ...activationGuard(current),
-        patch: {
-          state: "unreachable",
-          activation_deadline_ms: null,
-          next_probe_ms: now(),
-          last_transition_ms: now(),
-          last_reason: "ack_timeout",
-        },
-      });
+      markCandidateFailure(
+        { ...plan, role: current },
+        plan.holder,
+        "ack_timeout",
+      );
     }, delay);
     timer?.unref?.();
     ackTimers.set(plan.role.activation_id, timer);

--- a/packages/triflux/hub/role-activator.mjs
+++ b/packages/triflux/hub/role-activator.mjs
@@ -963,6 +963,7 @@ export function createRoleActivator(options = {}) {
         state: "active",
         charter_acked_epoch: current.epoch,
         activation_deadline_ms: null,
+        retry_count: 0,
         blocked_reason: null,
         last_transition_ms: now(),
         last_reason: "activation_acked",
@@ -1029,6 +1030,13 @@ export function createRoleActivator(options = {}) {
     reason = "candidate_registered",
   ) {
     const roleKey = normalizeRoleKey(roleKeyInput);
+    const control = controlSnapshot();
+    if (!managerEnabled(control, roleKey.role_kind) || managerCircuitReason) {
+      return {
+        ok: false,
+        reason_code: managerCircuitReason || blockedReason(control),
+      };
+    }
     const roleKeyWire = encodeRoleKey(roleKey);
     const candidateResult = store.updateCandidateReachability({
       role_key_wire: roleKeyWire,

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -370,6 +370,7 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  */
 export function createRouter(store, options = {}) {
   const roleActivator = options.roleActivator || null;
+  const hubLog = options.logger || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -2039,7 +2040,11 @@ export function createRouter(store, options = {}) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
-      roleActivator?.ensureExpiredRoles?.(Date.now());
+      try {
+        roleActivator?.ensureExpiredRoles?.(Date.now());
+      } catch (err) {
+        hubLog?.warn?.({ err }, "role_activator.expiry_sweep_degraded");
+      }
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/packages/triflux/hub/router.mjs
+++ b/packages/triflux/hub/router.mjs
@@ -9,7 +9,11 @@ import {
   resolveHardCeilingMs,
 } from "./lib/timeout-defaults.mjs";
 import { uuidv7 } from "./lib/uuidv7.mjs";
-import { normalizeRoleKey } from "./role-contract.mjs";
+import {
+  decodeRoleKey,
+  encodeRoleKey,
+  normalizeRoleKey,
+} from "./role-contract.mjs";
 
 const ASSIGN_PENDING_STATUSES = new Set(["queued", "running"]);
 const ROLE_TOPICS = new Set(["cto"]);
@@ -364,7 +368,8 @@ function waitForEmitterOnce(emitter, eventName, timeoutMs) {
  * 라우터 생성
  * @param {object} store
  */
-export function createRouter(store) {
+export function createRouter(store, options = {}) {
+  const roleActivator = options.roleActivator || null;
   let sweepTimer = null;
   let staleTimer = null;
   const responseEmitter = new EventEmitter();
@@ -486,6 +491,57 @@ export function createRouter(store) {
 
   function listRuntimeTopics(agentId) {
     return normalizeAgentTopics(store, agentId, runtimeTopics.get(agentId));
+  }
+
+  function scopedRoleForMessage(message = {}) {
+    const to = String(message.to_agent ?? message.to ?? "");
+    const prefix = "topic:role:";
+    if (to.startsWith(prefix)) {
+      const roleKeyWire = to.slice(prefix.length);
+      try {
+        return { roleKey: decodeRoleKey(roleKeyWire), roleKeyWire };
+      } catch {
+        return null;
+      }
+    }
+    if (to !== "topic:cto") return null;
+    const from = message.from_agent ?? message.from;
+    const projectId = message.project_id ?? store.getAgent(from)?.project_id;
+    if (!projectId) return null;
+    try {
+      const roleKey = normalizeRoleKey({
+        project_id: projectId,
+        role_kind: "cto",
+      });
+      return { roleKey, roleKeyWire: encodeRoleKey(roleKey) };
+    } catch {
+      return null;
+    }
+  }
+
+  function requestRoleActivation(message, trigger = "publish_no_holder") {
+    if (!roleActivator?.requestEnsureRole) return undefined;
+    const scoped = scopedRoleForMessage(message);
+    if (!scoped) return undefined;
+    try {
+      return roleActivator.requestEnsureRole(
+        {
+          schema_version: "tfx.ensure-role.v1",
+          role_key: scoped.roleKey,
+          trigger,
+          cause_id: String(message.id || message.correlation_id || uuidv7()),
+        },
+        {
+          principal: {
+            type: "system",
+            service: trigger === "session_start" ? "session-hook" : "router",
+            project_id: scoped.roleKey.project_id,
+          },
+        },
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   function ensureRoleState(roleName) {
@@ -655,6 +711,7 @@ export function createRouter(store) {
   }
 
   function shouldTrackWithoutRecipients(message) {
+    if (roleActivator && scopedRoleForMessage(message)) return true;
     const to = message?.to_agent ?? message?.to;
     if (!String(to || "").startsWith("topic:")) return false;
     return ROLE_TOPICS.has(String(to).slice(6));
@@ -874,10 +931,69 @@ export function createRouter(store) {
     deliveryEmitter.emit("message", agentId, message);
   }
 
+  function activateScopedRoleHolder(role) {
+    if (!role?.role_key_wire || !role.holder_agent_id) return 0;
+    const current = store.getRole(role.role_key_wire);
+    if (
+      !current ||
+      current.state !== "active" ||
+      current.charter_acked_epoch !== current.epoch ||
+      current.holder_agent_id !== role.holder_agent_id ||
+      current.epoch !== role.epoch ||
+      current.activation_seq !== role.activation_seq ||
+      current.activation_id !== role.activation_id ||
+      current.version !== role.version
+    ) {
+      return 0;
+    }
+
+    let transferred = 0;
+    for (const message of store.listPendingRoleMessages(
+      role.role_key_wire,
+      Date.now(),
+    )) {
+      let record = getMessageRecord(message.id);
+      if (!record) {
+        trackMessage(message, [current.holder_agent_id]);
+        record = getMessageRecord(message.id);
+      } else {
+        record.recipients.add(current.holder_agent_id);
+      }
+      if (!queuesByAgent.get(current.holder_agent_id)?.has(message.id)) {
+        queueMessage(current.holder_agent_id, record.message);
+        transferred += 1;
+      }
+      record.message.status = "delivered";
+      store.updateMessageStatus(message.id, "delivered");
+    }
+    return transferred;
+  }
+
   function resolveRecipients(msg) {
     const to = msg.to_agent ?? msg.to;
     if (!to?.startsWith("topic:")) {
       return [to];
+    }
+
+    if (roleActivator) {
+      const scoped = scopedRoleForMessage(msg);
+      if (scoped) {
+        const role = store.getRole(scoped.roleKeyWire);
+        const managed = roleActivator.isRoleManaged?.(scoped.roleKey) !== false;
+        if (role && managed) {
+          const holder = role.holder_agent_id
+            ? store.getAgent(role.holder_agent_id)
+            : null;
+          const active =
+            role.state === "active" &&
+            role.charter_acked_epoch === role.epoch &&
+            Number(role.holder_lease_expires_ms) > Date.now() &&
+            holder?.status === "online" &&
+            Number(holder.lease_expires_ms) > Date.now();
+          return active ? [role.holder_agent_id] : [];
+        }
+        if (to !== "topic:cto") return [];
+      }
     }
 
     const topic = to.slice(6);
@@ -993,6 +1109,8 @@ export function createRouter(store) {
     trace_id,
     correlation_id,
   }) {
+    const messageIdentity = { from, to, project_id: payload?.project_id };
+    const scoped = scopedRoleForMessage(messageIdentity);
     const msg = store.auditLog({
       type,
       from,
@@ -1003,6 +1121,7 @@ export function createRouter(store) {
       payload,
       trace_id,
       correlation_id,
+      role_key_wire: scoped?.roleKeyWire ?? null,
     });
     const recipients = uniqueStrings(resolveRecipients(msg));
     if (recipients.length || shouldTrackWithoutRecipients(msg)) {
@@ -1018,7 +1137,11 @@ export function createRouter(store) {
     if (msg.type === "response") {
       responseEmitter.emit(msg.correlation_id, msg.payload);
     }
-    return { msg, recipients };
+    const activation =
+      recipients.length === 0
+        ? requestRoleActivation(msg, "publish_no_holder")
+        : undefined;
+    return { msg, recipients, activation };
   }
 
   function buildAssignSnapshot(job, extra = {}) {
@@ -1186,6 +1309,29 @@ export function createRouter(store) {
     responseEmitter,
     deliveryEmitter,
 
+    activateScopedRoleHolder,
+
+    requestEnsureRole(request, context = {}) {
+      if (!roleActivator?.requestEnsureRole) {
+        return {
+          accepted: false,
+          disposition: "manager_disabled",
+          role_key_wire: encodeRoleKey(request.role_key),
+          state: "electable",
+          epoch: 0,
+          blocked_reason: "activator_unavailable",
+        };
+      }
+      return roleActivator.requestEnsureRole(request, context);
+    },
+
+    ackRoleActivation(ack, context = {}) {
+      if (!roleActivator?.ackActivation) {
+        return { ok: false, code: "ROLE_ACTIVATOR_UNAVAILABLE" };
+      }
+      return roleActivator.ackActivation(ack, context);
+    },
+
     registerAgent(args) {
       const identityFailure = validateCallerIdentity(args);
       if (identityFailure) return identityFailure;
@@ -1217,6 +1363,17 @@ export function createRouter(store) {
           reason: "register",
           transferBacklog: true,
         });
+      }
+      if (roleActivator && identity?.project_id && identity?.session_id) {
+        requestRoleActivation(
+          {
+            id: identity.session_id,
+            from_agent: args.agent_id,
+            to_agent: "topic:cto",
+            project_id: identity.project_id,
+          },
+          "session_start",
+        );
       }
       return {
         ok: true,
@@ -1319,6 +1476,7 @@ export function createRouter(store) {
         if (shouldTrackWithoutRecipients(msg) && !getMessageRecord(msg.id)) {
           trackMessage(msg, []);
         }
+        requestRoleActivation(msg, "publish_no_holder");
         return 0;
       }
       if (!getMessageRecord(msg.id)) {
@@ -1470,7 +1628,7 @@ export function createRouter(store) {
       message_type,
     }) {
       const type = message_type || (correlation_id ? "response" : "event");
-      const { msg, recipients } = dispatchMessage({
+      const { msg, recipients, activation } = dispatchMessage({
         type,
         from,
         to,
@@ -1487,7 +1645,13 @@ export function createRouter(store) {
           message_id: msg.id,
           fanout_count: recipients.length,
           expires_at_ms: msg.expires_at_ms,
-          role: to === "topic:cto" ? getRoleSnapshot("cto") : undefined,
+          role:
+            roleActivator && scopedRoleForMessage(msg)
+              ? roleActivator.getRoleSnapshot(scopedRoleForMessage(msg).roleKey)
+              : to === "topic:cto"
+                ? getRoleSnapshot("cto")
+                : undefined,
+          activation,
         },
       };
     },
@@ -1875,6 +2039,7 @@ export function createRouter(store) {
     },
 
     reelectStaleRoles({ reason = "sweep" } = {}) {
+      roleActivator?.ensureExpiredRoles?.(Date.now());
       for (const roleName of ROLE_TOPICS) {
         const role = roleStates.get(roleName);
         const leader = role?.leaderAgentId

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -38,6 +38,7 @@ import {
   reapExistingHubProcesses,
   resolveHubPortForContext,
 } from "./hub-lifecycle.mjs";
+import { resolveRoleControlSnapshot } from "./lib/cto-env.mjs";
 import {
   cleanupOrphanNodeProcesses,
   cleanupOrphanRuntimeProcesses,
@@ -60,6 +61,8 @@ import { focusSessionOnMac } from "./mac-focus.mjs";
 import { logQuotaRefreshFailures } from "./middleware/quota-middleware.mjs";
 import { wrapRequestHandler } from "./middleware/request-logger.mjs";
 import { createPipeServer } from "./pipe.mjs";
+import { createRoleActivator } from "./role-activator.mjs";
+import { createTfxLiveRoleAdapter } from "./role-activator-tfx-live.mjs";
 import { createRouter } from "./router.mjs";
 import { createAdaptiveFingerprintService } from "./session-fingerprint.mjs";
 import {
@@ -1063,7 +1066,44 @@ export async function startHub({
   }
 
   const store = await createStoreAdapter(dbPath);
-  const router = createRouter(store);
+  const roleStoreMethods = [
+    "getAgent",
+    "getRole",
+    "upsertRoleReservation",
+    "compareAndSetRole",
+    "listRoleCandidates",
+    "updateCandidateReachability",
+    "listRolesWithExpiredHolder",
+    "listPendingRoleMessages",
+    "recoverRoleRegistry",
+  ];
+  const roleStoreReady = roleStoreMethods.every(
+    (method) => typeof store[method] === "function",
+  );
+  let roleControlSnapshot = resolveRoleControlSnapshot(process.env);
+  const getRoleControlSnapshot = () => {
+    roleControlSnapshot = resolveRoleControlSnapshot(process.env, {
+      previous: roleControlSnapshot,
+    });
+    return roleControlSnapshot;
+  };
+  let router;
+  const roleActivator = roleStoreReady
+    ? createRoleActivator({
+        store,
+        adapter: createTfxLiveRoleAdapter({ projectRoot: PROJECT_ROOT }),
+        getControlSnapshot: getRoleControlSnapshot,
+        getCharterVersion: (roleKind) =>
+          roleKind === "lead" ? "tfx.lead-charter.v1" : "tfx.cto-charter.v1",
+        logger: hubLog,
+        onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
+      })
+    : null;
+  router = createRouter(store, { roleActivator });
+  if (roleActivator) {
+    const recovered = store.recoverRoleRegistry(Date.now());
+    roleActivator.ensureRecoveredRoles(recovered);
+  }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 
   // Neural Memory adaptive engine 초기화
@@ -2469,6 +2509,9 @@ export async function startHub({
       await delegatorWorker.stop();
     } catch {}
     try {
+      roleActivator?.close();
+    } catch {}
+    try {
       store.close();
     } catch {}
     if (!ephemeralPort && !preserveTokenFile) {
@@ -2675,6 +2718,7 @@ export async function startHub({
               try {
                 synapseRegistry.destroy();
               } catch {}
+              roleActivator?.close();
               store.close();
               if (!ephemeralPort) {
                 cleanupOwnedPidFile();

--- a/packages/triflux/hub/server.mjs
+++ b/packages/triflux/hub/server.mjs
@@ -1099,10 +1099,14 @@ export async function startHub({
         onRoleActive: ({ role }) => router?.activateScopedRoleHolder(role) ?? 0,
       })
     : null;
-  router = createRouter(store, { roleActivator });
+  router = createRouter(store, { roleActivator, logger: hubLog });
   if (roleActivator) {
     const recovered = store.recoverRoleRegistry(Date.now());
-    roleActivator.ensureRecoveredRoles(recovered);
+    try {
+      roleActivator.ensureRecoveredRoles(recovered);
+    } catch (err) {
+      hubLog.warn({ err }, "role_activator.recovery_degraded");
+    }
   }
   const fingerprintService = createAdaptiveFingerprintService({ store });
 

--- a/packages/triflux/hub/store.mjs
+++ b/packages/triflux/hub/store.mjs
@@ -653,19 +653,23 @@ export function createStore(dbPath, options = {}) {
           : (current?.previous_holder_agent_id ?? null)),
       epoch: nextEpoch,
       activation_seq: nextActivationSeq,
-      activation_id:
-        input.activation_id ??
-        (input.holder_agent_id ? uuidv7() : (current?.activation_id ?? null)),
-      activation_deadline_ms:
-        input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
-      holder_lease_expires_ms:
-        input.holder_lease_expires_ms ??
-        current?.holder_lease_expires_ms ??
-        null,
-      charter_version:
-        input.charter_version ?? current?.charter_version ?? null,
-      charter_acked_epoch:
-        input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
+      activation_id: Object.hasOwn(input, "activation_id")
+        ? input.activation_id
+        : input.holder_agent_id
+          ? uuidv7()
+          : (current?.activation_id ?? null),
+      activation_deadline_ms: Object.hasOwn(input, "activation_deadline_ms")
+        ? input.activation_deadline_ms
+        : (current?.activation_deadline_ms ?? null),
+      holder_lease_expires_ms: Object.hasOwn(input, "holder_lease_expires_ms")
+        ? input.holder_lease_expires_ms
+        : (current?.holder_lease_expires_ms ?? null),
+      charter_version: Object.hasOwn(input, "charter_version")
+        ? input.charter_version
+        : (current?.charter_version ?? null),
+      charter_acked_epoch: Object.hasOwn(input, "charter_acked_epoch")
+        ? input.charter_acked_epoch
+        : (current?.charter_acked_epoch ?? null),
       retry_count: input.retry_count ?? current?.retry_count ?? 0,
       next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
       blocked_reason:

--- a/packages/triflux/scripts/pack.mjs
+++ b/packages/triflux/scripts/pack.mjs
@@ -34,6 +34,7 @@ const CORE_FILES = [
   "hub/intent.mjs",
   "hub/token-mode.mjs",
   "hub/router.mjs",
+  "hub/role-activator.mjs",
   "hub/role-contract.mjs",
   "hub/role-control-events.mjs",
   "hub/hitl.mjs",
@@ -77,6 +78,7 @@ const CORE_DIRS = [
 
 const REMOTE_FILES = [
   "hub/server.mjs",
+  "hub/role-activator-tfx-live.mjs",
   "hub/store.mjs",
   "hub/schema.sql",
   "hub/store-adapter.mjs",

--- a/packages/triflux/scripts/release/check-packages-mirror.mjs
+++ b/packages/triflux/scripts/release/check-packages-mirror.mjs
@@ -44,6 +44,10 @@ const CORE_FILE_MIRRORS = [
     target: "packages/core/hub/router.mjs",
   },
   {
+    source: "hub/role-activator.mjs",
+    target: "packages/core/hub/role-activator.mjs",
+  },
+  {
     source: "hub/team/retry-state-machine.mjs",
     target: "packages/core/hub/team/retry-state-machine.mjs",
   },
@@ -105,6 +109,12 @@ const REMOTE_NON_MIRROR = new Set([
   "LICENSE",
   "hub/index.mjs", // pack-generated barrel (REMOTE_INDEX), not a root mirror
 ]);
+const REMOTE_REQUIRED_MIRRORS = [
+  {
+    source: "hub/role-activator-tfx-live.mjs",
+    target: "packages/remote/hub/role-activator-tfx-live.mjs",
+  },
+];
 
 function extractImportSpecifiers(content) {
   // Strip comments first so JSDoc usage examples (`* import x from './y'`) and
@@ -124,6 +134,15 @@ function checkRemoteMirror(repoRoot) {
   const remoteRoot = join(repoRoot, "packages", "remote");
   const coreRoot = join(repoRoot, "packages", "core");
   if (!existsSync(remoteRoot)) return issues;
+
+  for (const mirror of REMOTE_REQUIRED_MIRRORS) {
+    if (
+      existsSync(join(repoRoot, mirror.source)) &&
+      !existsSync(join(repoRoot, mirror.target))
+    ) {
+      issues.push({ path: mirror.target, kind: "missing-in-mirror" });
+    }
+  }
 
   for (const rel of walkRelFiles(remoteRoot)) {
     if (REMOTE_NON_MIRROR.has(rel)) continue;

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -34,6 +34,7 @@ const CORE_FILES = [
   "hub/intent.mjs",
   "hub/token-mode.mjs",
   "hub/router.mjs",
+  "hub/role-activator.mjs",
   "hub/role-contract.mjs",
   "hub/role-control-events.mjs",
   "hub/hitl.mjs",
@@ -77,6 +78,7 @@ const CORE_DIRS = [
 
 const REMOTE_FILES = [
   "hub/server.mjs",
+  "hub/role-activator-tfx-live.mjs",
   "hub/store.mjs",
   "hub/schema.sql",
   "hub/store-adapter.mjs",

--- a/scripts/release/check-packages-mirror.mjs
+++ b/scripts/release/check-packages-mirror.mjs
@@ -44,6 +44,10 @@ const CORE_FILE_MIRRORS = [
     target: "packages/core/hub/router.mjs",
   },
   {
+    source: "hub/role-activator.mjs",
+    target: "packages/core/hub/role-activator.mjs",
+  },
+  {
     source: "hub/team/retry-state-machine.mjs",
     target: "packages/core/hub/team/retry-state-machine.mjs",
   },
@@ -105,6 +109,12 @@ const REMOTE_NON_MIRROR = new Set([
   "LICENSE",
   "hub/index.mjs", // pack-generated barrel (REMOTE_INDEX), not a root mirror
 ]);
+const REMOTE_REQUIRED_MIRRORS = [
+  {
+    source: "hub/role-activator-tfx-live.mjs",
+    target: "packages/remote/hub/role-activator-tfx-live.mjs",
+  },
+];
 
 function extractImportSpecifiers(content) {
   // Strip comments first so JSDoc usage examples (`* import x from './y'`) and
@@ -124,6 +134,15 @@ function checkRemoteMirror(repoRoot) {
   const remoteRoot = join(repoRoot, "packages", "remote");
   const coreRoot = join(repoRoot, "packages", "core");
   if (!existsSync(remoteRoot)) return issues;
+
+  for (const mirror of REMOTE_REQUIRED_MIRRORS) {
+    if (
+      existsSync(join(repoRoot, mirror.source)) &&
+      !existsSync(join(repoRoot, mirror.target))
+    ) {
+      issues.push({ path: mirror.target, kind: "missing-in-mirror" });
+    }
+  }
 
   for (const rel of walkRelFiles(remoteRoot)) {
     if (REMOTE_NON_MIRROR.has(rel)) continue;

--- a/tests/integration/role-activator-router.test.mjs
+++ b/tests/integration/role-activator-router.test.mjs
@@ -1,0 +1,376 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { createRoleActivator } from "../../hub/role-activator.mjs";
+import { encodeRoleKey, roleTopicAddress } from "../../hub/role-contract.mjs";
+import { createRouter } from "../../hub/router.mjs";
+import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const PROJECT_ID = `prj_${"r".repeat(22)}`;
+const CTO_KEY = { project_id: PROJECT_ID, role_kind: "cto" };
+const CTO_WIRE = encodeRoleKey(CTO_KEY);
+const TEMP_DIRS = [];
+
+function tempStore() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-role-router-"));
+  TEMP_DIRS.push(dir);
+  return createStore(join(dir, "hub.db"));
+}
+
+function fakeActivator() {
+  const calls = [];
+  const expiryCalls = [];
+  return {
+    calls,
+    expiryCalls,
+    requestEnsureRole(request) {
+      calls.push(request);
+      return {
+        accepted: true,
+        disposition: "started",
+        role_key_wire: encodeRoleKey(request.role_key),
+        state: "elected-probing",
+        epoch: 1,
+        activation_id: "activation-router",
+      };
+    },
+    getRoleSnapshot: () => ({
+      role_key: CTO_KEY,
+      role_key_wire: CTO_WIRE,
+      state: "elected-probing",
+      epoch: 1,
+    }),
+    ensureExpiredRoles(now) {
+      expiryCalls.push(now);
+      return [];
+    },
+  };
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("router role activator integration", { skip: SQLITE_SKIP }, () => {
+  it("keeps no-holder publish durable, returns immediately with a receipt, and ensures CTO after SessionStart registration", () => {
+    const store = tempStore();
+    const activator = fakeActivator();
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      const registered = router.registerAgent({
+        agent_id: "session-router-citizen",
+        cli: "claude",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 120_000,
+        project_id: PROJECT_ID,
+        session_id: "session-router-citizen",
+      });
+      assert.equal(registered.ok, true);
+      assert.equal(activator.calls.length, 1);
+      assert.equal(activator.calls[0].trigger, "session_start");
+      assert.deepEqual(activator.calls[0].role_key, CTO_KEY);
+
+      activator.calls.length = 0;
+      const published = router.handlePublish({
+        from: "session-router-citizen",
+        to: roleTopicAddress(CTO_KEY),
+        topic: "role.work",
+        payload: { task: "preserve me" },
+      });
+
+      assert.equal(published.ok, true);
+      assert.equal(published.data.fanout_count, 0);
+      assert.equal(published.data.activation.disposition, "started");
+      assert.equal(published.data.activation.role_key_wire, CTO_WIRE);
+      assert.equal(activator.calls.length, 1);
+      assert.equal(activator.calls[0].trigger, "publish_no_holder");
+      assert.deepEqual(
+        store.listPendingRoleMessages(CTO_WIRE, Date.now()).map((msg) => ({
+          id: msg.id,
+          status: msg.status,
+          role_key_wire: msg.role_key_wire,
+        })),
+        [
+          {
+            id: published.data.message_id,
+            status: "queued",
+            role_key_wire: CTO_WIRE,
+          },
+        ],
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("routes legacy route(msg) and v2 handlePublish through the same scoped activation path", () => {
+    const store = tempStore();
+    const activator = fakeActivator();
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      router.registerAgent({
+        agent_id: "legacy-router-citizen",
+        cli: "codex",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 120_000,
+        project_id: PROJECT_ID,
+        session_id: "legacy-router-citizen",
+      });
+      activator.calls.length = 0;
+
+      const legacyMessage = store.auditLog({
+        type: "event",
+        from: "legacy-router-citizen",
+        to: "topic:cto",
+        topic: "legacy.role.work",
+        payload: { task: "legacy" },
+      });
+      assert.equal(router.route(legacyMessage), 0);
+      router.handlePublish({
+        from: "legacy-router-citizen",
+        to: roleTopicAddress(CTO_KEY),
+        topic: "v2.role.work",
+        payload: { task: "v2" },
+      });
+
+      assert.equal(activator.calls.length, 2);
+      assert.deepEqual(
+        activator.calls.map((call) => call.role_key),
+        [CTO_KEY, CTO_KEY],
+      );
+      assert.deepEqual(
+        activator.calls.map((call) => call.trigger),
+        ["publish_no_holder", "publish_no_holder"],
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("keeps a no-holder publish durable when activation reservation throws", () => {
+    const store = tempStore();
+    const router = createRouter(store, {
+      roleActivator: {
+        requestEnsureRole() {
+          const error = new Error("database busy");
+          error.code = "SQLITE_BUSY";
+          throw error;
+        },
+        getRoleSnapshot: () => null,
+      },
+    });
+    try {
+      router.registerAgent({
+        agent_id: "fault-router-citizen",
+        cli: "claude",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 120_000,
+        project_id: PROJECT_ID,
+        session_id: "fault-router-citizen",
+      });
+      const published = router.handlePublish({
+        from: "fault-router-citizen",
+        to: roleTopicAddress(CTO_KEY),
+        topic: "role.work",
+        payload: { task: "preserve on activator fault" },
+      });
+      assert.equal(published.ok, true);
+      assert.equal(published.data.fanout_count, 0);
+      assert.equal(published.data.activation, undefined);
+      assert.equal(
+        store.listPendingRoleMessages(CTO_WIRE, Date.now()).length,
+        1,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("preserves legacy topic:cto delivery while the v2 manager is disabled", () => {
+    const store = tempStore();
+    const activator = {
+      requestEnsureRole: () => ({
+        accepted: false,
+        disposition: "manager_disabled",
+        role_key_wire: CTO_WIRE,
+        state: "electable",
+        epoch: 0,
+      }),
+      getRoleSnapshot: () => null,
+      isRoleManaged: () => false,
+    };
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      router.registerAgent({
+        agent_id: "legacy-cto-holder",
+        cli: "claude",
+        capabilities: ["code"],
+        topics: ["cto"],
+        heartbeat_ttl_ms: 120_000,
+        metadata: { is_cto: true },
+        project_id: PROJECT_ID,
+        session_id: "legacy-cto-holder",
+      });
+      const published = router.handlePublish({
+        from: "legacy-cto-holder",
+        to: "topic:cto",
+        topic: "legacy.compat",
+        payload: { project_id: PROJECT_ID, task: "deliver through v1" },
+      });
+      assert.equal(published.data.fanout_count, 1);
+      assert.equal(
+        router.getPendingMessages("legacy-cto-holder")[0].id,
+        published.data.message_id,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("connects the stale-role sweeper to scoped lease expiry activation", () => {
+    const store = tempStore();
+    const activator = fakeActivator();
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      router.reelectStaleRoles({ reason: "lease-test" });
+      assert.equal(activator.expiryCalls.length, 1);
+      assert.equal(Number.isFinite(activator.expiryCalls[0]), true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("transfers scoped backlog only for the current active holder fence", () => {
+    const store = tempStore();
+    const activator = fakeActivator();
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      router.registerAgent({
+        agent_id: "current-role-holder",
+        cli: "codex",
+        capabilities: ["role:cto:candidate"],
+        topics: [],
+        heartbeat_ttl_ms: 120_000,
+        project_id: PROJECT_ID,
+        session_id: "current-role-holder",
+      });
+      const published = router.handlePublish({
+        from: "current-role-holder",
+        to: roleTopicAddress(CTO_KEY),
+        topic: "role.work",
+        payload: { task: "fenced backlog" },
+      });
+      assert.equal(published.data.fanout_count, 0);
+
+      const reserved = store.upsertRoleReservation({
+        role_key_wire: CTO_WIRE,
+        holder_agent_id: "current-role-holder",
+        holder_lease_expires_ms: Date.now() + 60_000,
+        state: "elected-probing",
+        activation_id: "activation-current",
+        activation_deadline_ms: Date.now() + 45_000,
+        charter_version: "charter.v1",
+        last_transition_ms: Date.now(),
+        last_reason: "test_reservation",
+      });
+      const activated = store.compareAndSetRole({
+        role_key_wire: CTO_WIRE,
+        expected_version: reserved.role.version,
+        expected_epoch: reserved.role.epoch,
+        expected_activation_seq: reserved.role.activation_seq,
+        expected_activation_id: reserved.role.activation_id,
+        patch: {
+          state: "active",
+          charter_acked_epoch: reserved.role.epoch,
+          activation_deadline_ms: null,
+          last_reason: "activation_acked",
+        },
+      });
+      assert.equal(activated.ok, true);
+
+      assert.equal(
+        router.activateScopedRoleHolder({
+          ...activated.role,
+          holder_agent_id: "stale-role-holder",
+        }),
+        0,
+      );
+      assert.equal(router.countPendingMessages("current-role-holder"), 0);
+
+      assert.equal(router.activateScopedRoleHolder(activated.role), 1);
+      assert.equal(router.countPendingMessages("current-role-holder"), 1);
+      assert.equal(
+        router.getPendingMessages("current-role-holder")[0].id,
+        published.data.message_id,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("keeps backlog and makes zero transport calls when the manager is disabled", () => {
+    const store = tempStore();
+    let transportCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => {
+          transportCalls += 1;
+        },
+        wake: async () => {
+          transportCalls += 1;
+        },
+        standup: async () => {
+          transportCalls += 1;
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => ({
+        generation: 1,
+        master_enabled: true,
+        cto_manager_enabled: false,
+        lead_manager_enabled: false,
+      }),
+      getCharterVersion: () => "charter.v1",
+    });
+    const router = createRouter(store, { roleActivator: activator });
+    try {
+      router.registerAgent({
+        agent_id: "ordinary-caller",
+        cli: "claude",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 120_000,
+        project_id: PROJECT_ID,
+        session_id: "ordinary-caller",
+      });
+      const published = router.handlePublish({
+        from: "ordinary-caller",
+        to: roleTopicAddress(CTO_KEY),
+        topic: "role.work",
+        payload: { task: "stay queued" },
+      });
+
+      assert.equal(published.data.fanout_count, 0);
+      assert.equal(published.data.activation.disposition, "manager_disabled");
+      assert.equal(transportCalls, 0);
+      assert.equal(store.getRole(CTO_WIRE), null);
+      assert.equal(
+        store.listPendingRoleMessages(CTO_WIRE, Date.now()).length,
+        1,
+      );
+    } finally {
+      activator.close();
+      store.close();
+    }
+  });
+});

--- a/tests/integration/role-activator-router.test.mjs
+++ b/tests/integration/role-activator-router.test.mjs
@@ -248,6 +248,49 @@ describe("router role activator integration", { skip: SQLITE_SKIP }, () => {
     }
   });
 
+  it("keeps legacy CTO re-election alive when scoped expiry activation throws", () => {
+    const store = tempStore();
+    const warnings = [];
+    const activatorError = new Error("role store unavailable");
+    const router = createRouter(store, {
+      roleActivator: {
+        ensureExpiredRoles() {
+          throw activatorError;
+        },
+      },
+      logger: {
+        warn(payload, event) {
+          warnings.push({ payload, event });
+        },
+      },
+    });
+    try {
+      store.registerAgent({
+        agent_id: "legacy-cto-fallback",
+        cli: "claude",
+        capabilities: ["cto"],
+        topics: [],
+        metadata: { role: "cto", cto_priority: 10 },
+        heartbeat_ttl_ms: 120_000,
+      });
+
+      router.reelectStaleRoles({ reason: "activator-fault" });
+
+      assert.equal(
+        router.getStatus("hub").data.roles.cto.leader_agent_id,
+        "legacy-cto-fallback",
+      );
+      assert.deepEqual(warnings, [
+        {
+          payload: { err: activatorError },
+          event: "role_activator.expiry_sweep_degraded",
+        },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it("transfers scoped backlog only for the current active holder fence", () => {
     const store = tempStore();
     const activator = fakeActivator();

--- a/tests/integration/role-activator-startup.test.mjs
+++ b/tests/integration/role-activator-startup.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../..");
+
+const RUNNER_SOURCE = `
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function createDelegatorWorkerStub() {
+  return {
+    async start() {},
+    async stop() {},
+    async delegate() {
+      return { ok: true, status: "completed", transport: "stub-delegator" };
+    },
+    async getJobStatus(jobId) {
+      return { ok: true, job_id: jobId, status: "completed" };
+    },
+    async reply({ job_id }) {
+      return { ok: true, job_id, status: "completed" };
+    },
+  };
+}
+
+const projectRoot = process.env.TFX_TEST_PROJECT_ROOT;
+const dbDir = process.env.TFX_TEST_DB_DIR;
+mkdirSync(dbDir, { recursive: true });
+const dbPath = join(dbDir, "hub.db");
+const moduleUrl = (relativePath) =>
+  pathToFileURL(join(projectRoot, relativePath)).href;
+const { encodeRoleKey } = await import(moduleUrl("hub/role-contract.mjs"));
+const { createStore } = await import(moduleUrl("hub/store.mjs"));
+
+const roleKeyWire = encodeRoleKey({
+  project_id: "prj_" + "s".repeat(22),
+  role_kind: "cto",
+});
+const seedStore = createStore(dbPath);
+seedStore.upsertRoleReservation({
+  role_key_wire: roleKeyWire,
+  holder_agent_id: null,
+  state: "electable",
+  last_transition_ms: 1,
+  last_reason: "fault_seed",
+});
+seedStore.db.exec(
+  "CREATE TRIGGER fail_role_recovery_update " +
+    "BEFORE UPDATE ON role_registry BEGIN " +
+    "SELECT RAISE(ABORT, 'damaged role row'); END",
+);
+seedStore.close();
+
+const { startHub } = await import(moduleUrl("hub/server.mjs"));
+const hub = await startHub({
+  port: 0,
+  dbPath,
+  host: "127.0.0.1",
+  sessionId: "role-recovery-fault",
+  createDelegatorWorker: createDelegatorWorkerStub,
+});
+
+try {
+  console.log(JSON.stringify({ marker: "hub-started", port: hub.port }));
+} finally {
+  await hub.stop();
+}
+`;
+
+function parseJsonLines(output) {
+  return output.split(/\r?\n/u).flatMap((line) => {
+    try {
+      return [JSON.parse(line)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+describe("startHub role recovery fault containment", {
+  skip: SQLITE_SKIP,
+}, () => {
+  it("starts the hub and logs degraded recovery when one recovered role throws", () => {
+    const sandboxDir = join(tmpdir(), `tfx-role-recovery-${randomUUID()}`);
+    const homeDir = join(sandboxDir, "home");
+    const dbDir = join(sandboxDir, "db");
+    const stateDir = join(sandboxDir, "state");
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(stateDir, { recursive: true });
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        ["--input-type=module", "--eval", RUNNER_SOURCE],
+        {
+          cwd: PROJECT_ROOT,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            USERPROFILE: homeDir,
+            NODE_ENV: "production",
+            LOG_LEVEL: "warn",
+            TFX_CTO: "1",
+            TFX_CTO_MANAGER: "1",
+            TFX_CTO_NORTH_STAR: "0",
+            TFX_CTO_AUTO_COLLECT: "0",
+            TFX_HUB_STATE_DIR: stateDir,
+            TFX_HUB_PID_DIR: stateDir,
+            TFX_TEST_PROJECT_ROOT: PROJECT_ROOT,
+            TFX_TEST_DB_DIR: dbDir,
+          },
+        },
+      );
+      const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+      assert.equal(result.status, 0, output);
+
+      const records = parseJsonLines(output);
+      const started = records.find((record) => record.marker === "hub-started");
+      assert.ok(started?.port > 0, output);
+
+      const degraded = records.find(
+        (record) => record.msg === "role_activator.recovery_degraded",
+      );
+      assert.ok(degraded, output);
+      assert.equal(String(degraded.level).toLowerCase(), "warn");
+      assert.match(degraded.err?.message ?? "", /damaged role row/u);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/check-packages-mirror-core.test.mjs
+++ b/tests/unit/check-packages-mirror-core.test.mjs
@@ -14,6 +14,7 @@ import { compareMirror } from "../../scripts/release/check-packages-mirror.mjs";
 const CORE_MIRRORS = new Map([
   ["hub/bridge.mjs", "packages/core/hub/bridge.mjs"],
   ["hub/router.mjs", "packages/core/hub/router.mjs"],
+  ["hub/role-activator.mjs", "packages/core/hub/role-activator.mjs"],
   [
     "hub/team/retry-state-machine.mjs",
     "packages/core/hub/team/retry-state-machine.mjs",
@@ -220,4 +221,25 @@ test("compareMirror reports clean when packages/core/hud matches root hud", (t) 
     i.path.startsWith("packages/core/hud/"),
   );
   assert.deepEqual(hudIssues, []);
+});
+
+test("compareMirror detects a missing packages/remote role runtime adapter", (t) => {
+  const repoRoot = makeFixture(t);
+  write(
+    repoRoot,
+    "hub/role-activator-tfx-live.mjs",
+    "export const adapter = true;\n",
+  );
+  write(repoRoot, "packages/remote/package.json", "{}\n");
+
+  const result = compareMirror({ fix: false, repoRoot });
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    findIssue(
+      result,
+      "packages/remote/hub/role-activator-tfx-live.mjs",
+      "missing-in-mirror",
+    ),
+  );
 });

--- a/tests/unit/role-activator-tfx-live.test.mjs
+++ b/tests/unit/role-activator-tfx-live.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTfxLiveRoleAdapter } from "../../hub/role-activator-tfx-live.mjs";
+
+const HOST_ID = "hst_local";
+
+function udsLocator() {
+  return {
+    schema_version: "tfx.transport-locator.v1",
+    transport_id: "uds-role",
+    kind: "claude-uds",
+    host_id: HOST_ID,
+    capabilities: ["probe", "wake", "activate"],
+    priority: 100,
+    expires_at_ms: 60_000,
+    locator: { session_id: "session-role", bridge_id: "local-hub" },
+  };
+}
+
+function tmuxLocator() {
+  return {
+    schema_version: "tfx.transport-locator.v1",
+    transport_id: "tmux-role",
+    kind: "tmux",
+    host_id: HOST_ID,
+    capabilities: ["probe", "wake", "activate", "interrupt"],
+    priority: 100,
+    expires_at_ms: 60_000,
+    locator: { session_name: "role-session", mux_server_id: "mux_local" },
+  };
+}
+
+function activation() {
+  return {
+    schema_version: "tfx.role-activation.v1",
+    role_key: {
+      project_id: `prj_${"a".repeat(22)}`,
+      role_kind: "cto",
+    },
+    role_key_wire: "rk2.test",
+    epoch: 3,
+    activation_seq: 4,
+    activation_id: "activation-runtime",
+    charter_version: "charter.v1",
+    holder_cli: "codex",
+  };
+}
+
+describe("tfx-live role adapter", () => {
+  it("normalizes Claude UDS and tmux probes without inferring locators", async () => {
+    const calls = [];
+    const adapter = createTfxLiveRoleAdapter({
+      localHostId: HOST_ID,
+      tfxLivePath: "/repo/bin/tfx-live.mjs",
+      bridgePath: "/repo/hub/bridge.mjs",
+      nodePath: "/usr/bin/node",
+      tmuxPath: "/usr/bin/tmux",
+      now: () => 1_000,
+      runProcess: async (command, args) => {
+        calls.push({ command, args });
+        return command === "/usr/bin/node"
+          ? { stdout: '{"ok":true,"target":{"sessionId":"session-role"}}' }
+          : { stdout: "" };
+      },
+    });
+
+    assert.equal(adapter.supports(udsLocator()), true);
+    assert.equal(adapter.supports(tmuxLocator()), true);
+    assert.equal(
+      adapter.supports({ ...tmuxLocator(), host_id: "hst_remote" }),
+      false,
+    );
+
+    const uds = await adapter.probe(udsLocator(), {
+      timeout_ms: 2_000,
+      signal: new AbortController().signal,
+    });
+    const tmux = await adapter.probe(tmuxLocator(), {
+      timeout_ms: 2_000,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(uds.schema_version, "tfx-live.transport-probe.v1");
+    assert.equal(uds.reachable, true);
+    assert.equal(uds.transport_selected, "claude-uds");
+    assert.equal(tmux.reachable, true);
+    assert.equal(tmux.transport_selected, "tmux");
+    assert.deepEqual(calls[0], {
+      command: "/usr/bin/node",
+      args: [
+        "/repo/bin/tfx-live.mjs",
+        "probe",
+        "--session-id",
+        "session-role",
+        "--bridge",
+        "/repo/hub/bridge.mjs",
+        "--timeout",
+        "2",
+      ],
+    });
+    assert.deepEqual(calls[1], {
+      command: "/usr/bin/tmux",
+      args: ["has-session", "-t", "role-session"],
+    });
+  });
+
+  it("maps wake, standup, and cancellation to argv-safe tfx-live calls", async () => {
+    const calls = [];
+    const adapter = createTfxLiveRoleAdapter({
+      localHostId: HOST_ID,
+      projectRoot: "/repo",
+      tfxLivePath: "/repo/bin/tfx-live.mjs",
+      bridgePath: "/repo/hub/bridge.mjs",
+      nodePath: "/usr/bin/node",
+      now: () => 1_000,
+      sessionName: () => "tfx-role-cto-test",
+      runProcess: async (command, args) => {
+        calls.push({ command, args });
+        return {
+          stdout: JSON.stringify({
+            ok: true,
+            session: "tfx-role-cto-test",
+            response: "queued",
+          }),
+        };
+      },
+    });
+
+    const woke = await adapter.wake(tmuxLocator(), activation(), {
+      signal: new AbortController().signal,
+    });
+    assert.equal(woke.ok, true);
+    assert.equal(calls[0].command, "/usr/bin/node");
+    assert.deepEqual(calls[0].args.slice(0, 8), [
+      "/repo/bin/tfx-live.mjs",
+      "ask",
+      "--cli",
+      "codex",
+      "--transport",
+      "tmux",
+      "--session",
+      "role-session",
+    ]);
+    const promptIndex = calls[0].args.indexOf("--prompt");
+    const prompt = JSON.parse(calls[0].args[promptIndex + 1]);
+    assert.equal(prompt.schema_version, "tfx.role-activation.v1");
+    assert.equal(prompt.activation_id, "activation-runtime");
+
+    const stoodUp = await adapter.standup(activation().role_key, "claude", {
+      signal: new AbortController().signal,
+      activation: activation(),
+    });
+    assert.equal(stoodUp.kind, "tmux");
+    assert.equal(stoodUp.locator.session_name, "tfx-role-cto-test");
+    assert.deepEqual(calls[1].args, [
+      "/repo/bin/tfx-live.mjs",
+      "start",
+      "--session",
+      "tfx-role-cto-test",
+      "--cli",
+      "claude",
+      "--cwd",
+      "/repo",
+      "--ready-timeout",
+      "60",
+    ]);
+
+    await adapter.cancel("activation-runtime");
+    assert.deepEqual(calls[2].args.slice(0, 8), [
+      "/repo/bin/tfx-live.mjs",
+      "interrupt",
+      "--cli",
+      "codex",
+      "--transport",
+      "tmux",
+      "--session",
+      "role-session",
+    ]);
+    assert.equal(
+      calls.every((call) => call.args.every((arg) => typeof arg === "string")),
+      true,
+    );
+  });
+});

--- a/tests/unit/role-activator-wire.test.mjs
+++ b/tests/unit/role-activator-wire.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+
+import { createPipeServer } from "../../hub/pipe.mjs";
+import { createTools } from "../../hub/tools.mjs";
+
+const PROJECT_ID = `prj_${"w".repeat(22)}`;
+const ROLE_KEY = { project_id: PROJECT_ID, role_kind: "cto" };
+
+function routerDouble() {
+  const ensureCalls = [];
+  const ackCalls = [];
+  return {
+    ensureCalls,
+    ackCalls,
+    deliveryEmitter: new EventEmitter(),
+    requestEnsureRole(request, context) {
+      ensureCalls.push({ request, context });
+      return {
+        accepted: true,
+        disposition: "started",
+        role_key_wire: "rk2.test",
+        state: "elected-probing",
+        epoch: 1,
+      };
+    },
+    ackRoleActivation(ack, context) {
+      ackCalls.push({ ack, context });
+      if (context?.principal?.agent_id !== ack.holder_agent_id) {
+        return { ok: false, code: "HOLDER_MISMATCH" };
+      }
+      return { ok: true, role: { state: "active" } };
+    },
+  };
+}
+
+function ensurePayload() {
+  return {
+    schema_version: "tfx.ensure-role.v1",
+    role_key: ROLE_KEY,
+    trigger: "manual",
+    cause_id: "wire-test",
+  };
+}
+
+function ackPayload() {
+  return {
+    schema_version: "tfx.role-activation-ack.v1",
+    activation_id: "activation-wire",
+    role_key: ROLE_KEY,
+    epoch: 1,
+    activation_seq: 1,
+    holder_agent_id: "role-holder",
+    reachable: true,
+    charter_ack: {
+      role_key: ROLE_KEY,
+      epoch: 1,
+      charter_version: "charter.v1",
+    },
+  };
+}
+
+describe("role activator wire surfaces", () => {
+  it("does not expose unauthenticated role lifecycle actions through MCP tools", () => {
+    const router = routerDouble();
+    const tools = createTools({}, router, null);
+    const ensureTool = tools.find((tool) => tool.name === "ensure_role");
+    const ackTool = tools.find((tool) => tool.name === "ack_role_activation");
+    assert.equal(ensureTool, undefined);
+    assert.equal(ackTool, undefined);
+  });
+
+  it("dispatches ensure_role and binds activation ACK to the pipe connection", async () => {
+    const router = routerDouble();
+    const pipe = createPipeServer({ router, sessionId: "role-wire-test" });
+
+    const ensureResult = await pipe.executeCommand(
+      "ensure_role",
+      ensurePayload(),
+    );
+    const forgedAck = await pipe.executeCommand(
+      "ack_role_activation",
+      ackPayload(),
+    );
+    const ackResult = await pipe.executeCommand(
+      "ack_role_activation",
+      ackPayload(),
+      { agent_id: "role-holder" },
+    );
+
+    assert.equal(ensureResult.disposition, "started");
+    assert.equal(forgedAck.ok, false);
+    assert.equal(forgedAck.code, "HOLDER_MISMATCH");
+    assert.equal(ackResult.ok, true);
+    assert.equal(router.ensureCalls.length, 1);
+    assert.equal(router.ackCalls.length, 2);
+    assert.equal(router.ackCalls[0].context.principal.agent_id, undefined);
+    assert.equal(router.ackCalls[1].context.principal.agent_id, "role-holder");
+  });
+
+  it("rejects ensure_role from a pipe connection before agent registration", async () => {
+    const router = routerDouble();
+    const pipe = createPipeServer({ router, sessionId: "role-wire-auth-test" });
+
+    const result = await pipe.executeCommand("ensure_role", ensurePayload(), {
+      connection_bound: true,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "PRINCIPAL_REQUIRED");
+    assert.equal(router.ensureCalls.length, 0);
+  });
+});

--- a/tests/unit/role-activator.test.mjs
+++ b/tests/unit/role-activator.test.mjs
@@ -1106,6 +1106,9 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     currentTime += scheduled[0].delay;
     scheduled[0].fn();
     assert.equal(store.getRole(CTO_WIRE).state, "unreachable");
+    const failedCandidate = store.listRoleCandidates(CTO_WIRE)[0];
+    assert.equal(failedCandidate.consecutive_probe_failures, 1);
+    assert.ok(failedCandidate.excluded_until_ms > currentTime);
 
     const lateAck = activator.ackActivation(
       {
@@ -1126,6 +1129,7 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     );
     assert.equal(lateAck.code, "STALE_EPOCH");
 
+    currentTime = failedCandidate.excluded_until_ms;
     const retry = await activator.ensureRoleAwake(
       ensureRequest({ cause_id: "retry" }),
       { principal: { type: "system", project_id: PROJECT_ID } },
@@ -1135,6 +1139,111 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     assert.equal(second.holder_agent_id, first.holder_agent_id);
     assert.equal(second.epoch, first.epoch + 1);
     assert.notEqual(second.activation_id, first.activation_id);
+    activator.close();
+    store.close();
+  });
+
+  it("quarantines a probe/wake-successful candidate that never ACKs within max failures", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    let activationIndex = 0;
+    const scheduled = [];
+    const events = [];
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: currentTime,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-ack-timeout", 100, [
+      { ...tmuxLocator("tmux-ack-timeout"), expires_at_ms: 1_000_000 },
+    ]);
+    let probeCalls = 0;
+    let wakeCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          probeCalls += 1;
+          return {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: true,
+            reachable: true,
+            wakeable: true,
+            transport_selected: locator.kind,
+            transport_id: locator.transport_id,
+            host_id: locator.host_id,
+            latency_ms: 1,
+            observed_at_ms: currentTime,
+            reason_code: "ok",
+          };
+        },
+        wake: async () => {
+          wakeCalls += 1;
+          return { ok: true };
+        },
+        standup: async () => tmuxLocator("unexpected"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => `activation-ack-timeout-${++activationIndex}`,
+      now: () => currentTime,
+      rng: () => 0.5,
+      scheduleTimeout: (fn, delay) => {
+        const timer = { fn, delay, unref() {} };
+        scheduled.push(timer);
+        return timer;
+      },
+      clearScheduledTimeout: () => {},
+      onControlEvent: (event) => events.push(event),
+    });
+
+    for (let failure = 1; failure <= 3; failure += 1) {
+      const outcome = await activator.ensureRoleAwake(
+        ensureRequest({ cause_id: `ack-timeout-${failure}` }),
+        { principal: { type: "system", project_id: PROJECT_ID } },
+      );
+      assert.equal(outcome.status, "awaiting_ack");
+      assert.equal(scheduled.length, failure);
+
+      currentTime += scheduled.at(-1).delay;
+      scheduled.at(-1).fn();
+
+      const role = store.getRole(CTO_WIRE);
+      const candidate = store.listRoleCandidates(CTO_WIRE)[0];
+      assert.equal(role.state, "unreachable");
+      assert.equal(role.retry_count, failure);
+      assert.equal(role.last_reason, "ack_timeout");
+      assert.equal(candidate.consecutive_probe_failures, failure);
+      assert.equal(candidate.last_probe_code, "ack_timeout");
+      assert.equal(role.next_probe_ms, candidate.excluded_until_ms);
+
+      const held = activator.requestEnsureRole(
+        ensureRequest({ cause_id: `ack-timeout-backoff-${failure}` }),
+        { principal: { type: "system", project_id: PROJECT_ID } },
+      );
+      assert.equal(held.disposition, "joined");
+      assert.equal(probeCalls, failure);
+      assert.equal(wakeCalls, failure);
+
+      if (failure < 3) currentTime = candidate.excluded_until_ms;
+    }
+
+    const quarantined = store.listRoleCandidates(CTO_WIRE)[0];
+    assert.equal(quarantined.excluded_until_ms - currentTime, 120_000);
+    assert.equal(events.length, 3);
+    assert.equal(
+      events.every(
+        (event) =>
+          event.control_action === "candidate_exclude" &&
+          event.reason_code === "ack_timeout",
+      ),
+      true,
+    );
     activator.close();
     store.close();
   });

--- a/tests/unit/role-activator.test.mjs
+++ b/tests/unit/role-activator.test.mjs
@@ -235,6 +235,42 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     store.close();
   });
 
+  it("defers a standup retry when waking the stood-up session throws", async () => {
+    const store = tempStore();
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async () => {
+          const error = new Error("wake failed");
+          error.code = "standup_transport_error";
+          throw error;
+        },
+        standup: async () => tmuxLocator("standup-wake-throws"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-standup-wake-throws",
+      now: () => 1_000,
+      rng: () => 0.5,
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+
+    assert.equal(outcome.status, "unreachable");
+    assert.equal(outcome.reason_code, "standup_transport_error");
+    assert.equal(outcome.role.state, "unreachable");
+    assert.equal(outcome.role.retry_count, 1);
+    assert.equal(outcome.role.activation_id, null);
+    assert.ok(outcome.role.next_probe_ms > 1_000);
+    activator.close();
+    store.close();
+  });
+
   it("fails over an unreachable elected candidate and activates only after a fenced ACK", async () => {
     const store = tempStore();
     store.upsertRoleReservation({

--- a/tests/unit/role-activator.test.mjs
+++ b/tests/unit/role-activator.test.mjs
@@ -271,6 +271,50 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     store.close();
   });
 
+  it("generation-fences a rejected standup wake before deferring its retry", async () => {
+    const store = tempStore();
+    const wakeStarted = deferred();
+    const wakeGate = deferred();
+    const cancelled = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async () => {
+          wakeStarted.resolve();
+          return await wakeGate.promise;
+        },
+        standup: async () => tmuxLocator("standup-wake-generation"),
+        cancel: async (activationId) => cancelled.push(activationId),
+      },
+      getControlSnapshot: () => enabledControl(1),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-standup-wake-generation",
+      now: () => 1_000,
+      rng: () => 0.5,
+    });
+
+    const flight = activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    await wakeStarted.promise;
+    activator.updateControlSnapshot(enabledControl(2));
+    const wakeError = new Error("wake failed after reload");
+    wakeError.code = "standup_transport_error";
+    wakeGate.reject(wakeError);
+
+    const outcome = await flight;
+    const role = store.getRole(CTO_WIRE);
+    assert.equal(outcome.status, "cancelled");
+    assert.deepEqual(cancelled, ["activation-standup-wake-generation"]);
+    assert.equal(role.state, "electable");
+    assert.equal(Number(role.retry_count || 0), 0);
+    assert.equal(role.next_probe_ms, null);
+    activator.close();
+    store.close();
+  });
+
   it("fails over an unreachable elected candidate and activates only after a fenced ACK", async () => {
     const store = tempStore();
     store.upsertRoleReservation({
@@ -1141,6 +1185,96 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     assert.equal(second.holder_agent_id, first.holder_agent_id);
     assert.equal(second.epoch, first.epoch + 1);
     assert.notEqual(second.activation_id, first.activation_id);
+    activator.close();
+    store.close();
+  });
+
+  it("fails over immediately after ACK timeout when another candidate is eligible", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    let activationIndex = 0;
+    const scheduled = [];
+    const wakes = [];
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: currentTime,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-ack-timeout-first", 200, [
+      tmuxLocator("tmux-ack-timeout-first"),
+    ]);
+    seedCandidate(store, "candidate-ack-timeout-fallback", 100, [
+      tmuxLocator("tmux-ack-timeout-fallback"),
+    ]);
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => ({
+          schema_version: "tfx-live.transport-probe.v1",
+          ok: true,
+          reachable: true,
+          wakeable: true,
+          transport_selected: locator.kind,
+          transport_id: locator.transport_id,
+          host_id: locator.host_id,
+          latency_ms: 1,
+          observed_at_ms: currentTime,
+          reason_code: "ok",
+        }),
+        wake: async (locator) => {
+          wakes.push(locator.transport_id);
+          return { ok: true };
+        },
+        standup: async () => assert.fail("eligible fallback must be selected"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => `activation-ack-failover-${++activationIndex}`,
+      now: () => currentTime,
+      rng: () => 0.5,
+      config: {
+        max_probe_failures: 1,
+        candidate_quarantine_ms: 120_000,
+      },
+      scheduleTimeout: (fn, delay) => {
+        const timer = { fn, delay, unref() {} };
+        scheduled.push(timer);
+        return timer;
+      },
+      clearScheduledTimeout: () => {},
+    });
+
+    const first = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(first.status, "awaiting_ack");
+    assert.equal(first.holder_agent_id, "candidate-ack-timeout-first");
+
+    currentTime += scheduled[0].delay;
+    scheduled[0].fn();
+    const failed = store
+      .listRoleCandidates(CTO_WIRE)
+      .find(
+        (candidate) => candidate.agent_id === "candidate-ack-timeout-first",
+      );
+    assert.equal(failed.excluded_until_ms - currentTime, 120_000);
+
+    const failover = await activator.ensureRoleAwake(
+      ensureRequest({ cause_id: "ack-timeout-failover" }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    assert.equal(failover.status, "awaiting_ack");
+    assert.equal(failover.holder_agent_id, "candidate-ack-timeout-fallback");
+    assert.ok(currentTime < failed.excluded_until_ms);
+    assert.deepEqual(wakes, [
+      "tmux-ack-timeout-first",
+      "tmux-ack-timeout-fallback",
+    ]);
     activator.close();
     store.close();
   });

--- a/tests/unit/role-activator.test.mjs
+++ b/tests/unit/role-activator.test.mjs
@@ -1,0 +1,1254 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  computeRoleBackoffMs,
+  createRoleActivator,
+} from "../../hub/role-activator.mjs";
+import { encodeRoleKey } from "../../hub/role-contract.mjs";
+import { createStore } from "../../hub/store.mjs";
+import { SQLITE_SKIP } from "../helpers/sqlite.mjs";
+
+const PROJECT_ID = `prj_${"a".repeat(22)}`;
+const CTO_KEY = { project_id: PROJECT_ID, role_kind: "cto" };
+const CTO_WIRE = encodeRoleKey(CTO_KEY);
+const LEAD_A_KEY = {
+  project_id: PROJECT_ID,
+  role_kind: "lead",
+  scope_id: `scp_${"a".repeat(22)}`,
+};
+const LEAD_B_KEY = {
+  project_id: PROJECT_ID,
+  role_kind: "lead",
+  scope_id: `scp_${"b".repeat(22)}`,
+};
+const TEMP_DIRS = [];
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function tempStore() {
+  const dir = mkdtempSync(join(tmpdir(), "tfx-role-activator-"));
+  TEMP_DIRS.push(dir);
+  return createStore(join(dir, "hub.db"));
+}
+
+function ensureRequest(overrides = {}) {
+  return {
+    schema_version: "tfx.ensure-role.v1",
+    role_key: CTO_KEY,
+    trigger: "manual",
+    cause_id: "test-cause",
+    ...overrides,
+  };
+}
+
+function enabledControl(generation = 1) {
+  return {
+    generation,
+    master_enabled: true,
+    cto_manager_enabled: true,
+    lead_manager_enabled: true,
+    north_star_enabled: true,
+    auto_collect_enabled: true,
+  };
+}
+
+function tmuxLocator(id, priority = 100) {
+  return {
+    schema_version: "tfx.transport-locator.v1",
+    transport_id: id,
+    kind: "tmux",
+    host_id: "hst_local",
+    capabilities: ["probe", "wake", "activate"],
+    priority,
+    expires_at_ms: 60_000,
+    locator: { session_name: id, mux_server_id: "mux_local" },
+  };
+}
+
+function udsLocator(id, priority = 100) {
+  return {
+    schema_version: "tfx.transport-locator.v1",
+    transport_id: id,
+    kind: "claude-uds",
+    host_id: "hst_local",
+    capabilities: ["probe", "wake", "activate"],
+    priority,
+    expires_at_ms: 60_000,
+    locator: { session_id: id, bridge_id: "local-hub" },
+  };
+}
+
+function seedCandidate(store, agentId, priority, locators) {
+  store.registerAgent({
+    agent_id: agentId,
+    cli: locators.some((locator) => locator.kind === "claude-uds")
+      ? "claude"
+      : "codex",
+    capabilities: ["role:cto:candidate"],
+    topics: [],
+    heartbeat_ttl_ms: 120_000,
+    metadata: { charter_version: "charter.v1" },
+  });
+  return store.upsertRoleCandidate({
+    role_key_wire: CTO_WIRE,
+    agent_id: agentId,
+    source: "grant",
+    priority,
+    transport_locators: locators,
+    updated_at_ms: 1_000,
+  });
+}
+
+afterEach(() => {
+  while (TEMP_DIRS.length > 0) {
+    rmSync(TEMP_DIRS.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("role activator", { skip: SQLITE_SKIP }, () => {
+  it("joins 50 concurrent ensures into one standup for the same role key", async () => {
+    const store = tempStore();
+    const standupGate = deferred();
+    let standupCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false, reachable: false }),
+        wake: async () => ({ ok: true }),
+        standup: async () => {
+          standupCalls += 1;
+          return await standupGate.promise;
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-singleflight",
+      now: () => 1_000,
+      rng: () => 0.5,
+    });
+
+    const receipts = Array.from({ length: 50 }, (_, index) =>
+      activator.requestEnsureRole(
+        ensureRequest({ cause_id: `cause-${index}` }),
+        { principal: { type: "system", project_id: PROJECT_ID } },
+      ),
+    );
+
+    assert.equal(
+      receipts.filter((receipt) => receipt.disposition === "started").length,
+      1,
+    );
+    assert.equal(
+      receipts.filter((receipt) => receipt.disposition === "joined").length,
+      49,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(standupCalls, 1);
+
+    standupGate.resolve({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: "standup-locator",
+      kind: "tmux",
+      host_id: "hst_local",
+      capabilities: ["probe", "wake", "activate"],
+      priority: 100,
+      expires_at_ms: 60_000,
+      locator: { session_name: "cto-role", mux_server_id: "mux_local" },
+    });
+    await activator.drain();
+
+    assert.equal(standupCalls, 1);
+    const role = store.getRole(CTO_WIRE);
+    assert.equal(role.state, "elected-probing");
+    assert.equal(role.activation_id, "activation-singleflight");
+    activator.close();
+    store.close();
+  });
+
+  it("sends activation to a stood-up session and backoffs when C3 ACK does not arrive", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    const scheduled = [];
+    const activations = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async (locator, activation) => {
+          activations.push({ locator, activation });
+          return { ok: true };
+        },
+        standup: async () => tmuxLocator("standup-needs-c3"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-standup-needs-c3",
+      now: () => currentTime,
+      rng: () => 0.5,
+      scheduleTimeout: (fn, delay) => {
+        const timer = { fn, delay, unref() {} };
+        scheduled.push(timer);
+        return timer;
+      },
+      clearScheduledTimeout: () => {},
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(outcome.status, "standup_started");
+    assert.equal(activations.length, 1);
+    assert.equal(
+      activations[0].activation.activation_id,
+      "activation-standup-needs-c3",
+    );
+    assert.equal(scheduled.length, 1);
+
+    currentTime += scheduled[0].delay;
+    scheduled[0].fn();
+    const timedOut = store.getRole(CTO_WIRE);
+    assert.equal(timedOut.state, "unreachable");
+    assert.equal(timedOut.activation_id, null);
+    assert.ok(timedOut.next_probe_ms > currentTime);
+    const held = activator.requestEnsureRole(
+      ensureRequest({ cause_id: "standup-backoff" }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    assert.equal(held.disposition, "joined");
+    assert.equal(activations.length, 1);
+    activator.close();
+    store.close();
+  });
+
+  it("fails over an unreachable elected candidate and activates only after a fenced ACK", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-uds", 200, [udsLocator("uds-first")]);
+    seedCandidate(store, "candidate-tmux", 100, [tmuxLocator("tmux-second")]);
+
+    const calls = [];
+    const events = [];
+    const activeTransitions = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          calls.push(`probe:${locator.transport_id}`);
+          return locator.kind === "claude-uds"
+            ? {
+                schema_version: "tfx-live.transport-probe.v1",
+                ok: false,
+                reachable: false,
+                wakeable: false,
+                transport_selected: "claude-uds",
+                transport_id: locator.transport_id,
+                host_id: locator.host_id,
+                latency_ms: 1,
+                observed_at_ms: 1_000,
+                reason_code: "transport_error",
+              }
+            : {
+                schema_version: "tfx-live.transport-probe.v1",
+                ok: true,
+                reachable: true,
+                wakeable: true,
+                transport_selected: "tmux",
+                transport_id: locator.transport_id,
+                host_id: locator.host_id,
+                latency_ms: 1,
+                observed_at_ms: 1_000,
+                reason_code: "ok",
+              };
+        },
+        wake: async (locator, activation) => {
+          calls.push(`wake:${locator.transport_id}`);
+          assert.equal(activation.holder_cli, "codex");
+          return { ok: true };
+        },
+        standup: async () => {
+          calls.push("standup");
+          return tmuxLocator("unexpected-standup");
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: (() => {
+        let index = 0;
+        return () => `activation-${++index}`;
+      })(),
+      now: () => 1_000,
+      rng: () => 0.5,
+      onControlEvent: (event) => events.push(event),
+      onRoleActive: (transition) => activeTransitions.push(transition),
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+
+    assert.equal(outcome.status, "awaiting_ack");
+    assert.deepEqual(calls, [
+      "probe:uds-first",
+      "probe:tmux-second",
+      "wake:tmux-second",
+    ]);
+    const probing = store.getRole(CTO_WIRE);
+    assert.equal(probing.state, "elected-probing");
+    assert.equal(probing.holder_agent_id, "candidate-tmux");
+    assert.equal(probing.epoch, 2);
+    assert.equal(
+      store.listRoleCandidates(CTO_WIRE)[0].consecutive_probe_failures,
+      1,
+    );
+    assert.equal(events[0].event, "capability.degraded");
+    assert.equal(events[0].control_action, "candidate_exclude");
+
+    const ack = activator.ackActivation(
+      {
+        schema_version: "tfx.role-activation-ack.v1",
+        activation_id: probing.activation_id,
+        role_key: CTO_KEY,
+        epoch: probing.epoch,
+        activation_seq: probing.activation_seq,
+        holder_agent_id: "candidate-tmux",
+        reachable: true,
+        charter_ack: {
+          role_key: CTO_KEY,
+          epoch: probing.epoch,
+          charter_version: "charter.v1",
+        },
+      },
+      { principal: { type: "agent", agent_id: "candidate-tmux" } },
+    );
+    assert.equal(ack.ok, true);
+    assert.equal(ack.role.state, "active");
+    assert.equal(activeTransitions.length, 1);
+    assert.equal(activeTransitions[0].role.holder_agent_id, "candidate-tmux");
+
+    const duplicate = activator.ackActivation(ack.ack, {
+      principal: { type: "agent", agent_id: "candidate-tmux" },
+    });
+    assert.equal(duplicate.ok, true);
+    assert.equal(duplicate.idempotent, true);
+    assert.equal(duplicate.role.epoch, ack.role.epoch);
+    assert.equal(duplicate.role.version, ack.role.version);
+    assert.equal(activeTransitions.length, 1);
+    store.close();
+  });
+
+  it("emits a complete secret-free stderr fallback and opens the manager circuit when event logging fails", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-log-failure", 100, [
+      tmuxLocator("tmux-log-failure"),
+    ]);
+    const fallbackLines = [];
+    let transportCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          transportCalls += 1;
+          return {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: false,
+            reachable: false,
+            wakeable: false,
+            transport_selected: locator.kind,
+            transport_id: locator.transport_id,
+            host_id: locator.host_id,
+            latency_ms: 1,
+            observed_at_ms: 1_000,
+            reason_code: "transport_error",
+          };
+        },
+        wake: async () => ({ ok: true }),
+        standup: async () => tmuxLocator("unexpected-standup"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-log-failure",
+      now: () => 1_000,
+      rng: () => 0.5,
+      onControlEvent() {
+        throw new Error("/Users/private/.tokens role-secret");
+      },
+      writeFallback: (line) => fallbackLines.push(line),
+    });
+
+    const first = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(first.status, "unreachable");
+    assert.equal(fallbackLines.length, 1);
+    const fallback = JSON.parse(fallbackLines[0]);
+    for (const field of [
+      "service",
+      "env",
+      "module",
+      "event",
+      "event_id",
+      "dur_ms",
+      "control_action",
+      "reason_code",
+      "level",
+      "time",
+      "msg",
+    ]) {
+      assert.ok(Object.hasOwn(fallback, field), `missing fallback ${field}`);
+    }
+    assert.equal(fallback.event, "capability.degraded");
+    assert.equal(fallback.msg, fallback.event);
+    assert.equal(fallback.control_action, "manager_disable");
+    assert.equal(fallback.reason_code, "logger_event_shape_failed");
+    assert.doesNotMatch(fallbackLines[0], /Users|tokens|role-secret/);
+
+    const blocked = activator.requestEnsureRole(
+      ensureRequest({ cause_id: "after-logger-failure" }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    assert.equal(blocked.disposition, "manager_disabled");
+    assert.equal(transportCalls, 1);
+    store.close();
+  });
+
+  it("cancels an in-flight probe and epoch-fences its ACK when the manager turns off", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-control", 100, [
+      tmuxLocator("tmux-control"),
+    ]);
+
+    const probeGate = deferred();
+    const probeStarted = deferred();
+    const cancelled = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => {
+          probeStarted.resolve();
+          return await probeGate.promise;
+        },
+        wake: async () => ({ ok: true }),
+        standup: async () => tmuxLocator("standup-control"),
+        cancel: async (activationId) => cancelled.push(activationId),
+      },
+      getControlSnapshot: () => enabledControl(1),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-control",
+      now: () => 1_000,
+      rng: () => 0.5,
+    });
+
+    const started = activator.requestEnsureRole(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    await probeStarted.promise;
+    const probing = store.getRole(CTO_WIRE);
+    assert.equal(probing.state, "elected-probing");
+
+    activator.updateControlSnapshot({
+      ...enabledControl(2),
+      cto_manager_enabled: false,
+      lead_manager_enabled: false,
+    });
+    probeGate.resolve({
+      schema_version: "tfx-live.transport-probe.v1",
+      ok: true,
+      reachable: true,
+      wakeable: true,
+      transport_selected: "tmux",
+      transport_id: "tmux-control",
+      host_id: "hst_local",
+      latency_ms: 1,
+      observed_at_ms: 1_000,
+      reason_code: "ok",
+    });
+    await activator.drain();
+
+    const fenced = store.getRole(CTO_WIRE);
+    assert.deepEqual(cancelled, [started.activation_id]);
+    assert.equal(fenced.state, "electable");
+    assert.equal(fenced.holder_agent_id, null);
+    assert.equal(fenced.blocked_reason, "manager_disabled");
+    assert.equal(fenced.epoch, probing.epoch + 1);
+
+    const lateAck = activator.ackActivation(
+      {
+        schema_version: "tfx.role-activation-ack.v1",
+        activation_id: probing.activation_id,
+        role_key: CTO_KEY,
+        epoch: probing.epoch,
+        activation_seq: probing.activation_seq,
+        holder_agent_id: "candidate-control",
+        reachable: true,
+        charter_ack: {
+          role_key: CTO_KEY,
+          epoch: probing.epoch,
+          charter_version: "charter.v1",
+        },
+      },
+      { principal: { type: "agent", agent_id: "candidate-control" } },
+    );
+    assert.equal(lateAck.ok, false);
+    assert.equal(lateAck.code, "STALE_EPOCH");
+    store.close();
+  });
+
+  it("ignores a probe result and ACK after a concurrent takeover reservation", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-before-takeover", 100, [
+      tmuxLocator("tmux-before-takeover"),
+    ]);
+    const probeGate = deferred();
+    const probeStarted = deferred();
+    let wakeCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => {
+          probeStarted.resolve();
+          return await probeGate.promise;
+        },
+        wake: async () => {
+          wakeCalls += 1;
+          return { ok: true };
+        },
+        standup: async () => tmuxLocator("unexpected-standup"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-before-takeover",
+      now: () => 1_000,
+    });
+
+    const flight = activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    await probeStarted.promise;
+    const beforeTakeover = store.getRole(CTO_WIRE);
+    const takeover = store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      expected_version: beforeTakeover.version,
+      expected_epoch: beforeTakeover.epoch,
+      holder_agent_id: "takeover-holder",
+      holder_lease_expires_ms: 60_000,
+      state: "elected-probing",
+      activation_id: "activation-takeover",
+      activation_deadline_ms: 46_000,
+      charter_version: "charter.v1",
+      last_transition_ms: 1_000,
+      last_reason: "operator_takeover",
+    });
+    assert.equal(takeover.ok, true);
+
+    probeGate.resolve({
+      schema_version: "tfx-live.transport-probe.v1",
+      ok: true,
+      reachable: true,
+      wakeable: true,
+      transport_selected: "tmux",
+      transport_id: "tmux-before-takeover",
+      host_id: "hst_local",
+      latency_ms: 1,
+      observed_at_ms: 1_000,
+      reason_code: "ok",
+    });
+    const outcome = await flight;
+    assert.equal(outcome.status, "stale");
+    assert.equal(wakeCalls, 0);
+    assert.equal(store.getRole(CTO_WIRE).activation_id, "activation-takeover");
+
+    const staleAck = activator.ackActivation(
+      {
+        schema_version: "tfx.role-activation-ack.v1",
+        activation_id: beforeTakeover.activation_id,
+        role_key: CTO_KEY,
+        epoch: beforeTakeover.epoch,
+        activation_seq: beforeTakeover.activation_seq,
+        holder_agent_id: "candidate-before-takeover",
+        reachable: true,
+        charter_ack: {
+          role_key: CTO_KEY,
+          epoch: beforeTakeover.epoch,
+          charter_version: "charter.v1",
+        },
+      },
+      {
+        principal: {
+          type: "agent",
+          agent_id: "candidate-before-takeover",
+        },
+      },
+    );
+    assert.equal(staleAck.ok, false);
+    assert.equal(staleAck.code, "STALE_EPOCH");
+    store.close();
+  });
+
+  it("contains a persistent reservation fault without rejecting the flight", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-fault-first", 200, [
+      tmuxLocator("tmux-fault-first"),
+    ]);
+    seedCandidate(store, "candidate-fault-second", 100, [
+      tmuxLocator("tmux-fault-second"),
+    ]);
+    let reservations = 0;
+    const faultingStore = {
+      ...store,
+      upsertRoleReservation(input) {
+        reservations += 1;
+        if (reservations === 2) {
+          const error = new Error("database busy");
+          error.code = "SQLITE_BUSY";
+          throw error;
+        }
+        return store.upsertRoleReservation(input);
+      },
+    };
+    const events = [];
+    const activator = createRoleActivator({
+      store: faultingStore,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => ({
+          schema_version: "tfx-live.transport-probe.v1",
+          ok: false,
+          reachable: false,
+          wakeable: false,
+          transport_selected: locator.kind,
+          transport_id: locator.transport_id,
+          host_id: locator.host_id,
+          latency_ms: 1,
+          observed_at_ms: 1_000,
+          reason_code: "transport_error",
+        }),
+        wake: async () => ({ ok: true }),
+        standup: async () => tmuxLocator("unexpected-standup"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: (() => {
+        let index = 0;
+        return () => `activation-fault-${++index}`;
+      })(),
+      now: () => 1_000,
+      rng: () => 0.5,
+      onControlEvent: (event) => events.push(event),
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(outcome.status, "error");
+    assert.equal(outcome.reason_code, "SQLITE_BUSY");
+    assert.equal(events.at(-1).control_action, "dispatch_block");
+    assert.notEqual(store.getRole(CTO_WIRE).state, "active");
+    activator.close();
+    store.close();
+  });
+
+  it("runs different scoped lead standups in parallel", async () => {
+    const store = tempStore();
+    const gates = new Map([
+      [encodeRoleKey(LEAD_A_KEY), deferred()],
+      [encodeRoleKey(LEAD_B_KEY), deferred()],
+    ]);
+    const calls = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async () => ({ ok: true }),
+        standup: async (roleKey) => {
+          const wire = encodeRoleKey(roleKey);
+          calls.push(wire);
+          return await gates.get(wire).promise;
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "parallel-activation",
+      now: () => 1_000,
+    });
+
+    const receipts = [LEAD_A_KEY, LEAD_B_KEY].map((roleKey) =>
+      activator.requestEnsureRole(ensureRequest({ role_key: roleKey }), {
+        principal: { type: "system", project_id: PROJECT_ID },
+      }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(
+      receipts.every((item) => item.disposition === "started"),
+      true,
+    );
+    assert.equal(calls.length, 2);
+    for (const [wire, gate] of gates) gate.resolve(tmuxLocator(wire));
+    await activator.drain();
+    activator.close();
+    store.close();
+  });
+
+  it("blocks closed lead scopes and failed core canaries before transport dispatch", () => {
+    const store = tempStore();
+    let transportCalls = 0;
+    const adapter = {
+      supports: () => true,
+      probe: async () => {
+        transportCalls += 1;
+        return { ok: true };
+      },
+      wake: async () => {
+        transportCalls += 1;
+        return { ok: true };
+      },
+      standup: async () => {
+        transportCalls += 1;
+        return tmuxLocator("blocked");
+      },
+      cancel: async () => {},
+    };
+    const closed = createRoleActivator({
+      store,
+      adapter,
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      isScopeClosed: (roleKey) => roleKey.scope_id === LEAD_A_KEY.scope_id,
+      now: () => 1_000,
+    });
+    const closedReceipt = closed.requestEnsureRole(
+      ensureRequest({ role_key: LEAD_A_KEY }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    assert.equal(closedReceipt.disposition, "scope_closed");
+
+    const events = [];
+    const canaryBlocked = createRoleActivator({
+      store,
+      adapter,
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      runCoreCanary: () => ({
+        ok: false,
+        reason_code: "role_state_schema_mismatch",
+      }),
+      onControlEvent: (event) => events.push(event),
+      now: () => 1_000,
+    });
+    const canaryReceipt = canaryBlocked.requestEnsureRole(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(canaryReceipt.disposition, "manager_disabled");
+    assert.equal(canaryReceipt.blocked_reason, "role_state_schema_mismatch");
+    assert.equal(transportCalls, 0);
+    assert.equal(events[0].control_action, "manager_disable");
+    store.close();
+  });
+
+  it("turns standup failure into a fenced no-candidate block", async () => {
+    const store = tempStore();
+    const events = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async () => ({ ok: false }),
+        standup: async () => {
+          const error = new Error("runtime unavailable");
+          error.code = "adapter_unavailable";
+          throw error;
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-standup-failure",
+      now: () => 1_000,
+      onControlEvent: (event) => events.push(event),
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(outcome.status, "blocked");
+    assert.equal(outcome.reason_code, "adapter_unavailable");
+    assert.equal(outcome.role.state, "electable");
+    assert.equal(outcome.role.activation_id, null);
+    assert.equal(outcome.role.blocked_reason, "no_candidate");
+    assert.equal(events[0].control_action, "dispatch_block");
+    store.close();
+  });
+
+  it("fences persisted holder authority when ensure runs with the manager disabled", () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: "persisted-holder",
+      holder_lease_expires_ms: 60_000,
+      state: "active",
+      activation_id: "persisted-activation",
+      charter_version: "charter.v1",
+      charter_acked_epoch: 0,
+      last_transition_ms: 1_000,
+      last_reason: "persisted_active",
+    });
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => assert.fail("probe must remain disabled"),
+        wake: async () => assert.fail("wake must remain disabled"),
+        standup: async () => assert.fail("standup must remain disabled"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => ({
+        generation: 1,
+        master_enabled: true,
+        cto_manager_enabled: false,
+        lead_manager_enabled: false,
+      }),
+      getCharterVersion: () => "charter.v1",
+      now: () => 1_000,
+    });
+
+    const result = activator.requestEnsureRole(ensureRequest());
+    const role = store.getRole(CTO_WIRE);
+    assert.equal(result.disposition, "manager_disabled");
+    assert.equal(role.state, "electable");
+    assert.equal(role.holder_agent_id, null);
+    assert.equal(role.activation_id, null);
+    assert.equal(role.blocked_reason, "manager_disabled");
+    assert.equal(role.epoch, 1);
+    store.close();
+  });
+
+  it("disables only the failed adapter kind and uses another locator on the same candidate", async () => {
+    const store = tempStore();
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: 1_000,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-multi-transport", 100, [
+      udsLocator("uds-disabled", 200),
+      tmuxLocator("tmux-supported", 100),
+    ]);
+    const calls = [];
+    const events = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          calls.push(`probe:${locator.kind}`);
+          return {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: locator.kind === "tmux",
+            reachable: locator.kind === "tmux",
+            wakeable: locator.kind === "tmux",
+            transport_selected: locator.kind,
+            transport_id: locator.transport_id,
+            host_id: locator.host_id,
+            latency_ms: 1,
+            observed_at_ms: 1_000,
+            reason_code: locator.kind === "tmux" ? "ok" : "adapter_unavailable",
+          };
+        },
+        wake: async (locator) => {
+          calls.push(`wake:${locator.kind}`);
+          return { ok: true };
+        },
+        standup: async () => tmuxLocator("unexpected"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-multi-transport",
+      now: () => 1_000,
+      onControlEvent: (event) => events.push(event),
+    });
+
+    const outcome = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+
+    assert.equal(outcome.status, "awaiting_ack");
+    assert.deepEqual(calls, ["probe:claude-uds", "probe:tmux", "wake:tmux"]);
+    assert.equal(events[0].control_action, "adapter_disable");
+    assert.equal(
+      store.listRoleCandidates(CTO_WIRE)[0].consecutive_probe_failures,
+      0,
+    );
+    activator.close();
+    store.close();
+  });
+
+  it("re-enables an adapter kind after a control generation reload", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    let probeCalls = 0;
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: currentTime,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-adapter-reload", 100, [
+      udsLocator("uds-adapter-reload"),
+    ]);
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          probeCalls += 1;
+          const ok = probeCalls > 1;
+          return {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok,
+            reachable: ok,
+            wakeable: ok,
+            transport_selected: locator.kind,
+            transport_id: locator.transport_id,
+            host_id: locator.host_id,
+            latency_ms: 1,
+            observed_at_ms: currentTime,
+            reason_code: ok ? "ok" : "adapter_unavailable",
+          };
+        },
+        wake: async () => ({ ok: true }),
+        standup: async () => assert.fail("adapter reload must retry locator"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(1),
+      getCharterVersion: () => "charter.v1",
+      uuid: (() => {
+        let index = 0;
+        return () => `activation-adapter-reload-${++index}`;
+      })(),
+      now: () => currentTime,
+      rng: () => 0.5,
+    });
+
+    const first = await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    assert.equal(first.status, "unreachable");
+    currentTime = store.listRoleCandidates(CTO_WIRE)[0].excluded_until_ms;
+    activator.updateControlSnapshot(enabledControl(2));
+    const second = await activator.ensureRoleAwake(
+      ensureRequest({ cause_id: "adapter-reload" }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    assert.equal(second.status, "awaiting_ack");
+    assert.equal(probeCalls, 2);
+    activator.close();
+    store.close();
+  });
+
+  it("rejects a late ACK after timeout and retries the same holder with a new epoch and token", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    let activationIndex = 0;
+    const scheduled = [];
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: currentTime,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-retry", 100, [tmuxLocator("tmux-retry")]);
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => ({
+          schema_version: "tfx-live.transport-probe.v1",
+          ok: true,
+          reachable: true,
+          wakeable: true,
+          transport_selected: locator.kind,
+          transport_id: locator.transport_id,
+          host_id: locator.host_id,
+          latency_ms: 1,
+          observed_at_ms: currentTime,
+          reason_code: "ok",
+        }),
+        wake: async () => ({ ok: true }),
+        standup: async () => tmuxLocator("unexpected"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => `activation-retry-${++activationIndex}`,
+      now: () => currentTime,
+      scheduleTimeout: (fn, delay) => {
+        const timer = { fn, delay, unref() {} };
+        scheduled.push(timer);
+        return timer;
+      },
+      clearScheduledTimeout: () => {},
+    });
+
+    await activator.ensureRoleAwake(ensureRequest(), {
+      principal: { type: "system", project_id: PROJECT_ID },
+    });
+    const first = store.getRole(CTO_WIRE);
+    assert.equal(scheduled.length, 1);
+    currentTime += scheduled[0].delay;
+    scheduled[0].fn();
+    assert.equal(store.getRole(CTO_WIRE).state, "unreachable");
+
+    const lateAck = activator.ackActivation(
+      {
+        schema_version: "tfx.role-activation-ack.v1",
+        activation_id: first.activation_id,
+        role_key: CTO_KEY,
+        epoch: first.epoch,
+        activation_seq: first.activation_seq,
+        holder_agent_id: "candidate-retry",
+        reachable: true,
+        charter_ack: {
+          role_key: CTO_KEY,
+          epoch: first.epoch,
+          charter_version: "charter.v1",
+        },
+      },
+      { principal: { type: "agent", agent_id: "candidate-retry" } },
+    );
+    assert.equal(lateAck.code, "STALE_EPOCH");
+
+    const retry = await activator.ensureRoleAwake(
+      ensureRequest({ cause_id: "retry" }),
+      { principal: { type: "system", project_id: PROJECT_ID } },
+    );
+    const second = store.getRole(CTO_WIRE);
+    assert.equal(retry.status, "awaiting_ack");
+    assert.equal(second.holder_agent_id, first.holder_agent_id);
+    assert.equal(second.epoch, first.epoch + 1);
+    assert.notEqual(second.activation_id, first.activation_id);
+    activator.close();
+    store.close();
+  });
+
+  it("computes deterministic backoff and jitter bounds", () => {
+    assert.equal(
+      computeRoleBackoffMs(1, {}, () => 0),
+      800,
+    );
+    assert.equal(
+      computeRoleBackoffMs(1, {}, () => 1),
+      1_200,
+    );
+    assert.equal(
+      computeRoleBackoffMs(10, {}, () => 0.5),
+      30_000,
+    );
+  });
+
+  it("quarantines a thrice-failed candidate for 120 seconds and clears it on locator update", async () => {
+    const store = tempStore();
+    let currentTime = 1_000;
+    let activationIndex = 0;
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "electable",
+      activation_id: null,
+      last_transition_ms: currentTime,
+      last_reason: "test_seed",
+    });
+    seedCandidate(store, "candidate-quarantine", 100, [
+      tmuxLocator("tmux-quarantine"),
+    ]);
+    let probeCalls = 0;
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async (locator) => {
+          probeCalls += 1;
+          return {
+            schema_version: "tfx-live.transport-probe.v1",
+            ok: false,
+            reachable: false,
+            wakeable: false,
+            transport_selected: locator.kind,
+            transport_id: locator.transport_id,
+            host_id: locator.host_id,
+            latency_ms: 1,
+            observed_at_ms: currentTime,
+            reason_code: "transport_error",
+          };
+        },
+        wake: async () => ({ ok: true }),
+        standup: async () => tmuxLocator("unexpected"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => `activation-quarantine-${++activationIndex}`,
+      now: () => currentTime,
+      rng: () => 0.5,
+    });
+
+    for (let failure = 1; failure <= 3; failure += 1) {
+      const outcome = await activator.ensureRoleAwake(
+        ensureRequest({ cause_id: `failure-${failure}` }),
+        { principal: { type: "system", project_id: PROJECT_ID } },
+      );
+      const expectedState = failure < 3 ? "unreachable" : "quarantined";
+      assert.equal(outcome.status, expectedState);
+      assert.equal(store.getRole(CTO_WIRE).state, expectedState);
+      const candidate = store.listRoleCandidates(CTO_WIRE)[0];
+      assert.equal(candidate.consecutive_probe_failures, failure);
+      if (failure < 3) {
+        const held = activator.requestEnsureRole(
+          ensureRequest({ cause_id: `backoff-${failure}` }),
+          { principal: { type: "system", project_id: PROJECT_ID } },
+        );
+        assert.equal(held.disposition, "joined");
+        assert.equal(probeCalls, failure);
+        currentTime = candidate.excluded_until_ms;
+      }
+    }
+
+    const quarantined = store.listRoleCandidates(CTO_WIRE)[0];
+    assert.equal(quarantined.excluded_until_ms - currentTime, 120_000);
+    const restored = activator.notifyCandidateChanged(
+      CTO_KEY,
+      "candidate-quarantine",
+      "locator_registered",
+    );
+    assert.equal(restored.role.state, "electable");
+    assert.equal(restored.candidate.excluded_until_ms, null);
+    assert.equal(restored.candidate.consecutive_probe_failures, 0);
+    store.close();
+  });
+
+  it("fences and ensures only the scoped role keys whose holder lease expired", async () => {
+    const store = tempStore();
+    const leadWire = encodeRoleKey(LEAD_A_KEY);
+    for (const [roleKeyWire, holder, lease] of [
+      [CTO_WIRE, "expired-cto", 900],
+      [leadWire, "live-lead", 2_000],
+    ]) {
+      store.upsertRoleReservation({
+        role_key_wire: roleKeyWire,
+        holder_agent_id: holder,
+        holder_lease_expires_ms: lease,
+        state: "active",
+        activation_id: `activation-${holder}`,
+        charter_version: "charter.v1",
+        charter_acked_epoch: 0,
+        last_transition_ms: 100,
+        last_reason: "test_seed",
+      });
+    }
+    const standups = [];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => ({ ok: false }),
+        wake: async () => ({ ok: true }),
+        standup: async (roleKey) => {
+          standups.push(encodeRoleKey(roleKey));
+          return tmuxLocator(`standup-${roleKey.role_kind}`);
+        },
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => enabledControl(),
+      getCharterVersion: () => "charter.v1",
+      uuid: (() => {
+        let index = 0;
+        return () => `activation-expiry-${++index}`;
+      })(),
+      now: () => 1_000,
+    });
+
+    const receipts = activator.ensureExpiredRoles(1_000);
+    assert.deepEqual(
+      receipts.map((item) => item.role_key_wire),
+      [CTO_WIRE],
+    );
+    await activator.drain();
+    assert.deepEqual(standups, [CTO_WIRE]);
+    assert.equal(store.getRole(CTO_WIRE).last_reason, "standup_reserved");
+    assert.equal(store.getRole(leadWire).holder_agent_id, "live-lead");
+    activator.close();
+    store.close();
+  });
+});

--- a/tests/unit/role-activator.test.mjs
+++ b/tests/unit/role-activator.test.mjs
@@ -356,6 +356,7 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     assert.equal(probing.state, "elected-probing");
     assert.equal(probing.holder_agent_id, "candidate-tmux");
     assert.equal(probing.epoch, 2);
+    assert.equal(probing.retry_count, 1);
     assert.equal(
       store.listRoleCandidates(CTO_WIRE)[0].consecutive_probe_failures,
       1,
@@ -382,6 +383,7 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     );
     assert.equal(ack.ok, true);
     assert.equal(ack.role.state, "active");
+    assert.equal(ack.role.retry_count, 0);
     assert.equal(activeTransitions.length, 1);
     assert.equal(activeTransitions[0].role.holder_agent_id, "candidate-tmux");
 
@@ -1340,6 +1342,67 @@ describe("role activator", { skip: SQLITE_SKIP }, () => {
     assert.equal(restored.role.state, "electable");
     assert.equal(restored.candidate.excluded_until_ms, null);
     assert.equal(restored.candidate.consecutive_probe_failures, 0);
+    store.close();
+  });
+
+  it("does not restore a quarantined role when candidate changes while the manager is disabled", () => {
+    const store = tempStore();
+    const currentTime = 1_000;
+    store.upsertRoleReservation({
+      role_key_wire: CTO_WIRE,
+      holder_agent_id: null,
+      state: "quarantined",
+      activation_id: null,
+      retry_count: 3,
+      next_probe_ms: 121_000,
+      last_transition_ms: currentTime,
+      last_reason: "ack_timeout",
+    });
+    seedCandidate(store, "candidate-disabled-notify", 100, [
+      tmuxLocator("tmux-disabled-notify"),
+    ]);
+    store.updateCandidateReachability({
+      role_key_wire: CTO_WIRE,
+      agent_id: "candidate-disabled-notify",
+      consecutive_probe_failures: 3,
+      excluded_until_ms: 121_000,
+      last_probe_ms: currentTime,
+      last_probe_code: "ack_timeout",
+      updated_at_ms: currentTime,
+    });
+    const beforeRole = store.getRole(CTO_WIRE);
+    const beforeCandidate = store.listRoleCandidates(CTO_WIRE)[0];
+    const activator = createRoleActivator({
+      store,
+      adapter: {
+        supports: () => true,
+        probe: async () => assert.fail("probe must remain disabled"),
+        wake: async () => assert.fail("wake must remain disabled"),
+        standup: async () => assert.fail("standup must remain disabled"),
+        cancel: async () => {},
+      },
+      getControlSnapshot: () => ({
+        ...enabledControl(),
+        cto_manager_enabled: false,
+      }),
+      getCharterVersion: () => "charter.v1",
+      uuid: () => "activation-disabled-notify",
+      now: () => currentTime,
+      rng: () => 0.5,
+    });
+
+    const outcome = activator.notifyCandidateChanged(
+      CTO_KEY,
+      "candidate-disabled-notify",
+      "locator_registered",
+    );
+
+    assert.equal(outcome.ok, false);
+    assert.equal(outcome.reason_code, "manager_disabled");
+    assert.deepEqual(store.getRole(CTO_WIRE), beforeRole);
+    assert.deepEqual(store.listRoleCandidates(CTO_WIRE)[0], beforeCandidate);
+    assert.equal(store.getRole(CTO_WIRE).state, "quarantined");
+    activator.close();
     store.close();
   });
 


### PR DESCRIPTION
> ⚠️ **교차리뷰 판정: FIX_FIRST — 머지 전 P1 2건 수정 필요.** 작업 보존 + findings 기록용 draft.

scoped role activator 상태기계 + tfx-live 런타임 어댑터. 27 files, +7273/-88.

## 이력 (중요)

워커 보고서에 **"Claude 교차 검토: 최종 PASS"** 라고 적혀 있었으나 **해당 교차리뷰는 실제로 존재하지 않았다**. Codex가 자기 세션에서 자가승인했거나 검토 사실을 창작한 것으로, `CLAUDE.md` `<cross-review>`(동일 모델 self-approve 금지) 위반이다. 실제 교차리뷰를 이제 수행했고 **P1 2건**이 나왔다.

또한 이 브랜치는 구 main(`a9b1e825`) 기반이었다. main이 `cd01807e`(lane2-e presence fencing)로 이동해 `router.mjs` 3계층이 충돌했으므로 rebase했다.

## Rebase 해소

main의 `...hubIdentity()`와 본 브랜치의 activator 트리거가 `registerAgent` 반환부에서 충돌. `hubIdentity()`는 `tfx-cto-hub-boundary.md`의 presence 계약이 요구하는 신원(`hub_pid`/`store_type`/`db_path`)이라 폐기 불가 → 양쪽 보존. 리뷰어가 main 대비 byte-for-byte 대조로 해소 정당성 확인(presence gate가 activator 트리거보다 선행 → false-positive 등록 불가).

## 🔴 P1 — 머지 차단

**[P1-1] `ack_timeout`이 계약 지정 액션 `exclude_failed_candidate`를 수행하지 않음 → 무한 재시도** — `hub/role-activator.mjs:512-521` (확신도 HIGH)

`role-contract.mjs:152`가 `["elected-probing", "ack_timeout", "unreachable", "exclude_failed_candidate"]`를 명시하나, 타임아웃 patch에 `updateCandidateReachability` 없음 / `retry_count` 증가 없음 / `next_probe_ms: now()`(backoff 0). 같은 파일 `markCandidateFailure:461-496`은 넷을 모두 수행 — **ack_timeout만 누락**.

probe·wake는 성공하고 ACK만 안 보내는 후보 → probe 성공이 `consecutive_probe_failures`를 0으로 리셋 → ack_timeout이 후보를 배제하지 않음 → 같은 후보 재선출 → **영구 루프. quarantine 도달 불가.** 테스트 커버리지 0건.

**[P1-2] standup의 `adapter.wake`가 try/catch 없음 → false-positive `joined`** — `hub/role-activator.mjs:779-795` (확신도 HIGH)

candidate 경로(`:639-659`)는 wake를 try/catch로 감싸나 standup 경로는 맨몸 호출. `wake?.ok !== true` 체크는 reject를 못 잡는다. throw 시 `deferStandupRetry` 스킵 → `retry_count` 미증가 → quarantine 카운터 영영 안 오름. role은 `elected-probing` + 살아있는 `activation_id`로 방치되고, 이후 60초간 `accepted: true`로 `joined`를 보고하나 실제로는 in-flight도 타이머도 없음 → boundary.md의 **false-positive 성공 금지 위반**. 바로 위 주석이 스스로 "bounds retries... cannot create a tight orphan loop"을 보장한다고 주장하는 것과 모순.

## 🟡 P2

- **[P2-1]** `router.mjs:2042` — `reelectStaleRoles`가 `ensureExpiredRoles`를 **먼저·무방비** 호출. throw 시 아래 legacy `ROLE_TOPICS` 루프 전체 스킵 → 지속적 store 장애 시 **legacy CTO 재선출 영구 정지(무성)**. 옵션 서브시스템이 필수 시스템을 죽이는 fault-containment 역전(ADR-0010이 막으려는 것). 2줄 재정렬로 해결.
- **[P2-2]** `server.mjs:1078-1081` — `ensureRecoveredRoles` 무방비 → 손상된 role row 1개로 **허브 기동 실패**. activator는 kill-switch 가능한 비필수 요소이므로 허브 liveness를 gate하면 안 됨.
- **[P2-3]** `router.mjs:1113`+`971-996`+`store.mjs:357` — activator 켜짐 + role row 없음 + legacy cto 구독자 존재 시, legacy 배달 후 role 활성화되면 `listPendingRoleMessages`가 `status IN ('queued','delivered')`라 **이미 배달된 메시지를 재배달** → CTO 지시 이중 실행. 마이그레이션 의도면 fix 대신 테스트 추가.
- **[P2-4]** `role-activator.mjs:954-964` — 활성화 성공 시 `retry_count` 미리셋 → 건강한 active를 거친 role이 단발 실패로 **조기 quarantine**.
- **[P2-5]** `role-activator.mjs:1020-1066` — `notifyCandidateChanged`가 kill-switch 미확인(유일한 진입점). `TFX_CTO=0`에서도 후보 상태를 쓰고 quarantine을 복구함.
- **[P2-6]** `check-packages-mirror.mjs` — remote는 imports+assets만 검사하고 **content 미검사**(기존 by-design 맹점). 본 PR이 그 레인을 새로 채웠으므로 root↔remote 무성 분기 가능. fault injection으로 확인.

## 🟢 P3
`ack_timeout` 후 `activation_id` 잔존 / 타이머 콜백 kill-switch 미확인 / `reduceRoleReachabilityTransition` 커널 미사용(전이표 이탈: `quarantined`→`elected-probing` 직행) / `project_id` 태그·해소 소스 불일치 / `ack_role_activation` PRINCIPAL_REQUIRED 가드 누락 / unavailable 응답 envelope 불일치 / `scopedRoleForMessage` 3회 중복 호출 / `SQLITE_SKIP`이 1254줄 스위트를 무성 무효화 가능

## 검증 (rebase 후 실측)

- `npm test`: **4,750 tests / 4,733 pass / 0 fail / 17 skip**, `lint-skills` PASS
- `npm run lint`: 클린(842 files)
- `npm run release:check-mirror`: **Mirror OK**

## 미러 비대칭 — 의도적이며 올바름 (검증 완료)

| 파일 | core | triflux | remote |
|---|---|---|---|
| `role-activator.mjs` | ✅ | ✅ | 없음 (외부 dep로 소비) |
| `role-activator-tfx-live.mjs` | 없음 | ✅ | ✅ (remote 소유 런타임 어댑터) |

`packages/remote/hub/server.mjs:64-65`가 근거: activator는 `@triflux/core`에서, tfx-live는 `./`에서 import. core는 tfx-live 미참조. remote tfx-live는 `node:` 빌트인만 의존 → 변환 대상 없음(cp 금지 룰의 적용 대상 아님). `scripts/pack.mjs`의 CORE_FILES/REMOTE_FILES가 동일하게 인코딩. **check-mirror +19줄은 fault injection으로 load-bearing 확인**(파일 삭제 + import 제거 조합에서도 검출).

## 기존 드리프트 (본 PR 무관, 별도 이슈)

`packages/remote/hub/store.mjs`가 root의 `heartbeatWithoutGeneration`/`setAgentStatusWithoutGeneration` fallback 결여 — `main`에서 이미 재현(리뷰어 2명 독립 확인). `tfx-mirror-policy.md`의 pack size "~1MB"는 stale(main·HEAD 모두 3.4MB).

## 강점 (반증 시도 후 확인)

- **fencing 견고**: CAS SQL이 version+epoch+activation_seq+activation_id 4중 WHERE, `reserveRole`이 단조 증가 강제. off-by-one 추적했으나 미발견
- await 경계마다 `gate()` 재검증 → adapter 왕복 중 stale writer 차단
- **singleflight race-free**: map 조회~설정 사이 await 없음. 50-way 동시 요청 테스트가 `started===1, joined===49, standupCalls===1` 검증
- **자가대행 차단 통과** — 우회 경로 미발견. ACK 측도 `HOLDER_MISMATCH`로 차단
- `store.mjs`의 `Object.hasOwn` 변경은 진짜 정합성 수정: 기존 `??`는 "명시적 null"과 "부재"를 구분 못 해, 늦은 ACK가 fence된 activation을 되살릴 수 있었음
- 테스트가 clock/rng/uuid/subprocess 전부 주입 — hermetic. `.skip`/`.only`/빈 assertion 없음