### PR TITLE
fix(release): resync packages/triflux + packages/remote mirrors

### DIFF
--- a/packages/remote/hub/pipe.mjs
+++ b/packages/remote/hub/pipe.mjs
@@ -271,17 +271,7 @@ export function createPipeServer({
           payload,
         );
         if (client) touchClient(client);
-        if (result?.effective?.updated === false) {
-          return {
-            ok: false,
-            error: {
-              code: "STALE_PRESENCE_OWNER",
-              message: `stale or unknown presence owner: ${agentId}`,
-            },
-            data: result,
-          };
-        }
-        return { ok: true, data: result };
+        return result;
       }
 
       case "publish": {

--- a/packages/remote/hub/server.mjs
+++ b/packages/remote/hub/server.mjs
@@ -2365,102 +2365,99 @@ export async function startHub({
   let rateLimitTimer = null;
 
   const startBackgroundTimers = () => {
-
-  hitlTimer = setInterval(() => {
-    try {
-      hitl.checkTimeouts();
-    } catch (err) {
-      hubLog.warn({ err }, "hitl.timeout_check_failed");
-    }
-  }, 10000);
-  hitlTimer.unref();
-
-  // MCP session TTL: sessions idle for SESSION_TTL_MS are closed automatically.
-  // Configurable via SESSION_TTL_MS (default 30 minutes). The sweep runs every 60 s.
-  const SESSION_TTL_MS =
-    parseInt(process.env.TFX_SESSION_TTL_MS || "", 10) || 30 * 60 * 1000;
-  sessionTimer = setInterval(() => {
-    const now = Date.now();
-    for (const [sid, session] of transports) {
-      if (now - (session.transport._lastActivity || 0) <= SESSION_TTL_MS)
-        continue;
-      void closeMcpTransportSession(sid, session, "session_ttl");
-    }
-  }, 60000);
-  sessionTimer.unref();
-
-  synapsePruneTimer = setInterval(() => {
-    try {
-      const { count } = synapseRegistry.pruneExpired();
-      if (count > 0) hubLog.info({ count }, "synapse.prune");
-    } catch (err) {
-      hubLog.warn({ err }, "synapse.prune_failed");
-    }
-  }, 60000);
-  synapsePruneTimer.unref();
-
-  // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
-  // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
-  orphanCleanupTimer = setInterval(
-    () => {
-      if (process.env.TFX_DISABLE_ORPHAN_CLEANUP === "1") return;
+    hitlTimer = setInterval(() => {
       try {
-        const { killed, killedProcesses = [] } = cleanupOrphanNodeProcesses();
-        const {
-          killed: runtimeKilled,
-          killedProcesses: runtimeKilledProcesses = [],
-        } = cleanupOrphanRuntimeProcesses();
-        const totalKilled = killed + runtimeKilled;
-        if (totalKilled > 0) {
-          hubLog.info(
-            {
-              killed: totalKilled,
-              processes: [...killedProcesses, ...runtimeKilledProcesses],
-              caller: "timer",
-            },
-            "hub.orphan_cleanup",
-          );
-        }
-
-        const { killed: fsmonitorKilled, stale } = cleanupStaleFsmonitorDaemons(
-          {
-            minAgeMs: 24 * 60 * 60 * 1000,
-          },
-        );
-        if (fsmonitorKilled > 0) {
-          hubLog.info(
-            { killed: fsmonitorKilled, stale: stale.length },
-            "hub.fsmonitor_cleanup",
-          );
-        }
-      } catch {}
-
-      // stale tfx-spawn-* psmux 세션 정리 (30분 이상 idle)
-      try {
-        const staleKilled = cleanupStaleSpawnSessions(hubLog);
-        if (staleKilled > 0) {
-          hubLog.info({ killed: staleKilled }, "hub.stale_spawn_cleanup");
-        }
-      } catch {}
-    },
-    5 * 60 * 1000,
-  );
-  orphanCleanupTimer.unref();
-
-  // Evict stale rate-limit buckets once per minute to bound memory usage.
-  rateLimitTimer = setInterval(() => {
-    const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
-    for (const [ip, timestamps] of rateLimitMap) {
-      const fresh = timestamps.filter((t) => t >= cutoff);
-      if (fresh.length === 0) {
-        rateLimitMap.delete(ip);
-      } else {
-        rateLimitMap.set(ip, fresh);
+        hitl.checkTimeouts();
+      } catch (err) {
+        hubLog.warn({ err }, "hitl.timeout_check_failed");
       }
-    }
-  }, RATE_LIMIT_WINDOW_MS);
-  rateLimitTimer.unref();
+    }, 10000);
+    hitlTimer.unref();
 
+    // MCP session TTL: sessions idle for SESSION_TTL_MS are closed automatically.
+    // Configurable via SESSION_TTL_MS (default 30 minutes). The sweep runs every 60 s.
+    const SESSION_TTL_MS =
+      parseInt(process.env.TFX_SESSION_TTL_MS || "", 10) || 30 * 60 * 1000;
+    sessionTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [sid, session] of transports) {
+        if (now - (session.transport._lastActivity || 0) <= SESSION_TTL_MS)
+          continue;
+        void closeMcpTransportSession(sid, session, "session_ttl");
+      }
+    }, 60000);
+    sessionTimer.unref();
+
+    synapsePruneTimer = setInterval(() => {
+      try {
+        const { count } = synapseRegistry.pruneExpired();
+        if (count > 0) hubLog.info({ count }, "synapse.prune");
+      } catch (err) {
+        hubLog.warn({ err }, "synapse.prune_failed");
+      }
+    }, 60000);
+    synapsePruneTimer.unref();
+
+    // 고아 node.exe 프로세스 + stale spawn 세션 주기적 정리 (5분마다)
+    // TFX_DISABLE_ORPHAN_CLEANUP=1 로 비활성 (active SSH/swarm 세션 보호 회피용 hotfix gate)
+    orphanCleanupTimer = setInterval(
+      () => {
+        if (process.env.TFX_DISABLE_ORPHAN_CLEANUP === "1") return;
+        try {
+          const { killed, killedProcesses = [] } = cleanupOrphanNodeProcesses();
+          const {
+            killed: runtimeKilled,
+            killedProcesses: runtimeKilledProcesses = [],
+          } = cleanupOrphanRuntimeProcesses();
+          const totalKilled = killed + runtimeKilled;
+          if (totalKilled > 0) {
+            hubLog.info(
+              {
+                killed: totalKilled,
+                processes: [...killedProcesses, ...runtimeKilledProcesses],
+                caller: "timer",
+              },
+              "hub.orphan_cleanup",
+            );
+          }
+
+          const { killed: fsmonitorKilled, stale } =
+            cleanupStaleFsmonitorDaemons({
+              minAgeMs: 24 * 60 * 60 * 1000,
+            });
+          if (fsmonitorKilled > 0) {
+            hubLog.info(
+              { killed: fsmonitorKilled, stale: stale.length },
+              "hub.fsmonitor_cleanup",
+            );
+          }
+        } catch {}
+
+        // stale tfx-spawn-* psmux 세션 정리 (30분 이상 idle)
+        try {
+          const staleKilled = cleanupStaleSpawnSessions(hubLog);
+          if (staleKilled > 0) {
+            hubLog.info({ killed: staleKilled }, "hub.stale_spawn_cleanup");
+          }
+        } catch {}
+      },
+      5 * 60 * 1000,
+    );
+    orphanCleanupTimer.unref();
+
+    // Evict stale rate-limit buckets once per minute to bound memory usage.
+    rateLimitTimer = setInterval(() => {
+      const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
+      for (const [ip, timestamps] of rateLimitMap) {
+        const fresh = timestamps.filter((t) => t >= cutoff);
+        if (fresh.length === 0) {
+          rateLimitMap.delete(ip);
+        } else {
+          rateLimitMap.set(ip, fresh);
+        }
+      }
+    }, RATE_LIMIT_WINDOW_MS);
+    rateLimitTimer.unref();
   };
 
   mkdirSync(PID_DIR, { recursive: true });
@@ -2469,7 +2466,13 @@ export async function startHub({
     try {
       router.stopSweeper();
     } catch {}
-    for (const timer of [hitlTimer, sessionTimer, synapsePruneTimer, orphanCleanupTimer, rateLimitTimer]) {
+    for (const timer of [
+      hitlTimer,
+      sessionTimer,
+      synapsePruneTimer,
+      orphanCleanupTimer,
+      rateLimitTimer,
+    ]) {
       if (timer) clearInterval(timer);
     }
     for (const [sid, session] of Array.from(transports)) {
@@ -2503,7 +2506,14 @@ export async function startHub({
       run_immediately: false,
       interval_ms: 10000,
       onSweepError: ({ source, error, consecutive_failures }) => {
-        hubLog.warn({ source, code: error?.code || "UNKNOWN", consecutive_failures }, "hub.sweep_failed");
+        hubLog.warn(
+          {
+            source,
+            code: error?.code || "UNKNOWN",
+            consecutive_failures,
+          },
+          "hub.sweep_failed",
+        );
       },
     });
     startBackgroundTimers();

--- a/packages/remote/hub/store.mjs
+++ b/packages/remote/hub/store.mjs
@@ -1,8 +1,8 @@
 // hub/store.mjs — SQLite 감사 로그/메타데이터/역할 레지스트리 저장소
 // 실시간 배달은 router/pipe가 담당하고, 역할 권한과 복구 상태는 SQLite가 보존한다.
 
-import { mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,10 +13,7 @@ import {
 } from "@triflux/core/hub/lib/timeout-defaults.mjs";
 import { uuidv7 } from "@triflux/core/hub/lib/uuidv7.mjs";
 import { recalcConfidence } from "@triflux/core/hub/reflexion.mjs";
-import {
-  decodeRoleKey,
-  ROLE_REACHABILITY_STATES,
-} from "@triflux/core/hub/role-contract.mjs";
+import { decodeRoleKey, ROLE_REACHABILITY_STATES } from "@triflux/core/hub/role-contract.mjs";
 
 export { uuidv7 };
 
@@ -135,9 +132,7 @@ function ensureV7Columns(db) {
 }
 
 function storeFingerprint(dbPath) {
-  return `sqlite:${createHash("sha256")
-    .update(String(dbPath))
-    .digest("hex")}`;
+  return `sqlite:${createHash("sha256").update(String(dbPath)).digest("hex")}`;
 }
 
 /**
@@ -238,8 +233,14 @@ export function createStore(dbPath, options = {}) {
     heartbeat: db.prepare(
       "UPDATE agents SET last_seen_ms=?, lease_expires_ms=?, status='online' WHERE agent_id=? AND presence_generation=?",
     ),
+    heartbeatWithoutGeneration: db.prepare(
+      "UPDATE agents SET last_seen_ms=?, lease_expires_ms=?, status='online' WHERE agent_id=?",
+    ),
     setAgentStatus: db.prepare(
       "UPDATE agents SET status=? WHERE agent_id=? AND presence_generation=?",
+    ),
+    setAgentStatusWithoutGeneration: db.prepare(
+      "UPDATE agents SET status=? WHERE agent_id=?",
     ),
     onlineAgents: db.prepare("SELECT * FROM agents WHERE status != 'offline'"),
     allAgents: db.prepare("SELECT * FROM agents"),
@@ -253,9 +254,7 @@ export function createStore(dbPath, options = {}) {
       "UPDATE agents SET status='offline' WHERE agent_id=? AND presence_generation=? AND status='stale' AND lease_expires_ms < ? - 300000",
     ),
 
-    getRole: db.prepare(
-      "SELECT * FROM role_registry WHERE role_key_wire = ?",
-    ),
+    getRole: db.prepare("SELECT * FROM role_registry WHERE role_key_wire = ?"),
     insertRoleReservation: db.prepare(`
       INSERT INTO role_registry (
         role_key_wire, project_id, role_kind, scope_id, state,
@@ -312,9 +311,7 @@ export function createStore(dbPath, options = {}) {
         AND activation_seq=@expected_activation_seq
         AND activation_id IS @expected_activation_id
         AND version=@expected_version`),
-    listRoles: db.prepare(
-      "SELECT * FROM role_registry ORDER BY role_key_wire",
-    ),
+    listRoles: db.prepare("SELECT * FROM role_registry ORDER BY role_key_wire"),
     expiredHolderRoles: db.prepare(`
       SELECT * FROM role_registry
       WHERE holder_agent_id IS NOT NULL
@@ -655,27 +652,28 @@ export function createStore(dbPath, options = {}) {
       previous_holder_agent_id:
         input.previous_holder_agent_id ??
         (current?.holder_agent_id !== input.holder_agent_id
-          ? current?.holder_agent_id ?? null
-          : current?.previous_holder_agent_id ?? null),
+          ? (current?.holder_agent_id ?? null)
+          : (current?.previous_holder_agent_id ?? null)),
       epoch: nextEpoch,
       activation_seq: nextActivationSeq,
       activation_id:
         input.activation_id ??
-        (input.holder_agent_id ? uuidv7() : current?.activation_id ?? null),
+        (input.holder_agent_id ? uuidv7() : (current?.activation_id ?? null)),
       activation_deadline_ms:
         input.activation_deadline_ms ?? current?.activation_deadline_ms ?? null,
       holder_lease_expires_ms:
         input.holder_lease_expires_ms ??
         current?.holder_lease_expires_ms ??
         null,
-      charter_version: input.charter_version ?? current?.charter_version ?? null,
+      charter_version:
+        input.charter_version ?? current?.charter_version ?? null,
       charter_acked_epoch:
         input.charter_acked_epoch ?? current?.charter_acked_epoch ?? null,
       retry_count: input.retry_count ?? current?.retry_count ?? 0,
       next_probe_ms: input.next_probe_ms ?? current?.next_probe_ms ?? null,
       blocked_reason:
         input.blocked_reason === undefined
-          ? current?.blocked_reason ?? null
+          ? (current?.blocked_reason ?? null)
           : input.blocked_reason,
       last_transition_ms: input.last_transition_ms ?? Date.now(),
       last_reason: input.last_reason ?? "role_reserved",
@@ -727,14 +725,10 @@ export function createStore(dbPath, options = {}) {
     return {
       roles,
       candidates: roles.flatMap((role) =>
-        S.listRoleCandidates
-          .all(role.role_key_wire)
-          .map(parseRoleCandidateRow),
+        S.listRoleCandidates.all(role.role_key_wire).map(parseRoleCandidateRow),
       ),
       pending_messages: roles.flatMap((role) =>
-        S.pendingRoleMessages
-          .all(role.role_key_wire, now)
-          .map(parseMessageRow),
+        S.pendingRoleMessages.all(role.role_key_wire, now).map(parseMessageRow),
       ),
     };
   });
@@ -800,12 +794,10 @@ export function createStore(dbPath, options = {}) {
 
     refreshLease(agentId, ttlMs = 30000, presenceGeneration) {
       const now = Date.now();
-      const write = S.heartbeat.run(
-        now,
-        now + ttlMs,
-        agentId,
-        presenceGeneration,
-      );
+      const write =
+        presenceGeneration == null
+          ? S.heartbeatWithoutGeneration.run(now, now + ttlMs, agentId)
+          : S.heartbeat.run(now, now + ttlMs, agentId, presenceGeneration);
       return {
         agent_id: agentId,
         lease_expires_ms: now + ttlMs,
@@ -868,7 +860,12 @@ export function createStore(dbPath, options = {}) {
     },
 
     updateAgentStatus(agentId, status, presenceGeneration) {
-      return S.setAgentStatus.run(status, agentId, presenceGeneration).changes > 0;
+      return (
+        (presenceGeneration == null
+          ? S.setAgentStatusWithoutGeneration.run(status, agentId)
+          : S.setAgentStatus.run(status, agentId, presenceGeneration)
+        ).changes > 0
+      );
     },
 
     getRole(roleKeyWire) {
@@ -894,7 +891,8 @@ export function createStore(dbPath, options = {}) {
         Object.hasOwn(input, "expectedActivationId") ||
         Object.hasOwn(input, "activation_id");
       const expected = {
-        version: input.expected_version ?? input.expectedVersion ?? input.version,
+        version:
+          input.expected_version ?? input.expectedVersion ?? input.version,
         epoch: input.expected_epoch ?? input.expectedEpoch ?? input.epoch,
         activation_seq:
           input.expected_activation_seq ??
@@ -1036,15 +1034,15 @@ export function createStore(dbPath, options = {}) {
           0,
         excluded_until_ms:
           input.excluded_until_ms === undefined
-            ? current?.excluded_until_ms ?? null
+            ? (current?.excluded_until_ms ?? null)
             : input.excluded_until_ms,
         last_probe_ms:
           input.last_probe_ms === undefined
-            ? current?.last_probe_ms ?? null
+            ? (current?.last_probe_ms ?? null)
             : input.last_probe_ms,
         last_probe_code:
           input.last_probe_code === undefined
-            ? current?.last_probe_code ?? null
+            ? (current?.last_probe_code ?? null)
             : input.last_probe_code,
         updated_at_ms: input.updated_at_ms ?? Date.now(),
       });
@@ -1059,9 +1057,11 @@ export function createStore(dbPath, options = {}) {
       if (!current) return { ok: false, reason: "not_found" };
 
       let failures =
-        input.consecutive_probe_failures ??
-        current.consecutive_probe_failures;
-      if (input.probe_failed === true || input.increment_probe_failures === true) {
+        input.consecutive_probe_failures ?? current.consecutive_probe_failures;
+      if (
+        input.probe_failed === true ||
+        input.increment_probe_failures === true
+      ) {
         failures = current.consecutive_probe_failures + 1;
       } else if (input.probe_succeeded === true) {
         failures = 0;
@@ -1530,8 +1530,15 @@ export function createStore(dbPath, options = {}) {
             reason: "ttl_expired",
             failed_at_ms: now_ms,
           });
-          const dlqInserted = S.insertDL.run(row.id, "ttl_expired", now_ms, null).changes === 1;
-          transitions.push({ message: parseMessageRow(row), previous_status: row.status, reason: "ttl_expired", failed_at_ms: now_ms, dlq_inserted: dlqInserted });
+          const dlqInserted =
+            S.insertDL.run(row.id, "ttl_expired", now_ms, null).changes === 1;
+          transitions.push({
+            message: parseMessageRow(row),
+            previous_status: row.status,
+            reason: "ttl_expired",
+            failed_at_ms: now_ms,
+            dlq_inserted: dlqInserted,
+          });
         }
         return { now_ms, messages: transitions.length, transitions };
       })();

--- a/packages/remote/hub/team/claude-daemon-control.mjs
+++ b/packages/remote/hub/team/claude-daemon-control.mjs
@@ -321,10 +321,12 @@ export async function probeClaudeDaemonCandidates({
   short,
   sessionId,
   timeoutMs = 6000,
+  tmpRoot = "/tmp",
 } = {}) {
   const candidates = await buildClaudeDaemonDiscoveryCandidates({
     configDir,
     env,
+    tmpRoot,
   });
   const callerProvenance = detectCallerProvenance(env);
   const targetRequested = Boolean(short || sessionId);

--- a/packages/remote/hub/team/headless.mjs
+++ b/packages/remote/hub/team/headless.mjs
@@ -272,12 +272,16 @@ export async function deregisterHeadlessWorkers(
       requestJsonFn("/bridge/deregister", {
         body: {
           agent_id: getHeadlessWorkerAgentId(sessionName, index),
-          ...(presenceOwnerByAgent.get(getHeadlessWorkerAgentId(sessionName, index)) || {}),
+          ...(presenceOwnerByAgent.get(
+            getHeadlessWorkerAgentId(sessionName, index),
+          ) || {}),
         },
       })
         .catch(() => {})
         .finally(() =>
-          presenceOwnerByAgent.delete(getHeadlessWorkerAgentId(sessionName, index)),
+          presenceOwnerByAgent.delete(
+            getHeadlessWorkerAgentId(sessionName, index),
+          ),
         ),
     ),
   );

--- a/packages/remote/hub/team/synapse-http.mjs
+++ b/packages/remote/hub/team/synapse-http.mjs
@@ -1,6 +1,9 @@
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
+import { normalizeRoleKey } from "@triflux/core/hub/role-contract.mjs";
 
 const HUB_DEFAULT_PORT = 27888;
 // Same token file as hub/bridge.mjs (HUB_TOKEN_FILE). Kept inline rather than
@@ -19,6 +22,144 @@ function normalizeToken(raw) {
   if (raw == null) return null;
   const token = String(raw).trim();
   return token || null;
+}
+
+function opaqueId(prefix, value) {
+  return `${prefix}_${createHash("sha256")
+    .update(String(value || ""))
+    .digest("base64url")
+    .slice(0, 22)}`;
+}
+
+function normalizedProjectId(value) {
+  try {
+    return normalizeRoleKey({ project_id: value, role_kind: "cto" }).project_id;
+  } catch {
+    return "";
+  }
+}
+
+function resolveProjectId(cwd, meta, opts = {}) {
+  const explicit = meta?.project_id || process.env.TFX_PROJECT_ID;
+  if (explicit) return normalizedProjectId(explicit);
+  if (typeof opts.resolveProjectId === "function") {
+    return normalizedProjectId(opts.resolveProjectId(cwd));
+  }
+  let current = cwd;
+  while (current) {
+    const manifest = join(current, ".triflux", "project.json");
+    if (existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(readFileSync(manifest, "utf8"));
+        if (parsed?.schema_version !== "tfx.project.v1") return "";
+        return normalizedProjectId(parsed.project_id);
+      } catch {
+        return "";
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return "";
+}
+
+function inferSessionCli(meta, opts = {}) {
+  const explicit = String(meta?.cli || meta?.actor_cli || "")
+    .trim()
+    .toLowerCase();
+  if (explicit === "codex" || explicit === "claude") return explicit;
+  const entrypoint = String(opts.entrypoint ?? process.argv[1] ?? "");
+  if (entrypoint.includes("codex-session-hook")) return "codex";
+  if (entrypoint.includes("agy-session-hook")) return "other";
+  return "claude";
+}
+
+function resolveTmuxSession(meta, opts = {}) {
+  const explicit =
+    meta?.tmux_session || meta?.session_name || process.env.TFX_TMUX_SESSION;
+  if (explicit) return String(explicit).trim();
+  if (!process.env.TMUX) return "";
+  try {
+    const run =
+      opts.tmuxSessionName ||
+      (() =>
+        execFileSync("tmux", ["display-message", "-p", "#{session_name}"], {
+          encoding: "utf8",
+          timeout: 200,
+          windowsHide: true,
+        }));
+    return String(run() || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function buildSynapseRegistrationMeta(meta, opts = {}) {
+  if (!meta || meta.sessionKind !== "interactive") return meta;
+  const sessionId = String(meta.sessionId || "").trim();
+  if (!sessionId) return meta;
+  const cwd = typeof meta.cwd === "string" ? meta.cwd : process.cwd();
+  const cli = inferSessionCli(meta, opts);
+  const hostId = String(
+    meta.host_id ||
+      process.env.TFX_HOST_ID ||
+      opaqueId("hst", opts.hostname?.() || hostname()),
+  ).trim();
+  const expiresAtMs = Number(opts.nowMs?.() ?? Date.now()) + 299000;
+  const transportLocators = [];
+  if (cli === "claude") {
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `claude-uds:${hostId}:${sessionId}`),
+      kind: "claude-uds",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: 100,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_id: sessionId,
+        bridge_id: String(
+          meta.bridge_id || process.env.TFX_BRIDGE_ID || "local-hub",
+        ),
+      },
+    });
+  }
+  const tmuxSession = resolveTmuxSession(meta, opts);
+  if (tmuxSession) {
+    const muxServerSource =
+      meta.mux_server_id ||
+      process.env.TFX_MUX_SERVER_ID ||
+      String(process.env.TMUX || "default").split(",", 1)[0];
+    transportLocators.push({
+      schema_version: "tfx.transport-locator.v1",
+      transport_id: opaqueId("trn", `tmux:${hostId}:${tmuxSession}`),
+      kind: "tmux",
+      host_id: hostId,
+      capabilities: ["probe", "wake", "activate", "interrupt"],
+      priority: cli === "codex" ? 100 : 50,
+      expires_at_ms: expiresAtMs,
+      locator: {
+        session_name: tmuxSession,
+        mux_server_id: opaqueId("mux", muxServerSource),
+      },
+    });
+  }
+  const directAgentId = `session:${sessionId}`;
+  return {
+    ...meta,
+    agent_id:
+      meta.agent_id ||
+      (directAgentId.length <= 64 && /^[a-zA-Z0-9._:-]+$/u.test(directAgentId)
+        ? directAgentId
+        : opaqueId("session", sessionId)),
+    cli,
+    project_id: resolveProjectId(cwd, meta, opts) || undefined,
+    session_id: meta.session_id || sessionId,
+    host_id: hostId,
+    transport_locators_json:
+      meta.transport_locators_json ?? JSON.stringify(transportLocators),
+  };
 }
 
 // Mirrors hub/bridge.mjs:readHubToken — env override first, then the token file.
@@ -139,7 +280,11 @@ export function drainPendingSynapse(timeoutMs = 1000) {
 }
 
 export function registerSynapseSession(meta, opts = {}) {
-  return fireAndForgetSynapse("/synapse/register", meta, opts);
+  return fireAndForgetSynapse(
+    "/synapse/register",
+    buildSynapseRegistrationMeta(meta, opts),
+    opts,
+  );
 }
 
 export function heartbeatSynapseSession(

--- a/packages/remote/hub/tools.mjs
+++ b/packages/remote/hub/tools.mjs
@@ -159,7 +159,10 @@ export function createTools(store, router, hitl, pipe = null) {
           transport_locators_json: {
             description:
               "tfx.transport-locator.v1 객체 배열 또는 그 JSON 문자열",
-            oneOf: [{ type: "array", items: { type: "object" } }, { type: "string" }],
+            oneOf: [
+              { type: "array", items: { type: "object" } },
+              { type: "string" },
+            ],
           },
           hub_instance_id: { type: "string" },
           store_fingerprint: { type: "string" },

--- a/packages/remote/hub/workers/delegator-mcp.mjs
+++ b/packages/remote/hub/workers/delegator-mcp.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as z from "zod";
-import { resolveCodexAgentPolicy } from "@triflux/core/scripts/lib/agent-route-policy.mjs";
+import { resolveCodexAgentPolicy } from "../../scripts/lib/agent-route-policy.mjs";
 import { resolveBashExecutable } from "@triflux/core/hub/lib/bash-path.mjs";
 import { runHeadlessWithCleanup } from "../team/headless.mjs";
 import { buildWorkerSandboxEnv } from "../team/worker-sandbox.mjs";

--- a/packages/remote/scripts/lib/agent-route-policy.mjs
+++ b/packages/remote/scripts/lib/agent-route-policy.mjs
@@ -207,15 +207,23 @@ export const DEFAULT_CODEX_AGENT = "executor";
 
 export const CANONICAL_CODEX_PROFILE_OVERRIDES = Object.freeze(
   new Set([
-    "gpt56_luna_low", "gpt56_terra_med", "gpt56_terra_high", "gpt56_sol_xhigh",
-    "gpt56_sol_max", "gpt56_sol_ultra",
+    "gpt56_luna_low",
+    "gpt56_terra_med",
+    "gpt56_terra_high",
+    "gpt56_sol_xhigh",
+    "gpt56_sol_max",
+    "gpt56_sol_ultra",
   ]),
 );
 export const ULTRA_ELIGIBLE_CODEX_AGENTS = Object.freeze(
   new Set(["deep-executor", "scientist-deep"]),
 );
+
 const NESTED_GLOBAL_PROFILE_OVERRIDES = new Set([
-  "max", "ultra", "gpt56_sol_max", "gpt56_sol_ultra",
+  "max",
+  "ultra",
+  "gpt56_sol_max",
+  "gpt56_sol_ultra",
 ]);
 
 export function resolveCodexAgentPolicy(agent) {
@@ -224,32 +232,77 @@ export function resolveCodexAgentPolicy(agent) {
   );
 }
 
+/**
+ * Resolves a requested Codex profile against the canonical role policy.
+ *
+ * `retryProfile` intentionally wins over `profileOverride`: retry snapshots
+ * represent an already-selected escalation step and must not be replaced by a
+ * later process-level `TFX_CODEX_PROFILE`. Ultra is reserved for an eligible
+ * top-level role; every nested/sandboxed or ineligible request is max.
+ */
 export function resolveCodexAgentProfile(
   agent,
-  { profileOverride = "auto", retryProfile = null, nested = false, allowCustom = false } = {},
+  {
+    profileOverride = "auto",
+    retryProfile = null,
+    nested = false,
+    allowCustom = false,
+  } = {},
 ) {
   const defaultProfile = resolveCodexAgentPolicy(agent).profile;
   const retryRequested = String(retryProfile ?? "").trim();
   const requested = retryRequested || String(profileOverride || "auto").trim();
   if (!requested || requested === "auto") return defaultProfile;
-  const canonical = requested === "max" ? "gpt56_sol_max" : requested === "ultra" ? "gpt56_sol_ultra" : requested;
+
+  const canonical =
+    requested === "max"
+      ? "gpt56_sol_max"
+      : requested === "ultra"
+        ? "gpt56_sol_ultra"
+        : requested;
   if (!CANONICAL_CODEX_PROFILE_OVERRIDES.has(canonical)) {
     if (allowCustom) return requested;
-    throw new Error(`[agent-route-policy] unsupported profile override: ${requested}`);
+    throw new Error(
+      `[agent-route-policy] unsupported profile override: ${requested}`,
+    );
   }
   if (canonical !== "gpt56_sol_ultra") return canonical;
-  return nested || !ULTRA_ELIGIBLE_CODEX_AGENTS.has(agent) ? "gpt56_sol_max" : canonical;
+  return nested || !ULTRA_ELIGIBLE_CODEX_AGENTS.has(agent)
+    ? "gpt56_sol_max"
+    : canonical;
 }
 
+/**
+ * Nested headless, team, worker, and delegator launches always select an
+ * explicit role profile rather than inheriting the global Codex config. A
+ * custom profile that resolves to ultra is also downgraded to max.
+ */
 export function resolveNestedCodexAgentProfile(
   agent,
-  { profileOverride = "auto", globalProfile = "auto", retryProfile = null, codexHome } = {},
+  {
+    profileOverride = "auto",
+    globalProfile = "auto",
+    retryProfile = null,
+    codexHome,
+  } = {},
 ) {
   const explicitProfile = String(profileOverride || "auto").trim();
   const globalOverride = String(globalProfile || "auto").trim();
-  const effectiveOverride = explicitProfile !== "auto" ? explicitProfile : NESTED_GLOBAL_PROFILE_OVERRIDES.has(globalOverride) ? globalOverride : "auto";
+  // Headless lanes must select their role policy explicitly. Only the max and
+  // ultra exception lanes may cross the process environment boundary.
+  const effectiveOverride =
+    explicitProfile !== "auto"
+      ? explicitProfile
+      : NESTED_GLOBAL_PROFILE_OVERRIDES.has(globalOverride)
+        ? globalOverride
+        : "auto";
   const fallback = resolveCodexAgentProfile(agent);
-  const candidate = resolveCodexAgentProfile(agent, { profileOverride: effectiveOverride, retryProfile, nested: true, allowCustom: true });
+  const candidate = resolveCodexAgentProfile(agent, {
+    profileOverride: effectiveOverride,
+    retryProfile,
+    nested: true,
+    allowCustom: true,
+  });
   const { effort } = resolveCodexProfileConfigValues(candidate, { codexHome });
   if (!effort) return fallback;
   return effort.toLowerCase() === "ultra" ? "gpt56_sol_max" : candidate;

--- a/packages/remote/scripts/lib/cli-codex.mjs
+++ b/packages/remote/scripts/lib/cli-codex.mjs
@@ -18,6 +18,8 @@ import {
   resolveNestedCodexAgentProfile,
 } from "./agent-route-policy.mjs";
 
+// Compatibility re-exports for launchers which historically imported these
+// helpers from this adapter. The policy module owns the semantics.
 export { resolveCodexAgentProfile, resolveNestedCodexAgentProfile };
 
 export function plan({

--- a/packages/remote/scripts/lib/codex-recovery.sh
+++ b/packages/remote/scripts/lib/codex-recovery.sh
@@ -8,9 +8,16 @@
 # 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
 
 recover_codex_stdout() {
+  # 복구 진입 여부 플래그(전역, local 아님) — 아우터 no-op 가드가 읽는다.
+  # 0 = 진짜 stdout 존재(복구 미진입), 1 = stdout 이 애초에 비어 복구 진입함.
+  CODEX_STDOUT_WAS_RECOVERED=0
   if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
     return 0
   fi
+  # 여기 도달 = stdout 이 애초에 비어있었다. 아래에서 STDOUT_LOG 에 채워지는 내용은
+  # 전부 stderr 에서 복구된 것이지 워커의 진짜 산출물이 아니다. 이 플래그로 아우터
+  # 가드가 "복구된 stderr 노이즈"를 성공 출력으로 오인하지 않게 한다(#result-verification).
+  CODEX_STDOUT_WAS_RECOVERED=1
 
   # 1차: codex marker
   sed 's/\r$//' "$STDERR_LOG" \
@@ -47,4 +54,16 @@ recover_codex_stdout() {
     echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
     echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
   fi
+}
+
+# ── MCP transport 채널 사망 판정 ──
+# Codex MCP transport 채널이 실행 중 죽으면 codex exec 가 exit 0 + 빈 stdout 으로
+# 끝나는 변형이 있다(래퍼 부재로 인한 pre-flight CODEX_MCP_TRANSPORT_EXIT_CODE=70
+# 과 구분됨 — 이건 런타임 채널 사망). stderr 의 하드 크래시 서명으로 이 사망을
+# 검출한다. 아우터 가드가 exit 0 이어도 결과를 실패로 승격하는 근거로 쓴다.
+# 인자: [stderr_log] (미지정 시 $STDERR_LOG). 반환: 0=크래시 서명 있음, 1=없음.
+codex_stdout_transport_crashed() {
+  local stderr_log="${1:-${STDERR_LOG:-}}"
+  [[ -n "$stderr_log" && -f "$stderr_log" ]] || return 1
+  grep -qE 'Transport channel closed|rmcp::transport worker quit with fatal' "$stderr_log" 2>/dev/null
 }

--- a/packages/triflux/scripts/lib/codex-recovery.sh
+++ b/packages/triflux/scripts/lib/codex-recovery.sh
@@ -8,9 +8,16 @@
 # 4차 FALLBACK_FAILED → 모두 실패 시 marker + stderr_log 경로 출력
 
 recover_codex_stdout() {
+  # 복구 진입 여부 플래그(전역, local 아님) — 아우터 no-op 가드가 읽는다.
+  # 0 = 진짜 stdout 존재(복구 미진입), 1 = stdout 이 애초에 비어 복구 진입함.
+  CODEX_STDOUT_WAS_RECOVERED=0
   if [[ -s "$STDOUT_LOG" || ! -s "$STDERR_LOG" ]]; then
     return 0
   fi
+  # 여기 도달 = stdout 이 애초에 비어있었다. 아래에서 STDOUT_LOG 에 채워지는 내용은
+  # 전부 stderr 에서 복구된 것이지 워커의 진짜 산출물이 아니다. 이 플래그로 아우터
+  # 가드가 "복구된 stderr 노이즈"를 성공 출력으로 오인하지 않게 한다(#result-verification).
+  CODEX_STDOUT_WAS_RECOVERED=1
 
   # 1차: codex marker
   sed 's/\r$//' "$STDERR_LOG" \
@@ -47,4 +54,16 @@ recover_codex_stdout() {
     echo "[tfx-route] FALLBACK_FAILED stderr_log=$STDERR_LOG" >&2
     echo "[tfx-route] 경고: codex stdout 비어있음, stderr 복구도 실패. 위 stderr_log 경로에서 raw codex 출력 확인 가능." >&2
   fi
+}
+
+# ── MCP transport 채널 사망 판정 ──
+# Codex MCP transport 채널이 실행 중 죽으면 codex exec 가 exit 0 + 빈 stdout 으로
+# 끝나는 변형이 있다(래퍼 부재로 인한 pre-flight CODEX_MCP_TRANSPORT_EXIT_CODE=70
+# 과 구분됨 — 이건 런타임 채널 사망). stderr 의 하드 크래시 서명으로 이 사망을
+# 검출한다. 아우터 가드가 exit 0 이어도 결과를 실패로 승격하는 근거로 쓴다.
+# 인자: [stderr_log] (미지정 시 $STDERR_LOG). 반환: 0=크래시 서명 있음, 1=없음.
+codex_stdout_transport_crashed() {
+  local stderr_log="${1:-${STDERR_LOG:-}}"
+  [[ -n "$stderr_log" && -f "$stderr_log" ]] || return 1
+  grep -qE 'Transport channel closed|rmcp::transport worker quit with fatal' "$stderr_log" 2>/dev/null
 }

--- a/packages/triflux/scripts/tfx-route-post.mjs
+++ b/packages/triflux/scripts/tfx-route-post.mjs
@@ -326,6 +326,15 @@ function trackCliIssue(cliType, agent, stderrText, exitCode) {
 
   const patterns = [
     {
+      // MCP transport 채널 런타임 사망 — codex exec 가 exit 0 으로 끝나도 워커가
+      // 빈손으로 죽은 케이스. tfx-route.sh 가드가 이를 실패(exit 68)로 승격하고,
+      // 여기서 원인을 cli-issues.jsonl 에 기록해 관측성을 확보한다(#result-verification).
+      regex: /Transport channel closed|rmcp::transport worker quit with fatal/i,
+      pattern: "mcp_transport",
+      msg: "MCP transport channel closed mid-run (worker likely produced no result)",
+      severity: "error",
+    },
+    {
       regex: /sandbox image.*missing/i,
       pattern: "sandbox_missing",
       msg: "Docker sandbox image not found",
@@ -377,6 +386,13 @@ function trackCliIssue(cliType, agent, stderrText, exitCode) {
       msg: `Exit code ${exitCode}`,
       severity: "warn",
     };
+  }
+
+  // mcp_transport 는 실행 실패를 유발한 크래시일 때만 이슈로 기록한다. exit 0
+  // (진짜 산출물이 있어 가드가 미승격)에서의 "Transport channel closed" 는 정상
+  // 종료 teardown 노이즈이므로 관측 오탐을 피해 제외한다(#result-verification P3-3).
+  if (matched && matched.pattern === "mcp_transport" && exitCode === 0) {
+    matched = null;
   }
 
   if (!matched) return;

--- a/packages/triflux/scripts/tfx-route.sh
+++ b/packages/triflux/scripts/tfx-route.sh
@@ -3066,6 +3066,9 @@ FALLBACK_EOF
   if workspace_signature_before=$(capture_workspace_signature); then
     workspace_probe_supported=true
   fi
+  # recover_codex_stdout 이 복구 진입 시 1로 세운다(dynamic scope로 이 local 이 갱신됨).
+  # 매 실행 초기화로 스테일 방지. 진짜 산출물 부재 판정(아래 no-op 가드)에 쓰인다.
+  local CODEX_STDOUT_WAS_RECOVERED=0
 
   # tee 활성화 조건: 팀 모드 + 실제 터미널(TTY/tmux)
   # Agent 래퍼 안에서는 가상 stdout 캡처로 tee 출력이 사용자에게 안 보임 → 파일 전용
@@ -3307,8 +3310,31 @@ EOF
       fi
     fi
 
-    if [[ ! -s "$STDOUT_LOG" && "$workspace_changed" == "no" && "$CLI_TYPE" != "antigravity" ]]; then
-      printf '%s\n' "[tfx-route] exit 0 이지만 stdout 비어있고 워크스페이스 변화가 없습니다. no-op 성공을 실패로 승격합니다." >> "$STDERR_LOG"
+    # 진짜 산출물 부재 판정 — 빈 stdout 이거나, recover_codex_stdout 이 stderr
+    # 노이즈로 backfill 한 경우(복구 플래그)면 진짜 워커 출력이 아니다. 복구가
+    # `! -s STDOUT_LOG` 를 무력화해 빈손 실행을 success 로 오보고하던 갭을 막는다.
+    local no_genuine_output="no"
+    if [[ ! -s "$STDOUT_LOG" || "${CODEX_STDOUT_WAS_RECOVERED:-0}" == "1" ]]; then
+      no_genuine_output="yes"
+    fi
+
+    # MCP transport 채널이 실행 중 죽었는지(exit 0 이어도) stderr 서명으로 판정.
+    local mcp_transport_crashed="no"
+    if declare -F codex_stdout_transport_crashed >/dev/null 2>&1 \
+       && codex_stdout_transport_crashed "$STDERR_LOG"; then
+      mcp_transport_crashed="yes"
+    fi
+
+    # 승격 조건: 진짜 출력이 없고(무근거 성공) + (워크스페이스 무변화 = 완전 no-op
+    # 이거나 transport 채널 사망 = 결과 신뢰 불가). antigravity 는 stdout 계약이
+    # 달라 제외. 진짜 출력이 있는 성공은 no_genuine_output=no 라 절대 승격되지 않는다.
+    # ★의도된 보수적 트레이드오프: codex 가 stdout 없이 stderr 로만 답을 쓰고 recover
+    # 가 salvage 한 경우(no_genuine_output=yes)라도 transport 채널이 죽었으면 결과를
+    # 신뢰 불가로 보고 실패로 승격한다. 채널 사망 후 salvage 는 완결 보장이 없기
+    # 때문이며, 극히 드문 stdout-없는 정상완료보다 false-success 방지를 우선한다.
+    if [[ "$CLI_TYPE" != "antigravity" && "$no_genuine_output" == "yes" ]] \
+       && { [[ "$workspace_changed" == "no" ]] || [[ "$mcp_transport_crashed" == "yes" ]]; }; then
+      printf '%s\n' "[tfx-route] exit 0 이지만 진짜 산출물이 없습니다 (recovered=${CODEX_STDOUT_WAS_RECOVERED:-0}, workspace_changed=${workspace_changed}, mcp_transport_crash=${mcp_transport_crashed}). no-op/실패 실행을 실패로 승격합니다." >> "$STDERR_LOG"
       exit_code=68
     fi
   fi


### PR DESCRIPTION
## Summary
- Commit f1a981bf (MCP transport false-success guard, merged 2026-07-20) touched root `scripts/tfx-route-post.mjs` and `scripts/tfx-route.sh` without syncing `packages/triflux`, so the published npm package (`triflux` on npm, what `npm install -g triflux` actually installs) was missing that bugfix.
- Running the mirror tooling to fix it surfaced that `packages/remote` had drifted much further — 10 files (hub/pipe, hub/server, hub/store, hub/team/*, hub/workers/delegator-mcp, scripts/lib/*) were stale relative to root, likely since before f1a981bf.

## Changes
- `npm run release:check-mirror --fix` → resynced `packages/triflux/scripts/{tfx-route-post.mjs,tfx-route.sh,lib/codex-recovery.sh}`
- `npm run pack:remote` → regenerated all of `packages/remote` (import-path rewrite for `@triflux/core`); spot-checked several files byte-identical to root after normalizing import paths
- `node scripts/release/check-packages-mirror.mjs` now reports clean for both packages/triflux and packages/remote

## Test plan
- [x] `node scripts/release/check-packages-mirror.mjs` → "Mirror OK"
- [x] Full suite: 4754 tests run, 4736 pass
- [x] 1 failure on first run (`tests/unit/uds-orchestrator.test.mjs`) confirmed pre-existing/flaky and unrelated: same file/module this diff never touches, passes 3/3 on repeat, and passes identically with this diff stashed — not caused by this change