### PR TITLE
feat: codex tmux session discovery in tfx-live + Hub self-register for codex/OMX

### DIFF
--- a/bin/tfx-live.mjs
+++ b/bin/tfx-live.mjs
@@ -52,6 +52,7 @@ function usage() {
     "  tfx-live interrupt --session NAME [--cli codex|claude] [--transport tmux|uds|auto] [--short SHORT | --session-id ID] [--config-dir DIR] [--bridge ABS] [--timeout 5]",
     "  tfx-live stop --session NAME [--cli codex|claude] [--remote HOST]",
     "  tfx-live probe [--short SHORT] [--session-id ID] [--config-dir DIR] [--bridge ABS] [--timeout 10]",
+    "  tfx-live list-sessions --cli codex [--cwd DIR]",
     "  tfx-live converse --session NAME --prompts-file PATH [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500]",
     "  tfx-live goal-driven --session NAME --goal TEXT [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500] [--max-rounds 8] [--done-token DONE]",
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
@@ -350,6 +351,119 @@ async function runTmux(remote, tmuxArgs, options = {}) {
       .filter(Boolean)
       .join("\n");
     throw new Error(detail);
+  }
+}
+
+function normalizeCwd(value) {
+  if (!value) return null;
+  const resolved = pathResolve(value);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isCodexTmuxPane(currentCommand, startCommand) {
+  const current = String(currentCommand ?? "").trim();
+  const currentBase = current.split("/").at(-1);
+  if (currentBase === "codex") {
+    return true;
+  }
+
+  const started = String(startCommand ?? "").trim();
+  const directStart = started
+    .replace(/^exec\s+/, "")
+    .replace(/^['"]|['"]$/g, "");
+  if (/^(?:\S*\/)?codex(?:\s|$)/.test(directStart)) {
+    return true;
+  }
+
+  return (
+    /\bomx_codex_pid\b/.test(started) &&
+    /(?:^|[\s'""])(?:[^'" \t]+\/)?codex(?:[\s'"]|$)/.test(started)
+  );
+}
+
+function parseCodexTmuxSessions(stdout, cwd = null) {
+  const cwdFilter = normalizeCwd(cwd);
+  const sessions = new Map();
+
+  for (const line of String(stdout).split(/\r?\n/)) {
+    if (!line) continue;
+    const [
+      session,
+      createdRaw,
+      attachedRaw,
+      paneCwd,
+      currentCommand,
+      ...startParts
+    ] = line.split("\t");
+    const startCommand = startParts.join("\t");
+    if (!session || !isCodexTmuxPane(currentCommand, startCommand)) {
+      continue;
+    }
+
+    const normalizedPaneCwd = normalizeCwd(paneCwd);
+    if (cwdFilter && normalizedPaneCwd !== cwdFilter) {
+      continue;
+    }
+
+    const startedAtEpoch = Number.parseInt(createdRaw, 10);
+    const startedAt = Number.isSafeInteger(startedAtEpoch)
+      ? new Date(startedAtEpoch * 1000).toISOString()
+      : null;
+    const existing = sessions.get(session);
+    if (existing) {
+      if (!existing.cwd && normalizedPaneCwd) {
+        existing.cwd = normalizedPaneCwd;
+      }
+      continue;
+    }
+
+    sessions.set(session, {
+      session,
+      startedAt,
+      startedAtEpoch: Number.isSafeInteger(startedAtEpoch)
+        ? startedAtEpoch
+        : null,
+      cwd: normalizedPaneCwd,
+      attached: Number.parseInt(attachedRaw, 10) > 0,
+    });
+  }
+
+  return [...sessions.values()].sort((left, right) =>
+    left.session.localeCompare(right.session),
+  );
+}
+
+async function discoverCodexTmuxSessions({ cwd = null } = {}) {
+  const format = [
+    "#{session_name}",
+    "#{session_created}",
+    "#{session_attached}",
+    "#{pane_current_path}",
+    "#{pane_current_command}",
+    "#{pane_start_command}",
+  ].join("\t");
+
+  try {
+    const { stdout } = await runTmux(null, ["list-panes", "-a", "-F", format]);
+    return {
+      ok: true,
+      cli: "codex",
+      cwd: normalizeCwd(cwd),
+      sessions: parseCodexTmuxSessions(stdout, cwd),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      cli: "codex",
+      cwd: normalizeCwd(cwd),
+      reason: "tmux-unavailable",
+      error: error.message,
+      sessions: [],
+    };
   }
 }
 
@@ -1887,6 +2001,14 @@ async function probe(flags) {
   );
 }
 
+async function listSessions(flags) {
+  const adapter = selectAdapter(flags);
+  if (adapter.cli !== "codex") {
+    throw new Error("list-sessions currently supports only --cli codex");
+  }
+  printJson(await discoverCodexTmuxSessions({ cwd: flags.cwd }));
+}
+
 function startOptsForSession(flags, session) {
   return {
     session,
@@ -2344,6 +2466,8 @@ async function main() {
     await interrupt(flags);
   } else if (command === "probe") {
     await probe(flags);
+  } else if (command === "list-sessions") {
+    await listSessions(flags);
   } else if (command === "converse") {
     await converse(flags);
   } else if (command === "goal-driven") {
@@ -2364,9 +2488,11 @@ export {
   buildRemoteLiveCommand,
   callRemoteLive,
   ctoHygieneNotify,
+  discoverCodexTmuxSessions,
   extractAssistantResponse,
   extractClaudeCompletedTaskListResponse,
   hasClaudeCompletedTaskListResponse,
+  parseCodexTmuxSessions,
   parseRemoteLiveJson,
   resolveAskTransport,
 };

--- a/hooks/codex-session-hook.mjs
+++ b/hooks/codex-session-hook.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
 import { argv, exit, stdin, stdout } from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
 import {
   heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
@@ -51,6 +52,59 @@ function normalizeMode(mode, payload) {
   return "";
 }
 
+/**
+ * Start a detached bridge call so Codex/OMX presence reaches both the Synapse
+ * session registry and the hub agents table. This is intentionally independent
+ * of the legacy session-start work below: a missing or unavailable hub must
+ * never delay or fail SessionStart.
+ */
+export function launchCodexPresenceRegistration(payload, opts = {}) {
+  try {
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return false;
+
+    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
+      ? payload.cwd
+      : process.cwd();
+    const bridgePath = opts.bridgePath || fileURLToPath(
+      new URL("../hub/bridge.mjs", import.meta.url),
+    );
+    const spawnFn = opts.spawnFn || spawn;
+    const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
+    const tmuxSession = String(
+      process.env.OMX_TMUX_SESSION_NAME || process.env.OMX_TMUX_SESSION || "",
+    ).trim();
+    const tmuxPane = String(process.env.TMUX_PANE || "").trim();
+    const args = [
+      bridgePath,
+      "register",
+      "--session-id", sessionId,
+      "--cwd", cwd,
+      "--worktree-path", cwd,
+      "--session-kind", "interactive",
+      "--host", "local",
+      "--codex-session-id", sessionId,
+    ];
+    if (canonicalSessionId && canonicalSessionId !== sessionId) {
+      args.push("--omx-session-id", canonicalSessionId);
+    }
+    if (tmuxSession) args.push("--tmux-session", tmuxSession);
+    if (tmuxPane) args.push("--tmux-pane", tmuxPane);
+
+    const child = spawnFn(process.execPath, args, {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+      env: process.env,
+    });
+    child?.once?.("error", () => {});
+    child?.unref?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
   const done =
     typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
@@ -91,10 +145,15 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
     opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
   const drainPendingSynapse =
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
+  const launchPresenceRegistration =
+    opts.launchPresenceRegistration || launchCodexPresenceRegistration;
 
   try {
     await runHookSideEffectsWithStdoutSuppressed(async () => {
       if (mode === "register") {
+        try {
+          launchPresenceRegistration(parsed.payload);
+        } catch {}
         try {
           await hubEnsureRun(stdinData);
         } catch {}

--- a/hooks/codex-session-hook.mjs
+++ b/hooks/codex-session-hook.mjs
@@ -63,12 +63,13 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const sessionId = String(payload?.session_id || "").trim();
     if (!sessionId) return false;
 
-    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
-      ? payload.cwd
-      : process.cwd();
-    const bridgePath = opts.bridgePath || fileURLToPath(
-      new URL("../hub/bridge.mjs", import.meta.url),
-    );
+    const cwd =
+      typeof payload?.cwd === "string" && payload.cwd.trim()
+        ? payload.cwd
+        : process.cwd();
+    const bridgePath =
+      opts.bridgePath ||
+      fileURLToPath(new URL("../hub/bridge.mjs", import.meta.url));
     const spawnFn = opts.spawnFn || spawn;
     const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
     const tmuxSession = String(
@@ -78,12 +79,18 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const args = [
       bridgePath,
       "register",
-      "--session-id", sessionId,
-      "--cwd", cwd,
-      "--worktree-path", cwd,
-      "--session-kind", "interactive",
-      "--host", "local",
-      "--codex-session-id", sessionId,
+      "--session-id",
+      sessionId,
+      "--cwd",
+      cwd,
+      "--worktree-path",
+      cwd,
+      "--session-kind",
+      "interactive",
+      "--host",
+      "local",
+      "--codex-session-id",
+      sessionId,
     ];
     if (canonicalSessionId && canonicalSessionId !== sessionId) {
       args.push("--omx-session-id", canonicalSessionId);

--- a/hub/bridge.mjs
+++ b/hub/bridge.mjs
@@ -400,6 +400,16 @@ export function parseArgs(argv) {
       command: { type: "string" },
       role: { type: "string" },
       "session-id": { type: "string" },
+      cwd: { type: "string" },
+      "worktree-path": { type: "string" },
+      branch: { type: "string" },
+      host: { type: "string" },
+      "session-kind": { type: "string" },
+      "is-remote": { type: "string" },
+      "tmux-session": { type: "string" },
+      "tmux-pane": { type: "string" },
+      "omx-session-id": { type: "string" },
+      "codex-session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
       from: { type: "string" },
@@ -606,6 +616,71 @@ function unavailableResult() {
   return { ok: false, reason: "hub_unavailable" };
 }
 
+function nonEmptyString(value, fallback = "") {
+  const normalized = String(value ?? "").trim();
+  return normalized || fallback;
+}
+
+function readBoolean(value) {
+  return ["1", "true", "yes"].includes(nonEmptyString(value).toLowerCase());
+}
+
+function sessionAgentId(sessionId) {
+  return `codex-session-${sessionId.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+export function buildInteractiveSessionRegistrationPayload(args = {}) {
+  const sessionId = nonEmptyString(args["session-id"]);
+  if (!sessionId) return null;
+
+  const cwd = nonEmptyString(args.cwd, process.cwd());
+  const worktreePath = nonEmptyString(args["worktree-path"], cwd);
+  const host = nonEmptyString(args.host, "local");
+  const sessionKind = nonEmptyString(args["session-kind"], "interactive");
+  const agentId = nonEmptyString(args.agent, sessionAgentId(sessionId));
+  const metadata = {
+    pid: process.ppid,
+    registered_at: Date.now(),
+    cwd,
+    worktree_path: worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    session_kind: sessionKind,
+    is_remote: readBoolean(args["is-remote"]),
+    ...(nonEmptyString(args["tmux-session"])
+      ? { tmux_session: nonEmptyString(args["tmux-session"]) }
+      : {}),
+    ...(nonEmptyString(args["tmux-pane"])
+      ? { tmux_pane: nonEmptyString(args["tmux-pane"]) }
+      : {}),
+    ...(nonEmptyString(args["omx-session-id"])
+      ? { omx_session_id: nonEmptyString(args["omx-session-id"]) }
+      : {}),
+    ...(nonEmptyString(args["codex-session-id"])
+      ? { codex_session_id: nonEmptyString(args["codex-session-id"]) }
+      : {}),
+  };
+
+  return {
+    sessionId,
+    cwd,
+    worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    sessionKind,
+    isRemote: readBoolean(args["is-remote"]),
+    agent_id: agentId,
+    cli: nonEmptyString(args.cli, "codex"),
+    capabilities: args.capabilities
+      ? String(args.capabilities).split(",")
+      : ["code"],
+    topics: args.topics ? String(args.topics).split(",") : [],
+    heartbeat_ttl_ms: 300000,
+    session_id: sessionId,
+    metadata,
+  };
+}
+
 function emitJson(payload) {
   if (payload !== undefined) {
     console.log(JSON.stringify(payload));
@@ -614,6 +689,15 @@ function emitJson(payload) {
 }
 
 async function cmdRegister(args) {
+  const interactiveSession = buildInteractiveSessionRegistrationPayload(args);
+  if (interactiveSession) {
+    const result = await requestJson("/synapse/register", {
+      body: interactiveSession,
+      timeoutMs: 3000,
+    });
+    return emitJson(result || unavailableResult());
+  }
+
   const agentId = args.agent;
   const timeoutSec = parseInt(args.timeout || "600", 10);
   const outcome = await requestHub(HUB_OPERATIONS.register, {

--- a/packages/core/hooks/codex-session-hook.mjs
+++ b/packages/core/hooks/codex-session-hook.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
 import { argv, exit, stdin, stdout } from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
 import {
   heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
@@ -51,6 +52,59 @@ function normalizeMode(mode, payload) {
   return "";
 }
 
+/**
+ * Start a detached bridge call so Codex/OMX presence reaches both the Synapse
+ * session registry and the hub agents table. This is intentionally independent
+ * of the legacy session-start work below: a missing or unavailable hub must
+ * never delay or fail SessionStart.
+ */
+export function launchCodexPresenceRegistration(payload, opts = {}) {
+  try {
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return false;
+
+    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
+      ? payload.cwd
+      : process.cwd();
+    const bridgePath = opts.bridgePath || fileURLToPath(
+      new URL("../hub/bridge.mjs", import.meta.url),
+    );
+    const spawnFn = opts.spawnFn || spawn;
+    const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
+    const tmuxSession = String(
+      process.env.OMX_TMUX_SESSION_NAME || process.env.OMX_TMUX_SESSION || "",
+    ).trim();
+    const tmuxPane = String(process.env.TMUX_PANE || "").trim();
+    const args = [
+      bridgePath,
+      "register",
+      "--session-id", sessionId,
+      "--cwd", cwd,
+      "--worktree-path", cwd,
+      "--session-kind", "interactive",
+      "--host", "local",
+      "--codex-session-id", sessionId,
+    ];
+    if (canonicalSessionId && canonicalSessionId !== sessionId) {
+      args.push("--omx-session-id", canonicalSessionId);
+    }
+    if (tmuxSession) args.push("--tmux-session", tmuxSession);
+    if (tmuxPane) args.push("--tmux-pane", tmuxPane);
+
+    const child = spawnFn(process.execPath, args, {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+      env: process.env,
+    });
+    child?.once?.("error", () => {});
+    child?.unref?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
   const done =
     typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
@@ -91,10 +145,15 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
     opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
   const drainPendingSynapse =
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
+  const launchPresenceRegistration =
+    opts.launchPresenceRegistration || launchCodexPresenceRegistration;
 
   try {
     await runHookSideEffectsWithStdoutSuppressed(async () => {
       if (mode === "register") {
+        try {
+          launchPresenceRegistration(parsed.payload);
+        } catch {}
         try {
           await hubEnsureRun(stdinData);
         } catch {}

--- a/packages/core/hooks/codex-session-hook.mjs
+++ b/packages/core/hooks/codex-session-hook.mjs
@@ -63,12 +63,13 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const sessionId = String(payload?.session_id || "").trim();
     if (!sessionId) return false;
 
-    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
-      ? payload.cwd
-      : process.cwd();
-    const bridgePath = opts.bridgePath || fileURLToPath(
-      new URL("../hub/bridge.mjs", import.meta.url),
-    );
+    const cwd =
+      typeof payload?.cwd === "string" && payload.cwd.trim()
+        ? payload.cwd
+        : process.cwd();
+    const bridgePath =
+      opts.bridgePath ||
+      fileURLToPath(new URL("../hub/bridge.mjs", import.meta.url));
     const spawnFn = opts.spawnFn || spawn;
     const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
     const tmuxSession = String(
@@ -78,12 +79,18 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const args = [
       bridgePath,
       "register",
-      "--session-id", sessionId,
-      "--cwd", cwd,
-      "--worktree-path", cwd,
-      "--session-kind", "interactive",
-      "--host", "local",
-      "--codex-session-id", sessionId,
+      "--session-id",
+      sessionId,
+      "--cwd",
+      cwd,
+      "--worktree-path",
+      cwd,
+      "--session-kind",
+      "interactive",
+      "--host",
+      "local",
+      "--codex-session-id",
+      sessionId,
     ];
     if (canonicalSessionId && canonicalSessionId !== sessionId) {
       args.push("--omx-session-id", canonicalSessionId);

--- a/packages/core/hub/bridge.mjs
+++ b/packages/core/hub/bridge.mjs
@@ -400,6 +400,16 @@ export function parseArgs(argv) {
       command: { type: "string" },
       role: { type: "string" },
       "session-id": { type: "string" },
+      cwd: { type: "string" },
+      "worktree-path": { type: "string" },
+      branch: { type: "string" },
+      host: { type: "string" },
+      "session-kind": { type: "string" },
+      "is-remote": { type: "string" },
+      "tmux-session": { type: "string" },
+      "tmux-pane": { type: "string" },
+      "omx-session-id": { type: "string" },
+      "codex-session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
       from: { type: "string" },
@@ -606,6 +616,71 @@ function unavailableResult() {
   return { ok: false, reason: "hub_unavailable" };
 }
 
+function nonEmptyString(value, fallback = "") {
+  const normalized = String(value ?? "").trim();
+  return normalized || fallback;
+}
+
+function readBoolean(value) {
+  return ["1", "true", "yes"].includes(nonEmptyString(value).toLowerCase());
+}
+
+function sessionAgentId(sessionId) {
+  return `codex-session-${sessionId.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+export function buildInteractiveSessionRegistrationPayload(args = {}) {
+  const sessionId = nonEmptyString(args["session-id"]);
+  if (!sessionId) return null;
+
+  const cwd = nonEmptyString(args.cwd, process.cwd());
+  const worktreePath = nonEmptyString(args["worktree-path"], cwd);
+  const host = nonEmptyString(args.host, "local");
+  const sessionKind = nonEmptyString(args["session-kind"], "interactive");
+  const agentId = nonEmptyString(args.agent, sessionAgentId(sessionId));
+  const metadata = {
+    pid: process.ppid,
+    registered_at: Date.now(),
+    cwd,
+    worktree_path: worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    session_kind: sessionKind,
+    is_remote: readBoolean(args["is-remote"]),
+    ...(nonEmptyString(args["tmux-session"])
+      ? { tmux_session: nonEmptyString(args["tmux-session"]) }
+      : {}),
+    ...(nonEmptyString(args["tmux-pane"])
+      ? { tmux_pane: nonEmptyString(args["tmux-pane"]) }
+      : {}),
+    ...(nonEmptyString(args["omx-session-id"])
+      ? { omx_session_id: nonEmptyString(args["omx-session-id"]) }
+      : {}),
+    ...(nonEmptyString(args["codex-session-id"])
+      ? { codex_session_id: nonEmptyString(args["codex-session-id"]) }
+      : {}),
+  };
+
+  return {
+    sessionId,
+    cwd,
+    worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    sessionKind,
+    isRemote: readBoolean(args["is-remote"]),
+    agent_id: agentId,
+    cli: nonEmptyString(args.cli, "codex"),
+    capabilities: args.capabilities
+      ? String(args.capabilities).split(",")
+      : ["code"],
+    topics: args.topics ? String(args.topics).split(",") : [],
+    heartbeat_ttl_ms: 300000,
+    session_id: sessionId,
+    metadata,
+  };
+}
+
 function emitJson(payload) {
   if (payload !== undefined) {
     console.log(JSON.stringify(payload));
@@ -614,6 +689,15 @@ function emitJson(payload) {
 }
 
 async function cmdRegister(args) {
+  const interactiveSession = buildInteractiveSessionRegistrationPayload(args);
+  if (interactiveSession) {
+    const result = await requestJson("/synapse/register", {
+      body: interactiveSession,
+      timeoutMs: 3000,
+    });
+    return emitJson(result || unavailableResult());
+  }
+
   const agentId = args.agent;
   const timeoutSec = parseInt(args.timeout || "600", 10);
   const outcome = await requestHub(HUB_OPERATIONS.register, {

--- a/packages/triflux/bin/tfx-live.mjs
+++ b/packages/triflux/bin/tfx-live.mjs
@@ -52,6 +52,7 @@ function usage() {
     "  tfx-live interrupt --session NAME [--cli codex|claude] [--transport tmux|uds|auto] [--short SHORT | --session-id ID] [--config-dir DIR] [--bridge ABS] [--timeout 5]",
     "  tfx-live stop --session NAME [--cli codex|claude] [--remote HOST]",
     "  tfx-live probe [--short SHORT] [--session-id ID] [--config-dir DIR] [--bridge ABS] [--timeout 10]",
+    "  tfx-live list-sessions --cli codex [--cwd DIR]",
     "  tfx-live converse --session NAME --prompts-file PATH [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500]",
     "  tfx-live goal-driven --session NAME --goal TEXT [--cli codex|claude] [--remote HOST] [--cwd DIR] [--timeout 60] [--settle 1500] [--max-rounds 8] [--done-token DONE]",
     "  tfx-live peer [--cli-a codex] [--cli-b claude] [--session-a peerA] [--session-b peerB] [--transport-a tmux|uds|auto] [--transport-b tmux|uds|auto] [--short-a SHORT] [--short-b SHORT] [--session-id-a ID] [--session-id-b ID] [--bridge ABS] [--remote HOST] [--cwd DIR] [--rounds 4] [--mode counting|freeform] [--seed TEXT] [--timeout 60]",
@@ -350,6 +351,119 @@ async function runTmux(remote, tmuxArgs, options = {}) {
       .filter(Boolean)
       .join("\n");
     throw new Error(detail);
+  }
+}
+
+function normalizeCwd(value) {
+  if (!value) return null;
+  const resolved = pathResolve(value);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isCodexTmuxPane(currentCommand, startCommand) {
+  const current = String(currentCommand ?? "").trim();
+  const currentBase = current.split("/").at(-1);
+  if (currentBase === "codex") {
+    return true;
+  }
+
+  const started = String(startCommand ?? "").trim();
+  const directStart = started
+    .replace(/^exec\s+/, "")
+    .replace(/^['"]|['"]$/g, "");
+  if (/^(?:\S*\/)?codex(?:\s|$)/.test(directStart)) {
+    return true;
+  }
+
+  return (
+    /\bomx_codex_pid\b/.test(started) &&
+    /(?:^|[\s'""])(?:[^'" \t]+\/)?codex(?:[\s'"]|$)/.test(started)
+  );
+}
+
+function parseCodexTmuxSessions(stdout, cwd = null) {
+  const cwdFilter = normalizeCwd(cwd);
+  const sessions = new Map();
+
+  for (const line of String(stdout).split(/\r?\n/)) {
+    if (!line) continue;
+    const [
+      session,
+      createdRaw,
+      attachedRaw,
+      paneCwd,
+      currentCommand,
+      ...startParts
+    ] = line.split("\t");
+    const startCommand = startParts.join("\t");
+    if (!session || !isCodexTmuxPane(currentCommand, startCommand)) {
+      continue;
+    }
+
+    const normalizedPaneCwd = normalizeCwd(paneCwd);
+    if (cwdFilter && normalizedPaneCwd !== cwdFilter) {
+      continue;
+    }
+
+    const startedAtEpoch = Number.parseInt(createdRaw, 10);
+    const startedAt = Number.isSafeInteger(startedAtEpoch)
+      ? new Date(startedAtEpoch * 1000).toISOString()
+      : null;
+    const existing = sessions.get(session);
+    if (existing) {
+      if (!existing.cwd && normalizedPaneCwd) {
+        existing.cwd = normalizedPaneCwd;
+      }
+      continue;
+    }
+
+    sessions.set(session, {
+      session,
+      startedAt,
+      startedAtEpoch: Number.isSafeInteger(startedAtEpoch)
+        ? startedAtEpoch
+        : null,
+      cwd: normalizedPaneCwd,
+      attached: Number.parseInt(attachedRaw, 10) > 0,
+    });
+  }
+
+  return [...sessions.values()].sort((left, right) =>
+    left.session.localeCompare(right.session),
+  );
+}
+
+async function discoverCodexTmuxSessions({ cwd = null } = {}) {
+  const format = [
+    "#{session_name}",
+    "#{session_created}",
+    "#{session_attached}",
+    "#{pane_current_path}",
+    "#{pane_current_command}",
+    "#{pane_start_command}",
+  ].join("\t");
+
+  try {
+    const { stdout } = await runTmux(null, ["list-panes", "-a", "-F", format]);
+    return {
+      ok: true,
+      cli: "codex",
+      cwd: normalizeCwd(cwd),
+      sessions: parseCodexTmuxSessions(stdout, cwd),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      cli: "codex",
+      cwd: normalizeCwd(cwd),
+      reason: "tmux-unavailable",
+      error: error.message,
+      sessions: [],
+    };
   }
 }
 
@@ -1887,6 +2001,14 @@ async function probe(flags) {
   );
 }
 
+async function listSessions(flags) {
+  const adapter = selectAdapter(flags);
+  if (adapter.cli !== "codex") {
+    throw new Error("list-sessions currently supports only --cli codex");
+  }
+  printJson(await discoverCodexTmuxSessions({ cwd: flags.cwd }));
+}
+
 function startOptsForSession(flags, session) {
   return {
     session,
@@ -2344,6 +2466,8 @@ async function main() {
     await interrupt(flags);
   } else if (command === "probe") {
     await probe(flags);
+  } else if (command === "list-sessions") {
+    await listSessions(flags);
   } else if (command === "converse") {
     await converse(flags);
   } else if (command === "goal-driven") {
@@ -2364,9 +2488,11 @@ export {
   buildRemoteLiveCommand,
   callRemoteLive,
   ctoHygieneNotify,
+  discoverCodexTmuxSessions,
   extractAssistantResponse,
   extractClaudeCompletedTaskListResponse,
   hasClaudeCompletedTaskListResponse,
+  parseCodexTmuxSessions,
   parseRemoteLiveJson,
   resolveAskTransport,
 };

--- a/packages/triflux/hooks/codex-session-hook.mjs
+++ b/packages/triflux/hooks/codex-session-hook.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
 import { argv, exit, stdin, stdout } from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { drainPendingSynapse as defaultDrainPendingSynapse } from "../hub/team/synapse-http.mjs";
 import {
   heartbeatInteractiveSession as defaultHeartbeatInteractiveSession,
@@ -51,6 +52,59 @@ function normalizeMode(mode, payload) {
   return "";
 }
 
+/**
+ * Start a detached bridge call so Codex/OMX presence reaches both the Synapse
+ * session registry and the hub agents table. This is intentionally independent
+ * of the legacy session-start work below: a missing or unavailable hub must
+ * never delay or fail SessionStart.
+ */
+export function launchCodexPresenceRegistration(payload, opts = {}) {
+  try {
+    const sessionId = String(payload?.session_id || "").trim();
+    if (!sessionId) return false;
+
+    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
+      ? payload.cwd
+      : process.cwd();
+    const bridgePath = opts.bridgePath || fileURLToPath(
+      new URL("../hub/bridge.mjs", import.meta.url),
+    );
+    const spawnFn = opts.spawnFn || spawn;
+    const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
+    const tmuxSession = String(
+      process.env.OMX_TMUX_SESSION_NAME || process.env.OMX_TMUX_SESSION || "",
+    ).trim();
+    const tmuxPane = String(process.env.TMUX_PANE || "").trim();
+    const args = [
+      bridgePath,
+      "register",
+      "--session-id", sessionId,
+      "--cwd", cwd,
+      "--worktree-path", cwd,
+      "--session-kind", "interactive",
+      "--host", "local",
+      "--codex-session-id", sessionId,
+    ];
+    if (canonicalSessionId && canonicalSessionId !== sessionId) {
+      args.push("--omx-session-id", canonicalSessionId);
+    }
+    if (tmuxSession) args.push("--tmux-session", tmuxSession);
+    if (tmuxPane) args.push("--tmux-pane", tmuxPane);
+
+    const child = spawnFn(process.execPath, args, {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+      env: process.env,
+    });
+    child?.once?.("error", () => {});
+    child?.unref?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function swallowStdoutWrite(_chunk, encodingOrCallback, callback) {
   const done =
     typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
@@ -91,10 +145,15 @@ export async function runCodexSessionHook(stdinData, opts = {}) {
     opts.heartbeatInteractiveSession || defaultHeartbeatInteractiveSession;
   const drainPendingSynapse =
     opts.drainPendingSynapse || defaultDrainPendingSynapse;
+  const launchPresenceRegistration =
+    opts.launchPresenceRegistration || launchCodexPresenceRegistration;
 
   try {
     await runHookSideEffectsWithStdoutSuppressed(async () => {
       if (mode === "register") {
+        try {
+          launchPresenceRegistration(parsed.payload);
+        } catch {}
         try {
           await hubEnsureRun(stdinData);
         } catch {}

--- a/packages/triflux/hooks/codex-session-hook.mjs
+++ b/packages/triflux/hooks/codex-session-hook.mjs
@@ -63,12 +63,13 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const sessionId = String(payload?.session_id || "").trim();
     if (!sessionId) return false;
 
-    const cwd = typeof payload?.cwd === "string" && payload.cwd.trim()
-      ? payload.cwd
-      : process.cwd();
-    const bridgePath = opts.bridgePath || fileURLToPath(
-      new URL("../hub/bridge.mjs", import.meta.url),
-    );
+    const cwd =
+      typeof payload?.cwd === "string" && payload.cwd.trim()
+        ? payload.cwd
+        : process.cwd();
+    const bridgePath =
+      opts.bridgePath ||
+      fileURLToPath(new URL("../hub/bridge.mjs", import.meta.url));
     const spawnFn = opts.spawnFn || spawn;
     const canonicalSessionId = String(process.env.OMX_SESSION_ID || "").trim();
     const tmuxSession = String(
@@ -78,12 +79,18 @@ export function launchCodexPresenceRegistration(payload, opts = {}) {
     const args = [
       bridgePath,
       "register",
-      "--session-id", sessionId,
-      "--cwd", cwd,
-      "--worktree-path", cwd,
-      "--session-kind", "interactive",
-      "--host", "local",
-      "--codex-session-id", sessionId,
+      "--session-id",
+      sessionId,
+      "--cwd",
+      cwd,
+      "--worktree-path",
+      cwd,
+      "--session-kind",
+      "interactive",
+      "--host",
+      "local",
+      "--codex-session-id",
+      sessionId,
     ];
     if (canonicalSessionId && canonicalSessionId !== sessionId) {
       args.push("--omx-session-id", canonicalSessionId);

--- a/packages/triflux/hub/bridge.mjs
+++ b/packages/triflux/hub/bridge.mjs
@@ -400,6 +400,16 @@ export function parseArgs(argv) {
       command: { type: "string" },
       role: { type: "string" },
       "session-id": { type: "string" },
+      cwd: { type: "string" },
+      "worktree-path": { type: "string" },
+      branch: { type: "string" },
+      host: { type: "string" },
+      "session-kind": { type: "string" },
+      "is-remote": { type: "string" },
+      "tmux-session": { type: "string" },
+      "tmux-pane": { type: "string" },
+      "omx-session-id": { type: "string" },
+      "codex-session-id": { type: "string" },
       reason: { type: "string" },
       type: { type: "string" },
       from: { type: "string" },
@@ -606,6 +616,71 @@ function unavailableResult() {
   return { ok: false, reason: "hub_unavailable" };
 }
 
+function nonEmptyString(value, fallback = "") {
+  const normalized = String(value ?? "").trim();
+  return normalized || fallback;
+}
+
+function readBoolean(value) {
+  return ["1", "true", "yes"].includes(nonEmptyString(value).toLowerCase());
+}
+
+function sessionAgentId(sessionId) {
+  return `codex-session-${sessionId.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+export function buildInteractiveSessionRegistrationPayload(args = {}) {
+  const sessionId = nonEmptyString(args["session-id"]);
+  if (!sessionId) return null;
+
+  const cwd = nonEmptyString(args.cwd, process.cwd());
+  const worktreePath = nonEmptyString(args["worktree-path"], cwd);
+  const host = nonEmptyString(args.host, "local");
+  const sessionKind = nonEmptyString(args["session-kind"], "interactive");
+  const agentId = nonEmptyString(args.agent, sessionAgentId(sessionId));
+  const metadata = {
+    pid: process.ppid,
+    registered_at: Date.now(),
+    cwd,
+    worktree_path: worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    session_kind: sessionKind,
+    is_remote: readBoolean(args["is-remote"]),
+    ...(nonEmptyString(args["tmux-session"])
+      ? { tmux_session: nonEmptyString(args["tmux-session"]) }
+      : {}),
+    ...(nonEmptyString(args["tmux-pane"])
+      ? { tmux_pane: nonEmptyString(args["tmux-pane"]) }
+      : {}),
+    ...(nonEmptyString(args["omx-session-id"])
+      ? { omx_session_id: nonEmptyString(args["omx-session-id"]) }
+      : {}),
+    ...(nonEmptyString(args["codex-session-id"])
+      ? { codex_session_id: nonEmptyString(args["codex-session-id"]) }
+      : {}),
+  };
+
+  return {
+    sessionId,
+    cwd,
+    worktreePath,
+    branch: nonEmptyString(args.branch),
+    host,
+    sessionKind,
+    isRemote: readBoolean(args["is-remote"]),
+    agent_id: agentId,
+    cli: nonEmptyString(args.cli, "codex"),
+    capabilities: args.capabilities
+      ? String(args.capabilities).split(",")
+      : ["code"],
+    topics: args.topics ? String(args.topics).split(",") : [],
+    heartbeat_ttl_ms: 300000,
+    session_id: sessionId,
+    metadata,
+  };
+}
+
 function emitJson(payload) {
   if (payload !== undefined) {
     console.log(JSON.stringify(payload));
@@ -614,6 +689,15 @@ function emitJson(payload) {
 }
 
 async function cmdRegister(args) {
+  const interactiveSession = buildInteractiveSessionRegistrationPayload(args);
+  if (interactiveSession) {
+    const result = await requestJson("/synapse/register", {
+      body: interactiveSession,
+      timeoutMs: 3000,
+    });
+    return emitJson(result || unavailableResult());
+  }
+
   const agentId = args.agent;
   const timeoutSec = parseInt(args.timeout || "600", 10);
   const outcome = await requestHub(HUB_OPERATIONS.register, {

--- a/packages/triflux/skills/tfx-live/SKILL.md
+++ b/packages/triflux/skills/tfx-live/SKILL.md
@@ -3,7 +3,7 @@ name: tfx-live
 description: >
   Use when Claude, Codex, or a Triflux worker needs live Claude↔Codex orchestration:
   start/ask/stop, multi-turn, peer relay, daemon UDS attach, or UDS-first with tmux fallback.
-argument-hint: "<start|ask|stop|probe|peer|converse|goal-driven> ..."
+argument-hint: "<start|ask|stop|probe|list-sessions|peer|converse|goal-driven> ..."
 ---
 
 # tfx-live — Claude↔Codex live orchestration
@@ -54,6 +54,24 @@ For explicit UDS-only failure behavior:
 tfx-live ask --cli claude --transport uds --short <8hex> --prompt "..." --timeout 120
 ```
 
+## Codex tmux session discovery
+
+List the Codex CLI sessions already running in tmux; this does not require a
+prior `tfx-live start`. The JSON result includes the tmux session name, start
+time, current working directory, and attachment state.
+
+```bash
+# All locally running Codex tmux sessions
+tfx-live list-sessions --cli codex
+
+# Limit discovery to sessions whose pane cwd exactly matches this worktree
+tfx-live list-sessions --cli codex --cwd ~/Projects/my-worktree
+```
+
+`probe` remains the Claude daemon/UDS discovery command. Use
+`list-sessions --cli codex` when selecting an existing Codex tmux session to
+pass to `tfx-live ask --session <name>`.
+
 ## Peer relay
 
 ```bash
@@ -99,6 +117,9 @@ tfx-live --help
 
 # Probe daemon sessions through Triflux bridge
 tfx-live probe
+
+# Discover existing Codex tmux sessions
+tfx-live list-sessions --cli codex
 ```
 
 If auto falls back, inspect `~/.claude/cache/triflux/tfx-live/bug-reports/uds-fallback-*.json` (override with `$TFX_LIVE_BUG_REPORT_DIR` for tests).

--- a/skills/tfx-live/SKILL.md
+++ b/skills/tfx-live/SKILL.md
@@ -3,7 +3,7 @@ name: tfx-live
 description: >
   Use when Claude, Codex, or a Triflux worker needs live Claude↔Codex orchestration:
   start/ask/stop, multi-turn, peer relay, daemon UDS attach, or UDS-first with tmux fallback.
-argument-hint: "<start|ask|stop|probe|peer|converse|goal-driven> ..."
+argument-hint: "<start|ask|stop|probe|list-sessions|peer|converse|goal-driven> ..."
 ---
 
 # tfx-live — Claude↔Codex live orchestration
@@ -54,6 +54,24 @@ For explicit UDS-only failure behavior:
 tfx-live ask --cli claude --transport uds --short <8hex> --prompt "..." --timeout 120
 ```
 
+## Codex tmux session discovery
+
+List the Codex CLI sessions already running in tmux; this does not require a
+prior `tfx-live start`. The JSON result includes the tmux session name, start
+time, current working directory, and attachment state.
+
+```bash
+# All locally running Codex tmux sessions
+tfx-live list-sessions --cli codex
+
+# Limit discovery to sessions whose pane cwd exactly matches this worktree
+tfx-live list-sessions --cli codex --cwd ~/Projects/my-worktree
+```
+
+`probe` remains the Claude daemon/UDS discovery command. Use
+`list-sessions --cli codex` when selecting an existing Codex tmux session to
+pass to `tfx-live ask --session <name>`.
+
 ## Peer relay
 
 ```bash
@@ -99,6 +117,9 @@ tfx-live --help
 
 # Probe daemon sessions through Triflux bridge
 tfx-live probe
+
+# Discover existing Codex tmux sessions
+tfx-live list-sessions --cli codex
 ```
 
 If auto falls back, inspect `~/.claude/cache/triflux/tfx-live/bug-reports/uds-fallback-*.json` (override with `$TFX_LIVE_BUG_REPORT_DIR` for tests).

--- a/tests/integration/bridge.test.mjs
+++ b/tests/integration/bridge.test.mjs
@@ -232,6 +232,9 @@ describe("bridge.mjs interactive session registration", () => {
   });
 
   it("does not turn legacy agent registration into an interactive session registration", () => {
-    assert.equal(buildInteractiveSessionRegistrationPayload({ agent: "legacy-agent" }), null);
+    assert.equal(
+      buildInteractiveSessionRegistrationPayload({ agent: "legacy-agent" }),
+      null,
+    );
   });
 });

--- a/tests/integration/bridge.test.mjs
+++ b/tests/integration/bridge.test.mjs
@@ -3,7 +3,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { parseArgs, parseJsonSafe } from "../../hub/bridge.mjs";
+import {
+  buildInteractiveSessionRegistrationPayload,
+  parseArgs,
+  parseJsonSafe,
+} from "../../hub/bridge.mjs";
 
 describe("bridge.mjs parseArgs()", () => {
   it("--agent 플래그를 올바르게 파싱해야 한다", () => {
@@ -154,5 +158,80 @@ describe("bridge.mjs parseJsonSafe()", () => {
 
   it("배열 JSON을 올바르게 파싱해야 한다", () => {
     assert.deepEqual(parseJsonSafe("[1,2,3]", []), [1, 2, 3]);
+  });
+});
+
+describe("bridge.mjs interactive session registration", () => {
+  it("converts a Codex SessionStart into synapse and agents-table registration data", () => {
+    const payload = buildInteractiveSessionRegistrationPayload({
+      "session-id": "codex-session-01",
+      cwd: "/tmp/codex-worktree",
+      "worktree-path": "/tmp/codex-worktree",
+      branch: "feature/presence",
+      host: "local",
+      "session-kind": "interactive",
+      "tmux-session": "omx-presence",
+      "omx-session-id": "omx-session-01",
+      "codex-session-id": "codex-session-01",
+    });
+
+    assert.deepEqual(
+      {
+        sessionId: payload.sessionId,
+        cwd: payload.cwd,
+        worktreePath: payload.worktreePath,
+        branch: payload.branch,
+        host: payload.host,
+        sessionKind: payload.sessionKind,
+        isRemote: payload.isRemote,
+        agent_id: payload.agent_id,
+        cli: payload.cli,
+        capabilities: payload.capabilities,
+        topics: payload.topics,
+        heartbeat_ttl_ms: payload.heartbeat_ttl_ms,
+        session_id: payload.session_id,
+        metadata: {
+          cwd: payload.metadata.cwd,
+          worktree_path: payload.metadata.worktree_path,
+          branch: payload.metadata.branch,
+          host: payload.metadata.host,
+          session_kind: payload.metadata.session_kind,
+          is_remote: payload.metadata.is_remote,
+          tmux_session: payload.metadata.tmux_session,
+          omx_session_id: payload.metadata.omx_session_id,
+          codex_session_id: payload.metadata.codex_session_id,
+        },
+      },
+      {
+        sessionId: "codex-session-01",
+        cwd: "/tmp/codex-worktree",
+        worktreePath: "/tmp/codex-worktree",
+        branch: "feature/presence",
+        host: "local",
+        sessionKind: "interactive",
+        isRemote: false,
+        agent_id: "codex-session-codex-session-01",
+        cli: "codex",
+        capabilities: ["code"],
+        topics: [],
+        heartbeat_ttl_ms: 300000,
+        session_id: "codex-session-01",
+        metadata: {
+          cwd: "/tmp/codex-worktree",
+          worktree_path: "/tmp/codex-worktree",
+          branch: "feature/presence",
+          host: "local",
+          session_kind: "interactive",
+          is_remote: false,
+          tmux_session: "omx-presence",
+          omx_session_id: "omx-session-01",
+          codex_session_id: "codex-session-01",
+        },
+      },
+    );
+  });
+
+  it("does not turn legacy agent registration into an interactive session registration", () => {
+    assert.equal(buildInteractiveSessionRegistrationPayload({ agent: "legacy-agent" }), null);
   });
 });

--- a/tests/unit/codex-session-hook.test.mjs
+++ b/tests/unit/codex-session-hook.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { runCodexSessionHook } from "../../hooks/codex-session-hook.mjs";
+import {
+  launchCodexPresenceRegistration,
+  runCodexSessionHook,
+} from "../../hooks/codex-session-hook.mjs";
 import { registerInteractiveSession } from "../../hooks/session-start-fast.mjs";
 
 function payload(overrides = {}) {
@@ -25,10 +28,17 @@ describe("codex-session-hook", () => {
       heartbeatInteractiveSession: () => calls.push(["heartbeat"]),
       drainPendingSynapse: async (timeoutMs) =>
         calls.push(["drain", timeoutMs]),
+      launchPresenceRegistration: (hookPayload) =>
+        calls.push(["presence", hookPayload]),
     });
 
     assert.equal(result, "{}\n");
     assert.deepEqual(calls, [
+      ["presence", {
+        session_id: "codex-session-1",
+        cwd: "/work/triflux",
+        hook_event_name: "session_start",
+      }],
       ["ensure", payload()],
       ["register", payload()],
       ["drain", 1000],
@@ -56,6 +66,54 @@ describe("codex-session-hook", () => {
       ["heartbeat", payload({ hook_event_name: "user_prompt_submit" })],
       ["drain", 500],
     ]);
+  });
+
+  it("launches bridge registration detached with Codex, OMX, and tmux context", () => {
+    const launches = [];
+    const originalOmxSession = process.env.OMX_SESSION_ID;
+    const originalTmuxSession = process.env.OMX_TMUX_SESSION;
+    const originalTmuxPane = process.env.TMUX_PANE;
+    try {
+      process.env.OMX_SESSION_ID = "omx-session-01";
+      process.env.OMX_TMUX_SESSION = "omx-presence";
+      process.env.TMUX_PANE = "%42";
+      const child = { once: () => child, unref: () => {} };
+      assert.equal(launchCodexPresenceRegistration(JSON.parse(payload()), {
+        bridgePath: "/tmp/bridge.mjs",
+        spawnFn: (...args) => {
+          launches.push(args);
+          return child;
+        },
+      }), true);
+      assert.deepEqual(launches, [[
+        process.execPath,
+        [
+          "/tmp/bridge.mjs", "register",
+          "--session-id", "codex-session-1",
+          "--cwd", "/work/triflux",
+          "--worktree-path", "/work/triflux",
+          "--session-kind", "interactive",
+          "--host", "local",
+          "--codex-session-id", "codex-session-1",
+          "--omx-session-id", "omx-session-01",
+          "--tmux-session", "omx-presence",
+          "--tmux-pane", "%42",
+        ],
+        {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+          env: process.env,
+        },
+      ]]);
+    } finally {
+      if (originalOmxSession === undefined) delete process.env.OMX_SESSION_ID;
+      else process.env.OMX_SESSION_ID = originalOmxSession;
+      if (originalTmuxSession === undefined) delete process.env.OMX_TMUX_SESSION;
+      else process.env.OMX_TMUX_SESSION = originalTmuxSession;
+      if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
+      else process.env.TMUX_PANE = originalTmuxPane;
+    }
   });
 
   it("falls back to hook_event_name case-insensitively when argv mode is absent", async () => {

--- a/tests/unit/codex-session-hook.test.mjs
+++ b/tests/unit/codex-session-hook.test.mjs
@@ -34,11 +34,14 @@ describe("codex-session-hook", () => {
 
     assert.equal(result, "{}\n");
     assert.deepEqual(calls, [
-      ["presence", {
-        session_id: "codex-session-1",
-        cwd: "/work/triflux",
-        hook_event_name: "session_start",
-      }],
+      [
+        "presence",
+        {
+          session_id: "codex-session-1",
+          cwd: "/work/triflux",
+          hook_event_name: "session_start",
+        },
+      ],
       ["ensure", payload()],
       ["register", payload()],
       ["drain", 1000],
@@ -78,38 +81,54 @@ describe("codex-session-hook", () => {
       process.env.OMX_TMUX_SESSION = "omx-presence";
       process.env.TMUX_PANE = "%42";
       const child = { once: () => child, unref: () => {} };
-      assert.equal(launchCodexPresenceRegistration(JSON.parse(payload()), {
-        bridgePath: "/tmp/bridge.mjs",
-        spawnFn: (...args) => {
-          launches.push(args);
-          return child;
-        },
-      }), true);
-      assert.deepEqual(launches, [[
-        process.execPath,
+      assert.equal(
+        launchCodexPresenceRegistration(JSON.parse(payload()), {
+          bridgePath: "/tmp/bridge.mjs",
+          spawnFn: (...args) => {
+            launches.push(args);
+            return child;
+          },
+        }),
+        true,
+      );
+      assert.deepEqual(launches, [
         [
-          "/tmp/bridge.mjs", "register",
-          "--session-id", "codex-session-1",
-          "--cwd", "/work/triflux",
-          "--worktree-path", "/work/triflux",
-          "--session-kind", "interactive",
-          "--host", "local",
-          "--codex-session-id", "codex-session-1",
-          "--omx-session-id", "omx-session-01",
-          "--tmux-session", "omx-presence",
-          "--tmux-pane", "%42",
+          process.execPath,
+          [
+            "/tmp/bridge.mjs",
+            "register",
+            "--session-id",
+            "codex-session-1",
+            "--cwd",
+            "/work/triflux",
+            "--worktree-path",
+            "/work/triflux",
+            "--session-kind",
+            "interactive",
+            "--host",
+            "local",
+            "--codex-session-id",
+            "codex-session-1",
+            "--omx-session-id",
+            "omx-session-01",
+            "--tmux-session",
+            "omx-presence",
+            "--tmux-pane",
+            "%42",
+          ],
+          {
+            detached: true,
+            stdio: "ignore",
+            windowsHide: true,
+            env: process.env,
+          },
         ],
-        {
-          detached: true,
-          stdio: "ignore",
-          windowsHide: true,
-          env: process.env,
-        },
-      ]]);
+      ]);
     } finally {
       if (originalOmxSession === undefined) delete process.env.OMX_SESSION_ID;
       else process.env.OMX_SESSION_ID = originalOmxSession;
-      if (originalTmuxSession === undefined) delete process.env.OMX_TMUX_SESSION;
+      if (originalTmuxSession === undefined)
+        delete process.env.OMX_TMUX_SESSION;
       else process.env.OMX_TMUX_SESSION = originalTmuxSession;
       if (originalTmuxPane === undefined) delete process.env.TMUX_PANE;
       else process.env.TMUX_PANE = originalTmuxPane;

--- a/tests/unit/tfx-live-cli.test.mjs
+++ b/tests/unit/tfx-live-cli.test.mjs
@@ -75,6 +75,69 @@ test("tfx-live runs main() when invoked through a symlink (npm global bin shim)"
   }
 });
 
+test("tfx-live list-sessions discovers Codex tmux sessions and filters exact cwd", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tfx-live-sessions-"));
+  try {
+    const codexCwd = path.join(dir, "codex-worktree");
+    const otherCwd = path.join(dir, "other-worktree");
+    const tmuxPath = path.join(dir, "tmux");
+    const logPath = path.join(dir, "tmux-args.json");
+    await fs.mkdir(codexCwd);
+    await fs.mkdir(otherCwd);
+    const normalizedCodexCwd = await fs.realpath(codexCwd);
+    await fs.writeFile(
+      tmuxPath,
+      [
+        "#!/usr/bin/env node",
+        "import fs from 'node:fs/promises';",
+        "await fs.writeFile(process.env.TMUX_LOG, JSON.stringify(process.argv.slice(2)));",
+        "console.log([",
+        `  'omx-live\\t1735689600\\t1\\t${codexCwd}\\tzsh\\tbash -lc \\'omx_codex_pid=123; exec codex\\'',`,
+        `  'manual-codex\\t1735776000\\t0\\t${otherCwd}\\tcodex\\tcodex',`,
+        `  'claude-live\\t1735862400\\t0\\t${codexCwd}\\tclaude\\tclaude',`,
+        "].join('\\n'));",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.chmod(tmuxPath, 0o755);
+
+    const env = {
+      TMUX_LOG: logPath,
+      PATH: `${dir}${path.delimiter}${process.env.PATH}`,
+    };
+    const all = JSON.parse(
+      await runTfxLive(["list-sessions", "--cli", "codex"], { env }),
+    );
+    const filtered = JSON.parse(
+      await runTfxLive(["list-sessions", "--cli", "codex", "--cwd", codexCwd], {
+        env,
+      }),
+    );
+    const tmuxArgs = JSON.parse(await fs.readFile(logPath, "utf8"));
+
+    assert.deepEqual(tmuxArgs.slice(0, 3), ["list-panes", "-a", "-F"]);
+    assert.equal(all.ok, true);
+    assert.equal(all.cli, "codex");
+    assert.deepEqual(
+      all.sessions.map((session) => session.session),
+      ["manual-codex", "omx-live"],
+    );
+    assert.deepEqual(all.sessions[1], {
+      session: "omx-live",
+      startedAt: "2025-01-01T00:00:00.000Z",
+      startedAtEpoch: 1735689600,
+      cwd: normalizedCodexCwd,
+      attached: true,
+    });
+    assert.deepEqual(
+      filtered.sessions.map((session) => session.session),
+      ["omx-live"],
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("tfx-live probe returns daemon-probe JSON through bundled bridge", async () => {
   const stdout = await runTfxLive([
     "probe",


### PR DESCRIPTION
## Summary
- tfx-live gains `list-sessions --cli codex [--cwd DIR]` to enumerate live codex tmux panes (name/start time/cwd/attach state) as JSON. `probe()` stays Claude-daemon/UDS only. Fills a gap where codex sessions were only reachable if the caller already knew the `--session` name they were started with (unlike Hermes-style discovery on the OMX side).
- Claude and Antigravity sessions already self-register presence with tfx-hub on SessionStart. Codex/OMX never did, so Hub had zero visibility into codex sessions. `codex-session-hook.mjs` now fires a detached/unref'd registration alongside its existing SessionStart behavior; `bridge.mjs`'s `register` CLI accepts `--session-id` and registers interactive-session + agents presence via `/synapse/register` in one call. OMX environments pass `omx_session_id`/`tmux_session`/`tmux_pane` when available. Hub unavailability is swallowed silently and never blocks/delays session start.

## Test plan
- [x] `node --test tests/unit/tfx-live-cli.test.mjs` (35 tests)
- [x] `node --test tests/unit/codex-session-hook.test.mjs tests/integration/bridge.test.mjs` (23 tests)
- [x] Biome + skill lint
- [x] Package mirror byte-identical check (packages/core, packages/triflux)
- [x] Live smoke: new codex tmux session detected via `list-sessions --cli codex`
- [x] Live smoke: new codex session shows up in `curl localhost:27888/status` agents table as `status: online` with cwd/worktree_path/session_kind preserved, and omx_session_id/tmux_session/tmux_pane preserved when present