### PR TITLE
fix(hud): stop stale 5h codex snapshot from winning the fallback

### DIFF
--- a/hud/providers/codex.mjs
+++ b/hud/providers/codex.mjs
@@ -89,6 +89,9 @@ export function expireStaleCodexBuckets(
 }
 
 const RESET_CLUSTER_TOLERANCE_SEC = 90;
+// A probe may miss the instant immediately after a reset. Keep that brief
+// polling gap, but never let a long-expired cached window win the fallback.
+const STALE_WINDOW_FALLBACK_GRACE_SEC = CODEX_PROBE_TTL_MS / 1000;
 
 function isNewerSnapshot(candidate, current) {
   if (!current) return true;
@@ -149,7 +152,13 @@ function selectCodexWindowSnapshot(snapshots, nowSec, windowKey) {
       })[0];
   } else {
     for (const snapshot of [
-      ...groups.map((group) => group.latest),
+      ...groups
+        .filter(
+          (group) =>
+            nowSec - Number(group.latest[windowKey]?.resets_at) <=
+            STALE_WINDOW_FALLBACK_GRACE_SEC,
+        )
+        .map((group) => group.latest),
       ...ungrouped,
     ]) {
       if (isNewerSnapshot(snapshot, selected)) selected = snapshot;

--- a/packages/core/hud/providers/codex.mjs
+++ b/packages/core/hud/providers/codex.mjs
@@ -89,6 +89,9 @@ export function expireStaleCodexBuckets(
 }
 
 const RESET_CLUSTER_TOLERANCE_SEC = 90;
+// A probe may miss the instant immediately after a reset. Keep that brief
+// polling gap, but never let a long-expired cached window win the fallback.
+const STALE_WINDOW_FALLBACK_GRACE_SEC = CODEX_PROBE_TTL_MS / 1000;
 
 function isNewerSnapshot(candidate, current) {
   if (!current) return true;
@@ -149,7 +152,13 @@ function selectCodexWindowSnapshot(snapshots, nowSec, windowKey) {
       })[0];
   } else {
     for (const snapshot of [
-      ...groups.map((group) => group.latest),
+      ...groups
+        .filter(
+          (group) =>
+            nowSec - Number(group.latest[windowKey]?.resets_at) <=
+            STALE_WINDOW_FALLBACK_GRACE_SEC,
+        )
+        .map((group) => group.latest),
       ...ungrouped,
     ]) {
       if (isNewerSnapshot(snapshot, selected)) selected = snapshot;

--- a/packages/triflux/hud/providers/codex.mjs
+++ b/packages/triflux/hud/providers/codex.mjs
@@ -89,6 +89,9 @@ export function expireStaleCodexBuckets(
 }
 
 const RESET_CLUSTER_TOLERANCE_SEC = 90;
+// A probe may miss the instant immediately after a reset. Keep that brief
+// polling gap, but never let a long-expired cached window win the fallback.
+const STALE_WINDOW_FALLBACK_GRACE_SEC = CODEX_PROBE_TTL_MS / 1000;
 
 function isNewerSnapshot(candidate, current) {
   if (!current) return true;
@@ -149,7 +152,13 @@ function selectCodexWindowSnapshot(snapshots, nowSec, windowKey) {
       })[0];
   } else {
     for (const snapshot of [
-      ...groups.map((group) => group.latest),
+      ...groups
+        .filter(
+          (group) =>
+            nowSec - Number(group.latest[windowKey]?.resets_at) <=
+            STALE_WINDOW_FALLBACK_GRACE_SEC,
+        )
+        .map((group) => group.latest),
       ...ungrouped,
     ]) {
       if (isNewerSnapshot(snapshot, selected)) selected = snapshot;

--- a/tests/unit/hud-codex-bucket.test.mjs
+++ b/tests/unit/hud-codex-bucket.test.mjs
@@ -277,6 +277,94 @@ describe("Codex multi-window selection", () => {
     }
   });
 
+  it("drops a long-expired five-hour fallback after Codex reports weekly-only primary data", () => {
+    const sessionsRoot = mkdtempSync(
+      join(tmpdir(), "triflux-codex-weekly-only-fallback-"),
+    );
+    const now = new Date("2026-07-23T06:00:00.000Z");
+    const nowSec = Math.floor(now.getTime() / 1000);
+    try {
+      // A stale local session can be written after the last weekly-only event,
+      // but its reset proves that its five-hour value is no longer usable.
+      writeRollout(sessionsRoot, now, "rollout-stale-five-hour.jsonl", [
+        {
+          timestamp: "2026-07-23T05:59:00.000Z",
+          payload: {
+            rate_limits: {
+              limit_id: "codex",
+              primary: {
+                used_percent: 10,
+                window_minutes: 300,
+                resets_at: nowSec - 6 * 60 * 60,
+              },
+              secondary: null,
+            },
+          },
+        },
+      ]);
+      writeRollout(sessionsRoot, now, "rollout-weekly-only.jsonl", [
+        {
+          timestamp: "2026-07-23T05:55:00.000Z",
+          payload: {
+            rate_limits: {
+              limit_id: "codex",
+              primary: {
+                used_percent: 13,
+                window_minutes: 10080,
+                resets_at: nowSec + 6 * 24 * 60 * 60,
+              },
+              secondary: null,
+            },
+          },
+        },
+      ]);
+
+      const buckets = getCodexRateLimits({ sessionsRoot, now });
+
+      assert.equal(
+        buckets.codex.primary,
+        null,
+        "a long-expired five-hour snapshot must not repopulate the 5h HUD slot",
+      );
+      assert.equal(buckets.codex.secondary.used_percent, 13);
+    } finally {
+      rmSync(sessionsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a just-reset five-hour fallback during the probe polling gap", () => {
+    const sessionsRoot = mkdtempSync(
+      join(tmpdir(), "triflux-codex-reset-grace-"),
+    );
+    const now = new Date("2026-07-23T06:00:00.000Z");
+    const nowSec = Math.floor(now.getTime() / 1000);
+    try {
+      writeRollout(sessionsRoot, now, "rollout-just-reset.jsonl", [
+        {
+          timestamp: "2026-07-23T05:59:00.000Z",
+          payload: {
+            rate_limits: {
+              limit_id: "codex",
+              primary: {
+                used_percent: 10,
+                window_minutes: 300,
+                resets_at: nowSec - 60,
+              },
+              secondary: null,
+            },
+          },
+        },
+      ]);
+
+      const buckets = getCodexRateLimits({ sessionsRoot, now });
+
+      assert.equal(buckets.codex.primary.used_percent, 0);
+      assert.equal(buckets.codex.primary.expired, true);
+    } finally {
+      rmSync(sessionsRoot, { recursive: true, force: true });
+    }
+  });
+
   it("selects an active heavy weekly window independently from the active five-hour window", () => {
     const sessionsRoot = mkdtempSync(join(tmpdir(), "triflux-codex-weekly-"));
     const now = new Date("2026-07-11T06:50:00.000Z");


### PR DESCRIPTION
## Summary
Codex recently started sending weekly-only `rate_limits` (window_minutes: 10080 inside the JSON `primary` key, `secondary: null`). `normalizeBuckets()` already reclassifies this correctly by `window_minutes`, but `selectCodexWindowSnapshot()`'s fallback ("no active group? take the newest one regardless of expiry") kept re-selecting a real five-hour snapshot recorded before the policy change, long after its `resets_at` had passed. Result: HUD showed a nonsensical `5h: 10% (166h22m)` instead of a dimmed `--%` placeholder.

Fix: fallback candidates now must have expired within `CODEX_PROBE_TTL_MS` (5 min, the normal reset-polling gap) to be eligible; anything older is dropped.

Note: an earlier attempt at this same symptom was reverted after independent review proved it was a byte-identical no-op (didn't touch the actual root cause). This PR targets the confirmed root cause instead, backed by a real raw `rate_limits` payload capture.

## Test plan
- [x] Reproduced the regression first: 24 pass / 1 fail without the fix (stale 300-min bucket wins fallback instead of null)
- [x] Fix flips it green: 25 pass / 0 fail
- [x] Full HUD test suite: 122 pass / 0 fail
- [x] Cross-reviewed by Claude (Codex-authored change, no self-approval per project policy) — independently reproduced the before/after via `git stash`, verified renderer draws `--%` for null primary, verified normal (non-expired) 5h+1w cases untouched, verified `RESET_CLUSTER_TOLERANCE_SEC`/grace-period interaction has no pathological edge case